### PR TITLE
feat(android): Phase 3 — wire cockpit + owner sign-in into NavHost

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -34,6 +34,9 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import world.clan.app.App
+import world.clan.app.cockpit.CockpitScreen
+import world.clan.app.owner.OwnerComingSoonScreen
+import world.clan.app.owner.OwnerSignInScreen
 import world.clan.app.ui.components.ClanWorldTabBar
 import world.clan.app.ui.components.LocalOnDisconnect
 import world.clan.app.ui.components.LocalWalletIdentity
@@ -56,7 +59,12 @@ object Routes {
   const val Hall = "hall"
   const val Codex = "codex"
   const val InftDetail = "inft/{clanId}"
+  const val Cockpit = "cockpit"
+  const val OwnerSignIn = "ownerSignIn/{clanId}"
+  const val OwnerComingSoon = "ownerComingSoon/{clanId}"
   fun inftDetail(clanId: Int) = "inft/$clanId"
+  fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
+  fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -182,11 +190,15 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
     currentRoute == Routes.Hall ||
     currentRoute == Routes.Codex ||
     currentRoute?.startsWith("inft/") == true
+  // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
     currentRoute == Routes.Hall -> RootTab.Hall
     currentRoute == Routes.Codex -> RootTab.Codex
     currentRoute?.startsWith("inft/") == true -> RootTab.Hall // detail derived from Hall
+    currentRoute == Routes.Cockpit ||
+      currentRoute?.startsWith("ownerSignIn/") == true ||
+      currentRoute?.startsWith("ownerComingSoon/") == true -> RootTab.Hall
     else -> RootTab.Hearth
   }
 
@@ -298,6 +310,58 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
             val clanId = entry.arguments?.getInt("clanId") ?: 1
             InftDetailScreenRoute(
               app = app,
+              clanId = clanId,
+              onBack = { nav.popBackStack() },
+              onEnterCockpit = { nav.navigate(Routes.Cockpit) },
+            )
+          }
+
+          // ── Cockpit (deep route from InftDetail "Enter Cockpit" CTA) ────
+          composable(
+            route = Routes.Cockpit,
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) {
+            CockpitScreen(
+              onOwnerControl = { clanId ->
+                nav.navigate(Routes.ownerSignIn(clanId))
+              },
+            )
+          }
+
+          // ── Owner sign-in (drill-in from CockpitScreen) ─────────────────
+          composable(
+            route = Routes.OwnerSignIn,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            OwnerSignInScreen(
+              clanId = clanId,
+              onSignedIn = {
+                nav.navigate(Routes.ownerComingSoon(clanId)) {
+                  // Replace the sign-in screen so back goes to Cockpit,
+                  // not back through SIWS again.
+                  popUpTo(Routes.OwnerSignIn) { inclusive = true }
+                }
+              },
+              onBack = { nav.popBackStack() },
+            )
+          }
+
+          // ── Owner coming-soon (placeholder after successful SIWS) ───────
+          composable(
+            route = Routes.OwnerComingSoon,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            OwnerComingSoonScreen(
               clanId = clanId,
               onBack = { nav.popBackStack() },
             )

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -78,6 +78,7 @@ fun InftDetailScreenRoute(
   app: App,
   clanId: Int,
   onBack: () -> Unit,
+  onEnterCockpit: () -> Unit = {},
 ) {
   val vm: InftDetailViewModel = viewModel(factory = InftDetailViewModelFactory(app, clanId))
   val state by vm.state.collectAsState()
@@ -86,6 +87,7 @@ fun InftDetailScreenRoute(
     clanId = clanId,
     onBack = onBack,
     onSelectDetailTab = vm::selectTab,
+    onEnterCockpit = onEnterCockpit,
   )
 }
 
@@ -95,6 +97,7 @@ private fun InftDetailScreen(
   clanId: Int,
   onBack: () -> Unit,
   onSelectDetailTab: (DetailTab) -> Unit,
+  onEnterCockpit: () -> Unit,
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
   Column(
@@ -109,6 +112,17 @@ private fun InftDetailScreen(
       clanId = clanId,
       state = state,
       modifier = Modifier.padding(horizontal = 22.dp),
+    )
+
+    Spacer(Modifier.height(14.dp))
+
+    // ── Enter Cockpit CTA — drill into the live game cockpit ───────────
+    world.clan.app.ui.components.EmberCta(
+      text = "Enter Cockpit",
+      onClick = onEnterCockpit,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 22.dp),
     )
 
     Spacer(Modifier.height(22.dp))


### PR DESCRIPTION
Fixes the cockpit-unreachable regression introduced when slice 1+2A (PR #55) landed in dev — `MainActivity` hosts `ClanWorldApp` instead of `AppNav`, so `CockpitScreen` had no nav path. This PR re-wires it as a deep route from iNFT Detail.

## What this adds

- **3 deep routes in `ui/ClanWorldApp.kt`**: `Routes.Cockpit`, `Routes.OwnerSignIn(clanId)`, `Routes.OwnerComingSoon(clanId)`. NavHost composables for each, using the same half-distance slide + crossfade transitions as InftDetail.
- **"Enter Cockpit" EmberCta on `InftDetailScreen`**, between the hero parchment and the tab strip. Tap drills into `CockpitScreen` (live game cockpit with Clansman/Comms/Terminal/Vault/ZeroG tabs from PR #56).
- **Cockpit → Owner sign-in wiring**: cockpit's `onOwnerControl(clanId)` callback navigates to `Routes.ownerSignIn(clanId)`. Owner sign-in success `popUpTo`'s the sign-in screen so back returns to Cockpit, not back through SIWS.
- **Tabbar predicate updated**: hides on Cockpit / OwnerSignIn / OwnerComingSoon (full-screen flows). Restores on Hearth/Hall/Codex/InftDetail as before.

## Flow now

```
Connect → Hearth (with sliding tabbar)
           ├── tab: Hall
           │     └── tap iNFT → InftDetail
           │           └── "Enter Cockpit" CTA → CockpitScreen (live game, no tabbar)
           │                 └── "Owner Control" → OwnerSignIn → SIWS via Phantom
           │                       └── (success) → OwnerComingSoon
           ├── tab: Codex
           └── (wallet pill dropdown → Disconnect → Connect)
```

## Build
`./gradlew :app:assembleDebug` green.

## Dead code left for follow-up
`nav/AppNav.kt` and `owner/Mwa.kt` are now unreachable — `OwnerSignInScreen` still uses `Mwa.signInAsOwner` so it stays wired functionally. A small follow-up PR can fold `signInAsOwner` into `wallet/MwaClient` and delete both files.

## Test plan
- [x] Build green
- [ ] Install APK; flow Hall → iNFT card → InftDetail → Enter Cockpit → CockpitScreen with live data
- [ ] Cockpit → Owner Control → OwnerSignIn → approve in Phantom → OwnerComingSoon
- [ ] Back nav at every step returns to the previous screen
- [ ] Tabbar hides on Cockpit/Owner screens, returns on Hearth/Hall/Codex/InftDetail

🤖 Generated with [Claude Code](https://claude.com/claude-code)