### PR TITLE
fix(server): pre-demo audit M-3 + M-5 — Convex hardening

### DIFF
--- a/apps/server/convex/clansmen.ts
+++ b/apps/server/convex/clansmen.ts
@@ -225,6 +225,12 @@ export const seedClansmen = internalMutation({
     clanId: v.number(),
     isStarving: v.optional(v.boolean()),
     starvationStartsAtTick: v.optional(v.number()),
+    // TODO(post-demo): tighten validator (M-5 audit). Each clansman entry is
+    // a deeply nested clanFullView projection with 10+ solidity-struct fields
+    // (clansman.clansman.{clansmanId,clanId,state,currentRegion,...} +
+    // activeMission.{active,action,startRegion,...}); enumerating them here
+    // doubles file size and drifts as the contract evolves. Persists into
+    // `clanView.clansmen` which is itself v.array(v.any()) by design.
     clansmen: v.optional(v.array(v.any())),
     currentTick: v.optional(v.number()),
   },

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -264,9 +264,30 @@ export const legacyClansFromClanViews = (clanViews: LegacyClanView[]) =>
       clansmen: view.clansmen ?? [],
     }));
 
+// M-5: tighten internal-mutation arg shape. We can't enumerate every event
+// payload here (the contract emits a wide discriminated union, and the args
+// are post-`bigintSafe` arbitrary nested records), but we CAN gate the
+// envelope: eventName must be a string, and the metadata fields must match
+// the parsed-log shape from viem (bigints from viem.Log.blockNumber are
+// passed through; convex serializes them via v.int64()).
+const indexerEventValidator = v.object({
+  eventName: v.string(),
+  // TODO(post-demo): if event union narrows enough, replace v.any with a
+  // discriminated union keyed on eventName (M-5 audit).
+  args: v.any(),
+  address: v.optional(v.string()),
+  blockHash: v.optional(v.union(v.string(), v.null())),
+  blockNumber: v.optional(
+    v.union(v.int64(), v.number(), v.string(), v.null()),
+  ),
+  transactionHash: v.optional(v.union(v.string(), v.null())),
+  transactionIndex: v.optional(v.union(v.number(), v.null())),
+  logIndex: v.optional(v.union(v.number(), v.null())),
+});
+
 export const ingestEvents = internalMutation({
   args: {
-    events: v.array(v.any()),
+    events: v.array(indexerEventValidator),
     blockNumber: v.number(),
     txHash: v.optional(v.string()),
     firedAtTs: v.optional(v.number()),
@@ -372,9 +393,24 @@ export const ingestEvents = internalMutation({
   },
 });
 
+// M-5: tighten the snapshot envelope. Inner contract-read blobs are kept
+// as v.any() — they're post-`bigintSafe` arbitrary records that mirror
+// dozens of solidity struct fields, and the handler defends with
+// `objectAt`/`asNumber`/`asString` coercers anyway.
+const snapshotValidator = v.object({
+  blockNumber: v.optional(v.number()),
+  txHash: v.optional(v.string()),
+  // TODO(post-demo): tighten world/market/bandit/clans inner record shapes
+  // once contract structs stabilize (M-5 audit).
+  world: v.any(),
+  market: v.optional(v.any()),
+  bandit: v.optional(v.any()),
+  clans: v.array(v.any()),
+});
+
 export const commitSnapshot = internalMutation({
   args: {
-    snapshot: v.any(),
+    snapshot: snapshotValidator,
   },
   handler: async (ctx, args) => {
     const snapshot = args.snapshot as SnapshotPayload;

--- a/apps/server/convex/kickstart.ts
+++ b/apps/server/convex/kickstart.ts
@@ -1,12 +1,18 @@
 import { action, internalAction, internalMutation, internalQuery, query } from "./_generated/server";
 import { internal } from "./_generated/api";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 
 const KICKSTART_HOME_URL = "https://kickstart.easya.io/api/home-launches";
 const PAGE_SIZE = 48;
 const PAGE_COUNT = 3;
 const TOP_LIMIT = 100;
 const WATCHED_TOKEN_LIMIT = 20;
+
+// Solana token mint = base58 (Bitcoin alphabet, no 0/O/I/l), 32-44 chars.
+// ed25519-derived addresses are typically 43-44 chars. This regex gates the
+// public watchAndRefreshToken action against unauthenticated cheap-write
+// amplification spam (M-3, codex 5.5 pre-demo audit).
+const SOLANA_MINT_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 
 type KickstartPool = {
   id?: string;
@@ -193,15 +199,24 @@ export const getKickstartTokenQuote = query({
 export const watchAndRefreshToken = action({
   args: { tokenMint: v.string() },
   handler: async (ctx, { tokenMint }) => {
-    await ctx.runMutation(internal.kickstart.markWatchedToken, { tokenMint });
+    // M-3: Validate base58 / length BEFORE any DB write. The watchedTokens
+    // table is otherwise an unauthenticated public spam vector — anyone could
+    // seed it with garbage strings to amplify cheap writes.
+    if (!SOLANA_MINT_REGEX.test(tokenMint)) {
+      throw new ConvexError("Invalid tokenMint format");
+    }
+    // Existence check: query the indexed kickstartTokens table first; if the
+    // mint isn't present, refresh leaderboard from upstream. Only AFTER we
+    // confirm the token is real do we record it as watched.
     const token = await ctx.runQuery(internal.kickstart.getTokenByMint, { tokenMint });
     let hasToken = token !== null;
-    if (!token) {
+    if (!hasToken) {
       const tokens = await fetchKickstartTopTokens();
       await ctx.runMutation(internal.kickstart.replaceKickstartTokens, { tokens });
       hasToken = tokens.some((entry) => entry.tokenMint === tokenMint);
     }
     if (!hasToken) return { ok: false, reason: "token-not-found" };
+    await ctx.runMutation(internal.kickstart.markWatchedToken, { tokenMint });
     const samples = await fetchJupiterChartSamples(tokenMint);
     await ctx.runMutation(internal.kickstart.updateTokenSparkline, { tokenMint, samples });
     return { ok: true, samples: samples.length };

--- a/apps/server/convex/vault.ts
+++ b/apps/server/convex/vault.ts
@@ -319,6 +319,11 @@ export const seedVaultMovement = internalMutation({
     clanId: v.number(),
     tick: v.number(),
     eventName: v.string(),
+    // TODO(post-demo): tighten validator (M-5 audit). `args` is a free-form
+    // event-payload blob persisted directly into `chainEvents.args`, which
+    // is itself v.any() in schema by design — narrowing here would over-
+    // constrain the event-name discriminated union (dozens of variants).
+    // Internal-only seed mutation; not reachable from public surface.
     args: v.any(),
   },
   handler: async (ctx, args) => {


### PR DESCRIPTION
Round 2 part 2 of the pre-demo audit. Companion to the Android-mostly bundle (also in flight).

## M-3 — `kickstart.watchAndRefreshToken` mint validation

Public action used to record any string into `kickstartWatchedTokens` before proving the token existed — unauthenticated write-amplification spam vector. Now:

1. Base58 / 32-44-char regex gate up front; bad input throws `ConvexError("Invalid tokenMint format")`.
2. Existence check (indexed `kickstartTokens` query, fallback to upstream leaderboard refresh) runs BEFORE `markWatchedToken`, so we never persist a watch row for a mint we couldn't verify.

## M-5 — Replace `v.any()` on internal mutation args

Tightened envelope validators on:

- `indexer.ts:269` — `ingestEvents.events`: `v.array(v.any())` → `v.array(indexerEventValidator)`
  - `indexerEventValidator = v.object({ eventName: v.string(), args: v.any(), address?, blockHash?, blockNumber? (int64|number|string|null), transactionHash?, transactionIndex?, logIndex? })`
  - Inner `args` left as `v.any()` (TODO post-demo): solidity emits a wide discriminated union, post-`bigintSafe` it's nested records with hundreds of fields across event variants. Envelope is gated; payload coerced by handler.
- `indexer.ts:377` — `commitSnapshot.snapshot`: `v.any()` → `snapshotValidator`
  - `snapshotValidator = v.object({ blockNumber?, txHash?, world: v.any(), market?: v.any(), bandit?: v.any(), clans: v.array(v.any()) })`
  - Inner blobs are post-`bigintSafe` solidity-struct projections; handler defends with `objectAt`/`asNumber`/`asString`.
- `clansmen.ts:228` — `seedClansmen.clansmen`: kept `v.optional(v.array(v.any()))` with TODO comment. Internal seed mutation only; payload is the same polymorphic clansman-view shape that `clanView.clansmen` stores as `v.array(v.any())` by design (10+ deep solidity-struct fields per entry).
- `vault.ts:322` — `seedVaultMovement.args`: kept `v.any()` with TODO comment. Internal seed mutation only; payload persists directly into `chainEvents.args` which is itself `v.any()` in schema. Narrowing here would over-constrain the dozens-strong event-name discriminated union.

### `schema.ts` entries left untouched

Per brief: schema-doc subtree validators (lines 41, 70, 120-122, 138-139) are field-level inside larger documents (`worldSnapshot.clans[].clansmen`, `chainEvents.args`, `clanView.westPlot/eastPlot/clansmen`, `marketState.currentTickQueue/nextTickQueue`), not entire-doc-level. Higher risk to change; deferred.

## Verification

- `pnpm --filter @clan-world/server typecheck` — clean
- `pnpm --filter @clan-world/server test` — all 27 tests pass (including 9 indexer.test.ts cases that exercise `ingestEvents._handler` and `commitSnapshot._handler` directly)
- Convex schema parse — skipped (no auth in worktree)