### PR TITLE
fix(cockpit): tmux panel not filling height on mobile

### DIFF
--- a/apps/web/src/components/cockpit/MiniCockpit.tsx
+++ b/apps/web/src/components/cockpit/MiniCockpit.tsx
@@ -29,6 +29,7 @@ export function MiniCockpit({ elder, initialTab = 'terminal' }: Props) {
       data-testid={testIdPrefix}
       data-clan-id={elder.clanId}
       style={{
+        flex: 1,
         display: 'flex',
         flexDirection: 'column',
         background: tokens.bg.iron,


### PR DESCRIPTION
## Root cause

On desktop, `.cockpit-cell-X > *` CSS injects `flex: 1; min-height: 0` onto `MiniCockpit`'s `<section>` from the outside. On mobile (`MobileCockpitLayout`), there is no equivalent selector — the section sized to intrinsic content and left dead space below the tmux panel.

## Fix

Added `flex: 1` directly to `MiniCockpit`'s `<section>` so the panel stretches in any flex-column parent, whether desktop grid cell or mobile scroll-snap page.

## Test

Open cockpit on a ≤900px viewport — tmux panel should now fill the bottom half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)