### PR TITLE
fix(android): stable signing key across releases (v0.1.10)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -44,6 +44,13 @@ jobs:
           fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
+      - name: Decode signing keystore
+        id: keystore
+        run: |
+          path="$RUNNER_TEMP/release.keystore"
+          echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 --decode > "$path"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+
       - name: Build Kickstart APK
         working-directory: apps/kickstart-mobile
         env:
@@ -53,10 +60,19 @@ jobs:
           # is provisioned.
           CLANWORLD_CONVEX_URL: ${{ secrets.CLANWORLD_CONVEX_URL || 'https://valuable-kudu-985.convex.cloud' }}
           KICKSTART_HOME_URL: ${{ secrets.KICKSTART_HOME_URL || 'https://kickstart.easya.io' }}
+          RELEASE_KEYSTORE_PATH: ${{ steps.keystore.outputs.path }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
         run: ./gradlew --no-daemon assembleDebug
 
       - name: Build Clan World APK
         working-directory: apps/clan-world-mobile
+        env:
+          RELEASE_KEYSTORE_PATH: ${{ steps.keystore.outputs.path }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
         run: ./gradlew --no-daemon assembleDebug
 
       - name: Prepare release assets

--- a/apps/clan-world-mobile/app/build.gradle.kts
+++ b/apps/clan-world-mobile/app/build.gradle.kts
@@ -6,6 +6,18 @@ plugins {
 val homeUrl = providers.environmentVariable("CLAN_WORLD_HOME_URL")
   .orElse("https://clan-world.com")
 
+// Optional stable signing key. See apps/kickstart-mobile/app/build.gradle.kts
+// for details — both apps share the same secret names so one CI step can
+// provision both.
+val releaseKeystorePath: String? = System.getenv("RELEASE_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }
+val releaseKeystorePassword: String? = System.getenv("RELEASE_KEYSTORE_PASSWORD")
+val releaseKeyAlias: String? = System.getenv("RELEASE_KEY_ALIAS")
+val releaseKeyPassword: String? = System.getenv("RELEASE_KEY_PASSWORD")
+val hasStableSigning = releaseKeystorePath != null &&
+  !releaseKeystorePassword.isNullOrBlank() &&
+  !releaseKeyAlias.isNullOrBlank() &&
+  !releaseKeyPassword.isNullOrBlank()
+
 android {
   namespace = "world.clan.app"
   compileSdk = 35
@@ -14,9 +26,28 @@ android {
     applicationId = "world.clan.app"
     minSdk = 26
     targetSdk = 35
-    versionCode = 2
-    versionName = "0.1.8"
+    versionCode = 3
+    versionName = "0.1.10"
     buildConfigField("String", "HOME_URL", "\"${homeUrl.get()}\"")
+  }
+
+  if (hasStableSigning) {
+    signingConfigs {
+      create("stable") {
+        storeFile = file(releaseKeystorePath!!)
+        storePassword = releaseKeystorePassword
+        keyAlias = releaseKeyAlias
+        keyPassword = releaseKeyPassword
+      }
+    }
+  }
+
+  buildTypes {
+    debug {
+      if (hasStableSigning) {
+        signingConfig = signingConfigs.getByName("stable")
+      }
+    }
   }
 
   buildFeatures {

--- a/apps/kickstart-mobile/app/build.gradle.kts
+++ b/apps/kickstart-mobile/app/build.gradle.kts
@@ -28,6 +28,20 @@ fun resolveBuildConfigUrl(envName: String, propName: String): String {
 val convexUrl = resolveBuildConfigUrl("CLANWORLD_CONVEX_URL", "clanworldConvexUrl")
 val homeUrl = resolveBuildConfigUrl("KICKSTART_HOME_URL", "kickstartHomeUrl")
 
+// Optional stable signing key. When all four env vars are set (CI builds), debug
+// APKs are signed with the same key across releases so users can upgrade in
+// place. When unset (local dev), Gradle falls back to its auto-generated debug
+// keystore — fine for `./gradlew assembleDebug` on a workstation but each
+// machine produces a different cert.
+val releaseKeystorePath: String? = System.getenv("RELEASE_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }
+val releaseKeystorePassword: String? = System.getenv("RELEASE_KEYSTORE_PASSWORD")
+val releaseKeyAlias: String? = System.getenv("RELEASE_KEY_ALIAS")
+val releaseKeyPassword: String? = System.getenv("RELEASE_KEY_PASSWORD")
+val hasStableSigning = releaseKeystorePath != null &&
+  !releaseKeystorePassword.isNullOrBlank() &&
+  !releaseKeyAlias.isNullOrBlank() &&
+  !releaseKeyPassword.isNullOrBlank()
+
 android {
   namespace = "io.easya.kickstart"
   compileSdk = 35
@@ -36,10 +50,29 @@ android {
     applicationId = "io.easya.kickstart"
     minSdk = 26
     targetSdk = 35
-    versionCode = 9
-    versionName = "0.1.9"
+    versionCode = 10
+    versionName = "0.1.10"
     buildConfigField("String", "CONVEX_URL", "\"$convexUrl\"")
     buildConfigField("String", "HOME_URL", "\"$homeUrl\"")
+  }
+
+  if (hasStableSigning) {
+    signingConfigs {
+      create("stable") {
+        storeFile = file(releaseKeystorePath!!)
+        storePassword = releaseKeystorePassword
+        keyAlias = releaseKeyAlias
+        keyPassword = releaseKeyPassword
+      }
+    }
+  }
+
+  buildTypes {
+    debug {
+      if (hasStableSigning) {
+        signingConfig = signingConfigs.getByName("stable")
+      }
+    }
   }
 
   buildFeatures {


### PR DESCRIPTION
## Summary

Fixes the \"conflicts with existing package\" upgrade error on every release. Each CI run was generating a fresh debug keystore, so v0.1.7, v0.1.8, and v0.1.9 each shipped with different signing certificates. Android sees that as different publishers and blocks the upgrade.

Confirmed by inspecting the signed certs:
- v0.1.7 cert SHA-256: \`78b7df8e19f495f1b7e94bac776101eb3fe05b11ec9ec6ab79e3c5b5219553d0\`
- v0.1.9 cert SHA-256: \`310079311d9a16b93cca3749691c0189ea7a9e1cd2af89305634696dc598bf44\`

## Fix

Both apps' \`build.gradle.kts\` now look for \`RELEASE_KEYSTORE_PATH\` + matching password/alias env vars at build time. When all four are set (CI), the debug build is signed with the stable release key. When unset (local dev), Gradle falls back to the auto-generated per-machine debug keystore exactly as before — no change for \`./gradlew assembleDebug\` on a workstation.

The release keystore lives in 4 GitHub Secrets (already uploaded):
- \`RELEASE_KEYSTORE_BASE64\` — base64-encoded \`.keystore\` file
- \`RELEASE_KEYSTORE_PASSWORD\`
- \`RELEASE_KEY_ALIAS\` (\`kickstart-release\`)
- \`RELEASE_KEY_PASSWORD\`

Workflow decodes the keystore into \`$RUNNER_TEMP\` and passes the env vars to both \`assembleDebug\` steps.

Stable cert SHA-256 (going forward): \`38:3B:D4:C0:C2:86:0B:EC:93:65:93:DE:6A:59:7E:1E:AB:0C:0A:11:21:9F:B1:F7:50:50:EE:50:EF:5F:08:A4\`

## Versioning

- kickstart-mobile: versionCode 9→10, versionName 0.1.9→0.1.10
- clan-world-mobile: versionCode 2→3, versionName 0.1.8→0.1.10

## Test plan

- [x] \`./gradlew assembleDebug\` GREEN for both apps locally with the env vars set; \`apksigner verify --print-certs\` confirms both APKs are signed with the new stable cert.
- [x] Same command without env vars also succeeds (falls back to auto-generated debug keystore — local dev stays uninterrupted).
- [ ] After merge + tag, install v0.1.10 (one final uninstall of the older random-cert version is needed).
- [ ] Push a v0.1.11 tag soon after — confirm the v0.1.10 → v0.1.11 upgrade installs without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)