### PR TITLE
feat(android): show kickstart token images in widgets

### DIFF
--- a/apps/kickstart-mobile/app/build.gradle.kts
+++ b/apps/kickstart-mobile/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
     applicationId = "io.easya.kickstart"
     minSdk = 26
     targetSdk = 35
-    versionCode = 3
-    versionName = "0.1.2"
+    versionCode = 4
+    versionName = "0.1.3"
     buildConfigField("String", "CONVEX_URL", "\"${convexUrl.get()}\"")
     buildConfigField("String", "HOME_URL", "\"${homeUrl.get()}\"")
   }

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetProvider.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetProvider.kt
@@ -38,9 +38,28 @@ open class KickstartWidgetProvider : AppWidgetProvider() {
         clickIntent,
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
       )
-      val views = KickstartWidgetRenderer.render(context, token, layoutRes, WidgetStore.getWidgetChartType(context, appWidgetId))
+      val views = KickstartWidgetRenderer.render(
+        context,
+        token,
+        layoutRes,
+        WidgetStore.getWidgetChartType(context, appWidgetId),
+        TokenImageLoader.widgetCoinBitmap(context, token, allowNetwork = false),
+      )
       views.setOnClickPendingIntent(R.id.widget_root, pendingIntent)
       manager.updateAppWidget(appWidgetId, views)
+      if (TokenImageLoader.shouldFetchWidgetImage(token)) {
+        Thread {
+          val refreshedViews = KickstartWidgetRenderer.render(
+            context,
+            token,
+            layoutRes,
+            WidgetStore.getWidgetChartType(context, appWidgetId),
+            TokenImageLoader.widgetCoinBitmap(context, token, allowNetwork = true),
+          )
+          refreshedViews.setOnClickPendingIntent(R.id.widget_root, pendingIntent)
+          manager.updateAppWidget(appWidgetId, refreshedViews)
+        }.start()
+      }
     }
   }
 }
