### PR TITLE
fix(android,server): pre-demo medium audit bundle (M-1, M-2, M-4, LOW, SIDE)

### DIFF
--- a/apps/clan-world-mobile/app/build.gradle.kts
+++ b/apps/clan-world-mobile/app/build.gradle.kts
@@ -3,8 +3,28 @@ plugins {
   id("org.jetbrains.kotlin.android")
 }
 
-val homeUrl = providers.environmentVariable("CLAN_WORLD_HOME_URL")
-  .orElse("https://clan-world.com")
+// Build-time URL config.
+//
+// We deliberately fall back from environment → Gradle project property → null.
+// If neither is set the build fails loudly: a hardcoded fallback previously
+// risked silently shipping a wrong/non-prod URL into release APKs.
+//
+// Local devs can keep the URL in `~/.gradle/gradle.properties`:
+//   clanWorldHomeUrl=https://clan-world.com
+// CI must pass the env var explicitly.
+fun resolveBuildConfigUrl(envName: String, propName: String): String {
+  val envValue = System.getenv(envName)?.takeIf { it.isNotBlank() }
+  if (envValue != null) return envValue
+  val propValue = (project.findProperty(propName) as? String)?.takeIf { it.isNotBlank() }
+  if (propValue != null) return propValue
+  error(
+    "$envName must be set at build time (env var or Gradle property `$propName`). " +
+      "Refusing to fall back to a hardcoded URL — that path silently shipped wrong " +
+      "backends in past releases.",
+  )
+}
+
+val homeUrl = resolveBuildConfigUrl("CLAN_WORLD_HOME_URL", "clanWorldHomeUrl")
 
 // Optional stable signing key. See apps/kickstart-mobile/app/build.gradle.kts
 // for details — both apps share the same secret names so one CI step can
