### PR TITLE
fix(release): regen ABI for WorldPauseFacet + route guard for /agents + /owner

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -51,9 +51,19 @@ const root = ReactDOM.createRoot(document.getElementById('root')!);
 // actual page.
 const pathname =
   typeof window !== 'undefined' ? window.location.pathname : '';
-const isStandalonePath = ['/cockpit', '/agents', '/owner'].some(
-  (p) => pathname === p || pathname.startsWith(p + '/'),
-);
+// Match the actual route shapes defined in App.tsx:
+//   /cockpit          → isCockpitRoute (startsWith '/cockpit')
+//   /owner            → isOwnerRoute   (startsWith '/owner')
+//   /agents/:digits   → parseAgentRoute (regex /^\/agents\/(\d+)\/?$/)
+// Bare `/agents` is NOT a real route in App.tsx — it falls through to
+// MainApp (the WorldMap), which DOES need Convex. So `/agents` must only
+// be treated as standalone when followed by a digit segment.
+const isStandalonePath =
+  pathname === '/cockpit' ||
+  pathname.startsWith('/cockpit/') ||
+  pathname === '/owner' ||
+  pathname.startsWith('/owner/') ||
+  /^\/agents\/\d+\/?$/.test(pathname);
 
 if (!convexUrl && !isStandalonePath) {
   // Fail soft instead of throwing — a thrown error here leaves a blank page,

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -43,11 +43,20 @@ const root = ReactDOM.createRoot(document.getElementById('root')!);
 // env is missing. The Phase-A panels are pure placeholders; the embedded
 // WorldMap consumes Convex via useQuery which returns undefined when no
 // data is available, so a stub client is enough to satisfy the provider.
-const isCockpitPath =
-  typeof window !== 'undefined' &&
-  window.location.pathname.startsWith('/cockpit');
+//
+// `/agents/:id` (PR #9) + `/owner` (PR #14) are also Convex-free: they
+// render without any useQuery/useMutation calls, so the stub provider is
+// sufficient. Without these exemptions, screenshot/dev environments
+// without VITE_CONVEX_URL render "Backend not configured" instead of the
+// actual page.
+const pathname =
+  typeof window !== 'undefined' ? window.location.pathname : '';
+const isStandalonePath =
+  pathname.startsWith('/cockpit') ||
+  pathname.startsWith('/agents') ||
+  pathname.startsWith('/owner');
 
-if (!convexUrl && !isCockpitPath) {
+if (!convexUrl && !isStandalonePath) {
   // Fail soft instead of throwing — a thrown error here leaves a blank page,
   // which is unacceptable for the hackathon submission. Render a visible
   // message so the user sees something even if the build is misconfigured.

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -51,10 +51,9 @@ const root = ReactDOM.createRoot(document.getElementById('root')!);
 // actual page.
 const pathname =
   typeof window !== 'undefined' ? window.location.pathname : '';
-const isStandalonePath =
-  pathname.startsWith('/cockpit') ||
-  pathname.startsWith('/agents') ||
-  pathname.startsWith('/owner');
+const isStandalonePath = ['/cockpit', '/agents', '/owner'].some(
+  (p) => pathname === p || pathname.startsWith(p + '/'),
+);
 
 if (!convexUrl && !isStandalonePath) {
   // Fail soft instead of throwing — a thrown error here leaves a blank page,

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2444,6 +2444,16 @@
               "internalType": "uint64"
             },
             {
+              "name": "worldPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "pausedAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
               "name": "winterActive",
               "type": "bool",
               "internalType": "bool"
@@ -2604,6 +2614,16 @@
               "name": "nextCommitSequence",
               "type": "uint64",
               "internalType": "uint64"
+            },
+            {
+              "name": "worldPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "pausedAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
             }
           ]
         }
@@ -2650,6 +2670,19 @@
     },
     {
       "type": "function",
+      "name": "isWorldPaused",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "mintClan",
       "inputs": [
         {
@@ -2670,6 +2703,13 @@
           "internalType": "uint256"
         }
       ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "pauseWorld",
+      "inputs": [],
+      "outputs": [],
       "stateMutability": "nonpayable"
     },
     {
@@ -3072,6 +3112,13 @@
           "internalType": "uint256"
         }
       ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "unpauseWorld",
+      "inputs": [],
       "outputs": [],
       "stateMutability": "nonpayable"
     },
@@ -4638,6 +4685,50 @@
         },
         {
           "name": "tick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WorldPaused",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "pausedAtTs",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WorldUnpaused",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "durationSeconds",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "nextHeartbeatAtTs",
           "type": "uint64",
           "indexed": false,
           "internalType": "uint64"

--- a/packages/contracts/abi/IClanWorldLens.json
+++ b/packages/contracts/abi/IClanWorldLens.json
@@ -1368,6 +1368,16 @@
               "internalType": "uint64"
             },
             {
+              "name": "worldPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "pausedAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
               "name": "winterActive",
               "type": "bool",
               "internalType": "bool"

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -219,6 +219,16 @@ export const CLAN_WORLD_ABI = [
             "name": "nextCommitSequence",
             "type": "uint64",
             "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
           }
         ]
       }
@@ -1089,6 +1099,16 @@ export const CLAN_WORLD_ABI = [
           },
           {
             "name": "nextHeartbeatAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
             "type": "uint64",
             "internalType": "uint64"
           },


### PR DESCRIPTION
Two bugs found by codex 5.5 manual review of PR #15 release. MUST land before #15 merges.

**HIGH** — `packages/contracts/abi/IClanWorld.json` was stale after PR #12 added pause fields to `WorldSnapshot` + `WorldState`. Convex indexer (`apps/server/convex/indexer.ts:580`) decoded `winterActive`/`activeBanditId`/`currentTickSeed` at wrong slot offsets. Regenerated via `pnpm codegen`.

**MEDIUM** — `/agents/:id` (PR #9) + `/owner` (PR #14) routes were caught by the no-Convex fallback guard in `main.tsx` and rendered "Backend not configured" instead of the page. Added to exemption list.

Found by codex 5.5 cross-cutting review.