### PR TITLE
fix(web): smooth base breathing animation (#5)

### DIFF
--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1332,12 +1332,16 @@ export function WorldMap() {
           const now = performance.now();
           drawn.bases.forEach((base) => {
             if (base.baseY <= 0) return;
-            base.container.zIndex = Math.round(base.baseY);
             // Breathing: scaleY stretches upward from the sprite's bottom anchor
             // (0.5, 1). 0.25 Hz period; 3% amplitude reads as alive without skewing
             // the painted rooflines. phaseOffset keeps bases out of sync.
+            // zIndex is already set during relayout (base.baseY is static between
+            // relayouts), so no need to reassign each tick.
+            const scaleY = 1 + Math.sin((now + base.phaseOffset) * Math.PI / 2000) * 0.03;
             if (base.sprite) {
-              base.sprite.scale.y = 1 + Math.sin((now + base.phaseOffset) * Math.PI / 2000) * 0.03;
+              base.sprite.scale.y = scaleY;
+            } else {
+              base.fallback.scale.y = scaleY;
             }
           });
           updateLiveClansmanPositions();

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1332,10 +1332,13 @@ export function WorldMap() {
           const now = performance.now();
           drawn.bases.forEach((base) => {
             if (base.baseY <= 0) return;
-            // 0.25 Hz (4-second period). 2π/4000 = π/2000 keeps units honest:
-            // sin((t + offset) * π / period_ms_half) cycles once per period.
-            base.container.y = base.baseY + Math.round(Math.sin((now + base.phaseOffset) * Math.PI / 2000) * 1);
             base.container.zIndex = Math.round(base.baseY);
+            // Breathing: scaleY stretches upward from the sprite's bottom anchor
+            // (0.5, 1). 0.25 Hz period; 3% amplitude reads as alive without skewing
+            // the painted rooflines. phaseOffset keeps bases out of sync.
+            if (base.sprite) {
+              base.sprite.scale.y = 1 + Math.sin((now + base.phaseOffset) * Math.PI / 2000) * 0.03;
+            }
           });
           updateLiveClansmanPositions();
         };


### PR DESCRIPTION
## Summary

- Bases on the world map jumped between three pixel rows instead of moving smoothly. The bob at `WorldMap.tsx:1337` wrapped `Math.sin(...) * 1` in `Math.round`, snapping output to `{-1, 0, +1}`.
- Replaced the y-translation with a **breathing** animation: `scale.y` stretch from the sprite's bottom anchor (`0.5, 1` — already set), 3% amplitude. Reads as alive without skewing the painted rooflines.
- Dropped `Math.round` so Pixi renders subpixel. Kept `phaseOffset` so bases breathe out of sync.

## Test plan

- [ ] `pnpm --filter @clan-world/web typecheck` — passes locally
- [ ] Visually verify bases breathe smoothly on the world map (no Y jitter, no roofline skew)
- [ ] Confirm `phaseOffset` still desyncs neighboring bases

Closes #5