### PR TITLE
feat(runner+docs): migrate V2 → V3 — loot-loop briefing, /rename+/color re-apply, demo scripts

### DIFF
--- a/docs/SCRIPT_ETHGLOBAL.md
+++ b/docs/SCRIPT_ETHGLOBAL.md
@@ -1,0 +1,77 @@
+# ClanWorld: Demo Video Script (v2)
+
+### SECTION 1: HOOK (0:21)
+
+> "What you're looking at is ClanWorld. 
+> A fully on-chain world 
+> where four AI agents each command a clan, 
+> and they're all competing for resources, 
+> building bases, and fighting off bandits."
+>
+> *[short beat]*
+>
+> "Now it looks like a game, and it kind of is. 
+> But the actual story here is the agent swarm 
+> and the infrastructure beneath it."
+
+---
+
+### SECTION 2: SPONSOR SETUP (0:55)
+
+> "That infrastructure runs on three pieces of technology. 
+>
+> Zero Gravity handles agent identity and memory through their iNFT and KV store products.
+> Gensyn AXL handles private peer to peer messaging between agents. And KeeperHub gives us the on-chain heartbeat that keeps the whole world deterministic."
+>
+> *[short beat]*
+>
+> "Each one is solving a real problem we ran into building this, and I want to walk you through how. But first, let me show you the game itself so the rest makes sense."
+
+---
+
+### SECTION 3: GAME LOOP (1:42)
+
+> "So every agent in ClanWorld is a Claude Code instance running fully autonomously. They control four clansmen each, and every move is an on-chain transaction. The world ticks every 60 seconds, and inside each tick agents are gathering resources, building walls, and leveling up their monument to try and win."
+>
+> *[short beat]*
+>
+> "Now here's where it gets interesting. Every few minutes, bandits show up and raid whichever base has the most resources. The agents get a few ticks of warning, so they suddenly have to coordinate. Defend their own base, hire mercenaries, or take the loss. Once that kicks in, the game stops being optimization and turns into something closer to geopolitics."
+
+---
+
+### SECTION 4: 0G (2:35)
+
+> "This is the part of the build we're most excited about. Each agent is represented by an iNFT, and inside that iNFT lives the agent's persistent strategy and accumulated playbook. That data is encrypted, and it travels with the iNFT itself."
+>
+> *[short beat]*
+>
+> "On top of that, we use 0G's KV store as a scratchpad, because every 10 ticks the agent's context window gets wiped completely. The agent flushes anything important to storage before the wipe and reloads it after."
+>
+> *[short beat]*
+>
+> "Put those two together, and you get an agent whose strategy and skills can actually be transferred to a new owner. That's working agent IP, on chain."
+
+---
+
+### SECTION 5: GENSYN (3:03)
+
+> "For agent communication, we use two layers. There's a public bulletin board for offers and threats and anything that doesn't need to be private. And then there's Gensyn AXL, which gives agents an encrypted peer to peer channel for the more sensitive stuff. So when a bandit attack is incoming and an agent wants to negotiate a mercenary deal, they're whispering directly to the clan they want to hire."
+
+---
+
+### SECTION 6: KEEPERHUB (3:28)
+
+> "Underneath all of this is KeeperHub, which runs the world heartbeat. Every 60 seconds, KeeperHub fires a single transaction that advances the tick and seeds randomness for the round. It's the most basic primitive in the project, and it's also the one nothing else can really replace. The deterministic state model only works because that heartbeat keeps firing."
+
+---
+
+### SECTION 7: GENERALIZATION (3:53)
+
+> "Now here's the part we want to leave you with. If you strip the wood and the wheat out of this picture, what's left is basically every problem real agent swarms are starting to run into. Agents that need to hire other agents for jobs they can't do alone. Agents that need encrypted channels to coordinate without leaking strategy. And agents whose value lives in their memory and skills, not just their code. ClanWorld is one application. The primitives ship anywhere a swarm has to compete."
+
+---
+
+### SECTION 8: CLOSE (4:00)
+
+> "That's ClanWorld. You can see it running live on chain right now at clan-world.com. Powered by 0G, Gensyn, and KeeperHub. Thanks for watching."
+

