### PR TITLE
feat(contracts): heartbeat split + WorldPauseFacet (foundation for owner escape hatches)

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -19,4 +19,28 @@ forge script script/Deploy.s.sol --rpc-url $RPC_URL_PRIMARY --broadcast
 - `src/IClanWorld.sol` — canonical seam interface (24KB, do not modify without ADR)
 - `foundry.toml` — Foundry config; reads `RPC_URL_PRIMARY` from env
 
+## World Pause Policy
+
+`pauseWorld()` is a true game-time freeze. While paused, gameplay entrypoints that advance ticks, settle state, alter player-owned clans, or commit ranking inputs revert with `ClanWorld: world paused`.
+
+Blocked during pause:
+
+- `heartbeat`
+- `settleClan`, `settleClansman`
+- `submitClanOrders`
+- `mintClan`
+- `transferClanOwnership`
+- `transferGold`, `transferVaultResource`, `transferBlueprint`, `transferBundle`
+- treasury writes: `initTreasury`, `seedPools`
+- `finalizeSeason`
+
+Allowed during pause, owner only:
+
+- `triggerBanditSpawn` — queues a spawn for the first post-unpause heartbeat; no bandit spawns until the clock resumes
+- `setHeartbeatIntervalSeconds`
+- `setClansmanCooldownSeconds`
+- ownership/admin controls such as `transferOwnership` and `diamondCut`
+
+Rationale: queued admin actions that do not advance ticks are allowed so operators can stage recovery safely. Gameplay state changes and deterministic season/ranking commits are blocked until `unpauseWorld()` resumes the clock.
+
 See `../../docs/guides/stream-contracts.md` for the full deploy workflow.

--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -37,6 +37,7 @@ import {SnapshotViewsFacet} from "../src/diamond/facets/SnapshotViewsFacet.sol";
 import {SubmitOrdersFacet} from "../src/diamond/facets/SubmitOrdersFacet.sol";
 import {TreasuryFacet} from "../src/diamond/facets/TreasuryFacet.sol";
 import {VaultResourceTransferFacet} from "../src/diamond/facets/VaultResourceTransferFacet.sol";
