### PR TITLE
fix(security,contracts): pre-demo HIGH x 2 — INDEXER_SECRET gate + ABI regen

### DIFF
--- a/apps/server/convex/authShared.ts
+++ b/apps/server/convex/authShared.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared auth helper for public mutations that must be gated by INDEXER_SECRET.
+ *
+ * Pattern mirrors `inft.ts.requireIndexerSecret`: callers (orchestrator,
+ * indexer, demo seed scripts) pass `secret: <string>` as a mutation arg, and
+ * the handler calls this helper before doing any writes. If INDEXER_SECRET is
+ * unset on the Convex deployment, mutations reject all writes (fail-closed).
+ *
+ * Used by: bulletins.seedBulletin, comms.seed{Whisper,OrchEvent,HumanSteering}.
+ *
+ * For mutations that have NO external callers (memory.seedEntry,
+ * memory.seedEvent, clansmen.seedClansmen) we use `internalMutation` instead;
+ * those don't need this helper.
+ */
+export function requireIndexerSecret(supplied: string): void {
+  const expected = process.env.INDEXER_SECRET;
+  if (!expected) {
+    throw new Error("INDEXER_SECRET is not configured on this Convex deployment");
+  }
+  if (supplied !== expected) {
+    throw new Error("invalid indexer secret");
+  }
+}

--- a/apps/server/convex/bulletins.ts
+++ b/apps/server/convex/bulletins.ts
@@ -1,5 +1,6 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
+import { requireIndexerSecret } from "./authShared";
 
 /**
  * Bulletins query layer. The bulletins table itself was added in an earlier
@@ -36,15 +37,22 @@ export const getAll = query({
   },
 });
 
+// Public seed mutation — gated by INDEXER_SECRET (fail-closed if unset on the
+// Convex deployment). The orchestrator process supplies the secret via
+// IConvexClient.postBulletin → set INDEXER_SECRET in the orchestrator env to
+// match Convex's INDEXER_SECRET.
 export const seedBulletin = mutation({
   args: {
+    secret: v.string(),
     clanId: v.number(),
     slot: v.number(),
     body: v.string(),
   },
   handler: async (ctx, args) => {
+    requireIndexerSecret(args.secret);
+    const { secret: _omit, ...row } = args;
     await ctx.db.insert("bulletins", {
-      ...args,
+      ...row,
       updatedAt: Date.now(),
     });
   },

--- a/apps/server/convex/clansmen.ts
+++ b/apps/server/convex/clansmen.ts
@@ -1,4 +1,4 @@
-import { query, mutation } from "./_generated/server";
+import { query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constants";
 
@@ -220,7 +220,7 @@ export const getClanClansmen = query({
  * Match the schema field-by-field; consumers (mock.ts, tests) may pass an
  * override `clansmen` array. Hunger isn't seeded — it's derived in the query.
  */
