### PR TITLE
fix(android): widen widget chart layout

### DIFF
--- a/apps/kickstart-mobile/app/build.gradle.kts
+++ b/apps/kickstart-mobile/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
     applicationId = "io.easya.kickstart"
     minSdk = 26
     targetSdk = 35
-    versionCode = 4
-    versionName = "0.1.3"
+    versionCode = 5
+    versionName = "0.1.4"
     buildConfigField("String", "CONVEX_URL", "\"${convexUrl.get()}\"")
     buildConfigField("String", "HOME_URL", "\"${homeUrl.get()}\"")
   }

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetRenderer.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetRenderer.kt
@@ -23,11 +23,12 @@ object KickstartWidgetRenderer {
     coinBitmap: Bitmap? = null,
   ): RemoteViews {
     val views = RemoteViews(context.packageName, layoutRes)
-    views.setTextViewText(R.id.symbol, token?.symbol ?: "PICK")
+    val symbol = token?.symbol ?: "PICK"
+    val projectName = token?.name ?: "Choose a token"
+    views.setTextViewText(R.id.symbol_glow, symbol)
+    views.setTextViewText(R.id.symbol, symbol)
     views.setTextViewText(R.id.price, token?.let { formatPrice(it.usdPrice) } ?: "$--")
-    if (layoutRes == R.layout.gold_widget_tall) {
-      views.setTextViewText(R.id.project_name, token?.name ?: "Choose a token")
-    }
+    views.setTextViewText(R.id.project_name, projectName)
     views.setChange(R.id.change_1h, "1H", token?.priceChange1h)
     views.setChange(R.id.change_6h, "6H", token?.priceChange6h)
     views.setChange(R.id.change_24h, "24H", token?.priceChange24h)

--- a/apps/kickstart-mobile/app/src/main/res/layout/gold_widget.xml
+++ b/apps/kickstart-mobile/app/src/main/res/layout/gold_widget.xml
@@ -20,6 +20,24 @@
     android:src="@drawable/gold_widget_logo" />
 
   <TextView
+    android:id="@+id/symbol_glow"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="top|start"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="8dp"
+    android:fontFamily="sans-serif-black"
+    android:includeFontPadding="false"
+    android:letterSpacing="0"
+    android:shadowColor="#E6000000"
+    android:shadowDx="0"
+    android:shadowDy="1"
+    android:shadowRadius="7"
+    android:text="GOLD"
+    android:textColor="@android:color/transparent"
+    android:textSize="24sp" />
+
+  <TextView
     android:id="@+id/symbol"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -35,7 +53,7 @@
     android:shadowRadius="3"
     android:text="GOLD"
     android:textColor="@color/widget_text"
-    android:textSize="22sp" />
+    android:textSize="24sp" />
 
   <LinearLayout
     android:id="@+id/change_column"
@@ -97,24 +115,48 @@
     android:layout_width="match_parent"
     android:layout_height="42dp"
     android:layout_gravity="center"
-    android:layout_marginStart="16dp"
+    android:layout_marginStart="12dp"
     android:layout_marginTop="8dp"
-    android:layout_marginEnd="82dp"
+    android:layout_marginEnd="64dp"
     android:background="@drawable/sparkline_placeholder"
     android:contentDescription="@string/app_name"
     android:scaleType="fitXY" />
 
-  <TextView
-    android:id="@+id/price"
+  <LinearLayout
+    android:id="@+id/price_block"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="bottom|start"
     android:layout_marginStart="8dp"
-    android:layout_marginBottom="7dp"
-    android:fontFamily="sans-serif-black"
-    android:includeFontPadding="false"
-    android:maxLines="1"
-    android:text="$--"
-    android:textColor="@color/widget_text"
-    android:textSize="19sp" />
+    android:layout_marginBottom="6dp"
+    android:orientation="vertical">
+
+    <TextView
+      android:id="@+id/price"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:fontFamily="sans-serif-black"
+      android:includeFontPadding="false"
+      android:maxLines="1"
+      android:text="$--"
+      android:textColor="@color/widget_text"
+      android:textSize="18sp" />
+
+    <TextView
+      android:id="@+id/project_name"
+      android:layout_width="128dp"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="1dp"
+      android:ellipsize="end"
+      android:fontFamily="sans-serif-medium"
+      android:includeFontPadding="false"
+      android:maxLines="1"
+      android:shadowColor="#CC000000"
+      android:shadowDx="1"
+      android:shadowDy="1"
+      android:shadowRadius="3"
+      android:text="Choose a token"
+      android:textColor="@color/widget_muted"
+      android:textSize="9sp" />
+  </LinearLayout>
 </FrameLayout>

--- a/apps/kickstart-mobile/app/src/main/res/layout/gold_widget_tall.xml
+++ b/apps/kickstart-mobile/app/src/main/res/layout/gold_widget_tall.xml
@@ -20,6 +20,24 @@
     android:src="@drawable/gold_widget_logo" />
 
   <TextView
+    android:id="@+id/symbol_glow"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="top|start"
+    android:layout_marginStart="12dp"
+    android:layout_marginTop="12dp"
+    android:fontFamily="sans-serif-black"
+    android:includeFontPadding="false"
+    android:letterSpacing="0"
+    android:shadowColor="#E6000000"
+    android:shadowDx="0"
+    android:shadowDy="1"
+    android:shadowRadius="9"
+    android:text="GOLD"
+    android:textColor="@android:color/transparent"
+    android:textSize="30sp" />
+
+  <TextView
     android:id="@+id/symbol"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -97,9 +115,9 @@
     android:layout_width="match_parent"
     android:layout_height="64dp"
     android:layout_gravity="center"
-    android:layout_marginStart="16dp"
+    android:layout_marginStart="12dp"
     android:layout_marginTop="12dp"
-    android:layout_marginEnd="84dp"
+    android:layout_marginEnd="64dp"
     android:background="@drawable/sparkline_placeholder"
     android:contentDescription="@string/app_name"
     android:scaleType="fitXY" />
@@ -139,6 +157,6 @@
       android:shadowRadius="3"
       android:text="Choose a token"
       android:textColor="@color/widget_muted"
-      android:textSize="11sp" />
+      android:textSize="12sp" />
   </LinearLayout>
 </FrameLayout>


### PR DESCRIPTION
## Summary
- widen compact and tall widget chart area toward the left 3/5 of the widget
- add project name under the compact widget price and slightly enlarge the tall project name
- enlarge compact ticker text and add a second fuzzy ticker shadow layer behind the crisp outline

## Validation
- `ANDROID_HOME=/opt/android-sdk ./gradlew --no-daemon assembleDebug` from `apps/kickstart-mobile`