+import {WorldPauseFacet} from "../src/diamond/facets/WorldPauseFacet.sol";
 
 contract DeployDiamond is Script {
     uint256 private constant INITIAL_WOOD_POOL_SEED = 1_000e18;
@@ -60,6 +61,7 @@ contract DeployDiamond is Script {
         OwnershipFacet adminOwnershipFacet = new OwnershipFacet();
         HeartbeatFacet heartbeatFacet = new HeartbeatFacet();
         HeartbeatConfigFacet heartbeatConfigFacet = new HeartbeatConfigFacet();
+        WorldPauseFacet worldPauseFacet = new WorldPauseFacet();
         FinalizeSeasonFacet finalizeSeasonFacet = new FinalizeSeasonFacet();
         RawWorldViewsFacet rawWorldViewsFacet = new RawWorldViewsFacet();
         RawTreasuryViewsFacet rawTreasuryViewsFacet = new RawTreasuryViewsFacet();
@@ -91,6 +93,7 @@ contract DeployDiamond is Script {
                     address(adminOwnershipFacet),
                     address(heartbeatFacet),
                     address(heartbeatConfigFacet),
+                    address(worldPauseFacet),
                     address(finalizeSeasonFacet),
                     address(rawWorldViewsFacet),
                     address(rawTreasuryViewsFacet),
@@ -196,6 +199,7 @@ contract DeployDiamond is Script {
         console.log("OWNERSHIP_FACET_ADDRESS:          ", address(adminOwnershipFacet));
         console.log("HEARTBEAT_FACET_ADDRESS:          ", address(heartbeatFacet));
         console.log("HEARTBEAT_CONFIG_FACET_ADDRESS:   ", address(heartbeatConfigFacet));
+        console.log("WORLD_PAUSE_FACET_ADDRESS:        ", address(worldPauseFacet));
         console.log("FINALIZE_SEASON_FACET_ADDRESS:    ", address(finalizeSeasonFacet));
         console.log("CLAN_LIFECYCLE_FACET_ADDRESS:     ", address(lifecycleFacet));
         console.log("RAW_WORLD_VIEWS_FACET_ADDRESS:    ", address(rawWorldViewsFacet));
@@ -228,6 +232,7 @@ contract DeployDiamond is Script {
         address adminOwnershipFacet,
         address heartbeatFacet,
         address heartbeatConfigFacet,
+        address worldPauseFacet,
         address finalizeSeasonFacet,
         address rawWorldViewsFacet,
         address rawTreasuryViewsFacet,
@@ -235,7 +240,7 @@ contract DeployDiamond is Script {
         address rawBanditViewsFacet,
         address lifecycleFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](10);
+        cut = new IDiamondCut.FacetCut[](11);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -257,31 +262,36 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.heartbeatConfigSelectors()
         });
         cut[4] = IDiamondCut.FacetCut({
+            facetAddress: worldPauseFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.worldPauseSelectors()
+        });
+        cut[5] = IDiamondCut.FacetCut({
             facetAddress: finalizeSeasonFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.seasonSelectors()
         });
-        cut[5] = IDiamondCut.FacetCut({
+        cut[6] = IDiamondCut.FacetCut({
             facetAddress: rawWorldViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawWorldViewsSelectors()
         });
-        cut[6] = IDiamondCut.FacetCut({
+        cut[7] = IDiamondCut.FacetCut({
             facetAddress: rawTreasuryViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawTreasuryViewsSelectors()
         });
-        cut[7] = IDiamondCut.FacetCut({
+        cut[8] = IDiamondCut.FacetCut({
             facetAddress: rawClanViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawClanViewsSelectors()
         });
-        cut[8] = IDiamondCut.FacetCut({
+        cut[9] = IDiamondCut.FacetCut({
             facetAddress: rawBanditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawBanditViewsSelectors()
         });
-        cut[9] = IDiamondCut.FacetCut({
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: lifecycleFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.lifecycleSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -6,6 +6,7 @@ import {IClanWorld} from "../src/IClanWorld.sol";
 import {HeartbeatConfigFacet} from "../src/diamond/facets/HeartbeatConfigFacet.sol";
 import {HeartbeatFacet} from "../src/diamond/facets/HeartbeatFacet.sol";
 import {OwnershipFacet} from "../src/diamond/facets/OwnershipFacet.sol";
+import {WorldPauseFacet} from "../src/diamond/facets/WorldPauseFacet.sol";
 
 library DiamondSelectors {
     function loupeSelectors() internal pure returns (bytes4[] memory selectors) {
@@ -29,6 +30,13 @@ library DiamondSelectors {
         selectors[3] = HeartbeatConfigFacet.setClansmanCooldownSeconds.selector;
         selectors[4] = HeartbeatConfigFacet.banditSpawnTriggered.selector;
         selectors[5] = HeartbeatConfigFacet.triggerBanditSpawn.selector;
+    }
+
+    function worldPauseSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](3);
+        selectors[0] = WorldPauseFacet.pauseWorld.selector;
+        selectors[1] = WorldPauseFacet.unpauseWorld.selector;
+        selectors[2] = WorldPauseFacet.isWorldPaused.selector;
     }
 
     function seasonSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -57,6 +57,8 @@ struct StoredWorldState {
     bytes32 currentTickSeed;
     uint32 activeBanditId;
     uint64 nextCommitSequence;
+    bool worldPaused;
+    uint64 pausedAtTs;
 }
 
 /// @title ClanWorld
@@ -2981,6 +2983,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     ///         7. Resolve world events (season boundary, winter transitions).
     ///         8. Increment tick and publish the next tick seed atomically.
     function heartbeat() external override nonReentrant {
+        _requireWorldNotPaused();
         require(block.timestamp >= _world.nextHeartbeatAtTs, "ClanWorld: heartbeat rate limited");
 
         // Freeze before side effects. While finalization is pending, keepers may
@@ -3038,6 +3041,28 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         _world.nextHeartbeatAtTick = newTick + 1;
 
         emit TickAdvanced(closedTick, newTick, newSeed);
+    }
+
+    function pauseWorld() external override nonReentrant {
+        require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+        require(!_world.worldPaused, "ClanWorld: already paused");
+        _world.worldPaused = true;
+        _world.pausedAtTs = uint64(block.timestamp);
+        emit WorldPaused(_world.currentTick, _world.pausedAtTs);
+    }
+
+    function unpauseWorld() external override nonReentrant {
+        require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+        require(_world.worldPaused, "ClanWorld: not paused");
+        uint64 durationSeconds = uint64(block.timestamp) - _world.pausedAtTs;
+        _world.worldPaused = false;
+        _world.pausedAtTs = 0;
+        _world.nextHeartbeatAtTs = uint64(block.timestamp) + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS;
+        emit WorldUnpaused(_world.currentTick, durationSeconds, _world.nextHeartbeatAtTs);
+    }
+
+    function isWorldPaused() external view override returns (bool) {
+        return _world.worldPaused;
     }
 
     /// @dev Resolve world events for the tick that was just closed.
@@ -3139,6 +3164,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         ws.currentTickSeed = _world.currentTickSeed;
         ws.activeBanditId = _world.activeBanditId;
         ws.nextCommitSequence = _world.nextCommitSequence;
+        ws.worldPaused = _world.worldPaused;
+        ws.pausedAtTs = _world.pausedAtTs;
         (ws.winterActive, ws.winterStartsAtTick, ws.winterEndsAtTick) = _winterWindowForTick(_world.currentTick);
     }
 
@@ -3163,6 +3190,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     /// @notice Finalize season by settling final state and publishing rankings.
     function finalizeSeason() external override nonReentrant {
+        _requireWorldNotPaused();
         require(_world.currentTick >= _world.seasonEndTick, "ClanWorld: season not ended");
         require(!_world.seasonFinalized, "ClanWorld: season finalized");
 
@@ -4700,6 +4728,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         require(!_isSeasonFinalizationPending(), "ClanWorld: season ended, awaiting finalization");
     }
 
+    function _requireWorldNotPaused() internal view {
+        require(!_world.worldPaused, "ClanWorld: world paused");
+    }
+
     // =========================================================================
     // TREASURY / POOL SEEDING
     // =========================================================================
@@ -5530,6 +5562,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             seasonFinalized: ws.seasonFinalized,
             currentSeasonNumber: ws.currentSeasonNumber,
             nextHeartbeatAtTick: ws.nextHeartbeatAtTick,
+            worldPaused: ws.worldPaused,
+            pausedAtTs: ws.pausedAtTs,
             winterActive: ws.winterActive,
             winterStartsAtTick: ws.winterStartsAtTick,
             winterEndsAtTick: ws.winterEndsAtTick,

--- a/packages/contracts/src/ClanWorldLens.sol
+++ b/packages/contracts/src/ClanWorldLens.sol
@@ -264,6 +264,8 @@ contract ClanWorldLens is IClanWorldLens {
             seasonFinalized: ws.seasonFinalized,
             currentSeasonNumber: ws.currentSeasonNumber,
             nextHeartbeatAtTick: ws.nextHeartbeatAtTick,
+            worldPaused: ws.worldPaused,
+            pausedAtTs: ws.pausedAtTs,
             winterActive: ws.winterActive,
             winterStartsAtTick: ws.winterStartsAtTick,
             winterEndsAtTick: ws.winterEndsAtTick,

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -78,6 +78,7 @@ contract ClanWorldStub is IClanWorld {
     // -------------------------------------------------------------------------
 
     function heartbeat() external override {
+        require(!_world.worldPaused, "ClanWorld: world paused");
         require(block.timestamp >= _world.nextHeartbeatAtTs, "ClanWorld: heartbeat rate limited");
 
         uint64 closed = _world.currentTick;
@@ -99,7 +100,31 @@ contract ClanWorldStub is IClanWorld {
 
     function settleClansman(uint32) external override {}
 
-    function finalizeSeason() external override {}
+    function finalizeSeason() external override {
+        require(!_world.worldPaused, "ClanWorld: world paused");
+    }
+
+    function pauseWorld() external override {
+        require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+        require(!_world.worldPaused, "ClanWorld: already paused");
+        _world.worldPaused = true;
+        _world.pausedAtTs = uint64(block.timestamp);
+        emit WorldPaused(_world.currentTick, _world.pausedAtTs);
+    }
+
+    function unpauseWorld() external override {
+        require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+        require(_world.worldPaused, "ClanWorld: not paused");
+        uint64 durationSeconds = uint64(block.timestamp) - _world.pausedAtTs;
+        _world.worldPaused = false;
+        _world.pausedAtTs = 0;
+        _world.nextHeartbeatAtTs = uint64(block.timestamp) + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS;
+        emit WorldUnpaused(_world.currentTick, durationSeconds, _world.nextHeartbeatAtTs);
+    }
+
+    function isWorldPaused() external view override returns (bool) {
+        return _world.worldPaused;
+    }
 
     // -------------------------------------------------------------------------
     // Clan lifecycle
@@ -517,6 +542,8 @@ contract ClanWorldStub is IClanWorld {
             seasonFinalized: false,
             currentSeasonNumber: ws.currentSeasonNumber,
             nextHeartbeatAtTick: ws.nextHeartbeatAtTick,
+            worldPaused: ws.worldPaused,
+            pausedAtTs: ws.pausedAtTs,
             winterActive: ws.winterActive,
             winterStartsAtTick: ws.winterStartsAtTick,
             winterEndsAtTick: ws.winterEndsAtTick,

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -227,6 +227,8 @@ struct WorldState {
     uint64 winterEndsAtTick; // 0 if not active
 
     uint64 nextCommitSequence; // global FIFO sequence for scheduled market actions
+    bool worldPaused;
+    uint64 pausedAtTs;
 }
 
 struct TreasuryState {
@@ -457,6 +459,8 @@ struct WorldSnapshot {
     bool seasonFinalized;
     uint64 currentSeasonNumber;
     uint64 nextHeartbeatAtTick;
+    bool worldPaused;
+    uint64 pausedAtTs;
     bool winterActive;
     uint64 winterStartsAtTick;
     uint64 winterEndsAtTick;
@@ -733,6 +737,15 @@ interface IClanWorld is IClanWorldEvents {
     ///         scheduled market actions and world events, advances the tick.
     ///         Rate-limited by WorldState.nextHeartbeatAtTs.
     function heartbeat() external;
+
+    /// @notice Owner-only emergency freeze for game-time advancement and gameplay writes.
+    function pauseWorld() external;
+
+    /// @notice Owner-only emergency unfreeze. Reschedules the next heartbeat from the unpause timestamp.
+    function unpauseWorld() external;
+
+    /// @notice True iff emergency world pause is currently active.
+    function isWorldPaused() external view returns (bool);
 
     /// @notice Lazily settle a clan forward to current tick. Idempotent.
     function settleClan(uint32 clanId) external;

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -537,6 +537,8 @@ struct RegionOccupant {
 interface IClanWorldEvents {
     // ----- world clock -----
     event TickAdvanced(uint64 closedTick, uint64 openedTick, bytes32 tickSeed);
+    event WorldPaused(uint64 indexed tick, uint64 pausedAtTs);
+    event WorldUnpaused(uint64 indexed tick, uint64 durationSeconds, uint64 nextHeartbeatAtTs);
     event WinterStarted(uint64 indexed tick);
     event WinterEnded(uint64 indexed tick);
     event SeasonFinalized(uint64 indexed tick, uint32[] rankedClanIds, uint256[] scores);

--- a/packages/contracts/src/diamond/facets/BlueprintTransferFacet.sol
+++ b/packages/contracts/src/diamond/facets/BlueprintTransferFacet.sol
@@ -11,6 +11,7 @@ contract BlueprintTransferFacet is IClanWorldEvents {
     function transferBlueprint(uint32 fromClanId, uint32 toClanId, uint256 amount) external {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
+        LibGameRules.requireWorldNotPaused(s);
         LibGameRules.requireNoPendingSeasonFinalization(s);
         require(amount > 0, "ClanWorld: zero amount");
         require(fromClanId != toClanId, "ClanWorld: same clan");

--- a/packages/contracts/src/diamond/facets/BundleTransferFacet.sol
+++ b/packages/contracts/src/diamond/facets/BundleTransferFacet.sol
@@ -20,6 +20,7 @@ contract BundleTransferFacet is IClanWorldEvents {
     ) external {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
+        LibGameRules.requireWorldNotPaused(s);
         LibGameRules.requireNoPendingSeasonFinalization(s);
         require(gold > 0 || blueprint > 0 || wood > 0 || iron > 0 || wheat > 0 || fish > 0, "ClanWorld: empty bundle");
         require(fromClanId != toClanId, "ClanWorld: same clan");

--- a/packages/contracts/src/diamond/facets/ClanLifecycleFacet.sol
+++ b/packages/contracts/src/diamond/facets/ClanLifecycleFacet.sol
@@ -20,6 +20,7 @@ contract ClanLifecycleFacet is IClanWorldEvents {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
 
+        LibGameRules.requireWorldNotPaused(s);
         LibGameRules.requireNoPendingSeasonFinalization(s);
         require(to != address(0), "ClanWorld: zero address");
         require(s.allClanIds.length < LibGameRules.MAX_CLANS, "ClanWorld: max clans");

--- a/packages/contracts/src/diamond/facets/ClanOwnershipFacet.sol
+++ b/packages/contracts/src/diamond/facets/ClanOwnershipFacet.sol
@@ -10,6 +10,7 @@ contract ClanOwnershipFacet is IClanWorldEvents {
     function transferClanOwnership(uint32 clanId, address newOwner) external {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
+        LibGameRules.requireWorldNotPaused(s);
         LibGameRules.requireNoPendingSeasonFinalization(s);
 
         require(s.clans[clanId].clanId != 0, "ClanWorld: clan not found");

--- a/packages/contracts/src/diamond/facets/FinalizeSeasonFacet.sol
+++ b/packages/contracts/src/diamond/facets/FinalizeSeasonFacet.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.34;
 
 import {ClanState, IClanWorldEvents} from "../../IClanWorld.sol";
 import {LibScoring} from "../../lib/LibScoring.sol";
+import {LibGameRules} from "../lib/LibGameRules.sol";
 import {LibSettlement} from "../lib/LibSettlement.sol";
 import {LibStorage} from "../lib/LibStorage.sol";
 
@@ -13,6 +14,7 @@ contract FinalizeSeasonFacet is IClanWorldEvents {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
         require(s.initialized, "ClanWorld: not initialized");
+        LibGameRules.requireWorldNotPaused(s);
         require(s.world.currentTick >= s.world.seasonEndTick, "ClanWorld: season not ended");
         require(!s.world.seasonFinalized, "ClanWorld: season finalized");
 

--- a/packages/contracts/src/diamond/facets/GoldTransferFacet.sol
+++ b/packages/contracts/src/diamond/facets/GoldTransferFacet.sol
@@ -10,6 +10,7 @@ contract GoldTransferFacet is IClanWorldEvents {
     function transferGold(uint32 fromClanId, uint32 toClanId, uint256 amount) external {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
+        LibGameRules.requireWorldNotPaused(s);
         LibGameRules.requireNoPendingSeasonFinalization(s);
         require(amount > 0, "ClanWorld: zero amount");
         require(fromClanId != toClanId, "ClanWorld: same clan");

--- a/packages/contracts/src/diamond/facets/HeartbeatConfigFacet.sol
+++ b/packages/contracts/src/diamond/facets/HeartbeatConfigFacet.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.34;
 import {ClanWorldConstants} from "../../IClanWorld.sol";
 import {LibDiamond} from "../lib/LibDiamond.sol";
 import {LibStorage} from "../lib/LibStorage.sol";
+import {LibWorldClock} from "../lib/LibWorldClock.sol";
 
 contract HeartbeatConfigFacet {
     uint64 private constant MAX_HEARTBEAT_INTERVAL_SECONDS = 1 hours;
@@ -14,7 +15,7 @@ contract HeartbeatConfigFacet {
     event BanditSpawnTriggered(uint64 currentTick);
 
     function heartbeatIntervalSeconds() external view returns (uint64) {
-        return _heartbeatIntervalSeconds(LibStorage.appStorage());
+        return LibWorldClock.heartbeatIntervalSeconds(LibStorage.appStorage());
     }
 
     function setHeartbeatIntervalSeconds(uint64 intervalSeconds) external {
@@ -25,7 +26,7 @@ contract HeartbeatConfigFacet {
         );
 
         LibStorage.AppStorage storage s = LibStorage.appStorage();
-        uint64 oldIntervalSeconds = _heartbeatIntervalSeconds(s);
+        uint64 oldIntervalSeconds = LibWorldClock.heartbeatIntervalSeconds(s);
         s.heartbeatIntervalSeconds = intervalSeconds;
 
         uint64 nextHeartbeatAtTs = uint64(block.timestamp) + intervalSeconds;
@@ -66,14 +67,6 @@ contract HeartbeatConfigFacet {
         s.world.currentBanditSpawnChanceBps = 10000;
 
         emit BanditSpawnTriggered(s.world.currentTick);
-    }
-
-    function _heartbeatIntervalSeconds(LibStorage.AppStorage storage s) private view returns (uint64) {
-        uint64 configuredIntervalSeconds = s.heartbeatIntervalSeconds;
-        if (configuredIntervalSeconds == 0) {
-            return ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS;
-        }
-        return configuredIntervalSeconds;
     }
 
     function _clansmanCooldownSeconds(LibStorage.AppStorage storage s) private view returns (uint64) {

--- a/packages/contracts/src/diamond/facets/HeartbeatConfigFacet.sol
+++ b/packages/contracts/src/diamond/facets/HeartbeatConfigFacet.sol
@@ -59,6 +59,12 @@ contract HeartbeatConfigFacet {
         return LibStorage.appStorage().forceBanditSpawnNextHeartbeat;
     }
 
+    /// @notice Owner-only pause allowlist action.
+    /// @dev Allowed during pause. This sets a queued flag
+    ///      (`forceBanditSpawnNextHeartbeat = true`) that fires on the first
+    ///      post-unpause heartbeat. Owners can use it to stage recovery scenarios;
+    ///      the spawn itself does not happen until the world is unpaused. See the
+    ///      contracts README pause allowlist for the full policy.
     function triggerBanditSpawn() external {
         LibDiamond.enforceIsContractOwner();
 

--- a/packages/contracts/src/diamond/facets/HeartbeatFacet.sol
+++ b/packages/contracts/src/diamond/facets/HeartbeatFacet.sol
@@ -1,135 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.34;
 
-import {ClanState, ClanWorldConstants, IClanWorldEvents, WheatPlot, WheatPlotState} from "../../IClanWorld.sol";
-import {LibBanditCombat} from "../lib/LibBanditCombat.sol";
-import {LibBanditLifecycle} from "../lib/LibBanditLifecycle.sol";
-import {LibBanditSpawning} from "../lib/LibBanditSpawning.sol";
-import {LibOrderMarket} from "../lib/LibOrderMarket.sol";
-import {LibSeason} from "../lib/LibSeason.sol";
-import {LibSettlement} from "../lib/LibSettlement.sol";
+import {IClanWorldEvents} from "../../IClanWorld.sol";
+import {LibHeartbeat} from "../lib/LibHeartbeat.sol";
 import {LibStorage} from "../lib/LibStorage.sol";
 
 contract HeartbeatFacet is IClanWorldEvents {
-    uint256 private constant MAX_CROP_TRANSITION_PER_TICK = 48;
-
     function heartbeat() external {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
-        require(block.timestamp >= s.world.nextHeartbeatAtTs, "ClanWorld: heartbeat rate limited");
-
-        if (_isSeasonFinalizationPending(s)) {
-            LibStorage.exitNonReentrant(s);
-            return;
-        }
-        if (_isSeasonRolloverPending(s)) {
-            s.world.nextHeartbeatAtTs = uint64(block.timestamp) + _heartbeatIntervalSeconds(s);
-            _rollSeason(s);
-            LibStorage.exitNonReentrant(s);
-            return;
-        }
-
-        uint64 closedTick = s.world.currentTick;
-        bytes32 closedTickSeed = s.world.currentTickSeed;
-        s.world.nextHeartbeatAtTs = uint64(block.timestamp) + _heartbeatIntervalSeconds(s);
-
-        for (uint256 i = 0; i < s.allClanIds.length; i++) {
-            uint32 clanId = s.allClanIds[i];
-            if (s.clans[clanId].clanState != ClanState.DEAD && s.clans[clanId].lastSettledTick <= closedTick) {
-                LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, closedTick + 1);
-                LibSettlement.commitSimulation(s, sim);
-                emit ClanSettled(clanId, s.clans[clanId].lastSettledTick);
-            }
-        }
-
-        LibOrderMarket.executeScheduledMarketActions(s, closedTick);
-        LibBanditLifecycle.advancePassiveBanditStates(s, closedTick);
-        LibBanditCombat.resolveAttackingBandits(s, closedTick);
-        LibBanditSpawning.evaluateBanditSpawns(s, closedTickSeed);
-        _resolveWorldEvents(s, closedTick);
-
-        uint64 newTick = closedTick + 1;
-        bytes32 newSeed = keccak256(abi.encode(block.prevrandao, closedTickSeed, closedTick));
-        s.world.currentTick = newTick;
-        s.tickSeeds[newTick] = newSeed;
-        s.world.currentTickSeed = newSeed;
-        s.world.nextHeartbeatAtTick = newTick + 1;
-
-        emit TickAdvanced(closedTick, newTick, newSeed);
+        LibHeartbeat.tick(s);
         LibStorage.exitNonReentrant(s);
-    }
-
-    function _isSeasonFinalizationPending(LibStorage.AppStorage storage s) private view returns (bool) {
-        return s.world.currentTick >= s.world.seasonEndTick && !s.world.seasonFinalized;
-    }
-
-    function _isSeasonRolloverPending(LibStorage.AppStorage storage s) private view returns (bool) {
-        return s.world.currentTick >= s.world.seasonEndTick && s.world.seasonFinalized;
-    }
-
-    function _heartbeatIntervalSeconds(LibStorage.AppStorage storage s) private view returns (uint64) {
-        uint64 configuredIntervalSeconds = s.heartbeatIntervalSeconds;
-        if (configuredIntervalSeconds == 0) {
-            return ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS;
-        }
-        return configuredIntervalSeconds;
-    }
-
-    function _rollSeason(LibStorage.AppStorage storage s) private {
-        s.world.currentSeasonNumber += 1;
-        s.world.seasonStartTick = s.world.seasonEndTick;
-        s.world.seasonEndTick = s.world.seasonStartTick + ClanWorldConstants.SEASON_DURATION_TICKS;
-        s.world.seasonFinalized = false;
-    }
-
-    function _resolveWorldEvents(LibStorage.AppStorage storage s, uint64 closedTick) private {
-        uint64 newTick = closedTick + 1;
-
-        if (newTick >= s.world.seasonEndTick && s.world.seasonFinalized) {
-            _rollSeason(s);
-        }
-
-        bool wasWinter = LibSeason.isWinterActiveAt(closedTick);
-        bool nowWinter = LibSeason.isWinterActiveAt(newTick);
-        if (!wasWinter && nowWinter) {
-            _lockWheatPlotsForWinter(s);
-            emit WinterStarted(newTick);
-        }
-        if (wasWinter && !nowWinter) {
-            _restartWheatPlotsAfterWinter(s, newTick);
-            emit WinterEnded(newTick);
-        }
-    }
-
-    function _lockWheatPlotsForWinter(LibStorage.AppStorage storage s) private {
-        uint256 transitions;
-        for (uint256 i = 0; i < s.allClanIds.length; i++) {
-            uint32 clanId = s.allClanIds[i];
-            for (uint256 pi = 0; pi < 2; pi++) {
-                require(transitions < MAX_CROP_TRANSITION_PER_TICK, "ClanWorld: crop transition cap");
-                WheatPlot storage plot = s.wheatPlots[clanId][pi];
-                plot.state = WheatPlotState.WinterLocked;
-                plot.remainingWheat = 0;
-                plot.regrowUntilTick = 0;
-                transitions++;
-            }
-        }
-    }
-
-    function _restartWheatPlotsAfterWinter(LibStorage.AppStorage storage s, uint64 currentTick) private {
-        uint256 transitions;
-        for (uint256 i = 0; i < s.allClanIds.length; i++) {
-            uint32 clanId = s.allClanIds[i];
-            for (uint256 pi = 0; pi < 2; pi++) {
-                require(transitions < MAX_CROP_TRANSITION_PER_TICK, "ClanWorld: crop transition cap");
-                WheatPlot storage plot = s.wheatPlots[clanId][pi];
-                if (plot.state == WheatPlotState.WinterLocked) {
-                    plot.state = WheatPlotState.Regrowing;
-                    plot.remainingWheat = 0;
-                    plot.regrowUntilTick = currentTick + ClanWorldConstants.WHEAT_PLOT_REGROW_TICKS;
-                }
-                transitions++;
-            }
-        }
     }
 }

--- a/packages/contracts/src/diamond/facets/RawWorldViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/RawWorldViewsFacet.sol
@@ -22,6 +22,8 @@ contract RawWorldViewsFacet {
         ws.currentTickSeed = s.world.currentTickSeed;
         ws.activeBanditId = s.world.activeBanditId;
         ws.nextCommitSequence = s.world.nextCommitSequence;
+        ws.worldPaused = s.world.worldPaused;
+        ws.pausedAtTs = s.world.pausedAtTs;
         (ws.winterActive, ws.winterStartsAtTick, ws.winterEndsAtTick) =
             LibSeason.winterWindowForTick(s.world.currentTick);
     }

--- a/packages/contracts/src/diamond/facets/SettlementFacet.sol
+++ b/packages/contracts/src/diamond/facets/SettlementFacet.sol
@@ -10,6 +10,7 @@ contract SettlementFacet is IClanWorldEvents {
     function settleClan(uint32 clanId) external {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
+        LibGameRules.requireWorldNotPaused(s);
         LibGameRules.requireNoPendingSeasonFinalization(s);
         _settleClan(s, clanId);
         LibStorage.exitNonReentrant(s);
@@ -18,6 +19,7 @@ contract SettlementFacet is IClanWorldEvents {
     function settleClansman(uint32 clansmanId) external {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
+        LibGameRules.requireWorldNotPaused(s);
         LibGameRules.requireNoPendingSeasonFinalization(s);
 
         uint32 clanId = s.clansmen[clansmanId].clanId;

--- a/packages/contracts/src/diamond/facets/SnapshotViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/SnapshotViewsFacet.sol
@@ -35,6 +35,8 @@ contract SnapshotViewsFacet {
             seasonFinalized: s.world.seasonFinalized,
             currentSeasonNumber: s.world.currentSeasonNumber,
             nextHeartbeatAtTick: s.world.nextHeartbeatAtTick,
+            worldPaused: s.world.worldPaused,
+            pausedAtTs: s.world.pausedAtTs,
             winterActive: winterActive,
             winterStartsAtTick: winterStartsAtTick,
             winterEndsAtTick: winterEndsAtTick,

--- a/packages/contracts/src/diamond/facets/TreasuryFacet.sol
+++ b/packages/contracts/src/diamond/facets/TreasuryFacet.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.34;
 import {IClanWorldEvents, PoolSeedConfig} from "../../IClanWorld.sol";
 import {MinimalERC20} from "../../MinimalERC20.sol";
 import {StubPool} from "../../StubPool.sol";
+import {LibGameRules} from "../lib/LibGameRules.sol";
 import {LibStorage} from "../lib/LibStorage.sol";
 
 contract TreasuryFacet is IClanWorldEvents {
@@ -16,6 +17,7 @@ contract TreasuryFacet is IClanWorldEvents {
 
     function initTreasury(address[6] calldata tokens, address[4] calldata pools) external nonReentrant {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibGameRules.requireWorldNotPaused(s);
         require(!s.treasury.poolsSeeded && s.treasury.woodToken == address(0), "ClanWorld: treasury already init");
         require(msg.sender == s.treasury.treasuryOwner, "ClanWorld: not owner");
         _validateTreasuryInit(tokens, pools);
@@ -35,6 +37,7 @@ contract TreasuryFacet is IClanWorldEvents {
 
     function seedPools(PoolSeedConfig calldata cfg) external nonReentrant {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibGameRules.requireWorldNotPaused(s);
         require(msg.sender == s.treasury.treasuryOwner, "ClanWorld: not owner");
         require(!s.treasury.poolsSeeded, "ClanWorld: pools already seeded");
         require(s.treasury.woodToken != address(0), "ClanWorld: treasury not init");

--- a/packages/contracts/src/diamond/facets/VaultResourceTransferFacet.sol
+++ b/packages/contracts/src/diamond/facets/VaultResourceTransferFacet.sol
@@ -11,6 +11,7 @@ contract VaultResourceTransferFacet is IClanWorldEvents {
     function transferVaultResource(uint32 fromClanId, uint32 toClanId, ResourceType resource, uint256 amount) external {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
+        LibGameRules.requireWorldNotPaused(s);
         LibGameRules.requireNoPendingSeasonFinalization(s);
         require(amount > 0, "ClanWorld: zero amount");
         require(fromClanId != toClanId, "ClanWorld: same clan");

--- a/packages/contracts/src/diamond/facets/WorldPauseFacet.sol
+++ b/packages/contracts/src/diamond/facets/WorldPauseFacet.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {IClanWorldEvents} from "../../IClanWorld.sol";
+import {LibDiamond} from "../lib/LibDiamond.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+import {LibWorldClock} from "../lib/LibWorldClock.sol";
+
+contract WorldPauseFacet is IClanWorldEvents {
+    function pauseWorld() external {
+        LibDiamond.enforceIsContractOwner();
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        require(!s.world.worldPaused, "ClanWorld: already paused");
+
+        s.world.worldPaused = true;
+        s.world.pausedAtTs = uint64(block.timestamp);
+
+        emit WorldPaused(s.world.currentTick, s.world.pausedAtTs);
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function unpauseWorld() external {
+        LibDiamond.enforceIsContractOwner();
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+        require(s.world.worldPaused, "ClanWorld: not paused");
+
+        uint64 durationSeconds = uint64(block.timestamp) - s.world.pausedAtTs;
+        s.world.worldPaused = false;
+        s.world.pausedAtTs = 0;
+        LibWorldClock.scheduleNextHeartbeat(s);
+
+        emit WorldUnpaused(s.world.currentTick, durationSeconds, s.world.nextHeartbeatAtTs);
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function isWorldPaused() external view returns (bool) {
+        return LibStorage.appStorage().world.worldPaused;
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibGameRules.sol
+++ b/packages/contracts/src/diamond/lib/LibGameRules.sol
@@ -18,6 +18,10 @@ library LibGameRules {
         );
     }
 
+    function requireWorldNotPaused(LibStorage.AppStorage storage s) internal view {
+        require(!s.world.worldPaused, "ClanWorld: world paused");
+    }
+
     function wallUpgradeCost(uint8 currentLevel) internal pure returns (uint256 wood, uint256 iron) {
         if (currentLevel == 0) return (20e18, 0);
         if (currentLevel == 1) return (35e18, 0);

--- a/packages/contracts/src/diamond/lib/LibHeartbeat.sol
+++ b/packages/contracts/src/diamond/lib/LibHeartbeat.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanState} from "../../IClanWorld.sol";
+import {LibBanditCombat} from "./LibBanditCombat.sol";
+import {LibBanditLifecycle} from "./LibBanditLifecycle.sol";
+import {LibBanditSpawning} from "./LibBanditSpawning.sol";
+import {LibOrderMarket} from "./LibOrderMarket.sol";
+import {LibSettlement} from "./LibSettlement.sol";
+import {LibStorage} from "./LibStorage.sol";
+import {LibWorldClock} from "./LibWorldClock.sol";
+import {LibWorldEvents} from "./LibWorldEvents.sol";
+
+library LibHeartbeat {
+    event TickAdvanced(uint64 closedTick, uint64 openedTick, bytes32 tickSeed);
+    event ClanSettled(uint32 indexed clanId, uint64 settledToTick);
+
+    function tick(LibStorage.AppStorage storage s) internal {
+        require(block.timestamp >= s.world.nextHeartbeatAtTs, "ClanWorld: heartbeat rate limited");
+
+        if (isSeasonFinalizationPending(s)) {
+            return;
+        }
+        if (isSeasonRolloverPending(s)) {
+            LibWorldClock.scheduleNextHeartbeat(s);
+            LibWorldEvents.rollSeason(s);
+            return;
+        }
+
+        uint64 closedTick = s.world.currentTick;
+        bytes32 closedTickSeed = s.world.currentTickSeed;
+        LibWorldClock.scheduleNextHeartbeat(s);
+
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            if (s.clans[clanId].clanState != ClanState.DEAD && s.clans[clanId].lastSettledTick <= closedTick) {
+                LibSettlement.SettlementSimulation memory sim = LibSettlement.simulateToTick(s, clanId, closedTick + 1);
+                LibSettlement.commitSimulation(s, sim);
+                emit ClanSettled(clanId, s.clans[clanId].lastSettledTick);
+            }
+        }
+
+        LibOrderMarket.executeScheduledMarketActions(s, closedTick);
+        LibBanditLifecycle.advancePassiveBanditStates(s, closedTick);
+        LibBanditCombat.resolveAttackingBandits(s, closedTick);
+        LibBanditSpawning.evaluateBanditSpawns(s, closedTickSeed);
+        LibWorldEvents.resolveWorldEvents(s, closedTick);
+
+        uint64 newTick = closedTick + 1;
+        bytes32 newSeed = keccak256(abi.encode(block.prevrandao, closedTickSeed, closedTick));
+        s.world.currentTick = newTick;
+        s.tickSeeds[newTick] = newSeed;
+        s.world.currentTickSeed = newSeed;
+        s.world.nextHeartbeatAtTick = newTick + 1;
+
+        emit TickAdvanced(closedTick, newTick, newSeed);
+    }
+
+    function isSeasonFinalizationPending(LibStorage.AppStorage storage s) internal view returns (bool) {
+        return s.world.currentTick >= s.world.seasonEndTick && !s.world.seasonFinalized;
+    }
+
+    function isSeasonRolloverPending(LibStorage.AppStorage storage s) internal view returns (bool) {
+        return s.world.currentTick >= s.world.seasonEndTick && s.world.seasonFinalized;
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibHeartbeat.sol
+++ b/packages/contracts/src/diamond/lib/LibHeartbeat.sol
@@ -5,6 +5,7 @@ import {ClanState} from "../../IClanWorld.sol";
 import {LibBanditCombat} from "./LibBanditCombat.sol";
 import {LibBanditLifecycle} from "./LibBanditLifecycle.sol";
 import {LibBanditSpawning} from "./LibBanditSpawning.sol";
+import {LibGameRules} from "./LibGameRules.sol";
 import {LibOrderMarket} from "./LibOrderMarket.sol";
 import {LibSettlement} from "./LibSettlement.sol";
 import {LibStorage} from "./LibStorage.sol";
@@ -16,6 +17,7 @@ library LibHeartbeat {
     event ClanSettled(uint32 indexed clanId, uint64 settledToTick);
 
     function tick(LibStorage.AppStorage storage s) internal {
+        LibGameRules.requireWorldNotPaused(s);
         require(block.timestamp >= s.world.nextHeartbeatAtTs, "ClanWorld: heartbeat rate limited");
 
         if (isSeasonFinalizationPending(s)) {

--- a/packages/contracts/src/diamond/lib/LibStorage.sol
+++ b/packages/contracts/src/diamond/lib/LibStorage.sol
@@ -31,6 +31,8 @@ library LibStorage {
         bytes32 currentTickSeed;
         uint32 activeBanditId;
         uint64 nextCommitSequence;
+        bool worldPaused;
+        uint64 pausedAtTs;
     }
 
     struct BanditSpawnState {

--- a/packages/contracts/src/diamond/lib/LibSubmitOrders.sol
+++ b/packages/contracts/src/diamond/lib/LibSubmitOrders.sol
@@ -23,6 +23,7 @@ library LibSubmitOrders {
     {
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
+        LibGameRules.requireWorldNotPaused(s);
         LibGameRules.requireNoPendingSeasonFinalization(s);
 
         Clan storage clan = s.clans[clanId];

--- a/packages/contracts/src/diamond/lib/LibWorldClock.sol
+++ b/packages/contracts/src/diamond/lib/LibWorldClock.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanWorldConstants} from "../../IClanWorld.sol";
+import {LibStorage} from "./LibStorage.sol";
+
+library LibWorldClock {
+    function heartbeatIntervalSeconds(LibStorage.AppStorage storage s) internal view returns (uint64) {
+        uint64 configuredIntervalSeconds = s.heartbeatIntervalSeconds;
+        if (configuredIntervalSeconds == 0) {
+            return ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS;
+        }
+        return configuredIntervalSeconds;
+    }
+
+    function scheduleNextHeartbeat(LibStorage.AppStorage storage s) internal {
+        s.world.nextHeartbeatAtTs = uint64(block.timestamp) + heartbeatIntervalSeconds(s);
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibWorldEvents.sol
+++ b/packages/contracts/src/diamond/lib/LibWorldEvents.sol
@@ -14,10 +14,6 @@ library LibWorldEvents {
     function resolveWorldEvents(LibStorage.AppStorage storage s, uint64 closedTick) internal {
         uint64 newTick = closedTick + 1;
 
-        if (newTick >= s.world.seasonEndTick && s.world.seasonFinalized) {
-            rollSeason(s);
-        }
-
         bool wasWinter = LibSeason.isWinterActiveAt(closedTick);
         bool nowWinter = LibSeason.isWinterActiveAt(newTick);
         if (!wasWinter && nowWinter) {

--- a/packages/contracts/src/diamond/lib/LibWorldEvents.sol
+++ b/packages/contracts/src/diamond/lib/LibWorldEvents.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {ClanWorldConstants, WheatPlot, WheatPlotState} from "../../IClanWorld.sol";
+import {LibSeason} from "./LibSeason.sol";
+import {LibStorage} from "./LibStorage.sol";
+
+library LibWorldEvents {
+    uint256 private constant MAX_CROP_TRANSITION_PER_TICK = 48;
+
+    event WinterStarted(uint64 indexed tick);
+    event WinterEnded(uint64 indexed tick);
+
+    function resolveWorldEvents(LibStorage.AppStorage storage s, uint64 closedTick) internal {
+        uint64 newTick = closedTick + 1;
+
+        if (newTick >= s.world.seasonEndTick && s.world.seasonFinalized) {
+            rollSeason(s);
+        }
+
+        bool wasWinter = LibSeason.isWinterActiveAt(closedTick);
+        bool nowWinter = LibSeason.isWinterActiveAt(newTick);
+        if (!wasWinter && nowWinter) {
+            lockWheatPlotsForWinter(s);
+            emit WinterStarted(newTick);
+        }
+        if (wasWinter && !nowWinter) {
+            restartWheatPlotsAfterWinter(s, newTick);
+            emit WinterEnded(newTick);
+        }
+    }
+
+    function rollSeason(LibStorage.AppStorage storage s) internal {
+        s.world.currentSeasonNumber += 1;
+        s.world.seasonStartTick = s.world.seasonEndTick;
+        s.world.seasonEndTick = s.world.seasonStartTick + ClanWorldConstants.SEASON_DURATION_TICKS;
+        s.world.seasonFinalized = false;
+    }
+
+    function lockWheatPlotsForWinter(LibStorage.AppStorage storage s) private {
+        uint256 transitions;
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            for (uint256 pi = 0; pi < 2; pi++) {
+                require(transitions < MAX_CROP_TRANSITION_PER_TICK, "ClanWorld: crop transition cap");
+                WheatPlot storage plot = s.wheatPlots[clanId][pi];
+                plot.state = WheatPlotState.WinterLocked;
+                plot.remainingWheat = 0;
+                plot.regrowUntilTick = 0;
+                transitions++;
+            }
+        }
+    }
+
+    function restartWheatPlotsAfterWinter(LibStorage.AppStorage storage s, uint64 currentTick) private {
+        uint256 transitions;
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            for (uint256 pi = 0; pi < 2; pi++) {
+                require(transitions < MAX_CROP_TRANSITION_PER_TICK, "ClanWorld: crop transition cap");
+                WheatPlot storage plot = s.wheatPlots[clanId][pi];
+                if (plot.state == WheatPlotState.WinterLocked) {
+                    plot.state = WheatPlotState.Regrowing;
+                    plot.remainingWheat = 0;
+                    plot.regrowUntilTick = currentTick + ClanWorldConstants.WHEAT_PLOT_REGROW_TICKS;
+                }
+                transitions++;
+            }
+        }
+    }
+}

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -65,6 +65,7 @@ import {SubmitOrdersFacet} from "../../src/diamond/facets/SubmitOrdersFacet.sol"
 import {StubPool} from "../../src/StubPool.sol";
 import {TreasuryFacet} from "../../src/diamond/facets/TreasuryFacet.sol";
 import {VaultResourceTransferFacet} from "../../src/diamond/facets/VaultResourceTransferFacet.sol";
+import {WorldPauseFacet} from "../../src/diamond/facets/WorldPauseFacet.sol";
 import {LibBanditCombat} from "../../src/diamond/lib/LibBanditCombat.sol";
 import {LibDiamond} from "../../src/diamond/lib/LibDiamond.sol";
 import {LibOrderDefenders} from "../../src/diamond/lib/LibOrderDefenders.sol";
@@ -1453,7 +1454,7 @@ contract DiamondSkeletonTest is Test {
     }
 
     function _productionCut(address loupeFacet) internal returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](26);
+        cut = new IDiamondCut.FacetCut[](27);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -1475,111 +1476,116 @@ contract DiamondSkeletonTest is Test {
             functionSelectors: DiamondSelectors.heartbeatConfigSelectors()
         });
         cut[4] = IDiamondCut.FacetCut({
+            facetAddress: address(new WorldPauseFacet()),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.worldPauseSelectors()
+        });
+        cut[5] = IDiamondCut.FacetCut({
             facetAddress: address(new FinalizeSeasonFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.seasonSelectors()
         });
-        cut[5] = IDiamondCut.FacetCut({
+        cut[6] = IDiamondCut.FacetCut({
             facetAddress: address(new RawWorldViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawWorldViewsSelectors()
         });
-        cut[6] = IDiamondCut.FacetCut({
+        cut[7] = IDiamondCut.FacetCut({
             facetAddress: address(new RawTreasuryViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawTreasuryViewsSelectors()
         });
-        cut[7] = IDiamondCut.FacetCut({
+        cut[8] = IDiamondCut.FacetCut({
             facetAddress: address(new RawClanViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawClanViewsSelectors()
         });
-        cut[8] = IDiamondCut.FacetCut({
+        cut[9] = IDiamondCut.FacetCut({
             facetAddress: address(new RawBanditViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawBanditViewsSelectors()
         });
-        cut[9] = IDiamondCut.FacetCut({
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: address(new ClanLifecycleFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.lifecycleSelectors()
         });
-        cut[10] = IDiamondCut.FacetCut({
+        cut[11] = IDiamondCut.FacetCut({
             facetAddress: address(new SubmitOrdersFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.submitOrdersSelectors()
         });
-        cut[11] = IDiamondCut.FacetCut({
+        cut[12] = IDiamondCut.FacetCut({
             facetAddress: address(new ClanOwnershipFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.ownershipSelectors()
         });
-        cut[12] = IDiamondCut.FacetCut({
+        cut[13] = IDiamondCut.FacetCut({
             facetAddress: address(new TreasuryFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.treasurySelectors()
         });
-        cut[13] = IDiamondCut.FacetCut({
+        cut[14] = IDiamondCut.FacetCut({
             facetAddress: address(new SettlementFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.settlementSelectors()
         });
-        cut[14] = IDiamondCut.FacetCut({
+        cut[15] = IDiamondCut.FacetCut({
             facetAddress: address(new GoldTransferFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.goldTransferSelectors()
         });
-        cut[15] = IDiamondCut.FacetCut({
+        cut[16] = IDiamondCut.FacetCut({
             facetAddress: address(new VaultResourceTransferFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.vaultResourceTransferSelectors()
         });
-        cut[16] = IDiamondCut.FacetCut({
+        cut[17] = IDiamondCut.FacetCut({
             facetAddress: address(new BlueprintTransferFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.blueprintTransferSelectors()
         });
-        cut[17] = IDiamondCut.FacetCut({
+        cut[18] = IDiamondCut.FacetCut({
             facetAddress: address(new BundleTransferFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.bundleTransferSelectors()
         });
-        cut[18] = IDiamondCut.FacetCut({
+        cut[19] = IDiamondCut.FacetCut({
             facetAddress: address(new DerivedViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-        cut[19] = IDiamondCut.FacetCut({
+        cut[20] = IDiamondCut.FacetCut({
             facetAddress: address(new MarketViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
-        cut[20] = IDiamondCut.FacetCut({
+        cut[21] = IDiamondCut.FacetCut({
             facetAddress: address(new BanditViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
-        cut[21] = IDiamondCut.FacetCut({
+        cut[22] = IDiamondCut.FacetCut({
             facetAddress: address(new RegionViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
-        cut[22] = IDiamondCut.FacetCut({
+        cut[23] = IDiamondCut.FacetCut({
             facetAddress: address(new SnapshotViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
-        cut[23] = IDiamondCut.FacetCut({
+        cut[24] = IDiamondCut.FacetCut({
             facetAddress: address(new ClanFullViewFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.clanFullViewSelectors()
         });
-        cut[24] = IDiamondCut.FacetCut({
+        cut[25] = IDiamondCut.FacetCut({
             facetAddress: address(new QuoteViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
-        cut[25] = IDiamondCut.FacetCut({
+        cut[26] = IDiamondCut.FacetCut({
             facetAddress: address(new ScoringViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.scoringViewsSelectors()
@@ -1587,13 +1593,14 @@ contract DiamondSkeletonTest is Test {
     }
 
     function _expectedProductionSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](65);
+        selectors = new bytes4[](68);
         uint256 offset;
         selectors[offset++] = IDiamondCut.diamondCut.selector;
         offset = _copySelectors(selectors, offset, DiamondSelectors.loupeSelectors());
         offset = _copySelectors(selectors, offset, DiamondSelectors.ownershipFacetSelectors());
         offset = _copySelectors(selectors, offset, DiamondSelectors.heartbeatSelectors());
         offset = _copySelectors(selectors, offset, DiamondSelectors.heartbeatConfigSelectors());
+        offset = _copySelectors(selectors, offset, DiamondSelectors.worldPauseSelectors());
         offset = _copySelectors(selectors, offset, DiamondSelectors.seasonSelectors());
         offset = _copySelectors(selectors, offset, DiamondSelectors.rawWorldViewsSelectors());
         offset = _copySelectors(selectors, offset, DiamondSelectors.rawTreasuryViewsSelectors());

--- a/packages/contracts/test/diamond/HeartbeatExtraction.t.sol
+++ b/packages/contracts/test/diamond/HeartbeatExtraction.t.sol
@@ -118,7 +118,16 @@ contract HeartbeatExtractionTest is Test {
         assertEq(actual.seasonFinalized, expected.seasonFinalized, "seasonFinalized");
         assertEq(actual.currentSeasonNumber, expected.currentSeasonNumber, "currentSeasonNumber");
         assertEq(actual.nextHeartbeatAtTick, expected.nextHeartbeatAtTick, "nextHeartbeatAtTick");
+        assertEq(actual.nextHeartbeatAtTs, expected.nextHeartbeatAtTs, "nextHeartbeatAtTs");
         assertEq(actual.nextBanditSpawnEligibleTick, expected.nextBanditSpawnEligibleTick, "nextBanditSpawnEligibleTick");
         assertEq(actual.currentBanditSpawnChanceBps, expected.currentBanditSpawnChanceBps, "spawn chance");
+        assertEq(actual.currentTickSeed, expected.currentTickSeed, "currentTickSeed");
+        assertEq(actual.activeBanditId, expected.activeBanditId, "activeBanditId");
+        assertEq(actual.winterActive, expected.winterActive, "winterActive");
+        assertEq(actual.winterStartsAtTick, expected.winterStartsAtTick, "winterStartsAtTick");
+        assertEq(actual.winterEndsAtTick, expected.winterEndsAtTick, "winterEndsAtTick");
+        assertEq(actual.nextCommitSequence, expected.nextCommitSequence, "nextCommitSequence");
+        assertEq(actual.worldPaused, expected.worldPaused, "worldPaused");
+        assertEq(actual.pausedAtTs, expected.pausedAtTs, "pausedAtTs");
     }
 }

--- a/packages/contracts/test/diamond/HeartbeatExtraction.t.sol
+++ b/packages/contracts/test/diamond/HeartbeatExtraction.t.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {DiamondSelectors} from "../../script/DiamondSelectors.sol";
+import {ClanWorld} from "../../src/ClanWorld.sol";
+import {ClanWorldDiamondInit} from "../../src/diamond/ClanWorldDiamondInit.sol";
+import {Diamond} from "../../src/diamond/Diamond.sol";
+import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {FinalizeSeasonFacet} from "../../src/diamond/facets/FinalizeSeasonFacet.sol";
+import {HeartbeatFacet} from "../../src/diamond/facets/HeartbeatFacet.sol";
+import {RawWorldViewsFacet} from "../../src/diamond/facets/RawWorldViewsFacet.sol";
+import {LibStorage} from "../../src/diamond/lib/LibStorage.sol";
+import {IClanWorld, ClanWorldConstants, WorldState} from "../../src/IClanWorld.sol";
+
+interface IHeartbeatExtractionHarness {
+    function setWorldForHeartbeat(uint64 currentTick, bool seasonFinalized) external;
+}
+
+contract HeartbeatExtractionHarnessFacet {
+    function setWorldForHeartbeat(uint64 currentTick, bool seasonFinalized) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        bytes32 tickSeed = bytes32(uint256(currentTick));
+        s.world.currentTick = currentTick;
+        s.world.nextHeartbeatAtTick = currentTick + 1;
+        s.world.nextHeartbeatAtTs = 0;
+        s.world.currentTickSeed = tickSeed;
+        s.world.seasonFinalized = seasonFinalized;
+        s.tickSeeds[currentTick] = tickSeed;
+    }
+}
+
+contract HeartbeatExtractionTest is Test {
+    event WinterStarted(uint64 indexed tick);
+
+    function test_emptyWorldHeartbeatAdvancesLikeCore() public {
+        ClanWorld core = new ClanWorld();
+        IClanWorld diamond = _deployDiamond();
+
+        for (uint256 i = 0; i < 3; i++) {
+            uint64 coreNext = core.getWorldState().nextHeartbeatAtTs;
+            uint64 diamondNext = diamond.getWorldState().nextHeartbeatAtTs;
+            vm.warp(coreNext > diamondNext ? coreNext : diamondNext);
+            core.heartbeat();
+            diamond.heartbeat();
+        }
+
+        _assertWorldStateEq(diamond.getWorldState(), core.getWorldState());
+    }
+
+    function test_heartbeatNoopsWhenSeasonFinalizationPending() public {
+        IClanWorld diamond = _deployDiamond();
+        IHeartbeatExtractionHarness(address(diamond)).setWorldForHeartbeat(ClanWorldConstants.SEASON_DURATION_TICKS, false);
+
+        diamond.heartbeat();
+
+        WorldState memory state = diamond.getWorldState();
+        assertEq(state.currentTick, ClanWorldConstants.SEASON_DURATION_TICKS, "tick unchanged");
+        assertFalse(state.seasonFinalized, "still pending finalization");
+    }
+
+    function test_heartbeatRollsSeasonAfterFinalization() public {
+        IClanWorld diamond = _deployDiamond();
+        IHeartbeatExtractionHarness(address(diamond)).setWorldForHeartbeat(ClanWorldConstants.SEASON_DURATION_TICKS, true);
+
+        diamond.heartbeat();
+
+        WorldState memory state = diamond.getWorldState();
+        assertEq(state.currentSeasonNumber, 2, "season number");
+        assertEq(state.seasonStartTick, ClanWorldConstants.SEASON_DURATION_TICKS, "season start");
+        assertEq(state.seasonEndTick, ClanWorldConstants.SEASON_DURATION_TICKS * 2, "season end");
+        assertFalse(state.seasonFinalized, "new season unfinalized");
+    }
+
+    function test_winterStartTransitionStillFires() public {
+        IClanWorld diamond = _deployDiamond();
+        IHeartbeatExtractionHarness(address(diamond)).setWorldForHeartbeat(ClanWorldConstants.WINTER_START_TICK - 1, false);
+
+        vm.expectEmit(true, true, true, true, address(diamond));
+        emit WinterStarted(ClanWorldConstants.WINTER_START_TICK);
+        diamond.heartbeat();
+
+        assertTrue(diamond.isWinter(), "winter active");
+        assertEq(diamond.getWorldState().currentTick, ClanWorldConstants.WINTER_START_TICK, "winter tick");
+    }
+
+    function _deployDiamond() internal returns (IClanWorld diamondWorld) {
+        DiamondCutFacet cutFacet = new DiamondCutFacet();
+        Diamond diamond = new Diamond(address(this), address(cutFacet));
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](4);
+        cut[0] = _facetCut(address(new RawWorldViewsFacet()), DiamondSelectors.rawWorldViewsSelectors());
+        cut[1] = _facetCut(address(new HeartbeatFacet()), DiamondSelectors.heartbeatSelectors());
+        cut[2] = _facetCut(address(new FinalizeSeasonFacet()), DiamondSelectors.seasonSelectors());
+        cut[3] = _facetCut(address(new HeartbeatExtractionHarnessFacet()), _harnessSelectors());
+
+        IDiamondCut(address(diamond)).diamondCut(cut, address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        diamondWorld = IClanWorld(address(diamond));
+    }
+
+    function _facetCut(address facet, bytes4[] memory selectors) internal pure returns (IDiamondCut.FacetCut memory) {
+        return IDiamondCut.FacetCut({
+            facetAddress: facet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+    }
+
+    function _harnessSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = HeartbeatExtractionHarnessFacet.setWorldForHeartbeat.selector;
+    }
+
+    function _assertWorldStateEq(WorldState memory actual, WorldState memory expected) internal pure {
+        assertEq(actual.currentTick, expected.currentTick, "currentTick");
+        assertEq(actual.seasonStartTick, expected.seasonStartTick, "seasonStartTick");
+        assertEq(actual.seasonEndTick, expected.seasonEndTick, "seasonEndTick");
+        assertEq(actual.seasonFinalized, expected.seasonFinalized, "seasonFinalized");
+        assertEq(actual.currentSeasonNumber, expected.currentSeasonNumber, "currentSeasonNumber");
+        assertEq(actual.nextHeartbeatAtTick, expected.nextHeartbeatAtTick, "nextHeartbeatAtTick");
+        assertEq(actual.nextBanditSpawnEligibleTick, expected.nextBanditSpawnEligibleTick, "nextBanditSpawnEligibleTick");
+        assertEq(actual.currentBanditSpawnChanceBps, expected.currentBanditSpawnChanceBps, "spawn chance");
+    }
+}

--- a/packages/contracts/test/diamond/StorageLayoutGuard.t.sol
+++ b/packages/contracts/test/diamond/StorageLayoutGuard.t.sol
@@ -19,6 +19,15 @@ contract StorageSlotProbe {
             slot := ds.slot
         }
     }
+
+    function writeWorldTailSentinels() external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        s.world.activeBanditId = 0xaabbccdd;
+        s.world.nextCommitSequence = 0x1122334455667788;
+        s.world.worldPaused = true;
+        s.world.pausedAtTs = 0x99aabbccddeeff00;
+        s.treasury.treasuryOwner = address(0x1234);
+    }
 }
 
 contract StorageLayoutGuardTest is Test {
@@ -31,5 +40,22 @@ contract StorageLayoutGuardTest is Test {
         assertEq(appSlot, keccak256("clan.world.app.storage.v1"), "app storage slot");
         assertEq(diamondSlot, keccak256("clan.world.diamond.storage.v1"), "diamond storage slot");
         assertTrue(appSlot != diamondSlot, "storage slots must not collide");
+    }
+
+    function testWorldPauseFieldsPackIntoExistingWorldTailSlot() public {
+        StorageSlotProbe probe = new StorageSlotProbe();
+        probe.writeWorldTailSentinels();
+
+        uint256 appSlot = uint256(probe.appStorageSlot());
+        uint256 worldTailSlot = uint256(appSlot) + 6;
+        uint256 expectedTail = uint256(0xaabbccdd) | (uint256(0x1122334455667788) << 32) | (uint256(1) << 96)
+            | (uint256(0x99aabbccddeeff00) << 104);
+
+        assertEq(uint256(vm.load(address(probe), bytes32(worldTailSlot))), expectedTail, "world tail packed slot");
+        assertEq(
+            address(uint160(uint256(vm.load(address(probe), bytes32(appSlot + 7))))),
+            address(0x1234),
+            "treasury still starts after world"
+        );
     }
 }

--- a/packages/contracts/test/diamond/StorageLayoutGuard.t.sol
+++ b/packages/contracts/test/diamond/StorageLayoutGuard.t.sol
@@ -47,6 +47,11 @@ contract StorageLayoutGuardTest is Test {
         probe.writeWorldTailSentinels();
 
         uint256 appSlot = uint256(probe.appStorageSlot());
+        // StoredWorldState starts at AppStorage slot 0. Slots 0-5 hold the
+        // earlier world fields through `currentTickSeed`; slot 6 packs
+        // `activeBanditId`, `nextCommitSequence`, `worldPaused`, and
+        // `pausedAtTs`. Treasury is the next AppStorage field, so it must still
+        // begin at appSlot + 7 after appending the pause fields.
         uint256 worldTailSlot = uint256(appSlot) + 6;
         uint256 expectedTail = uint256(0xaabbccdd) | (uint256(0x1122334455667788) << 32) | (uint256(1) << 96)
             | (uint256(0x99aabbccddeeff00) << 104);

--- a/packages/contracts/test/diamond/WorldPause.t.sol
+++ b/packages/contracts/test/diamond/WorldPause.t.sol
@@ -110,6 +110,8 @@ contract WorldPauseTest is Test {
         emit WorldPaused(0, pausedAt);
         pause.pauseWorld();
         assertTrue(pause.isWorldPaused(), "paused");
+        assertTrue(world.getWorldState().worldPaused, "world state paused");
+        assertEq(world.getWorldState().pausedAtTs, pausedAt, "world state pausedAt");
         assertEq(harness.pausedAtTs(), pausedAt, "pausedAt stored");
 
         vm.warp(block.timestamp + 37);
@@ -119,6 +121,8 @@ contract WorldPauseTest is Test {
         pause.unpauseWorld();
 
         assertFalse(pause.isWorldPaused(), "unpaused");
+        assertFalse(world.getWorldState().worldPaused, "world state unpaused");
+        assertEq(world.getWorldState().pausedAtTs, 0, "world state pausedAt cleared");
         assertEq(harness.pausedAtTs(), 0, "pausedAt cleared");
         assertEq(world.getWorldState().nextHeartbeatAtTs, expectedNextHeartbeatAtTs, "next heartbeat");
     }

--- a/packages/contracts/test/diamond/WorldPause.t.sol
+++ b/packages/contracts/test/diamond/WorldPause.t.sol
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {DiamondSelectors} from "../../script/DiamondSelectors.sol";
+import {ClanWorldDiamondInit} from "../../src/diamond/ClanWorldDiamondInit.sol";
+import {Diamond} from "../../src/diamond/Diamond.sol";
+import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
+import {BlueprintTransferFacet} from "../../src/diamond/facets/BlueprintTransferFacet.sol";
+import {BundleTransferFacet} from "../../src/diamond/facets/BundleTransferFacet.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {FinalizeSeasonFacet} from "../../src/diamond/facets/FinalizeSeasonFacet.sol";
+import {GoldTransferFacet} from "../../src/diamond/facets/GoldTransferFacet.sol";
+import {HeartbeatConfigFacet} from "../../src/diamond/facets/HeartbeatConfigFacet.sol";
+import {HeartbeatFacet} from "../../src/diamond/facets/HeartbeatFacet.sol";
+import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.sol";
+import {ClanOwnershipFacet} from "../../src/diamond/facets/ClanOwnershipFacet.sol";
+import {RawClanViewsFacet} from "../../src/diamond/facets/RawClanViewsFacet.sol";
+import {RawTreasuryViewsFacet} from "../../src/diamond/facets/RawTreasuryViewsFacet.sol";
+import {RawWorldViewsFacet} from "../../src/diamond/facets/RawWorldViewsFacet.sol";
+import {SettlementFacet} from "../../src/diamond/facets/SettlementFacet.sol";
+import {SubmitOrdersFacet} from "../../src/diamond/facets/SubmitOrdersFacet.sol";
+import {TreasuryFacet} from "../../src/diamond/facets/TreasuryFacet.sol";
+import {VaultResourceTransferFacet} from "../../src/diamond/facets/VaultResourceTransferFacet.sol";
+import {WorldPauseFacet} from "../../src/diamond/facets/WorldPauseFacet.sol";
+import {LibStorage} from "../../src/diamond/lib/LibStorage.sol";
+import {MinimalERC20} from "../../src/MinimalERC20.sol";
+import {StubPool} from "../../src/StubPool.sol";
+import {IClanWorld, ClanOrder, ClanWorldConstants, OrderResult, ResourceType, TreasuryState} from "../../src/IClanWorld.sol";
+
+interface IWorldPause {
+    function pauseWorld() external;
+    function unpauseWorld() external;
+    function isWorldPaused() external view returns (bool);
+}
+
+interface IWorldPauseHarness {
+    function grantBlueprint(uint32 clanId, uint256 amount) external;
+    function setCurrentTick(uint64 tick) external;
+}
+
+contract WorldPauseHarnessFacet {
+    function grantBlueprint(uint32 clanId, uint256 amount) external {
+        LibStorage.appStorage().clans[clanId].blueprintBalance += amount;
+    }
+
+    function setCurrentTick(uint64 tick) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        s.world.currentTick = tick;
+        s.world.nextHeartbeatAtTick = tick + 1;
+        s.world.nextHeartbeatAtTs = 0;
+    }
+}
+
+contract WorldPauseTest is Test {
+    IClanWorld private world;
+    IWorldPause private pause;
+    IWorldPauseHarness private harness;
+
+    function setUp() public {
+        world = _deployPauseHeartbeatDiamond();
+        pause = IWorldPause(address(world));
+        harness = IWorldPauseHarness(address(world));
+    }
+
+    function test_heartbeatAdvancesWhenNotPaused() public {
+        assertEq(world.getWorldState().currentTick, 0, "pre tick");
+
+        world.heartbeat();
+
+        assertEq(world.getWorldState().currentTick, 1, "post tick");
+    }
+
+    function test_pauseRevertsHeartbeat_beforeRateLimit() public {
+        world.heartbeat();
+        assertEq(world.getWorldState().currentTick, 1, "setup tick");
+        pause.pauseWorld();
+
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.heartbeat();
+    }
+
+    function test_settleClanWorksWhenNotPaused() public {
+        (uint32 clanId,) = world.mintClan(address(0xA11CE));
+        world.heartbeat();
+
+        world.settleClan(clanId);
+
+        assertEq(world.getClan(clanId).lastSettledTick, world.getWorldState().currentTick, "settled tick");
+    }
+
+    function test_settleClanRevertsWhenPaused() public {
+        (uint32 clanId,) = world.mintClan(address(0xA11CE));
+        pause.pauseWorld();
+
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.settleClan(clanId);
+    }
+
+    function test_settleClansmanWorksWhenNotPaused() public {
+        (uint32 clanId,) = world.mintClan(address(0xA11CE));
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        world.heartbeat();
+
+        world.settleClansman(clansmanId);
+
+        assertEq(world.getClan(clanId).lastSettledTick, world.getWorldState().currentTick, "settled tick");
+    }
+
+    function test_settleClansmanRevertsWhenPaused() public {
+        (uint32 clanId,) = world.mintClan(address(0xA11CE));
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        pause.pauseWorld();
+
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.settleClansman(clansmanId);
+    }
+
+    function test_submitOrdersWorksWhenNotPaused() public {
+        address elder = address(0xA11CE);
+        (uint32 clanId,) = world.mintClan(elder);
+        ClanOrder[] memory orders = new ClanOrder[](0);
+
+        vm.prank(elder);
+        OrderResult[] memory results = world.submitClanOrders(clanId, orders);
+
+        assertEq(results.length, 0, "empty orders accepted");
+    }
+
+    function test_submitOrdersRevertsWhenPaused() public {
+        address elder = address(0xA11CE);
+        (uint32 clanId,) = world.mintClan(elder);
+        ClanOrder[] memory orders = new ClanOrder[](0);
+        pause.pauseWorld();
+
+        vm.prank(elder);
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.submitClanOrders(clanId, orders);
+    }
+
+    function test_mintClanWorksWhenNotPaused() public {
+        (uint32 clanId,) = world.mintClan(address(0xA11CE));
+
+        assertEq(clanId, 1, "first clan minted");
+    }
+
+    function test_mintClanRevertsWhenPausedFromDifferentEoa() public {
+        pause.pauseWorld();
+
+        vm.prank(address(0xB0B));
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.mintClan(address(0xB0B));
+    }
+
+    function test_transferClanOwnershipWorksWhenNotPaused() public {
+        address elder = address(0xA11CE);
+        address nextOwner = address(0xB0B);
+        (uint32 clanId,) = world.mintClan(elder);
+
+        vm.prank(elder);
+        world.transferClanOwnership(clanId, nextOwner);
+
+        assertEq(world.getClan(clanId).owner, nextOwner, "new clan owner");
+    }
+
+    function test_transferClanOwnershipRevertsWhenPaused() public {
+        address elder = address(0xA11CE);
+        (uint32 clanId,) = world.mintClan(elder);
+        pause.pauseWorld();
+
+        vm.prank(elder);
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.transferClanOwnership(clanId, address(0xB0B));
+    }
+
+    function test_transferGoldWorksWhenNotPaused() public {
+        (uint32 fromClanId, uint32 toClanId, address elder,) = _mintTwoClans();
+
+        vm.prank(elder);
+        world.transferGold(fromClanId, toClanId, 1e18);
+
+        assertEq(world.getClan(toClanId).goldBalance, 4e18, "recipient gold");
+    }
+
+    function test_transferGoldRevertsWhenPaused() public {
+        (uint32 fromClanId, uint32 toClanId, address elder,) = _mintTwoClans();
+        pause.pauseWorld();
+
+        vm.prank(elder);
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.transferGold(fromClanId, toClanId, 1e18);
+    }
+
+    function test_transferVaultResourceWorksWhenNotPaused() public {
+        (uint32 fromClanId, uint32 toClanId, address elder,) = _mintTwoClans();
+
+        vm.prank(elder);
+        world.transferVaultResource(fromClanId, toClanId, ResourceType.Wood, 1e18);
+
+        assertEq(world.getClan(toClanId).vaultWood, 21e18, "recipient wood");
+    }
+
+    function test_transferVaultResourceRevertsWhenPaused() public {
+        (uint32 fromClanId, uint32 toClanId, address elder,) = _mintTwoClans();
+        pause.pauseWorld();
+
+        vm.prank(elder);
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.transferVaultResource(fromClanId, toClanId, ResourceType.Wood, 1e18);
+    }
+
+    function test_transferBlueprintWorksWhenNotPaused() public {
+        (uint32 fromClanId, uint32 toClanId, address elder,) = _mintTwoClans();
+        harness.grantBlueprint(fromClanId, 2e18);
+
+        vm.prank(elder);
+        world.transferBlueprint(fromClanId, toClanId, 1e18);
+
+        assertEq(world.getClan(toClanId).blueprintBalance, 1e18, "recipient blueprints");
+    }
+
+    function test_transferBlueprintRevertsWhenPaused() public {
+        (uint32 fromClanId, uint32 toClanId, address elder,) = _mintTwoClans();
+        pause.pauseWorld();
+
+        vm.prank(elder);
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.transferBlueprint(fromClanId, toClanId, 1e18);
+    }
+
+    function test_transferBundleWorksWhenNotPaused() public {
+        (uint32 fromClanId, uint32 toClanId, address elder,) = _mintTwoClans();
+
+        vm.prank(elder);
+        world.transferBundle(fromClanId, toClanId, 1e18, 0, 1e18, 0, 1e18, 0);
+
+        assertEq(world.getClan(toClanId).goldBalance, 4e18, "recipient bundle gold");
+        assertEq(world.getClan(toClanId).vaultWood, 21e18, "recipient bundle wood");
+        assertEq(world.getClan(toClanId).vaultWheat, 21e18, "recipient bundle wheat");
+    }
+
+    function test_transferBundleRevertsWhenPaused() public {
+        (uint32 fromClanId, uint32 toClanId, address elder,) = _mintTwoClans();
+        pause.pauseWorld();
+
+        vm.prank(elder);
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.transferBundle(fromClanId, toClanId, 1e18, 0, 0, 0, 0, 0);
+    }
+
+    function test_initTreasuryWorksWhenNotPaused() public {
+        (address[6] memory tokens, address[4] memory pools) = _deployTreasuryBoundary();
+
+        world.initTreasury(tokens, pools);
+
+        TreasuryState memory treasury = world.getTreasuryState();
+        assertEq(treasury.woodToken, tokens[0], "wood token");
+        assertEq(treasury.ironGoldPool, pools[3], "iron pool");
+    }
+
+    function test_initTreasuryRevertsWhenPaused() public {
+        address[6] memory tokens;
+        address[4] memory pools;
+        pause.pauseWorld();
+
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.initTreasury(tokens, pools);
+    }
+
+    function test_finalizeSeasonSucceedsWhilePausedAtSeasonBoundary() public {
+        harness.setCurrentTick(ClanWorldConstants.SEASON_DURATION_TICKS);
+        pause.pauseWorld();
+
+        world.finalizeSeason();
+
+        assertTrue(world.getWorldState().seasonFinalized, "season finalized while paused");
+    }
+
+    function _deployPauseHeartbeatDiamond() internal returns (IClanWorld diamondWorld) {
+        DiamondCutFacet cutFacet = new DiamondCutFacet();
+        Diamond diamond = new Diamond(address(this), address(cutFacet));
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](17);
+        cut[0] = _facetCut(address(new RawWorldViewsFacet()), DiamondSelectors.rawWorldViewsSelectors());
+        cut[1] = _facetCut(address(new HeartbeatFacet()), DiamondSelectors.heartbeatSelectors());
+        cut[2] = _facetCut(address(new HeartbeatConfigFacet()), DiamondSelectors.heartbeatConfigSelectors());
+        cut[3] = _facetCut(address(new WorldPauseFacet()), _worldPauseSelectors());
+        cut[4] = _facetCut(address(new ClanLifecycleFacet()), DiamondSelectors.lifecycleSelectors());
+        cut[5] = _facetCut(address(new RawClanViewsFacet()), DiamondSelectors.rawClanViewsSelectors());
+        cut[6] = _facetCut(address(new SettlementFacet()), DiamondSelectors.settlementSelectors());
+        cut[7] = _facetCut(address(new SubmitOrdersFacet()), DiamondSelectors.submitOrdersSelectors());
+        cut[8] = _facetCut(address(new ClanOwnershipFacet()), DiamondSelectors.ownershipSelectors());
+        cut[9] = _facetCut(address(new GoldTransferFacet()), DiamondSelectors.goldTransferSelectors());
+        cut[10] = _facetCut(address(new VaultResourceTransferFacet()), DiamondSelectors.vaultResourceTransferSelectors());
+        cut[11] = _facetCut(address(new BlueprintTransferFacet()), DiamondSelectors.blueprintTransferSelectors());
+        cut[12] = _facetCut(address(new BundleTransferFacet()), DiamondSelectors.bundleTransferSelectors());
+        cut[13] = _facetCut(address(new WorldPauseHarnessFacet()), _worldPauseHarnessSelectors());
+        cut[14] = _facetCut(address(new TreasuryFacet()), DiamondSelectors.treasurySelectors());
+        cut[15] = _facetCut(address(new RawTreasuryViewsFacet()), DiamondSelectors.rawTreasuryViewsSelectors());
+        cut[16] = _facetCut(address(new FinalizeSeasonFacet()), DiamondSelectors.seasonSelectors());
+
+        IDiamondCut(address(diamond)).diamondCut(cut, address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        diamondWorld = IClanWorld(address(diamond));
+        assertEq(diamondWorld.getWorldState().nextHeartbeatAtTs, block.timestamp, "initial heartbeat cadence");
+        assertEq(ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS, 60, "heartbeat interval fixture");
+    }
+
+    function _facetCut(address facet, bytes4[] memory selectors) internal pure returns (IDiamondCut.FacetCut memory) {
+        return IDiamondCut.FacetCut({
+            facetAddress: facet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+    }
+
+    function _worldPauseSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](3);
+        selectors[0] = WorldPauseFacet.pauseWorld.selector;
+        selectors[1] = WorldPauseFacet.unpauseWorld.selector;
+        selectors[2] = WorldPauseFacet.isWorldPaused.selector;
+    }
+
+    function _worldPauseHarnessSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](2);
+        selectors[0] = WorldPauseHarnessFacet.grantBlueprint.selector;
+        selectors[1] = WorldPauseHarnessFacet.setCurrentTick.selector;
+    }
+
+    function _mintTwoClans() internal returns (uint32 fromClanId, uint32 toClanId, address fromOwner, address toOwner) {
+        fromOwner = address(0xA11CE);
+        toOwner = address(0xB0B);
+        (fromClanId,) = world.mintClan(fromOwner);
+        (toClanId,) = world.mintClan(toOwner);
+    }
+
+    function _deployTreasuryBoundary() internal returns (address[6] memory tokens, address[4] memory pools) {
+        tokens[0] = address(new MinimalERC20("Wood", "WOOD"));
+        tokens[1] = address(new MinimalERC20("Iron", "IRON"));
+        tokens[2] = address(new MinimalERC20("Wheat", "WHEAT"));
+        tokens[3] = address(new MinimalERC20("Fish", "FISH"));
+        tokens[4] = address(new MinimalERC20("Gold", "GOLD"));
+        tokens[5] = address(new MinimalERC20("Blueprint", "BP"));
+
+        pools[0] = address(new StubPool(tokens[0], tokens[4], address(world)));
+        pools[1] = address(new StubPool(tokens[2], tokens[4], address(world)));
+        pools[2] = address(new StubPool(tokens[3], tokens[4], address(world)));
+        pools[3] = address(new StubPool(tokens[1], tokens[4], address(world)));
+    }
+}

--- a/packages/contracts/test/diamond/WorldPause.t.sol
+++ b/packages/contracts/test/diamond/WorldPause.t.sol
@@ -35,6 +35,7 @@ import {
     ClanOrder,
     ClanWorldConstants,
     OrderResult,
+    PoolSeedConfig,
     ResourceType,
     ScheduledMarketAction,
     TreasuryState,
@@ -379,6 +380,14 @@ contract WorldPauseTest is Test {
 
         vm.expectRevert(bytes("ClanWorld: world paused"));
         world.initTreasury(tokens, pools);
+    }
+
+    function test_seedPoolsRevertsWhenPaused() public {
+        PoolSeedConfig memory cfg;
+        pause.pauseWorld();
+
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.seedPools(cfg);
     }
 
     function test_finalizeSeasonSucceedsWhenNotPausedAtSeasonBoundary() public {

--- a/packages/contracts/test/diamond/WorldPause.t.sol
+++ b/packages/contracts/test/diamond/WorldPause.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
 import {DiamondSelectors} from "../../script/DiamondSelectors.sol";
 import {ClanWorldDiamondInit} from "../../src/diamond/ClanWorldDiamondInit.sol";
 import {Diamond} from "../../src/diamond/Diamond.sol";
@@ -48,6 +49,8 @@ interface IWorldPause {
 
 interface IHeartbeatAdmin {
     function setHeartbeatIntervalSeconds(uint64 intervalSeconds) external;
+    function triggerBanditSpawn() external;
+    function banditSpawnTriggered() external view returns (bool);
 }
 
 interface IWorldPauseHarness {
@@ -76,6 +79,7 @@ contract WorldPauseHarnessFacet {
 contract WorldPauseTest is Test {
     event WorldPaused(uint64 indexed tick, uint64 pausedAtTs);
     event WorldUnpaused(uint64 indexed tick, uint64 durationSeconds, uint64 nextHeartbeatAtTs);
+    event BanditSpawned(uint32 indexed banditId, uint8 region, uint8 tier, uint16 attackPower);
 
     IClanWorld private world;
     IWorldPause private pause;
@@ -159,6 +163,35 @@ contract WorldPauseTest is Test {
         pause.unpauseWorld();
 
         assertEq(world.getWorldState().nextHeartbeatAtTs, block.timestamp + 7, "unpause cadence");
+    }
+
+    function test_triggerBanditSpawnQueuedDuringPause_FiresAfterUnpause() public {
+        world.mintClan(address(0xA11CE));
+        IHeartbeatAdmin heartbeatAdmin = IHeartbeatAdmin(address(world));
+        pause.pauseWorld();
+
+        uint64 pausedTick = world.getWorldState().currentTick;
+        vm.recordLogs();
+        heartbeatAdmin.triggerBanditSpawn();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 1, "only queue event emitted");
+        assertTrue(heartbeatAdmin.banditSpawnTriggered(), "spawn queued");
+        assertEq(world.getWorldState().currentBanditSpawnChanceBps, 10000, "preview chance");
+        assertEq(world.getWorldState().currentTick, pausedTick, "tick frozen");
+        assertEq(world.getWorldState().activeBanditId, 0, "no immediate active bandit");
+        assertEq(world.getBanditTroop(1).id, 0, "no immediate bandit");
+
+        pause.unpauseWorld();
+        vm.warp(world.getWorldState().nextHeartbeatAtTs);
+
+        vm.expectEmit(true, false, false, false, address(world));
+        emit BanditSpawned(1, 0, 0, 0);
+        world.heartbeat();
+
+        assertFalse(heartbeatAdmin.banditSpawnTriggered(), "queue consumed");
+        assertEq(world.getWorldState().activeBanditId, 1, "bandit active after heartbeat");
+        assertEq(world.getBanditTroop(1).id, 1, "bandit spawned after unpause");
     }
 
     function test_settleClanWorksWhenNotPaused() public {

--- a/packages/contracts/test/diamond/WorldPause.t.sol
+++ b/packages/contracts/test/diamond/WorldPause.t.sol
@@ -344,13 +344,20 @@ contract WorldPauseTest is Test {
         world.initTreasury(tokens, pools);
     }
 
-    function test_finalizeSeasonSucceedsWhilePausedAtSeasonBoundary() public {
+    function test_finalizeSeasonSucceedsWhenNotPausedAtSeasonBoundary() public {
         harness.setCurrentTick(ClanWorldConstants.SEASON_DURATION_TICKS);
-        pause.pauseWorld();
 
         world.finalizeSeason();
 
-        assertTrue(world.getWorldState().seasonFinalized, "season finalized while paused");
+        assertTrue(world.getWorldState().seasonFinalized, "season finalized");
+    }
+
+    function test_finalizeSeasonRevertsWhilePaused() public {
+        harness.setCurrentTick(ClanWorldConstants.SEASON_DURATION_TICKS);
+        pause.pauseWorld();
+
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.finalizeSeason();
     }
 
     function test_invariantPausedWorldStateFrozenAcrossWarpAndRevertedWrites() public {

--- a/packages/contracts/test/diamond/WorldPause.t.sol
+++ b/packages/contracts/test/diamond/WorldPause.t.sol
@@ -16,6 +16,7 @@ import {HeartbeatFacet} from "../../src/diamond/facets/HeartbeatFacet.sol";
 import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.sol";
 import {ClanOwnershipFacet} from "../../src/diamond/facets/ClanOwnershipFacet.sol";
 import {RawClanViewsFacet} from "../../src/diamond/facets/RawClanViewsFacet.sol";
+import {RawBanditViewsFacet} from "../../src/diamond/facets/RawBanditViewsFacet.sol";
 import {RawTreasuryViewsFacet} from "../../src/diamond/facets/RawTreasuryViewsFacet.sol";
 import {RawWorldViewsFacet} from "../../src/diamond/facets/RawWorldViewsFacet.sol";
 import {SettlementFacet} from "../../src/diamond/facets/SettlementFacet.sol";
@@ -26,7 +27,18 @@ import {WorldPauseFacet} from "../../src/diamond/facets/WorldPauseFacet.sol";
 import {LibStorage} from "../../src/diamond/lib/LibStorage.sol";
 import {MinimalERC20} from "../../src/MinimalERC20.sol";
 import {StubPool} from "../../src/StubPool.sol";
-import {IClanWorld, ClanOrder, ClanWorldConstants, OrderResult, ResourceType, TreasuryState} from "../../src/IClanWorld.sol";
+import {
+    IClanWorld,
+    BanditTroop,
+    Clan,
+    ClanOrder,
+    ClanWorldConstants,
+    OrderResult,
+    ResourceType,
+    ScheduledMarketAction,
+    TreasuryState,
+    WorldState
+} from "../../src/IClanWorld.sol";
 
 interface IWorldPause {
     function pauseWorld() external;
@@ -34,9 +46,14 @@ interface IWorldPause {
     function isWorldPaused() external view returns (bool);
 }
 
+interface IHeartbeatAdmin {
+    function setHeartbeatIntervalSeconds(uint64 intervalSeconds) external;
+}
+
 interface IWorldPauseHarness {
     function grantBlueprint(uint32 clanId, uint256 amount) external;
     function setCurrentTick(uint64 tick) external;
+    function pausedAtTs() external view returns (uint64);
 }
 
 contract WorldPauseHarnessFacet {
@@ -50,9 +67,16 @@ contract WorldPauseHarnessFacet {
         s.world.nextHeartbeatAtTick = tick + 1;
         s.world.nextHeartbeatAtTs = 0;
     }
+
+    function pausedAtTs() external view returns (uint64) {
+        return LibStorage.appStorage().world.pausedAtTs;
+    }
 }
 
 contract WorldPauseTest is Test {
+    event WorldPaused(uint64 indexed tick, uint64 pausedAtTs);
+    event WorldUnpaused(uint64 indexed tick, uint64 durationSeconds, uint64 nextHeartbeatAtTs);
+
     IClanWorld private world;
     IWorldPause private pause;
     IWorldPauseHarness private harness;
@@ -78,6 +102,59 @@ contract WorldPauseTest is Test {
 
         vm.expectRevert(bytes("ClanWorld: world paused"));
         world.heartbeat();
+    }
+
+    function test_pauseWorldAndUnpauseWorldEmitPayloadsAndClearPausedAtTs() public {
+        uint64 pausedAt = uint64(block.timestamp);
+        vm.expectEmit(true, true, true, true, address(world));
+        emit WorldPaused(0, pausedAt);
+        pause.pauseWorld();
+        assertTrue(pause.isWorldPaused(), "paused");
+        assertEq(harness.pausedAtTs(), pausedAt, "pausedAt stored");
+
+        vm.warp(block.timestamp + 37);
+        uint64 expectedNextHeartbeatAtTs = uint64(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        vm.expectEmit(true, true, true, true, address(world));
+        emit WorldUnpaused(0, 37, expectedNextHeartbeatAtTs);
+        pause.unpauseWorld();
+
+        assertFalse(pause.isWorldPaused(), "unpaused");
+        assertEq(harness.pausedAtTs(), 0, "pausedAt cleared");
+        assertEq(world.getWorldState().nextHeartbeatAtTs, expectedNextHeartbeatAtTs, "next heartbeat");
+    }
+
+    function test_nonOwnerCannotPauseOrUnpause() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert();
+        pause.pauseWorld();
+
+        pause.pauseWorld();
+
+        vm.prank(address(0xBEEF));
+        vm.expectRevert();
+        pause.unpauseWorld();
+    }
+
+    function test_doublePauseReverts() public {
+        pause.pauseWorld();
+
+        vm.expectRevert(bytes("ClanWorld: already paused"));
+        pause.pauseWorld();
+    }
+
+    function test_doubleUnpauseReverts() public {
+        vm.expectRevert(bytes("ClanWorld: not paused"));
+        pause.unpauseWorld();
+    }
+
+    function test_heartbeatIntervalChangeWhilePausedAffectsUnpauseCadence() public {
+        pause.pauseWorld();
+        IHeartbeatAdmin(address(world)).setHeartbeatIntervalSeconds(7);
+        vm.warp(block.timestamp + 5);
+
+        pause.unpauseWorld();
+
+        assertEq(world.getWorldState().nextHeartbeatAtTs, block.timestamp + 7, "unpause cadence");
     }
 
     function test_settleClanWorksWhenNotPaused() public {
@@ -276,12 +353,51 @@ contract WorldPauseTest is Test {
         assertTrue(world.getWorldState().seasonFinalized, "season finalized while paused");
     }
 
+    function test_invariantPausedWorldStateFrozenAcrossWarpAndRevertedWrites() public {
+        address elder = address(0xA11CE);
+        (uint32 clanId,) = world.mintClan(elder);
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        pause.pauseWorld();
+
+        WorldState memory beforeWorld = world.getWorldState();
+        Clan memory beforeClan = world.getClan(clanId);
+        BanditTroop memory beforeBandit = world.getBanditTroop(1);
+        ScheduledMarketAction[] memory beforeMarketQueue =
+            world.getScheduledMarketActionsForTick(beforeWorld.currentTick + 1);
+
+        vm.warp(block.timestamp + 10 minutes);
+
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.heartbeat();
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.settleClan(clanId);
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.settleClansman(clansmanId);
+        vm.prank(elder);
+        vm.expectRevert(bytes("ClanWorld: world paused"));
+        world.transferGold(clanId, clanId + 1, 1e18);
+
+        WorldState memory afterWorld = world.getWorldState();
+        Clan memory afterClan = world.getClan(clanId);
+        BanditTroop memory afterBandit = world.getBanditTroop(1);
+        ScheduledMarketAction[] memory afterMarketQueue =
+            world.getScheduledMarketActionsForTick(beforeWorld.currentTick + 1);
+
+        assertEq(afterWorld.currentTick, beforeWorld.currentTick, "currentTick frozen");
+        assertEq(afterWorld.currentTickSeed, beforeWorld.currentTickSeed, "tick seed frozen");
+        assertEq(afterClan.lastSettledTick, beforeClan.lastSettledTick, "lastSettledTick frozen");
+        assertEq(afterClan.livingClansmen, beforeClan.livingClansmen, "living clansmen frozen");
+        assertEq(afterClan.vaultWheat, beforeClan.vaultWheat, "wheat/starvation state frozen");
+        assertEq(uint8(afterBandit.state), uint8(beforeBandit.state), "bandit state frozen");
+        assertEq(afterMarketQueue.length, beforeMarketQueue.length, "market queue frozen");
+    }
+
     function _deployPauseHeartbeatDiamond() internal returns (IClanWorld diamondWorld) {
         DiamondCutFacet cutFacet = new DiamondCutFacet();
         Diamond diamond = new Diamond(address(this), address(cutFacet));
         ClanWorldDiamondInit init = new ClanWorldDiamondInit();
 
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](17);
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](18);
         cut[0] = _facetCut(address(new RawWorldViewsFacet()), DiamondSelectors.rawWorldViewsSelectors());
         cut[1] = _facetCut(address(new HeartbeatFacet()), DiamondSelectors.heartbeatSelectors());
         cut[2] = _facetCut(address(new HeartbeatConfigFacet()), DiamondSelectors.heartbeatConfigSelectors());
@@ -299,6 +415,7 @@ contract WorldPauseTest is Test {
         cut[14] = _facetCut(address(new TreasuryFacet()), DiamondSelectors.treasurySelectors());
         cut[15] = _facetCut(address(new RawTreasuryViewsFacet()), DiamondSelectors.rawTreasuryViewsSelectors());
         cut[16] = _facetCut(address(new FinalizeSeasonFacet()), DiamondSelectors.seasonSelectors());
+        cut[17] = _facetCut(address(new RawBanditViewsFacet()), DiamondSelectors.rawBanditViewsSelectors());
 
         IDiamondCut(address(diamond)).diamondCut(cut, address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
         diamondWorld = IClanWorld(address(diamond));
@@ -320,9 +437,10 @@ contract WorldPauseTest is Test {
     }
 
     function _worldPauseHarnessSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](2);
+        selectors = new bytes4[](3);
         selectors[0] = WorldPauseHarnessFacet.grantBlueprint.selector;
         selectors[1] = WorldPauseHarnessFacet.setCurrentTick.selector;
+        selectors[2] = WorldPauseHarnessFacet.pausedAtTs.selector;
     }
 
     function _mintTwoClans() internal returns (uint32 fromClanId, uint32 toClanId, address fromOwner, address toOwner) {


### PR DESCRIPTION
## Summary

Foundation PR for the V3 contract improvement queue. Splits `HeartbeatFacet`'s 135-line `heartbeat()` god-method into focused libraries AND adds the demo-day-failure-mode fix: a real `pauseWorld()` flag at the contract layer.

## Why this exists

2026-05-06 demo: V2 game state died because "pausing" stopped processes but didn't pause the contract's tick advance / starvation timers — clansmen kept starving for hours with no orders, all 4 clans dead by morning. Recovery required a full V3-diamond pivot in 90 seconds.

Lesson: any state machine with autonomous timers must have a `worldPaused` flag at the **state-machine layer**, not just the **driver layer**. This PR introduces that.

## What changed

### Library extraction (behavior-neutral)

| File | Role |
|---|---|
| `lib/LibWorldClock.sol` (new) | Shared `heartbeatIntervalSeconds()` + `scheduleNextHeartbeat()`. Eliminates duplicated helper between `HeartbeatFacet` and `HeartbeatConfigFacet`. |
| `lib/LibWorldEvents.sol` (new) | Winter transitions, season rollover, wheat plot lock/unlock. Pulled out of HeartbeatFacet's privates. |
| `lib/LibHeartbeat.sol` (new) | Orchestration body (settle → market → bandits → world events → tick advance). |
| `facets/HeartbeatFacet.sol` | Slimmed to ~15 lines: `enterNonReentrant → LibHeartbeat.tick(s) → exitNonReentrant`. |
| `facets/HeartbeatConfigFacet.sol` | Uses `LibWorldClock.heartbeatIntervalSeconds`. |

No selectors removed. `heartbeat()` keeps its selector unchanged.

### Pause flag

| File | Change |
|---|---|
| `lib/LibStorage.sol::StoredWorldState` | Appends `bool worldPaused` + `uint64 pausedAtTs`. Both pack into the existing world-tail slot — `treasury` and following AppStorage fields are unshifted (verified by guard test). |
| `lib/LibGameRules.sol` | Adds `requireWorldNotPaused(s)` helper matching the existing `requireNoPendingSeasonFinalization` pattern. |
| `facets/WorldPauseFacet.sol` (new) | `pauseWorld()` / `unpauseWorld()` (onlyOwner) + `isWorldPaused()` view. Both use the reentrancy guard. Unpause resets `nextHeartbeatAtTs = block.timestamp + interval` so cadence resumes cleanly without a catch-up storm. |
| `lib/LibHeartbeat.sol` | Pause check runs **before** the rate-limit check — paused callers get "world paused" not "rate limited". |

### Storage layout safety

`test/diamond/StorageLayoutGuard.t.sol::testWorldPauseFieldsPackIntoExistingWorldTailSlot` verifies the appended fields pack into the tail slot of `StoredWorldState` and that `treasury` (the next AppStorage field) still starts at the expected slot offset.

## Why this is the foundation for the 5 owner-only escape hatches

`WorldPauseFacet` is the natural home for the planned `reviveClan/reviveClansman`, `airdropResources`, `forceFinalizeSeason`, `setSeasonDuration` — each a small additive method on the same facet, no new diamond cut per addition.

## What's NOT in this PR (follow-ups)

- [ ] Pause-gating on mutating entrypoints (`submitOrders`, `settleClan`, `transferClanOwnership`, `mintClan`, all transfers). Codex started this but the background task hit our wall-clock timeout before finishing the gate pass — needs a small follow-up PR.
- [ ] Pause-behavior unit tests: revert-when-paused per entrypoint, cadence reset on unpause, only-owner enforcement. Storage layout guard test is in.
- [ ] `DiamondSelectors.sol` + `DeployDiamond.s.sol` registration of `WorldPauseFacet` selectors + selector-count test update — needed before diamond cut.

## Test plan

- [x] `forge build --skip test` passes clean
- [x] Storage layout guard test added (verifies append safety)
- [ ] Full `forge test` run — too slow on this codebase to verify in this session window; need a longer test session
- [ ] Diamond cut deployment script exercise

## Provenance

- Plan: `~/claudes-world/tmp/20260506-124212-heartbeat-split-pause-plan.md` (Liam-shared design doc)
- Codex review: `~/claudes-world/tmp/20260506-125000-codex-review-of-heartbeat-plan.md`
- Implementation: codex 5.5 high-reasoning via `codex exec resume <session>`. Recovered from a corrupted git state mid-session (codex's commit-attempt object was dropped on timeout; orchestrator manually re-staged + committed the work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)