-export const seedClansmen = mutation({
+export const seedClansmen = internalMutation({
   args: {
     clanId: v.number(),
     isStarving: v.optional(v.boolean()),

--- a/apps/server/convex/comms.ts
+++ b/apps/server/convex/comms.ts
@@ -1,5 +1,6 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
+import { requireIndexerSecret } from "./authShared";
 
 /**
  * Combined Comms feed for one clan's AXL view.
@@ -73,41 +74,53 @@ export const getCombinedComms = query({
   },
 });
 
-// Seed mutations — used by mock.ts for local-Convex testing without a chain
-// indexer. Idempotent: callers re-invoke at will. Safe to ship to prod since
-// schema validation prevents bad data.
+// Public seed mutations — gated by INDEXER_SECRET (fail-closed if unset on the
+// Convex deployment). Used by mock.ts for local-Convex testing AND by the
+// orchestrator process for live cockpit Comms feed writes via IConvexClient.
+// Idempotent: callers re-invoke at will. Schema validation prevents bad data
+// but ALONE is not sufficient — without the secret gate, anyone with the
+// deployment URL could deface the cockpit-visible feed.
 
 export const seedWhisper = mutation({
   args: {
+    secret: v.string(),
     tick: v.number(),
     fromClanId: v.number(),
     toClanIds: v.array(v.number()),
     body: v.string(),
   },
   handler: async (ctx, args) => {
-    await ctx.db.insert("whispers", { ...args, timestamp: Date.now() });
+    requireIndexerSecret(args.secret);
+    const { secret: _omit, ...row } = args;
+    await ctx.db.insert("whispers", { ...row, timestamp: Date.now() });
   },
 });
 
 export const seedOrchEvent = mutation({
   args: {
+    secret: v.string(),
     tick: v.number(),
     kind: v.union(v.literal("world_event"), v.literal("directive"), v.literal("narration")),
     body: v.string(),
     targetClanId: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    await ctx.db.insert("orchEvents", { ...args, timestamp: Date.now() });
+    requireIndexerSecret(args.secret);
+    const { secret: _omit, ...row } = args;
+    await ctx.db.insert("orchEvents", { ...row, timestamp: Date.now() });
   },
 });
 
 export const seedHumanSteering = mutation({
   args: {
+    secret: v.string(),
     tick: v.number(),
     targetClanId: v.number(),
     body: v.string(),
   },
   handler: async (ctx, args) => {
-    await ctx.db.insert("humanSteeringMessages", { ...args, timestamp: Date.now() });
+    requireIndexerSecret(args.secret);
+    const { secret: _omit, ...row } = args;
+    await ctx.db.insert("humanSteeringMessages", { ...row, timestamp: Date.now() });
   },
 });

--- a/apps/server/convex/memory.ts
+++ b/apps/server/convex/memory.ts
@@ -1,4 +1,4 @@
-import { query, mutation } from "./_generated/server";
+import { query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 
 /**
@@ -36,7 +36,7 @@ export const getByClan = query({
   },
 });
 
-export const seedEntry = mutation({
+export const seedEntry = internalMutation({
   args: {
     clanId: v.number(),
     key: v.string(),
@@ -83,7 +83,7 @@ export const getEventsByClan = query({
   },
 });
 
-export const seedEvent = mutation({
+export const seedEvent = internalMutation({
   args: {
     tick: v.number(),
     clanId: v.number(),

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2444,6 +2444,16 @@
               "internalType": "uint64"
             },
             {
+              "name": "worldPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "pausedAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
               "name": "winterActive",
               "type": "bool",
               "internalType": "bool"
@@ -2604,6 +2614,16 @@
               "name": "nextCommitSequence",
               "type": "uint64",
               "internalType": "uint64"
+            },
+            {
+              "name": "worldPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "pausedAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
             }
           ]
         }
@@ -2650,6 +2670,19 @@
     },
     {
       "type": "function",
+      "name": "isWorldPaused",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "mintClan",
       "inputs": [
         {
@@ -2670,6 +2703,13 @@
           "internalType": "uint256"
         }
       ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "pauseWorld",
+      "inputs": [],
+      "outputs": [],
       "stateMutability": "nonpayable"
     },
     {
@@ -3072,6 +3112,13 @@
           "internalType": "uint256"
         }
       ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "unpauseWorld",
+      "inputs": [],
       "outputs": [],
       "stateMutability": "nonpayable"
     },
@@ -4638,6 +4685,50 @@
         },
         {
           "name": "tick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WorldPaused",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "pausedAtTs",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "WorldUnpaused",
+      "inputs": [
+        {
+          "name": "tick",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "durationSeconds",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "nextHeartbeatAtTs",
           "type": "uint64",
           "indexed": false,
           "internalType": "uint64"

--- a/packages/contracts/abi/IClanWorldLens.json
+++ b/packages/contracts/abi/IClanWorldLens.json
@@ -1368,6 +1368,16 @@
               "internalType": "uint64"
             },
             {
+              "name": "worldPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "pausedAtTs",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
               "name": "winterActive",
               "type": "bool",
               "internalType": "bool"

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -219,6 +219,16 @@ export const CLAN_WORLD_ABI = [
             "name": "nextCommitSequence",
             "type": "uint64",
             "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
           }
         ]
       }
@@ -1089,6 +1099,16 @@ export const CLAN_WORLD_ABI = [
           },
           {
             "name": "nextHeartbeatAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
             "type": "uint64",
             "internalType": "uint64"
           },

--- a/packages/shared/src/adapters/IConvexClient.ts
+++ b/packages/shared/src/adapters/IConvexClient.ts
@@ -134,33 +134,62 @@ class RealConvexClient implements IConvexClient {
   // Cockpit Comms write-side — best-effort, swallow + warn on failure so the
   // domain operation that triggered the post (chain whisper, orchestrator
   // tick, etc.) is never blocked by a Convex outage.
+  //
+  // Each call attaches `secret: INDEXER_SECRET` (read from env) so the
+  // server-side mutation passes its `requireIndexerSecret` gate. If the env
+  // var is missing the call is short-circuited with a single warn — same
+  // shape the user sees when the deployment URL is not configured.
+  private indexerSecret(): string | undefined {
+    return readEnv('INDEXER_SECRET');
+  }
+
   async postWhisper(args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; txHash?: string }): Promise<void> {
+    const secret = this.indexerSecret();
+    if (!secret) {
+      console.warn('[ConvexClient] postWhisper skipped: INDEXER_SECRET not set');
+      return;
+    }
     try {
-      await this.http.mutation(seedWhisperRef, args);
+      await this.http.mutation(seedWhisperRef, { secret, ...args });
     } catch (err) {
       console.warn('[ConvexClient] postWhisper failed (non-fatal):', err);
     }
   }
 
   async postOrchEvent(args: { tick: number; kind: 'world_event' | 'directive' | 'narration'; body: string; targetClanId?: number }): Promise<void> {
+    const secret = this.indexerSecret();
+    if (!secret) {
+      console.warn('[ConvexClient] postOrchEvent skipped: INDEXER_SECRET not set');
+      return;
+    }
     try {
-      await this.http.mutation(seedOrchEventRef, args);
+      await this.http.mutation(seedOrchEventRef, { secret, ...args });
     } catch (err) {
       console.warn('[ConvexClient] postOrchEvent failed (non-fatal):', err);
     }
   }
 
   async postHumanSteering(args: { tick: number; targetClanId: number; body: string; sentBy?: string }): Promise<void> {
+    const secret = this.indexerSecret();
+    if (!secret) {
+      console.warn('[ConvexClient] postHumanSteering skipped: INDEXER_SECRET not set');
+      return;
+    }
     try {
-      await this.http.mutation(seedHumanSteeringRef, args);
+      await this.http.mutation(seedHumanSteeringRef, { secret, ...args });
     } catch (err) {
       console.warn('[ConvexClient] postHumanSteering failed (non-fatal):', err);
     }
   }
 
   async postBulletin(args: { clanId: number; slot: number; body: string; dataHash?: string; txHash?: string }): Promise<void> {
+    const secret = this.indexerSecret();
+    if (!secret) {
+      console.warn('[ConvexClient] postBulletin skipped: INDEXER_SECRET not set');
+      return;
+    }
     try {
-      await this.http.mutation(seedBulletinRef, args);
+      await this.http.mutation(seedBulletinRef, { secret, ...args });
     } catch (err) {
       console.warn('[ConvexClient] postBulletin failed (non-fatal):', err);
     }


### PR DESCRIPTION
Pre-demo audit (codex 5.5 + Claude subagent) found two HIGH-severity issues on main `ba68ef8`. Single fix-PR, two commits.

## HIGH 1 — Demo seed mutations exposed (security)

`bulletins.seedBulletin`, `comms.seed{Whisper,OrchEvent,HumanSteering}`, `memory.seed{Entry,Event}`, `clansmen.seedClansmen` were public Convex `mutation()` writing to cockpit-visible tables. Anyone with the deployment URL could deface them.

**Two fix paths, depending on whether external callers exist:**

| Mutation | External caller? | Fix |
| --- | --- | --- |
| `bulletins.seedBulletin` | yes — `IConvexClient.postBulletin` | `secret: v.string()` arg + `requireIndexerSecret` gate |
| `comms.seedWhisper` | yes — `IConvexClient.postWhisper` | secret-gate |
| `comms.seedOrchEvent` | yes — `IConvexClient.postOrchEvent` (orchestrator main loop) | secret-gate |
| `comms.seedHumanSteering` | yes — `IConvexClient.postHumanSteering` | secret-gate |
| `memory.seedEntry` | none | `internalMutation` |
| `memory.seedEvent` | none | `internalMutation` |
| `clansmen.seedClansmen` | none (only mock.ts test seed) | `internalMutation` |

Pattern reuses the existing `requireIndexerSecret(supplied)` from `inft.ts` — extracted into a new `apps/server/convex/authShared.ts` so both files share it. Fail-closed if `INDEXER_SECRET` is unset on the Convex deployment.

`IConvexClient.post*` (in `packages/shared/src/adapters/IConvexClient.ts`) now reads `INDEXER_SECRET` from env via `readEnv` and forwards it as the first arg of every Convex mutation call. If the env var is missing on the orchestrator, the call short-circuits with a single warn (preserves the non-fatal contract).

**Removed the misleading "Safe to ship to prod since schema validation prevents bad data" comment in `comms.ts:76`** — schema validation alone is not sufficient to prevent defacement; the secret gate is what makes these prod-safe.

**Demo deploy checklist:** set `INDEXER_SECRET` on the Convex dashboard AND on the orchestrator process (Railway / wherever) BEFORE the demo. Without it, all `IConvexClient.post*` calls silently no-op (cockpit Comms feed will not get any new orchestrator narrations, but the chain orders still ship).

## HIGH 2 — `getWorldSnapshot` ABI struct drift (contracts)

PR #18 regenerated ABIs after PR #12 added the `worldPaused`/`pausedAtTs` fields to `WorldSnapshot` + `WorldState`, but a subsequent merge train undid the regen on main. Currently dormant (the live diamond predates the source change), but it flips to live mis-decoding the moment of redeploy:

- `winterActive` would be read from the `worldPaused` slot
- `winterStartsAtTick` would be read from the `pausedAtTs` unix-timestamp slot
- the new pause `getter`/`setter` selectors (`isWorldPaused`/`pauseWorld`/`unpauseWorld`) would be unreachable through `IChainClient`

Re-ran the canonical codegen pipeline:
```
bash scripts/forge.sh build src/IClanWorld.sol src/IClanWorldLens.sol
node scripts/gen-contract-abi.mjs
node scripts/gen-chainclient-abi.mjs
```

## Verification

- `pnpm --filter @clan-world/server typecheck`: clean
- `pnpm --filter @clan-world/shared typecheck`: clean
- `pnpm --filter @clan-world/orchestrator typecheck`: clean (consumer of `IConvexClient.post*`)
- `pnpm --filter @clan-world/runner typecheck`: clean
- `pnpm --filter @clan-world/agents typecheck`: clean
- `pnpm --filter @clan-world/contracts run check:abi`: clean diff (out/* vs abi/*)
- `node scripts/gen-chainclient-abi.mjs --check`: "fragment is up to date"
- `node packages/shared/scripts/check-chain-abi-parity.mjs`: "ClanWorld major struct ABI parity OK"
- `jq` grep on `abi/IClanWorld.json`: 5 new entries (3 functions + 2 events)
- `jq` on `abi/IClanWorld.json` `getWorldSnapshot.outputs[].components[]`: 2 new fields (`worldPaused`, `pausedAtTs`)

CI will run `test:chainclient-abi` + `test:abi-parity` on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)