### PR TITLE
fix(android): allow private release without attestations

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -58,6 +58,7 @@ jobs:
           sha256sum *.apk > SHA256SUMS.txt
 
       - name: Attest APK build provenance
+        continue-on-error: true
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: "release-assets/*.apk"


### PR DESCRIPTION
## What changed
- Makes APK provenance attestation non-blocking because GitHub attestations are unavailable on the current private org/repo plan.
- Keeps APK build, release artifact upload, and SHA256SUMS generation mandatory.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-release.yml")'`
- `yq . .github/workflows/android-release.yml`