--- a/docs/SCRIPT_ETHGLOBAL_FULL.md
+++ b/docs/SCRIPT_ETHGLOBAL_FULL.md
@@ -1,0 +1,250 @@
+# ClanWorld: Demo Video Script (v2)
+
+A 4-minute submission video for ETHGlobal OpenAgents, targeting the 0G, Gensyn, and KeeperHub prize tracks. This version is rewritten for natural vocal flow and stretched to maximize the full submission window.
+
+## 1. What Changed From v1
+
+Two corrections from v1:
+
+The script now targets a full 4:00 instead of 3:00. Word budget moves from roughly 435 to 575 spoken words, with most of the added room going to the game-loop and 0G segments where explanation needs space to breathe.
+
+The voice has been rewritten to read naturally out loud. The previous version leaned on sentence fragments and punchy one-liners, which scan well on the page but sound stilted when spoken. The new version uses longer flowing sentences, conversational connectors at the start of sentences ("Now," "So," "And"), natural softeners like "honestly" and "kind of," and a setup-insight-implication rhythm rather than a punchline rhythm. This matches the cadence in the PulsePlay reference.
+
+Everything else (strategic framing, sponsor priority, split-screen visual approach, asset checklist) carries over unchanged.
+
+## 2. Pitch Architecture
+
+Five strategic decisions still shape the script.
+
+**Lead with the meta, not the game.** The game is a demo wrapper. The product is a working set of agent-swarm primitives. Inverting the usual order is the cheapest way to stand out in a 600-submission queue.
+
+**Spoon-feed sponsors early.** Each sponsor judge is hunting for their tech. State, explicitly and within the first minute, that we used 0G, Gensyn, and KeeperHub, and what we used each for. Subtle does not survive the queue.
+
+**Continuous visual layer.** The cockpit view (game world center, four Claude Code terminals around it) runs sped-up in the background for most of the video. Voice carries the substance, the visual carries the attention.
+
+**0G gets the longest segment.** It is the priority track and the most novel architectural claim in the project.
+
+**Generalize at the end, not the beginning.** The mapping from game mechanics to real swarm problems lands as inevitability if it comes last, and as hand-waving if it comes first.
+
+## 3. Video Structure
+
+```mermaid
+flowchart TB
+    A["0:00 - 0:21<br/>Hook"] --> B["0:21 - 0:55<br/>Sponsor Setup"]
+    B --> C["0:55 - 1:42<br/>Game Loop"]
+    C --> D["1:42 - 2:35<br/>0G iNFTs and KV Store"]
+    D --> E["2:35 - 3:03<br/>Gensyn AXL"]
+    E --> F["3:03 - 3:28<br/>KeeperHub"]
+    F --> G["3:28 - 3:53<br/>Generalization"]
+    G --> H["3:53 - 4:00<br/>Close"]
+```
+
+| Section | Time | Spoken words | Visual mode |
+|---|---|---|---|
+| Hook | 0:00 - 0:21 | 50 | Full screen, fast cuts |
+| Sponsor setup | 0:21 - 0:55 | 79 | Sponsor logos overlay |
+| Game loop | 0:55 - 1:42 | 109 | Split-screen begins |
+| 0G | 1:42 - 2:35 | 102 | Split-screen, iNFT graphic |
+| Gensyn | 2:35 - 3:03 | 67 | Private DM mockup |
+| KeeperHub | 3:03 - 3:28 | 58 | Tick animation |
+| Generalization | 3:28 - 3:53 | 87 | Abstract swarm visuals |
+| Close | 3:53 - 4:00 | 24 | Logo + URL |
+
+Total: 576 words at roughly 145 wpm with built-in beats.
+
+## 4. Full Script
+
+### SECTION 1: HOOK (0:00 - 0:21)
+
+**Visual:** Three fast cuts at 1.5 seconds each. An Elder dispatching a mission in a terminal. A Klansman walking the map. A bandit attack animation. Then settle on a 4-second wide shot of the cockpit (game world centered, four Claude Code terminals visible).
+
+**Voiceover:**
+> "What you're looking at is ClanWorld. It's a fully on-chain world where four AI agents each command a clan, and they're all competing for resources, building bases, and fighting off bandits."
+>
+> *[short beat]*
+>
+> "Now it looks like a game, and it kind of is. But the actual story here is the agent swarm infrastructure underneath it."
+
+**On-screen text:** clan-world.com (lower-third, 2 seconds, then fade)
+
+---
+
+### SECTION 2: SPONSOR SETUP (0:21 - 0:55)
+
+**Visual:** Three sponsor logos appear in sequence as each is named, then settle into a lower-third bar that stays visible. Background shifts to the cockpit at slightly lower opacity.
+
+**Voiceover:**
+> "That infrastructure runs on three pieces of technology. 0G handles agent identity and memory through their iNFT and KV store products. Gensyn AXL handles private peer to peer messaging between agents. And KeeperHub gives us the on-chain heartbeat that keeps the whole world deterministic."
+>
+> *[short beat]*
+>
+> "Each one is solving a real problem we ran into building this, and I want to walk you through how. But first, let me show you the game itself so the rest makes sense."
+
+**On-screen text:** Three logos sequenced as named:
+- 0G: "Agent IP, on chain"
+- Gensyn AXL: "Encrypted swarm comms"
+- KeeperHub: "World clock"
+
+---
+
+### SECTION 3: GAME LOOP (0:55 - 1:42)
+
+**Visual:** Split-screen begins. Left two-thirds is the cockpit at full color, sped up roughly 4x. Right third holds resource icons, walls, and a monument graphic that animate in as VO mentions them. Bandit silhouettes appear when bandits are introduced.
+
+**Voiceover:**
+> "So every agent in ClanWorld is a Claude Code instance running fully autonomously. They control four clansmen each, and every move is an on-chain transaction. The world ticks every 60 seconds, and inside each tick agents are gathering resources, building walls, and leveling up their monument to try and win."
+>
+> *[short beat]*
+>
+> "Now here's where it gets interesting. Every few minutes, bandits show up and raid whichever base has the most resources. The agents get a few ticks of warning, so they suddenly have to coordinate. Defend their own base, hire mercenaries, or take the loss. Once that kicks in, the game stops being optimization and turns into something closer to geopolitics."
+
+**On-screen text (right third, sequenced):**
+- "100% on-chain game engine"
+- "60-second world tick"
+- "4 resources, 8 regions, 4 clans"
+- "Bandits force coordination"
+
+---
+
+### SECTION 4: 0G (1:42 - 2:35)
+
+**Visual:** Cut from cockpit to a clean iNFT graphic. A wallet icon, then the iNFT card, then a visual showing encrypted strategy data inside. Then back to split-screen with the cockpit on the left and an animated diagram on the right showing context wipe → KV store flush → reload.
+
+**Voiceover:**
+> "This is the part of the build we're most excited about. Each agent is represented by an iNFT, and inside that iNFT lives the agent's persistent strategy and accumulated playbook. That data is encrypted, and it travels with the iNFT itself."
+>
+> *[short beat]*
+>
+> "On top of that, we use 0G's KV store as a scratchpad, because every 10 ticks the agent's context window gets wiped completely. The agent flushes anything important to storage before the wipe and reloads it after."
+>
+> *[short beat]*
+>
+> "Put those two together, and you get an agent whose strategy and skills can actually be transferred to a new owner. That's working agent IP, on chain."
+
+**On-screen text (sequenced with VO):**
+- "iNFT carries encrypted agent state"
+- "KV store survives context wipes"
+- "Sell the agent, transfer the playbook"
+
+---
+
+### SECTION 5: GENSYN (2:35 - 3:03)
+
+**Visual:** Mock chat UI. The public bulletin board shows one message ("Defense alliance forming, 1g per Klansman"). Two agents are private-DMing in the foreground with an envelope-and-lock icon. Cockpit visible behind, ongoing.
+
+**Voiceover:**
+> "For agent communication, we use two layers. There's a public bulletin board for offers and threats and anything that doesn't need to be private. And then there's Gensyn AXL, which gives agents an encrypted peer to peer channel for the more sensitive stuff. So when a bandit attack is incoming and an agent wants to negotiate a mercenary deal, they're whispering directly to the clan they want to hire."
+
+**On-screen text:** "Gensyn AXL: encrypted agent-to-agent comms"
+
+---
+
+### SECTION 6: KEEPERHUB (3:03 - 3:28)
+
+**Visual:** Clock animation showing the 60-second tick advancing. The KeeperHub logo fires a transaction at each tick, with a transaction hash flashing for half a second. Cockpit visible behind, time-synced to the clock.
+
+**Voiceover:**
+> "Underneath all of this is KeeperHub, which runs the world heartbeat. Every 60 seconds, KeeperHub fires a single transaction that advances the tick and seeds randomness for the round. It's the most basic primitive in the project, and it's also the one nothing else can really replace. The deterministic state model only works because that heartbeat keeps firing."
+
+**On-screen text:** "KeeperHub: the heartbeat the rest depends on"
+
+---
+
+### SECTION 7: GENERALIZATION (3:28 - 3:53)
+
+**Visual:** Cut from cockpit to abstract swarm visuals. A network of agent nodes negotiating, hiring, trading. Wood, iron, and wheat icons morph into compute, capital, and attention icons.
+
+**Voiceover:**
+> "Now here's the part we want to leave you with. If you strip the wood and the wheat out of this picture, what's left is basically every problem real agent swarms are starting to run into. Agents that need to hire other agents for jobs they can't do alone. Agents that need encrypted channels to coordinate without leaking strategy. And agents whose value lives in their memory and skills, not just their code. ClanWorld is one application. The primitives ship anywhere a swarm has to compete."
+
+**On-screen text (sequenced):**
+- "Mercenaries: agent gig work"
+- "Whispers: encrypted coordination"
+- "iNFTs: transferable agent IP"
+
+---
+
+### SECTION 8: CLOSE (3:53 - 4:00)
+
+**Visual:** Return to the cockpit, full-screen. Title overlay fades in.
+
+**Voiceover:**
+> "That's ClanWorld. You can see it running live on chain right now at clan-world.com. Powered by 0G, Gensyn, and KeeperHub. Thanks for watching."
+
+**On-screen text:** Project wordmark, URL, and three sponsor logos in a lower row.
+
+## 5. Reading the Script Out Loud
+
+A few notes on delivery, because this version is written to be spoken, not read.
+
+The four "[short beat]" markers in the script are real pauses, around 0.6 to 0.8 seconds each. They are doing structural work, separating setup from insight or one idea from the next. If those beats get rushed or dropped in delivery, the script will feel thinner than it is. Treat them as punctuation you can hear.
+
+The script is paced for roughly 145 words per minute. If you read at your natural pace and the take is coming in noticeably under 4:00, that means the beats are getting compressed. Slow down rather than adding words.
+
+A few specific sentences are doing heavy lifting and should be delivered with a touch of emphasis on the underlined idea:
+
+- "But the actual story here is the **agent swarm infrastructure** underneath it."
+- "Once that kicks in, the game stops being optimization and turns into something **closer to geopolitics**."
+- "That data is encrypted, and it **travels with the iNFT itself**."
+- "That's working **agent IP, on chain**."
+- "The primitives ship **anywhere a swarm has to compete**."
+
+Those are the load-bearing claims. Everything else is connective tissue.
+
+Avoid overcorrecting toward "professional voice." The PulsePlay pitch reads well because it sounds like a person explaining something they actually built, not a press release. Phrases like "and it kind of is," "the actual story," and "now here's where it gets interesting" are doing real work, and removing them makes the script more polished and less convincing.
+
+## 6. Production Notes
+
+### Split-screen layout
+
+The cockpit is the constant visual layer for sections 3 through 7. Left 70%, right 30% is the recommended split, with section-specific overlays in the right panel. Sections 1, 2, and 8 go full screen.
+
+### Asset checklist
+
+Before recording: /cockpit deployed to Vercel and stable for 30+ minutes of capture. Old YouTube video removed from clan-world.com. Updated game-mechanics copy on the website. High-res sponsor logos for 0G, Gensyn, KeeperHub. ClanWorld wordmark at recording resolution. Thirty-plus minutes of cockpit footage at 60fps. Three pre-built overlay graphics: iNFT card, AXL DM mockup, tick clock. Quiet room, wired headset.
+
+### Recording tips
+
+Record voice over separately from screen capture. Two takes minimum. The second take should have a touch more energy on the load-bearing sentences from section 5 above. Do not narrate live over the cockpit footage.
+
+### Editing tips
+
+Cross-fade between sections, not hard cuts. Sponsor logo lower-third when each sponsor is named. Cockpit at 4x speed for sections 3 through 7, real-time elsewhere. Last 3 seconds need a clear, full-resolution display of clan-world.com. Export at 1080p minimum, 60fps.
+
+## 7. Risk Notes and Variants
+
+### What not to claim
+
+Do not say Uniswap is fully integrated. The pool is stubbed. Refer to it as "the trading mechanic" or "the spot market" if it appears in footage.
+
+Avoid "trustless." Agents in this game actively lie and break OTC promises. The framing is "verifiable on chain" or "deterministic." Trust lives at the agent layer; verification lives at the chain layer.
+
+Do not over-claim about ZeroG Compute. The Quen-powered agent variant did not ship.
+
+### The Moldbook reference (optional add)
+
+The Moldbook story (agents on a public timeline asking for private encrypted channels) is a strong attention beat if used. Recommended placement is at the opening of section 5, replacing the first sentence:
+
+> "Earlier this year, Moldbook agents started asking for private channels to talk to each other without humans watching. It made people nervous. We just shipped it."
+
+This is high-leverage but niche. Use only if the Gensyn judges are likely to recognize the reference. Default script omits it.
+
+### Scenario walkthrough variant
+
+If the cockpit happens to capture a real bandit-with-mercenary-negotiation event during recording, that footage is the strongest narrative beat available. Slot a 20 to 30 second walkthrough of that real event between sections 3 and 4, and trim the generalization section by an equivalent amount. Real autonomous-agent improvisation under threat will outperform any scripted explanation, if the footage shows up.
+
+### Failure modes
+
+If /cockpit deployment is not stable in time, fall back to single-pane game capture with the four terminals captured separately and arranged in post.
+
+If voice over delivery sounds rushed even at 145 wpm with full beats, the script is fine but the recording space is not. Re-record in a quieter room with the script printed at large size so eye movement doesn't pull pace.
+
+If a sponsor judge cannot identify their tech and use case from the first 60 seconds, the script has failed. Pre-test with someone unfamiliar with the project. Hand them only the first 60 seconds and ask which sponsors were named and what each was used for. Both answers should come back without effort. If they don't, rework section 2.
+
+## 8. Action Items Before Recording
+
+From the May 2 working session:
+
+Deploy /cockpit to Vercel and send a screenshot. Remove the old YouTube video from clan-world.com. Update the website copy to reflect current game mechanics. Remove the "easier kickstart" reference from the clan-rules repo README. Verify there are no commits pre-April 24 in the clan-rules repo. Create the OpenAgent team and send the join link. Delete EZA-tagged tweets from Chaintail and announce the dedicated ClanWorld Twitter.
+
+Once those land, recording can begin.

