### PR TITLE
feat(android): kickstart green theme + Top 100 default + image cache (v0.1.9)

### DIFF
--- a/apps/kickstart-mobile/app/build.gradle.kts
+++ b/apps/kickstart-mobile/app/build.gradle.kts
@@ -36,8 +36,8 @@ android {
     applicationId = "io.easya.kickstart"
     minSdk = 26
     targetSdk = 35
-    versionCode = 8
-    versionName = "0.1.8"
+    versionCode = 9
+    versionName = "0.1.9"
     buildConfigField("String", "CONVEX_URL", "\"$convexUrl\"")
     buildConfigField("String", "HOME_URL", "\"$homeUrl\"")
   }

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetProvider.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetProvider.kt
@@ -47,7 +47,7 @@ open class KickstartWidgetProvider : AppWidgetProvider() {
       )
       views.setOnClickPendingIntent(R.id.widget_root, pendingIntent)
       manager.updateAppWidget(appWidgetId, views)
-      if (TokenImageLoader.shouldFetchWidgetImage(token)) {
+      if (TokenImageLoader.shouldFetchWidgetImage(context, token)) {
         Thread {
           val refreshedViews = KickstartWidgetRenderer.render(
             context,

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/MainActivity.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/MainActivity.kt
@@ -28,18 +28,19 @@ class MainActivity : Activity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    selectedUrl = sanitizeIncomingUrl(intent.getStringExtra(EXTRA_URL))
-    window.statusBarColor = getColor(R.color.widget_bg)
-    window.navigationBarColor = getColor(R.color.widget_bg)
+    val rawIncomingUrl = intent.getStringExtra(EXTRA_URL)
+    selectedUrl = sanitizeIncomingUrl(rawIncomingUrl)
+    window.statusBarColor = getColor(R.color.kickstart_bg)
+    window.navigationBarColor = getColor(R.color.kickstart_bg)
 
     val root = LinearLayout(this).apply {
       orientation = LinearLayout.VERTICAL
-      setBackgroundColor(getColor(R.color.widget_bg))
+      setBackgroundColor(getColor(R.color.kickstart_bg))
     }
     val tabs = LinearLayout(this).apply {
       orientation = LinearLayout.HORIZONTAL
       setPadding(dp(10), dp(8), dp(10), dp(8))
-      setBackgroundColor(getColor(R.color.widget_bg))
+      setBackgroundColor(getColor(R.color.kickstart_bg))
     }
     homeTab = tab("Home")
     listTab = tab("Top 100")
@@ -58,7 +59,11 @@ class MainActivity : Activity() {
 
     homeTab.setOnClickListener { showHome(selectedUrl) }
     listTab.setOnClickListener { showLeaderboard() }
-    showHome(selectedUrl)
+    if (rawIncomingUrl != null) {
+      showHome(selectedUrl)
+    } else {
+      showLeaderboard()
+    }
   }
 
   override fun onNewIntent(intent: Intent) {
@@ -88,7 +93,7 @@ class MainActivity : Activity() {
       }
       settings.javaScriptEnabled = true
       settings.domStorageEnabled = true
-      setBackgroundColor(getColor(R.color.widget_bg))
+      setBackgroundColor(getColor(R.color.kickstart_bg))
     }
     content.addView(webView, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
     webView.loadUrl(url)
@@ -97,7 +102,7 @@ class MainActivity : Activity() {
   private fun showLeaderboard() {
     selectTab(listTab)
     content.removeAllViews()
-    val scroll = ScrollView(this).apply { setBackgroundColor(getColor(R.color.widget_bg)) }
+    val scroll = ScrollView(this).apply { setBackgroundColor(getColor(R.color.kickstart_bg)) }
     val list = LinearLayout(this).apply {
       orientation = LinearLayout.VERTICAL
       setPadding(dp(12), dp(8), dp(12), dp(24))
@@ -160,12 +165,14 @@ class MainActivity : Activity() {
     text = label
     gravity = Gravity.CENTER
     textSize = 15f
-    setTextColor(getColor(R.color.widget_text))
+    setTextColor(getColor(R.color.kickstart_text))
   }
 
   private fun selectTab(selected: TextView) {
-    homeTab.setBackgroundColor(if (selected === homeTab) Colorish.card else getColor(R.color.widget_bg))
-    listTab.setBackgroundColor(if (selected === listTab) Colorish.card else getColor(R.color.widget_bg))
+    val bg = getColor(R.color.kickstart_bg)
+    val bgSelected = getColor(R.color.kickstart_bg_selected)
+    homeTab.setBackgroundColor(if (selected === homeTab) bgSelected else bg)
+    listTab.setBackgroundColor(if (selected === listTab) bgSelected else bg)
   }
 
   private fun rowText(text: String, size: Int, color: Int) = TextView(this).apply {

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/TokenImageLoader.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/TokenImageLoader.kt
@@ -10,13 +10,17 @@ import android.graphics.Shader
 import android.graphics.BitmapShader
 import android.util.LruCache
 import android.widget.ImageView
+import java.io.File
+import java.io.FileOutputStream
 import java.net.HttpURLConnection
 import java.net.URL
+import java.security.MessageDigest
 import java.util.concurrent.Executors
 import kotlin.math.min
 
 object TokenImageLoader {
   private const val GOLD_MINT = "4kWysUHVqtFmxrvwPUxA66exm2iJBMkvD4EBRrNmcieL"
+  private const val DISK_CACHE_DIR = "token-icons"
 
   // Cap total bitmap memory at ~6MB. Each cached icon is small (~16-64KB after
   // BitmapFactory decode, larger if the source is uncompressed PNG), so this
@@ -42,9 +46,15 @@ object TokenImageLoader {
       imageView.setImageBitmap(it)
       return
     }
+    val context = imageView.context.applicationContext
+    decodeFromDisk(context, url)?.let { bitmap ->
+      cache.put(url, bitmap)
+      imageView.setImageBitmap(bitmap)
+      return
+    }
     imageView.setImageResource(fallbackRes)
     executor.execute {
-      val bitmap = loadBitmap(url) ?: return@execute
+      val bitmap = loadBitmap(context, url) ?: return@execute
       cache.put(url, bitmap)
       imageView.post {
         imageView.setImageBitmap(bitmap)
@@ -61,28 +71,60 @@ object TokenImageLoader {
     val source = when {
       url == null -> BitmapFactory.decodeResource(context.resources, R.drawable.kickstart_icon)
       cache.get(url) != null -> cache.get(url)
-      allowNetwork -> loadBitmap(url)?.also { cache.put(url, it) }
-        ?: BitmapFactory.decodeResource(context.resources, R.drawable.kickstart_icon)
-      else -> BitmapFactory.decodeResource(context.resources, R.drawable.kickstart_icon)
+      else -> {
+        val disk = decodeFromDisk(context, url)
+        if (disk != null) {
+          cache.put(url, disk)
+          disk
+        } else if (allowNetwork) {
+          loadBitmap(context, url)?.also { cache.put(url, it) }
+            ?: BitmapFactory.decodeResource(context.resources, R.drawable.kickstart_icon)
+        } else {
+          BitmapFactory.decodeResource(context.resources, R.drawable.kickstart_icon)
+        }
+      }
     }
     return source?.let { circleCrop(it) }
   }
 
-  fun shouldFetchWidgetImage(token: KickstartToken?): Boolean {
+  fun shouldFetchWidgetImage(context: Context, token: KickstartToken?): Boolean {
     val selected = token ?: return false
     val url = normalizeUrl(selected.iconUrl) ?: return false
-    return selected.tokenMint != GOLD_MINT && cache.get(url) == null
+    if (selected.tokenMint == GOLD_MINT) return false
+    if (cache.get(url) != null) return false
+    return !cacheFile(context, url).exists()
   }
 
-  private fun loadBitmap(url: String): Bitmap? {
-    return runCatching {
+  private fun loadBitmap(context: Context, url: String): Bitmap? {
+    val bitmap = runCatching {
       val connection = (URL(url).openConnection() as HttpURLConnection).apply {
         connectTimeout = 7_000
         readTimeout = 7_000
         instanceFollowRedirects = true
       }
       connection.inputStream.use { BitmapFactory.decodeStream(it) }
-    }.getOrNull()
+    }.getOrNull() ?: return null
+    runCatching {
+      val target = cacheFile(context, url)
+      target.parentFile?.mkdirs()
+      FileOutputStream(target).use { out ->
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+      }
+    }
+    return bitmap
+  }
+
+  private fun decodeFromDisk(context: Context, url: String): Bitmap? {
+    val file = cacheFile(context, url)
+    if (!file.exists() || file.length() == 0L) return null
+    return runCatching { BitmapFactory.decodeFile(file.absolutePath) }.getOrNull()
+  }
+
+  private fun cacheFile(context: Context, url: String): File {
+    val digest = MessageDigest.getInstance("SHA-256")
+      .digest(url.toByteArray(Charsets.UTF_8))
+    val name = digest.joinToString("") { "%02x".format(it) }
+    return File(File(context.applicationContext.cacheDir, DISK_CACHE_DIR), "$name.png")
   }
 
   private fun normalizeUrl(iconUrl: String?): String? {

--- a/apps/kickstart-mobile/app/src/main/res/values/colors.xml
+++ b/apps/kickstart-mobile/app/src/main/res/values/colors.xml
@@ -6,4 +6,7 @@
   <color name="widget_red">#FF6877</color>
   <color name="widget_gold">#F5C542</color>
   <color name="ic_launcher_background">#52FFA1</color>
+  <color name="kickstart_bg">#52FFA1</color>
+  <color name="kickstart_bg_selected">#2BCF7A</color>
+  <color name="kickstart_text">#0A4D2E</color>
 </resources>


### PR DESCRIPTION
## Summary

- **Green theme:** page chrome (root, tab bar, scroll views, WebView, status/nav bars) all use `#52FFA1` (kickstart mint). Tab text is `#0A4D2E` (dark forest green) for contrast; selected tab gets `#2BCF7A`.
- **Default tab:** cold start opens Top 100. Widget deep-links (with `EXTRA_URL`) still open Home pointing at the requested URL.
- **Persistent image cache:** `TokenImageLoader` now backs the in-memory map with a disk cache at `<cacheDir>/token-icons/<sha-256>.png`. Leaderboard icons survive app restarts; widget rendering also reads from disk before deciding whether to schedule network work.

## Files

- `app/src/main/res/values/colors.xml` — three new colors (`kickstart_bg`, `kickstart_bg_selected`, `kickstart_text`).
- `app/src/main/java/io/easya/kickstart/MainActivity.kt` — colors swapped to the green palette, default-tab branch on cold start.
- `app/src/main/java/io/easya/kickstart/TokenImageLoader.kt` — disk cache layer wrapping the existing memory cache.
- `app/src/main/java/io/easya/kickstart/KickstartWidgetProvider.kt` — `shouldFetchWidgetImage` now takes Context (disk-aware).
- `app/build.gradle.kts` — versionCode 8→9, versionName 0.1.8→0.1.9.

## Test plan

- [x] `./gradlew --no-daemon assembleDebug` GREEN.
- [ ] Install over v0.1.8 (versionCode bumped), launch — opens Top 100 with green chrome, leaderboard icons load, dark green tab text reads cleanly.
- [ ] Reopen the app — leaderboard icons appear instantly from disk cache.
- [ ] Tap a token in Top 100 → opens Home tab with the token URL.
- [ ] Long-press a widget on the home screen → tap → opens Home with the widget's token URL (deep link branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)