### PR TITLE
fix(android): expand tall widget chart

### DIFF
--- a/apps/kickstart-mobile/app/build.gradle.kts
+++ b/apps/kickstart-mobile/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
     applicationId = "io.easya.kickstart"
     minSdk = 26
     targetSdk = 35
-    versionCode = 6
-    versionName = "0.1.5"
+    versionCode = 7
+    versionName = "0.1.6"
     buildConfigField("String", "CONVEX_URL", "\"${convexUrl.get()}\"")
     buildConfigField("String", "HOME_URL", "\"${homeUrl.get()}\"")
   }

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetRenderer.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetRenderer.kt
@@ -25,7 +25,6 @@ object KickstartWidgetRenderer {
     val views = RemoteViews(context.packageName, layoutRes)
     val symbol = token?.symbol ?: "PICK"
     val projectName = token?.name ?: "Choose a token"
-    views.setTextViewText(R.id.symbol_glow, symbol)
     views.setTextViewText(R.id.symbol, symbol)
     views.setTextViewText(R.id.price, token?.let { formatPrice(it.usdPrice) } ?: "$--")
     views.setTextViewText(R.id.project_name, projectName)

--- a/apps/kickstart-mobile/app/src/main/res/layout/gold_widget.xml
+++ b/apps/kickstart-mobile/app/src/main/res/layout/gold_widget.xml
@@ -20,24 +20,6 @@
     android:src="@drawable/gold_widget_logo" />
 
   <TextView
-    android:id="@+id/symbol_glow"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_gravity="top|start"
-    android:layout_marginStart="8dp"
-    android:layout_marginTop="8dp"
-    android:fontFamily="sans-serif-black"
-    android:includeFontPadding="false"
-    android:letterSpacing="0"
-    android:shadowColor="#E6000000"
-    android:shadowDx="0"
-    android:shadowDy="1"
-    android:shadowRadius="7"
-    android:text="GOLD"
-    android:textColor="@android:color/transparent"
-    android:textSize="24sp" />
-
-  <TextView
     android:id="@+id/symbol"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"

--- a/apps/kickstart-mobile/app/src/main/res/layout/gold_widget_tall.xml
+++ b/apps/kickstart-mobile/app/src/main/res/layout/gold_widget_tall.xml
@@ -20,24 +20,6 @@
     android:src="@drawable/gold_widget_logo" />
 
   <TextView
-    android:id="@+id/symbol_glow"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_gravity="top|start"
-    android:layout_marginStart="12dp"
-    android:layout_marginTop="12dp"
-    android:fontFamily="sans-serif-black"
-    android:includeFontPadding="false"
-    android:letterSpacing="0"
-    android:shadowColor="#E6000000"
-    android:shadowDx="0"
-    android:shadowDy="1"
-    android:shadowRadius="9"
-    android:text="GOLD"
-    android:textColor="@android:color/transparent"
-    android:textSize="30sp" />
-
-  <TextView
     android:id="@+id/symbol"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -113,11 +95,11 @@
   <ImageView
     android:id="@+id/sparkline"
     android:layout_width="match_parent"
-    android:layout_height="64dp"
+    android:layout_height="128dp"
     android:layout_gravity="center"
     android:layout_marginStart="12dp"
     android:layout_marginTop="12dp"
-    android:layout_marginEnd="64dp"
+    android:layout_marginEnd="36dp"
     android:background="@drawable/sparkline_placeholder"
     android:contentDescription="@string/app_name"
     android:scaleType="fitXY" />
@@ -157,6 +139,6 @@
       android:shadowRadius="3"
       android:text="Choose a token"
       android:textColor="@color/widget_muted"
-      android:textSize="12sp" />
+      android:textSize="11sp" />
   </LinearLayout>
 </FrameLayout>


### PR DESCRIPTION
## Summary
- remove the extra fuzzy ticker shadow layer and return to the original single ticker shadow
- restore the tall widget project-name font size
- make the tall widget chart much taller and wider, using more of the available widget space

## Validation
- `ANDROID_HOME=/opt/android-sdk ./gradlew --no-daemon assembleDebug` from `apps/kickstart-mobile`
