### PR TITLE
fix(android): open Kickstart pages in Chrome Custom Tabs

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
     applicationId = "world.clan.gold"
     minSdk = 26
     targetSdk = 35
-    versionCode = 1
-    versionName = "0.1.0"
+    versionCode = 2
+    versionName = "0.1.1"
     buildConfigField("String", "CONVEX_URL", "\"${convexUrl.get()}\"")
     buildConfigField("String", "TOKEN_URL", "\"${tokenUrl.get()}\"")
   }
@@ -34,4 +34,8 @@ android {
   kotlinOptions {
     jvmTarget = "17"
   }
+}
+
+dependencies {
+  implementation("androidx.browser:browser:1.8.0")
 }

--- a/apps/android/app/src/main/java/world/clan/gold/MainActivity.kt
+++ b/apps/android/app/src/main/java/world/clan/gold/MainActivity.kt
@@ -1,47 +1,23 @@
 package world.clan.gold
 
 import android.app.Activity
+import android.net.Uri
 import android.os.Bundle
-import android.view.View
-import android.view.ViewGroup
 import android.widget.FrameLayout
-import android.webkit.WebView
-import android.webkit.WebViewClient
+import androidx.browser.customtabs.CustomTabsIntent
 
 class MainActivity : Activity() {
-  private lateinit var webView: WebView
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     window.statusBarColor = getColor(R.color.widget_bg)
     window.navigationBarColor = getColor(R.color.widget_bg)
 
-    val container = FrameLayout(this)
-    webView = WebView(this)
-    webView.webViewClient = WebViewClient()
-    webView.settings.javaScriptEnabled = true
-    webView.settings.domStorageEnabled = true
-    container.setBackgroundColor(getColor(R.color.widget_bg))
-    webView.setBackgroundColor(getColor(R.color.widget_bg))
-    container.addView(
-      webView,
-      FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT),
-    )
-    container.setOnApplyWindowInsetsListener { view, insets ->
-      @Suppress("DEPRECATION")
-      view.setPadding(0, insets.systemWindowInsetTop, 0, 0)
-      insets
-    }
+    val container = FrameLayout(this).apply { setBackgroundColor(getColor(R.color.widget_bg)) }
     setContentView(container)
-    container.requestApplyInsets()
-    webView.loadUrl(BuildConfig.TOKEN_URL)
-  }
-
-  override fun onBackPressed() {
-    if (::webView.isInitialized && webView.canGoBack()) {
-      webView.goBack()
-    } else {
-      super.onBackPressed()
-    }
+    CustomTabsIntent.Builder()
+      .setShowTitle(true)
+      .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+      .build()
+      .launchUrl(this, Uri.parse(BuildConfig.TOKEN_URL))
   }
 }

--- a/apps/android/gradle.properties
+++ b/apps/android/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/apps/kickstart-mobile/app/build.gradle.kts
+++ b/apps/kickstart-mobile/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
     applicationId = "io.easya.kickstart"
     minSdk = 26
     targetSdk = 35
-    versionCode = 1
-    versionName = "0.1.0"
+    versionCode = 2
+    versionName = "0.1.1"
     buildConfigField("String", "CONVEX_URL", "\"${convexUrl.get()}\"")
     buildConfigField("String", "HOME_URL", "\"${homeUrl.get()}\"")
   }
@@ -34,4 +34,8 @@ android {
   kotlinOptions {
     jvmTarget = "17"
   }
+}
+
+dependencies {
+  implementation("androidx.browser:browser:1.8.0")
 }

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/MainActivity.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/MainActivity.kt
@@ -1,19 +1,18 @@
 package io.easya.kickstart
 
 import android.app.Activity
+import android.net.Uri
 import android.os.Bundle
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
-import android.webkit.WebView
-import android.webkit.WebViewClient
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
+import androidx.browser.customtabs.CustomTabsIntent
 
 class MainActivity : Activity() {
-  private lateinit var webView: WebView
   private lateinit var content: FrameLayout
   private lateinit var homeTab: TextView
   private lateinit var listTab: TextView
@@ -57,14 +56,7 @@ class MainActivity : Activity() {
   private fun showHome(url: String) {
     selectedUrl = url
     selectTab(homeTab)
-    content.removeAllViews()
-    webView = WebView(this)
-    webView.webViewClient = WebViewClient()
-    webView.settings.javaScriptEnabled = true
-    webView.settings.domStorageEnabled = true
-    webView.setBackgroundColor(getColor(R.color.widget_bg))
-    content.addView(webView, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
-    webView.loadUrl(url)
+    openKickstartUrl(url)
   }
 
   private fun showLeaderboard() {
@@ -88,7 +80,9 @@ class MainActivity : Activity() {
           tokens.forEach { token ->
             list.addView(tokenRow(token) {
               KickstartClient.watchToken(token.tokenMint)
-              showHome("${BuildConfig.HOME_URL.trimEnd('/')}/token/${token.tokenMint}")
+              selectedUrl = "${BuildConfig.HOME_URL.trimEnd('/')}/token/${token.tokenMint}"
+              selectTab(homeTab)
+              openKickstartUrl(selectedUrl)
             })
           }
         }
@@ -147,9 +141,12 @@ class MainActivity : Activity() {
 
   private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
 
-  override fun onBackPressed() {
-    if (::webView.isInitialized && webView.canGoBack()) webView.goBack()
-    else super.onBackPressed()
+  private fun openKickstartUrl(url: String) {
+    CustomTabsIntent.Builder()
+      .setShowTitle(true)
+      .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+      .build()
+      .launchUrl(this, Uri.parse(url))
   }
 
   companion object {

--- a/apps/kickstart-mobile/gradle.properties
+++ b/apps/kickstart-mobile/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
## What changed
- Replaces embedded WebView loading for Kickstart pages with Android Chrome Custom Tabs in both Android apps.
- Adds AndroidX Browser and enables AndroidX for both app builds.
- Bumps both Android app versions to 0.1.1 / versionCode 2.

## Why
The embedded WebView cannot handle Solana Mobile Wallet Adapter URLs like `solana-wallet:/v1/associate...`, causing `UNKNOWN_URL_SCHEME`. Custom Tabs run the site in the browser path where mobile wallet handoff has a chance to work correctly on Solana Mobile.

## Validation
- `pnpm --filter @clan-world/android build`
- `pnpm --filter @clan-world/android test`
- `pnpm --filter @clan-world/kickstart-mobile build`
- `pnpm --filter @clan-world/kickstart-mobile test`