### PR TITLE
fix(android): show browser fallback for wallet links

### DIFF
--- a/apps/kickstart-mobile/app/build.gradle.kts
+++ b/apps/kickstart-mobile/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
     applicationId = "io.easya.kickstart"
     minSdk = 26
     targetSdk = 35
-    versionCode = 5
-    versionName = "0.1.4"
+    versionCode = 6
+    versionName = "0.1.5"
     buildConfigField("String", "CONVEX_URL", "\"${convexUrl.get()}\"")
     buildConfigField("String", "HOME_URL", "\"${homeUrl.get()}\"")
   }

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/MainActivity.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/MainActivity.kt
@@ -1,6 +1,7 @@
 package io.easya.kickstart
 
 import android.app.Activity
+import android.app.AlertDialog
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
@@ -23,6 +24,7 @@ class MainActivity : Activity() {
   private lateinit var homeTab: TextView
   private lateinit var listTab: TextView
   private var selectedUrl: String = BuildConfig.HOME_URL
+  private var walletDialog: AlertDialog? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -184,21 +186,57 @@ class MainActivity : Activity() {
   private fun handleExternalUrl(uri: Uri): Boolean {
     val scheme = uri.scheme?.lowercase() ?: return false
     if (scheme == "http" || scheme == "https") return false
-    val intent = if (scheme == "intent") {
-      runCatching { Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME) }.getOrNull()
-    } else {
-      Intent(Intent.ACTION_VIEW, uri)
-    } ?: return true
-    runCatching {
-      intent.addCategory(Intent.CATEGORY_BROWSABLE)
-      intent.component = null
-      startActivity(intent)
-    }.recoverCatching { error ->
-      if (error is ActivityNotFoundException && intent.getStringExtra("browser_fallback_url") != null) {
-        webView.loadUrl(intent.getStringExtra("browser_fallback_url")!!)
-      }
-    }
+    if (isWalletUrl(uri)) showOpenInChromeDialog()
     return true
+  }
+
+  private fun isWalletUrl(uri: Uri): Boolean {
+    val value = uri.toString().lowercase()
+    val scheme = uri.scheme?.lowercase()
+    if (scheme == "solana-wallet" || scheme == "phantom" || scheme == "solflare") return true
+    if (scheme != "intent") return value.contains("solana-wallet") || value.contains("phantom") || value.contains("solflare")
+    val intent = runCatching { Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME) }.getOrNull()
+    val parsedScheme = intent?.scheme?.lowercase()
+    val fallback = intent?.getStringExtra("browser_fallback_url")?.lowercase()
+    return parsedScheme == "solana-wallet" ||
+      parsedScheme == "phantom" ||
+      parsedScheme == "solflare" ||
+      fallback?.contains("solana-wallet") == true ||
+      fallback?.contains("phantom") == true ||
+      fallback?.contains("solflare") == true ||
+      value.contains("solana-wallet") ||
+      value.contains("phantom") ||
+      value.contains("solflare")
+  }
+
+  private fun showOpenInChromeDialog() {
+    if (isFinishing || isDestroyed) return
+    if (walletDialog?.isShowing == true) return
+    walletDialog = AlertDialog.Builder(this)
+      .setTitle("Open in Chrome")
+      .setMessage("Wallet connection is not supported inside this app. Open this token page in Chrome to connect a wallet.")
+      .setPositiveButton("Open") { _, _ -> openSelectedPageInBrowser() }
+      .setNegativeButton("Cancel", null)
+      .create()
+      .also { dialog ->
+        dialog.setOnDismissListener { walletDialog = null }
+        dialog.show()
+      }
+  }
+
+  private fun openSelectedPageInBrowser() {
+    val pageUrl = selectedUrl.takeIf { it.startsWith("http://") || it.startsWith("https://") } ?: BuildConfig.HOME_URL
+    val uri = Uri.parse(pageUrl)
+    val chromeIntent = Intent(Intent.ACTION_VIEW, uri).apply {
+      addCategory(Intent.CATEGORY_BROWSABLE)
+      setPackage("com.android.chrome")
+    }
+    runCatching { startActivity(chromeIntent) }
+      .recoverCatching { error ->
+        if (error is ActivityNotFoundException) {
+          startActivity(Intent(Intent.ACTION_VIEW, uri).addCategory(Intent.CATEGORY_BROWSABLE))
+        }
+      }
   }
 
   override fun onBackPressed() {


### PR DESCRIPTION
## Summary
- stop launching wallet app/deep-link intents from the Kickstart WebView
- intercept Solana/Phantom/Solflare wallet URLs and show an Open in Chrome modal instead
- open the current Kickstart HTTP page in Chrome/browser from that modal

## Validation
- `ANDROID_HOME=/opt/android-sdk ./gradlew --no-daemon assembleDebug` from `apps/kickstart-mobile`