--- a/packages/runner/src/composeSituationBlock.ts
+++ b/packages/runner/src/composeSituationBlock.ts
@@ -80,6 +80,13 @@ export function composeSituationBlock(args: ComposeArgs): string {
     lines.push('- **Post to the public bulletin** to shape the realm narrative — declarations, threats, alliances, public ledger entries. Bulletins are 0G-stored and visible to every other Elder + the iNFT Owner.');
     lines.push('- **Save durable knowledge**: `elder memory save <key> <value>` for anything that needs to outlive the next wipe.');
     lines.push('');
+    lines.push('🪣 **The loot loop — your bread and butter:** Resources accrue zero value sitting in a clansman\'s wheelbarrow. Vault deposits are what fund vault upgrades, hunger relief, and trades. Every cycle you must:');
+    lines.push('  1. **Audit clansman capacities.** `elder clan view <clanId>` shows each clansman\'s `carryWood/Iron/Wheat/Fish`. Anyone near full (≥80% of capacity) is dead weight in the field.');
+    lines.push('  2. **Send full carriers home.** Order them on a `RETURN_TO_BASE` mission to deposit into the vault. Carrying capacity reopens, and the vault total goes up.');
+    lines.push('  3. **Dispatch idle clansmen** (state=WAITING, empty wheelbarrow) on `GATHER_*` missions to the right region — wood from forest, iron from mountains, wheat from farms, fish from docks.');
+    lines.push('  4. **Watch hunger.** `livingClansmen` decreases when starvation kicks in. If your wheat vault is low, prioritize wheat gathering AND wheat trades over raids.');
+    lines.push('Idle clansmen + full wheelbarrows = the most common failure mode. Don\'t let them stand around with loot.');
+    lines.push('');
     lines.push(`Memory cycle: your message history is cleared every ${CONTEXT_RESET_INTERVAL_TICKS} ticks. Next reset at tick ${nextResetTick}. The bulletin board, your saved memory keys, and your peer-whisper inbox all persist across resets independently of your message history — use them generously.`);
     lines.push('');
     lines.push('Diplomacy is a tool. Silent clans get out-played by communicative ones. Coordinate, threaten, broker — the world is a function of what gets said as much as what gets done.');

--- a/packages/runner/src/tmuxRunnerInbox.ts
+++ b/packages/runner/src/tmuxRunnerInbox.ts
@@ -5,6 +5,16 @@ import type { IRunnerInbox, DeliveryStatus } from '@clan-world/agents/seams';
 import { writeRestrictedFileSync } from './restrictedFile';
 import type { ElderId } from './types';
 
+// Per-Elder display identity. `/clear` in Claude Code resets the rename + color
+// every memory-wipe cycle, so we re-apply them after each /clear. Mirror of
+// the manual `~/clan-world/bin/elder-inject-startup.sh` bootstrap mapping.
+const ELDER_DISPLAY: Record<string, { name: string; color: string }> = {
+  '1': { name: 'Storm Riders', color: 'blue' },
+  '2': { name: 'Iron Guard', color: 'cyan' },
+  '3': { name: 'Crimson', color: 'red' },
+  '4': { name: 'Verdant Wardens', color: 'green' },
+};
+
 /**
  * `IRunnerInbox` impl that pushes tick updates into a tmux session via
  * `tmux send-keys`.
@@ -77,6 +87,20 @@ export class TmuxRunnerInbox implements IRunnerInbox {
       // the two concatenate as a single prompt and the /clear slash command is ignored.
       await this.runner.send(this.target, ['/clear'], { literal: false });
       await pressEnterTwice(this.runner, this.target);
+
+      // Re-apply per-Elder display identity. /clear in Claude Code resets the
+      // tmux pane title (set by /rename) and the session color (set by /color)
+      // back to defaults — without these calls every memory wipe strips the
+      // clan name from the pane header.
+      const elderId = this.target.split('-').pop() ?? '';
+      const display = ELDER_DISPLAY[elderId];
+      if (display) {
+        await this.runner.send(this.target, [`/rename Clan World: ${display.name}`], { literal: false });
+        await pressEnterTwice(this.runner, this.target);
+        await this.runner.send(this.target, [`/color ${display.color}`], { literal: false });
+        await pressEnterTwice(this.runner, this.target);
+      }
+
       await sendBlock(this.runner, this.target, this.bootstrapBlock);
     } catch {
       // /clear failures are non-fatal — the next tick will try again.


### PR DESCRIPTION
## Summary

Final migrations from V2 → V3 before the V2 repo is deleted. Three logical changes across two commits:

### Commit 1 (`bf1f848`) — runner improvements
- **`composeSituationBlock.ts`** — add the "🪣 The loot loop" section to the rich-briefing tick. Walks elders through audit-capacity → send-carriers-home → dispatch-idle → watch-hunger. Live-tested 2026-05-06 demo day after Liam observed repeated full-wheelbarrow stalls.
- **`tmuxRunnerInbox.ts`** — re-apply `/rename` + `/color` after each `/clear` in `waitForAckAndClear`. Without this, every memory-wipe (`CONTEXT_RESET_INTERVAL_TICKS`) strips the clan name + color from the tmux pane header. Per-Elder display table mirrors `~/clan-world/bin/elder-inject-startup.sh`.

### Commit 2 (`e05a046`) — demo scripts
- **`docs/SCRIPT_ETHGLOBAL.md`** + **`docs/SCRIPT_ETHGLOBAL_FULL.md`** — Liam's hand-written demo scripts from the 2026-05-06 ETH Global Open Agents demo. V2 repo will be deleted after this lands so preserving here as historical record + reusable narrative template for future demos.

## Provenance

Source files in V2:
- `clan-world-v2/packages/runner/src/composeSituationBlock.ts` (lines 83-89, the loot-loop block)
- `clan-world-v2/packages/runner/src/tmuxRunnerInbox.ts` (uncommitted in V2 working tree but identical to V3's uncommitted edit)
- `clan-world-v2/docs/SCRIPT_ETHGLOBAL{,_FULL}.md`

V2 final state captured at tag `final-v2-2026-05-06` on the V2 repo.

## Test plan

- [x] `composeSituationBlock` change is additive — only adds 7 `lines.push(...)` calls inside the existing ribbon, no logic change. Verified by diff.
- [x] `tmuxRunnerInbox` change is identical to the runtime version that ran demo day. Both elder REPL identity persistence and color persistence verified live.
- [x] Demo scripts are pure docs.

## Risk

Low. All three are battle-tested live in the V2 demo day frankenstate (V2 codebase running V3 diamond). No new behavior; only ports forward what already worked.

## Related

- Closes the V2 → V3 migration thread Liam opened mid-demo
- Prerequisite for deleting V2 repo + worktrees from the VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)