### PR TITLE
fix(android): dim coin image to 80% opacity in kickstart widget

### DIFF
--- a/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetRenderer.kt
+++ b/apps/kickstart-mobile/app/src/main/java/io/easya/kickstart/KickstartWidgetRenderer.kt
@@ -46,7 +46,10 @@ object KickstartWidgetRenderer {
     views.setChange(R.id.change_6h, "6H", token?.priceChange6h)
     views.setChange(R.id.change_24h, "24H", token?.priceChange24h)
     views.setChange(R.id.change_7d, "7D", token?.priceChange7d)
-    coinBitmap?.let { views.setImageViewBitmap(R.id.coin, it) }
+    coinBitmap?.let {
+      views.setImageViewBitmap(R.id.coin, it)
+      views.setInt(R.id.coin, "setImageAlpha", 204)
+    }
     views.setImageViewBitmap(R.id.sparkline, drawChart(token, chartType))
     return views
   }


### PR DESCRIPTION
## Summary
- Applies `setImageAlpha(204)` (≈80%) to `R.id.coin` after the bitmap is set in `KickstartWidgetRenderer`.
- Improves contrast so the symbol / price / 1H-6H-24H-7D change rows read cleanly against the coin background.
- Same `R.id.coin` is shared by `gold_widget` and `gold_widget_tall`, so both widget sizes are covered.

## Test plan
- [ ] Install the kickstart-mobile build on a device, add a Gold widget to the home screen, confirm the coin image is visibly dimmer and ticker text is more legible
- [ ] Confirm the tall widget variant also shows the dimmed coin
- [ ] No layout / size regressions

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)