@@ -28,7 +48,7 @@ android {
     targetSdk = 35
     versionCode = 3
     versionName = "0.1.10"
-    buildConfigField("String", "HOME_URL", "\"${homeUrl.get()}\"")
+    buildConfigField("String", "HOME_URL", "\"$homeUrl\"")
   }
 
   if (hasStableSigning) {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/MainActivity.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/MainActivity.kt
@@ -37,6 +37,10 @@ class MainActivity : Activity() {
   }
 
   private fun showHome() {
+    // If a previous WebView exists (e.g. coming back from background or
+    // re-entering the home tab), tear it down before allocating a new one
+    // so we don't leak the renderer process across re-creates.
+    destroyWebViewIfPresent()
     shell.removeAllViews()
 
     val root = LinearLayout(this).apply {
@@ -106,8 +110,25 @@ class MainActivity : Activity() {
   }
 
   private fun handleUrl(uri: Uri): Boolean {
-    val scheme = uri.scheme?.lowercase() ?: return false
-    if (scheme == "http" || scheme == "https") return false
+    val scheme = uri.scheme?.lowercase() ?: return true
+    if (scheme == "http" || scheme == "https") {
+      // Allowlist enforcement: only allow http(s) navigations whose host
+      // matches the configured HOME_URL host or an explicit allowlist.
+      // Anything else (a phishing link injected via window.location, an
+      // adversarial deep link, etc.) is blocked from this JS-enabled,
+      // storage-backed WebView and instead handed to an external browser.
+      return if (isHttpUrlAllowed(uri)) {
+        false
+      } else {
+        runCatching {
+          startActivity(
+            Intent(Intent.ACTION_VIEW, uri)
+              .addCategory(Intent.CATEGORY_BROWSABLE),
+          )
+        }
+        true
+      }
+    }
     val intent = if (scheme == "intent") {
       runCatching { Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME) }.getOrNull()
     } else {
@@ -119,10 +140,33 @@ class MainActivity : Activity() {
       startActivity(intent)
     }.recoverCatching { error ->
       if (error is ActivityNotFoundException && intent.getStringExtra("browser_fallback_url") != null) {
-        webView.loadUrl(intent.getStringExtra("browser_fallback_url")!!)
+        val fallbackUrl = intent.getStringExtra("browser_fallback_url")!!
+        if (isHttpUrlAllowed(Uri.parse(fallbackUrl))) {
+          webView.loadUrl(fallbackUrl)
+        }
       }
     }
     return true
+  }
+
+  /**
+   * Allow only HTTPS URLs whose host matches the configured clan-world home
+   * or an explicit allowlist of trusted subdomains. Mirrors the kickstart
+   * pattern: every entry widens the trust surface of an exported, JS-enabled
+   * WebView, so keep the list narrow.
+   */
+  private fun isHttpUrlAllowed(uri: Uri): Boolean {
+    return runCatching {
+      val scheme = uri.scheme?.lowercase()
+      if (scheme != "https" && scheme != "http") return@runCatching false
+      val host = uri.host?.lowercase() ?: return@runCatching false
+      val homeHost = Uri.parse(BuildConfig.HOME_URL).host?.lowercase()
+      val allowedHosts = buildSet {
+        if (!homeHost.isNullOrBlank()) add(homeHost)
+        addAll(EXTRA_ALLOWED_HOSTS)
+      }
+      allowedHosts.any { allowed -> host == allowed || host.endsWith(".$allowed") }
+    }.getOrDefault(false)
   }
 
   private fun openExternal(url: String) {
@@ -136,5 +180,32 @@ class MainActivity : Activity() {
     else super.onBackPressed()
   }
 
+  override fun onDestroy() {
+    destroyWebViewIfPresent()
+    super.onDestroy()
+  }
+
+  private fun destroyWebViewIfPresent() {
+    if (::webView.isInitialized) {
+      webView.stopLoading()
+      webView.loadUrl("about:blank")
+      (webView.parent as? ViewGroup)?.removeView(webView)
+      webView.removeAllViews()
+      webView.destroy()
+    }
+  }
+
   private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+
+  companion object {
+    /**
+     * Hosts allowed for WebView loads in addition to the configured
+     * `BuildConfig.HOME_URL` host. Keep this list narrow; every entry
+     * widens the trust surface of an exported JS-enabled WebView.
+     */
+    private val EXTRA_ALLOWED_HOSTS = setOf(
+      "clan-world.com",
+      "app.clan-world.com",
+    )
+  }
 }

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/BackgroundExecutors.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/BackgroundExecutors.kt
@@ -1,0 +1,24 @@
+package io.easya.kickstart
+
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+/**
+ * Shared bounded executors for off-UI work.
+ *
+ * Replaces ad-hoc `Thread { ... }.start()` calls that previously fanned out
+ * unboundedly during widget refresh storms (one fresh OS thread per widget
+ * instance per onUpdate). Capping at 2 threads is enough headroom for the
+ * widget HTTP fetch + cache write to overlap, but bounded enough that a
+ * homescreen with N widgets won't trigger N concurrent network sockets +
+ * SharedPreferences writers.
+ *
+ * Note: TokenImageLoader has its own dedicated 4-thread pool for bitmap
+ * decode work; that's intentionally a separate pool because bitmap decode
+ * is much heavier per task than the widget refresh fetches and we don't
+ * want one to head-of-line block the other.
+ */
+object BackgroundExecutors {
+  /** For widget data refresh + config-screen async work. Cap at 2. */
+  val widget: Executor = Executors.newFixedThreadPool(2)
+}

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetProvider.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetProvider.kt
@@ -13,12 +13,12 @@ open class KickstartWidgetProvider : AppWidgetProvider() {
   override fun onUpdate(context: Context, manager: AppWidgetManager, appWidgetIds: IntArray) {
     appWidgetIds.forEach { appWidgetId ->
       updateWidget(context, manager, appWidgetId, WidgetStore.loadCachedToken(context, appWidgetId), layoutRes)
-      Thread {
+      BackgroundExecutors.widget.execute {
         val mint = WidgetStore.getWidgetTokenMint(context, appWidgetId)
         val fresh = mint?.let { runCatching { KickstartClient.fetchToken(it) }.getOrNull() }
         if (fresh != null) WidgetStore.saveCachedToken(context, appWidgetId, fresh)
         updateWidget(context, manager, appWidgetId, fresh ?: WidgetStore.loadCachedToken(context, appWidgetId), layoutRes)
-      }.start()
+      }
     }
   }
 
@@ -48,7 +48,7 @@ open class KickstartWidgetProvider : AppWidgetProvider() {
       views.setOnClickPendingIntent(R.id.widget_root, pendingIntent)
       manager.updateAppWidget(appWidgetId, views)
       if (TokenImageLoader.shouldFetchWidgetImage(context, token)) {
-        Thread {
+        BackgroundExecutors.widget.execute {
           val refreshedViews = KickstartWidgetRenderer.render(
             context,
             token,
@@ -58,7 +58,7 @@ open class KickstartWidgetProvider : AppWidgetProvider() {
           )
           refreshedViews.setOnClickPendingIntent(R.id.widget_root, pendingIntent)
           manager.updateAppWidget(appWidgetId, refreshedViews)
-        }.start()
+        }
       }
     }
   }

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/MainActivity.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/MainActivity.kt
@@ -79,6 +79,10 @@ class MainActivity : Activity() {
   private fun showHome(url: String) {
     selectedUrl = url
     selectTab(homeTab)
+    // Tear down any prior WebView before re-allocating: showHome() can be
+    // re-invoked (tab switch, deep link, onNewIntent) and otherwise leaks
+    // the renderer process per re-entry.
+    destroyWebViewIfPresent()
     content.removeAllViews()
     webView = WebView(this).apply {
       webViewClient = object : WebViewClient() {
@@ -250,6 +254,21 @@ class MainActivity : Activity() {
   override fun onBackPressed() {
     if (::webView.isInitialized && webView.canGoBack()) webView.goBack()
     else super.onBackPressed()
+  }
+
+  override fun onDestroy() {
+    destroyWebViewIfPresent()
+    super.onDestroy()
+  }
+
+  private fun destroyWebViewIfPresent() {
+    if (::webView.isInitialized) {
+      webView.stopLoading()
+      webView.loadUrl("about:blank")
+      (webView.parent as? ViewGroup)?.removeView(webView)
+      webView.removeAllViews()
+      webView.destroy()
+    }
   }
 
   /**

--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/WidgetConfigActivity.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/WidgetConfigActivity.kt
@@ -43,12 +43,12 @@ class WidgetConfigActivity : Activity() {
     list.addView(text("Top Kickstart tokens by market cap", 13, getColor(R.color.widget_muted)))
     list.addView(text("Loading...", 14, getColor(R.color.widget_muted)))
 
-    Thread {
+    BackgroundExecutors.widget.execute {
       val tokens = runCatching { KickstartClient.listTokens() }.getOrElse { emptyList() }
       runOnUiThread {
         renderTokenPicker(list, tokens)
       }
-    }.start()
+    }
   }
 
   private fun renderTokenPicker(list: LinearLayout, tokens: List<KickstartToken>) {

--- a/apps/server/convex/bulletins.ts
+++ b/apps/server/convex/bulletins.ts
@@ -41,6 +41,11 @@ export const seedBulletin = mutation({
     clanId: v.number(),
     slot: v.number(),
     body: v.string(),
+    // Optional provenance from the on-chain bulletin write — surfaced on
+    // the cockpit. Both fields are also optional in the bulletins table
+    // schema so older rows without them stay valid.
+    dataHash: v.optional(v.string()),
+    txHash: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await ctx.db.insert("bulletins", {

--- a/apps/server/convex/comms.ts
+++ b/apps/server/convex/comms.ts
@@ -83,6 +83,9 @@ export const seedWhisper = mutation({
     fromClanId: v.number(),
     toClanIds: v.array(v.number()),
     body: v.string(),
+    // Optional on-chain transaction hash from the whisper write — useful
+    // provenance for the cockpit feed. Optional in the whispers table.
+    txHash: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await ctx.db.insert("whispers", { ...args, timestamp: Date.now() });
@@ -106,6 +109,9 @@ export const seedHumanSteering = mutation({
     tick: v.number(),
     targetClanId: v.number(),
     body: v.string(),
+    // Optional wallet/owner address of the sender — surfaced on the
+    // cockpit feed. Optional in the humanSteeringMessages table schema.
+    sentBy: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await ctx.db.insert("humanSteeringMessages", { ...args, timestamp: Date.now() });


### PR DESCRIPTION
Round 2 from the pre-demo audit (PR #47 was round 1, HIGHs only).

## Findings addressed

- **M-1** clan-world-mobile WebView host allowlist (phishing carrier mitigation; mirrors kickstart pattern from #31). `shouldOverrideUrlLoading` now blocks any http/https navigation whose host doesn't match `BuildConfig.HOME_URL` host or the explicit `EXTRA_ALLOWED_HOSTS` allowlist (`clan-world.com`, `app.clan-world.com`); non-allowlisted URLs are handed off to an external browser intent.
- **M-2** `webView.destroy()` on `onDestroy()` + before re-create — both apps. `destroyWebViewIfPresent()` helper called from both `onDestroy` and at the top of `showHome()` so the prior renderer is reclaimed before allocating the next one.
- **M-4** clan-world-mobile `build.gradle.kts` fail-loud URL resolver. Replaces silent `.orElse("https://clan-world.com")` with the `resolveBuildConfigUrl()` helper from kickstart-mobile (PR #31, `86c1c20`). Build now errors clearly if neither `CLAN_WORLD_HOME_URL` env var nor the `clanWorldHomeUrl` Gradle property is set.
- **LOW** kickstart widget refresh paths now use shared bounded executor. Adds `BackgroundExecutors.kt` with a 2-thread fixed pool; refactors the 3 raw `Thread { ... }.start()` sites flagged in the audit (`KickstartWidgetProvider.onUpdate`, `updateWidget` post-render image refresh, `WidgetConfigActivity.onCreate` token list fetch). Kept separate from `TokenImageLoader`'s 4-thread bitmap pool — different work shapes.
- **SIDE-EFFECT** `IConvexClient.post*` args were rejected by server validators (silent fail) → comms feed wire-level break. **Approach A** (server adds the args): `dataHash`/`txHash`/`sentBy` are already optional fields on the bulletins/whispers/humanSteeringMessages table schemas, so extending the validators preserves provenance for the cockpit display without touching any caller. `seedOrchEvent` already accepted everything `postOrchEvent` passes — left untouched.

## Deferred to post-demo (audit MEDIUM scope expansion, per Liam)

- M-3 `watchAndRefreshToken` token mint validation
- M-5 `v.any()` validators on indexer/snapshot/clansmen/vault

## Verification

- `pnpm --filter @clan-world/server typecheck` clean
- `pnpm --filter @clan-world/shared typecheck` clean
- `pnpm --filter @clan-world/orchestrator typecheck` clean
- Gradle compile **skipped** — Android SDK not provisioned in this environment. Gradle config evaluation succeeds with required env vars set (verified via `./gradlew help`); the new fail-loud resolver correctly aborts when env unset (verified — that's its job).

## Follow-up note

With HIGH-1's secret gate (PR #47) now in place, the orchestrator also needs `INDEXER_SECRET` set or its `post*` calls will silently fail again — that's a separate (env-config) failure mode, not in this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)