@@ -72,7 +91,7 @@ object WidgetStore {
 
   fun getWidgetChartType(context: Context, appWidgetId: Int): String {
     return context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-      .getString("widget_${appWidgetId}_chart_type", "line")
+      .getString("widget_${appWidgetId}_chart_type", "candles")
       ?.takeIf { it == "candles" }
       ?: "line"
   }

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetRenderer.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetRenderer.kt
@@ -19,15 +19,20 @@ object KickstartWidgetRenderer {
     context: Context,
     token: KickstartToken?,
     layoutRes: Int = R.layout.gold_widget,
-    chartType: String = "line",
+    chartType: String = "candles",
+    coinBitmap: Bitmap? = null,
   ): RemoteViews {
     val views = RemoteViews(context.packageName, layoutRes)
     views.setTextViewText(R.id.symbol, token?.symbol ?: "PICK")
     views.setTextViewText(R.id.price, token?.let { formatPrice(it.usdPrice) } ?: "$--")
+    if (layoutRes == R.layout.gold_widget_tall) {
+      views.setTextViewText(R.id.project_name, token?.name ?: "Choose a token")
+    }
     views.setChange(R.id.change_1h, "1H", token?.priceChange1h)
     views.setChange(R.id.change_6h, "6H", token?.priceChange6h)
     views.setChange(R.id.change_24h, "24H", token?.priceChange24h)
     views.setChange(R.id.change_7d, "7D", token?.priceChange7d)
+    coinBitmap?.let { views.setImageViewBitmap(R.id.coin, it) }
     views.setImageViewBitmap(R.id.sparkline, drawChart(token, chartType))
     return views
   }

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/MainActivity.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/MainActivity.kt
@@ -12,6 +12,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
@@ -128,6 +129,11 @@ class MainActivity : Activity() {
       setPadding(dp(10), dp(10), dp(10), dp(10))
       setBackgroundColor(Colorish.card)
       setOnClickListener { onClick() }
+      val icon = ImageView(context).apply {
+        scaleType = ImageView.ScaleType.CENTER_CROP
+        clipToOutline = true
+      }
+      TokenImageLoader.loadInto(icon, token.iconUrl)
       val left = TextView(context).apply {
         text = "#${token.rank}  ${token.symbol}\n${token.name}"
         setTextColor(getColor(R.color.widget_text))
@@ -139,6 +145,9 @@ class MainActivity : Activity() {
         textSize = 13f
         gravity = Gravity.END
       }
+      addView(icon, LinearLayout.LayoutParams(dp(42), dp(42)).apply {
+        marginEnd = dp(10)
+      })
       addView(left, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
       addView(right)
     }

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/TokenImageLoader.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/TokenImageLoader.kt
@@ -1,0 +1,96 @@
+package io.easya.kickstart
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Shader
+import android.graphics.BitmapShader
+import android.widget.ImageView
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.min
+
+object TokenImageLoader {
+  private const val GOLD_MINT = "4kWysUHVqtFmxrvwPUxA66exm2iJBMkvD4EBRrNmcieL"
+  private val cache = ConcurrentHashMap<String, Bitmap>()
+
+  fun loadInto(imageView: ImageView, iconUrl: String?, fallbackRes: Int = R.drawable.kickstart_icon) {
+    val url = normalizeUrl(iconUrl)
+    if (url == null) {
+      imageView.setImageResource(fallbackRes)
+      return
+    }
+    cache[url]?.let {
+      imageView.setImageBitmap(it)
+      return
+    }
+    imageView.setImageResource(fallbackRes)
+    Thread {
+      val bitmap = loadBitmap(url) ?: return@Thread
+      cache[url] = bitmap
+      imageView.post {
+        imageView.setImageBitmap(bitmap)
+      }
+    }.start()
+  }
+
+  fun widgetCoinBitmap(context: Context, token: KickstartToken?, allowNetwork: Boolean): Bitmap? {
+    if (token == null) return null
+    if (token.tokenMint == GOLD_MINT) {
+      return circleCrop(BitmapFactory.decodeResource(context.resources, R.drawable.gold_widget_logo))
+    }
+    val url = normalizeUrl(token.iconUrl)
+    val source = when {
+      url == null -> BitmapFactory.decodeResource(context.resources, R.drawable.kickstart_icon)
+      cache[url] != null -> cache[url]
+      allowNetwork -> loadBitmap(url)?.also { cache[url] = it }
+        ?: BitmapFactory.decodeResource(context.resources, R.drawable.kickstart_icon)
+      else -> BitmapFactory.decodeResource(context.resources, R.drawable.kickstart_icon)
+    }
+    return source?.let { circleCrop(it) }
+  }
+
+  fun shouldFetchWidgetImage(token: KickstartToken?): Boolean {
+    val selected = token ?: return false
+    val url = normalizeUrl(selected.iconUrl) ?: return false
+    return selected.tokenMint != GOLD_MINT && cache[url] == null
+  }
+
+  private fun loadBitmap(url: String): Bitmap? {
+    return runCatching {
+      val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+        connectTimeout = 7_000
+        readTimeout = 7_000
+        instanceFollowRedirects = true
+      }
+      connection.inputStream.use { BitmapFactory.decodeStream(it) }
+    }.getOrNull()
+  }
+
+  private fun normalizeUrl(iconUrl: String?): String? {
+    val trimmed = iconUrl?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    return if (trimmed.startsWith("ipfs://")) {
+      "https://ipfs.io/ipfs/${trimmed.removePrefix("ipfs://").trimStart('/')}"
+    } else {
+      trimmed
+    }
+  }
+
+  private fun circleCrop(source: Bitmap): Bitmap {
+    val size = min(source.width, source.height)
+    val left = (source.width - size) / 2
+    val top = (source.height - size) / 2
+    val square = Bitmap.createBitmap(source, left, top, size, size)
+    val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(output)
+    val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+      shader = BitmapShader(square, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
+    }
+    canvas.drawOval(RectF(0f, 0f, size.toFloat(), size.toFloat()), paint)
+    return output
+  }
+}

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/WidgetConfigActivity.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/WidgetConfigActivity.kt
@@ -9,13 +9,14 @@ import android.view.ViewGroup
 import android.text.Editable
 import android.text.TextWatcher
 import android.widget.EditText
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 
 class WidgetConfigActivity : Activity() {
   private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
-  private var selectedChartType = "line"
+  private var selectedChartType = "candles"
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -109,8 +110,15 @@ class WidgetConfigActivity : Activity() {
     gravity = Gravity.CENTER_VERTICAL
     setPadding(dp(10), dp(12), dp(10), dp(12))
     setOnClickListener { onClick() }
+    val icon = ImageView(context).apply {
+      scaleType = ImageView.ScaleType.CENTER_CROP
+    }
+    TokenImageLoader.loadInto(icon, token.iconUrl)
     val left = text("#${token.rank}  ${token.symbol}\n${token.name}", 14, getColor(R.color.widget_text))
     val right = text("$" + "%,.0f".format(token.mcap), 13, getColor(R.color.widget_gold)).apply { gravity = Gravity.END }
+    addView(icon, LinearLayout.LayoutParams(dp(40), dp(40)).apply {
+      marginEnd = dp(10)
+    })
     addView(left, LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f))
     addView(right)
   }

--- a/apps/kickstart-mobile/app/src/main/res/layout/gold_widget.xml
+++ b/apps/kickstart-mobile/app/src/main/res/layout/gold_widget.xml
@@ -29,13 +29,17 @@
     android:fontFamily="sans-serif-black"
     android:includeFontPadding="false"
     android:letterSpacing="0"
+    android:shadowColor="#CC000000"
+    android:shadowDx="1"
+    android:shadowDy="1"
+    android:shadowRadius="3"
     android:text="GOLD"
     android:textColor="@color/widget_text"
     android:textSize="22sp" />
 
   <LinearLayout
     android:id="@+id/change_column"
-    android:layout_width="72dp"
+    android:layout_width="80dp"
     android:layout_height="wrap_content"
     android:layout_gravity="top|end"
     android:layout_marginTop="9dp"
@@ -91,11 +95,11 @@
   <ImageView
     android:id="@+id/sparkline"
     android:layout_width="match_parent"
-    android:layout_height="34dp"
+    android:layout_height="42dp"
     android:layout_gravity="center"
     android:layout_marginStart="16dp"
     android:layout_marginTop="8dp"
-    android:layout_marginEnd="72dp"
+    android:layout_marginEnd="82dp"
     android:background="@drawable/sparkline_placeholder"
     android:contentDescription="@string/app_name"
     android:scaleType="fitXY" />

--- a/apps/kickstart-mobile/app/src/main/res/layout/gold_widget_tall.xml
+++ b/apps/kickstart-mobile/app/src/main/res/layout/gold_widget_tall.xml
@@ -29,13 +29,17 @@
     android:fontFamily="sans-serif-black"
     android:includeFontPadding="false"
     android:letterSpacing="0"
+    android:shadowColor="#CC000000"
+    android:shadowDx="1"
+    android:shadowDy="1"
+    android:shadowRadius="4"
     android:text="GOLD"
     android:textColor="@color/widget_text"
     android:textSize="30sp" />
 
   <LinearLayout
     android:id="@+id/change_column"
-    android:layout_width="72dp"
+    android:layout_width="82dp"
     android:layout_height="wrap_content"
     android:layout_gravity="top|end"
     android:layout_marginTop="9dp"
@@ -52,7 +56,7 @@
       android:includeFontPadding="false"
       android:text="1H --"
       android:textColor="@color/widget_muted"
-      android:textSize="11sp" />
+      android:textSize="12sp" />
 
     <TextView
       android:id="@+id/change_6h"
@@ -63,7 +67,7 @@
       android:includeFontPadding="false"
       android:text="6H --"
       android:textColor="@color/widget_muted"
-      android:textSize="11sp" />
+      android:textSize="12sp" />
 
     <TextView
       android:id="@+id/change_24h"
@@ -74,7 +78,7 @@
       android:includeFontPadding="false"
       android:text="24H --"
       android:textColor="@color/widget_muted"
-      android:textSize="11sp" />
+      android:textSize="12sp" />
 
     <TextView
       android:id="@+id/change_7d"
@@ -85,32 +89,56 @@
       android:includeFontPadding="false"
       android:text="7D --"
       android:textColor="@color/widget_muted"
-      android:textSize="11sp" />
+      android:textSize="12sp" />
   </LinearLayout>
 
   <ImageView
     android:id="@+id/sparkline"
     android:layout_width="match_parent"
-    android:layout_height="50dp"
+    android:layout_height="64dp"
     android:layout_gravity="center"
     android:layout_marginStart="16dp"
     android:layout_marginTop="12dp"
-    android:layout_marginEnd="74dp"
+    android:layout_marginEnd="84dp"
     android:background="@drawable/sparkline_placeholder"
     android:contentDescription="@string/app_name"
     android:scaleType="fitXY" />
 
-  <TextView
-    android:id="@+id/price"
+  <LinearLayout
+    android:id="@+id/price_block"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="bottom|start"
     android:layout_marginStart="12dp"
     android:layout_marginBottom="12dp"
-    android:fontFamily="sans-serif-black"
-    android:includeFontPadding="false"
-    android:maxLines="1"
-    android:text="$--"
-    android:textColor="@color/widget_text"
-    android:textSize="23sp" />
+    android:orientation="vertical">
+
+    <TextView
+      android:id="@+id/price"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:fontFamily="sans-serif-black"
+      android:includeFontPadding="false"
+      android:maxLines="1"
+      android:text="$--"
+      android:textColor="@color/widget_text"
+      android:textSize="23sp" />
+
+    <TextView
+      android:id="@+id/project_name"
+      android:layout_width="138dp"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="2dp"
+      android:ellipsize="end"
+      android:fontFamily="sans-serif-medium"
+      android:includeFontPadding="false"
+      android:maxLines="1"
+      android:shadowColor="#CC000000"
+      android:shadowDx="1"
+      android:shadowDy="1"
+      android:shadowRadius="3"
+      android:text="Choose a token"
+      android:textColor="@color/widget_muted"
+      android:textSize="11sp" />
+  </LinearLayout>
 </FrameLayout>


### PR DESCRIPTION
## Summary
- load Kickstart token images into the Top 100 list and widget config picker
- render selected-token widget art as a circular cropped coin, with a GOLD-only override for the existing local GOLD widget logo
- default new widgets to candles and polish widget spacing, ticker contrast, chart height, and tall-widget project name

## Validation
- `ANDROID_HOME=/opt/android-sdk ./gradlew --no-daemon assembleDebug` from `apps/kickstart-mobile`
