### PR TITLE
chore: rip out lingering 'mini app' strings missed by PR #13

### DIFF
--- a/apps/landing/src/components/Footer.tsx
+++ b/apps/landing/src/components/Footer.tsx
@@ -10,8 +10,8 @@ export default function Footer() {
             <h4>Clan World <i>: Ælder Whispers</i></h4>
             <p style={{ color: 'var(--ink-soft)', fontSize: '0.95rem', maxWidth: '24rem' }}>
               An onchain realm of autonomous Elders, illuminated against parchment for those bold
-              enough to read it. A hackathon submission to <em>OpenAgents Track 2</em> and the
-              <em> World mini app</em> challenge — among others.
+              enough to read it. A hackathon submission to <em>OpenAgents Track 2</em> and
+              allied autonomous-agent tracks.
             </p>
             <p style={{ marginTop: '1rem' }} className="pixel">
               ⌬ Built on Base · 0G

--- a/apps/landing/src/components/Footer.tsx
+++ b/apps/landing/src/components/Footer.tsx
@@ -11,7 +11,7 @@ export default function Footer() {
             <p style={{ color: 'var(--ink-soft)', fontSize: '0.95rem', maxWidth: '24rem' }}>
               An onchain realm of autonomous Elders, illuminated against parchment for those bold
               enough to read it. A hackathon submission to <em>OpenAgents Track 2</em> and
-              allied autonomous-agent tracks.
+              <em>allied autonomous-agent tracks</em>.
             </p>
             <p style={{ marginTop: '1rem' }} className="pixel">
               ⌬ Built on Base · 0G

--- a/apps/web/tests/e2e/00-smoke.spec.ts
+++ b/apps/web/tests/e2e/00-smoke.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Smoke test — captures all browser console + pageerror events on initial
  * load and surfaces them. This is the orchestrator's "remote DevTools" for
- * the mini app: instead of asking the user to paste console logs, run this
+ * the web app: instead of asking the user to paste console logs, run this
  * and read the failure output.
  *
  * Usage:
@@ -23,7 +23,7 @@ const BENIGN_PATTERNS: RegExp[] = [
 
 const isBenign = (text: string) => BENIGN_PATTERNS.some((re) => re.test(text));
 
-test('mini app loads with no console errors', async ({ page }) => {
+test('web app loads with no console errors', async ({ page }) => {
   const consoleErrors: string[] = [];
   const consoleWarnings: string[] = [];
   const pageErrors: { message: string; stack: string | undefined }[] = [];


### PR DESCRIPTION
Two strings PR #13 missed:
- `apps/landing/src/components/Footer.tsx` — "World mini app challenge" → "allied autonomous-agent tracks"
- `apps/web/tests/e2e/00-smoke.spec.ts` — comment + test name "mini app" → "web app"

Origin: surfaced from dirty `clan-world-v3-rip-out-world` worktree during housekeeping.