### PR TITLE
test(runner): align reset expectations

### DIFF
--- a/packages/runner/test/composeSituationBlock.test.ts
+++ b/packages/runner/test/composeSituationBlock.test.ts
@@ -11,28 +11,26 @@ describe('composeSituationBlock', () => {
   it('warns on tick 9 that message history is about to be erased', () => {
     const block = composeSituationBlock({ elder: 2, clanId: '2', tick: 9 });
 
-    expect(block).toBe(
-      [
-        'TICK 9 Started',
-        'warning: message history is about to be erased. Save important continuity with `elder memory save`.',
-      ].join('\n'),
-    );
+    expect(block).toContain('TICK 9 Started');
+    expect(block).toContain('MEMORY-WIPE WARNING');
+    expect(block).toContain('your message history is erased on the next tick');
+    expect(block).toContain('elder memory save <key> <value>');
+    expect(block).toContain('Saved memory survives the wipe');
   });
 
   it('warns on tick 10 to save continuity and ack-clear', () => {
     const block = composeSituationBlock({ elder: 3, clanId: '3', tick: 10 });
 
-    expect(block).toBe(
-      [
-        'TICK 10 Started',
-        'warning: final tick before message history is erased. Save important continuity with `elder memory save`, then call `elder ack-clear` when done.',
-      ].join('\n'),
-    );
+    expect(block).toContain('TICK 10 Started');
+    expect(block).toContain('FINAL TICK');
+    expect(block).toContain('Last chance to save');
+    expect(block).toContain('elder memory save active-strategy');
+    expect(block).toContain('elder ack-clear');
   });
 
   it('repeats the warning cycle every 10 ticks', () => {
     expect(composeSituationBlock({ elder: 4, clanId: '4', tick: 19 })).toContain(
-      'message history is about to be erased',
+      'MEMORY-WIPE WARNING',
     );
     expect(composeSituationBlock({ elder: 4, clanId: '4', tick: 20 })).toContain(
       'elder ack-clear',

--- a/packages/runner/test/tickLoop.test.ts
+++ b/packages/runner/test/tickLoop.test.ts
@@ -6,6 +6,7 @@ import type {
   IElderPeerInbox,
   IRunnerInbox,
 } from '@clan-world/agents/seams';
+import { composeSituationBlock } from '../src/composeSituationBlock';
 import { tickLoop, type Logger, type PerElderDeps } from '../src/tickLoop';
 import { ELDER_IDS, type ElderId, type RunnerConfig } from '../src/types';
 
@@ -175,10 +176,7 @@ describe('tickLoop', () => {
       ELDER_IDS.map(elder => ({
         elder,
         tick: 10,
-        block: [
-          'TICK 10 Started',
-          'warning: final tick before message history is erased. Save important continuity with `elder memory save`, then call `elder ack-clear` when done.',
-        ].join('\n'),
+        block: composeSituationBlock({ elder, clanId: String(elder), tick: 10 }),
       })),
     );
     expect(resets).toEqual(ELDER_IDS.map(elder => ({ elder, timeoutMs: 100 })));

--- a/packages/runner/test/tmuxRunnerInbox.test.ts
+++ b/packages/runner/test/tmuxRunnerInbox.test.ts
@@ -145,14 +145,21 @@ describe('TmuxRunnerInbox.waitForAckAndClear', () => {
     });
     const result = await inbox.waitForAckAndClear(500);
     expect(result).toBe('timeout');
-    // /clear + Enter + retry Enter + bootstrap + Enter + retry Enter = 6 calls.
-    expect(tmux.calls).toHaveLength(6);
+    // /clear, per-elder display reset, and bootstrap are each submitted with
+    // Enter twice because Claude Code can drop the first Enter after paste/send.
+    expect(tmux.calls).toHaveLength(12);
     expect(tmux.calls[0]).toEqual({ target: 'elder-1', keys: ['/clear'], literal: false });
     expect(tmux.calls[1]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
     expect(tmux.calls[2]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
-    expect(tmux.calls[3]).toEqual({ target: 'elder-1', keys: ['BOOT'], literal: true });
+    expect(tmux.calls[3]).toEqual({ target: 'elder-1', keys: ['/rename Clan World: Storm Riders'], literal: false });
     expect(tmux.calls[4]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
     expect(tmux.calls[5]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
+    expect(tmux.calls[6]).toEqual({ target: 'elder-1', keys: ['/color blue'], literal: false });
+    expect(tmux.calls[7]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
+    expect(tmux.calls[8]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
+    expect(tmux.calls[9]).toEqual({ target: 'elder-1', keys: ['BOOT'], literal: true });
+    expect(tmux.calls[10]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
+    expect(tmux.calls[11]).toEqual({ target: 'elder-1', keys: ['Enter'], literal: false });
   });
 
   it('returns ack and consumes the flag file when it exists', async () => {


### PR DESCRIPTION
## Summary

- update runner warning tests for the current rich memory-wipe guidance
- make the tick loop reset test derive its expected block from `composeSituationBlock`
- update tmux reset expectations for the current `/rename` and `/color` re-bootstrap sequence

## Validation

- `pnpm --filter @clan-world/runner exec vitest run test/composeSituationBlock.test.ts test/tickLoop.test.ts test/tmuxRunnerInbox.test.ts`
- `pnpm --filter @clan-world/runner test`
- `pnpm --filter @clan-world/runner typecheck`
