### PR TITLE
feat(android): Phase 4a — Bazaar tab + Hire modal

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/BazaarListing.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/BazaarListing.kt
@@ -1,0 +1,69 @@
+package world.clan.app.data
+
+/**
+ * One row in the Bazaar marketplace. UI-demo data — no on-chain listing
+ * mechanism exists yet, so listings are a static const list seeded from
+ * the unlinked clan set (anything not in HearthViewModel.LINKED_CLAN_IDS).
+ */
+data class BazaarListing(
+  val tokenId: Int,
+  val clanId: Int,
+  /** Hire price in whole gold per season. */
+  val pricePerSeason: Int,
+  /** Display-only owner short label (truncated pubkey). */
+  val ownerShort: String,
+  /** Hire-style availability blurb shown above the price. */
+  val availability: String,
+  /** Single-line flavor copy. */
+  val pitch: String,
+)
+
+/**
+ * Hardcoded listings for the slice 4 Bazaar demo. The five clan IDs not in
+ * `HearthViewModel.LINKED_CLAN_IDS` (1, 3, 4, 7, 8) are listed.
+ */
+val BAZAAR_LISTINGS: List<BazaarListing> = listOf(
+  BazaarListing(
+    tokenId = 0x10A1,
+    clanId = 1,
+    pricePerSeason = 240,
+    ownerShort = "9pK4 · 7vQy",
+    availability = "available — i of i",
+    pitch = "Mountain-bred. Reads winter as plainly as a name.",
+  ),
+  BazaarListing(
+    tokenId = 0x10A3,
+    clanId = 3,
+    pricePerSeason = 320,
+    ownerShort = "Hr8e · q2Fm",
+    availability = "available — i of i",
+    pitch = "Sun-keeper. Coin discipline is its first oath.",
+  ),
+  BazaarListing(
+    tokenId = 0x10A4,
+    clanId = 4,
+    pricePerSeason = 180,
+    ownerShort = "C4ka · M6sz",
+    availability = "available — i of i",
+    pitch = "Of the green country. Patient. Reads weather first.",
+  ),
+  BazaarListing(
+    tokenId = 0x10A7,
+    clanId = 7,
+    pricePerSeason = 360,
+    ownerShort = "B2nv · F1xz",
+    availability = "available — i of i",
+    pitch = "Forge-born. Steady iron over showy gold.",
+  ),
+  BazaarListing(
+    tokenId = 0x10A8,
+    clanId = 8,
+    pricePerSeason = 280,
+    ownerShort = "Tg9q · 4kPx",
+    availability = "available — i of i",
+    pitch = "Walks the longer line. Treats the season as a cipher.",
+  ),
+)
+
+fun bazaarListingByClan(clanId: Int): BazaarListing? =
+  BAZAAR_LISTINGS.firstOrNull { it.clanId == clanId }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -57,12 +57,15 @@ object Routes {
   const val Connect = "connect"
   const val Hearth = "hearth"
   const val Hall = "hall"
+  const val Bazaar = "bazaar"
   const val Codex = "codex"
   const val InftDetail = "inft/{clanId}"
+  const val BazaarInftDetail = "bazaarInft/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
   const val OwnerComingSoon = "ownerComingSoon/{clanId}"
   fun inftDetail(clanId: Int) = "inft/$clanId"
+  fun bazaarInftDetail(clanId: Int) = "bazaarInft/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
 }
@@ -74,7 +77,8 @@ object Routes {
 private val tabIndex = mapOf(
   Routes.Hearth to 0,
   Routes.Hall to 1,
-  Routes.Codex to 2,
+  Routes.Bazaar to 2,
+  Routes.Codex to 3,
 )
 
 private fun NavBackStackEntry?.tabIdx(): Int? =
@@ -188,14 +192,18 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
   val currentRoute = currentBackStack?.destination?.route
   val showTabBar = currentRoute == Routes.Hearth ||
     currentRoute == Routes.Hall ||
+    currentRoute == Routes.Bazaar ||
     currentRoute == Routes.Codex ||
-    currentRoute?.startsWith("inft/") == true
+    currentRoute?.startsWith("inft/") == true ||
+    currentRoute?.startsWith("bazaarInft/") == true
   // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
     currentRoute == Routes.Hall -> RootTab.Hall
+    currentRoute == Routes.Bazaar -> RootTab.Bazaar
     currentRoute == Routes.Codex -> RootTab.Codex
     currentRoute?.startsWith("inft/") == true -> RootTab.Hall // detail derived from Hall
+    currentRoute?.startsWith("bazaarInft/") == true -> RootTab.Bazaar // detail derived from Bazaar
     currentRoute == Routes.Cockpit ||
       currentRoute?.startsWith("ownerSignIn/") == true ||
       currentRoute?.startsWith("ownerComingSoon/") == true -> RootTab.Hall
@@ -290,6 +298,33 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
           }
 
           composable(
+            route = Routes.Bazaar,
+            enterTransition = { tabEnter() },
+            exitTransition = {
+              if (targetState.destination.route == Routes.BazaarInftDetail)
+                fadeOut(tween(TAB_FADE_OUT_MS, easing = FastOutSlowInEasing))
+              else tabExit()
+            },
+            popEnterTransition = {
+              if (initialState.destination.route == Routes.BazaarInftDetail)
+                fadeIn(
+                  tween(
+                    durationMillis = TAB_FADE_IN_MS,
+                    delayMillis = TAB_FADE_IN_DELAY_MS,
+                    easing = FastOutSlowInEasing,
+                  ),
+                )
+              else tabEnter()
+            },
+          ) {
+            world.clan.app.ui.screens.BazaarScreenRoute(
+              app = app,
+              factory = factory,
+              onOpenListing = { clanId -> nav.navigate(Routes.bazaarInftDetail(clanId)) },
+            )
+          }
+
+          composable(
             route = Routes.Codex,
             enterTransition = { tabEnter() },
             exitTransition = { tabExit() },
@@ -313,6 +348,30 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
               clanId = clanId,
               onBack = { nav.popBackStack() },
               onEnterCockpit = { nav.navigate(Routes.Cockpit) },
+            )
+          }
+
+          // ── Bazaar iNFT detail (preview a hireable sigil; "Hire" instead
+          //    of "Enter Cockpit"). Confirms via HireModal → SIWS sign.
+          composable(
+            route = Routes.BazaarInftDetail,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            InftDetailScreenRoute(
+              app = app,
+              clanId = clanId,
+              onBack = { nav.popBackStack() },
+              isBazaar = true,
+              hostActivity = hostActivity,
+              onHireConfirmed = {
+                // For now: simply pop back to Bazaar. A future "Hired"
+                // confirmation screen could replace this.
+                nav.popBackStack()
+              },
             )
           }
 
@@ -379,6 +438,7 @@ private fun navigateTab(
   val route = when (tab) {
     RootTab.Hearth -> Routes.Hearth
     RootTab.Hall -> Routes.Hall
+    RootTab.Bazaar -> Routes.Bazaar
     RootTab.Codex -> Routes.Codex
   }
   nav.navigate(route) {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
@@ -1,0 +1,285 @@
+package world.clan.app.ui.components
+
+import androidx.activity.ComponentActivity
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import world.clan.app.App
+import world.clan.app.data.BazaarListing
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.ui.theme.clanGlyphRes
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.wallet.MwaResult
+
+/**
+ * Hire confirmation modal. Renders as a full-screen overlay (scrim + parchment
+ * card centered). On Confirm:
+ *   1. Sign a "Hire" message via MWA (real signMessage call against the
+ *      stored authToken).
+ *   2. Show a pulsing "Sealed ✓" success state for ~1.4s.
+ *   3. Call [onConfirmed] so the host can dismiss + navigate.
+ *
+ * If the user has no auth token (shouldn't happen on this screen — Connect
+ * gates everything), Confirm short-circuits to the success state without
+ * calling MWA.
+ */
+@Composable
+fun HireModal(
+  app: App,
+  hostActivity: ComponentActivity,
+  listing: BazaarListing,
+  onDismiss: () -> Unit,
+  onConfirmed: () -> Unit,
+) {
+  val scope = rememberCoroutineScope()
+  val state = remember { mutableStateOf(HireState.Idle) }
+  val errorMessage = remember { mutableStateOf<String?>(null) }
+
+  // Auto-dismiss after success.
+  LaunchedEffect(state.value) {
+    if (state.value == HireState.Sealed) {
+      delay(1400L)
+      onConfirmed()
+    }
+  }
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .background(Color(0xCC050505)) // scrim
+      .clickable(
+        enabled = state.value == HireState.Idle || state.value == HireState.Failed,
+        onClick = onDismiss,
+      ),
+    contentAlignment = Alignment.Center,
+  ) {
+    // Inner card; consume click so taps inside don't dismiss.
+    Box(
+      modifier = Modifier
+        .padding(horizontal = 28.dp)
+        .clickable(enabled = false) {},
+    ) {
+      ParchmentCard(
+        modifier = Modifier.fillMaxWidth(),
+      ) {
+        HireBody(
+          listing = listing,
+          state = state,
+          errorMessage = errorMessage,
+          onConfirm = {
+            scope.launch {
+              state.value = HireState.Signing
+              errorMessage.value = null
+              val token = app.sessionStore.read()?.mwaAuthToken
+              if (token == null) {
+                state.value = HireState.Sealed
+                return@launch
+              }
+              val message = "ClanWorld Hire — token 0x${"%04x".format(listing.tokenId)} clan ${listing.clanId}".toByteArray()
+              val result = app.mwaClient.signMessage(hostActivity, token, message)
+              when (result) {
+                is MwaResult.Ok -> state.value = HireState.Sealed
+                is MwaResult.WalletNotFound -> {
+                  state.value = HireState.Failed
+                  errorMessage.value = "no wallet found on device."
+                }
+                is MwaResult.UserDeclined -> {
+                  state.value = HireState.Idle
+                }
+                is MwaResult.Error -> {
+                  state.value = HireState.Failed
+                  errorMessage.value = result.cause.message ?: "the wallet refused the seal."
+                }
+              }
+            }
+          },
+          onDismiss = onDismiss,
+        )
+      }
+    }
+  }
+}
+
+private enum class HireState { Idle, Signing, Sealed, Failed }
+
+@Composable
+private fun HireBody(
+  listing: BazaarListing,
+  state: MutableState<HireState>,
+  errorMessage: MutableState<String?>,
+  onConfirm: () -> Unit,
+  onDismiss: () -> Unit,
+) {
+  val clanCol = clanColor(listing.clanId)
+
+  Row(
+    verticalAlignment = Alignment.Top,
+    horizontalArrangement = Arrangement.spacedBy(14.dp),
+  ) {
+    Column(Modifier.weight(1f)) {
+      Text(
+        text = "BIND THE CONTRACT",
+        style = ClanWorldTheme.type.monoMicro,
+        color = Ink3,
+      )
+      Text(
+        text = clanDisplayName(listing.clanId),
+        style = ClanWorldTheme.type.letterName,
+        color = Ink,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+      Text(
+        text = "tkn 0x${"%04x".format(listing.tokenId)}",
+        style = ClanWorldTheme.type.monoMicro,
+        color = Ink3,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+    WaxSeal(
+      glyph = painterResource(clanGlyphRes(listing.clanId)),
+      clanColor = clanCol,
+    )
+  }
+
+  Spacer(Modifier.height(12.dp))
+
+  Text(
+    text = listing.pitch,
+    style = ClanWorldTheme.type.scriptItalic,
+    color = Ink2,
+  )
+
+  Spacer(Modifier.height(14.dp))
+
+  // Stat strip
+  Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+    HireStat(label = "Price", value = "${listing.pricePerSeason}g", color = ClanWorldTheme.colors.gold)
+    HireStat(label = "Term", value = "i season", color = Ink)
+    HireStat(label = "Owner", value = listing.ownerShort, color = Ink3)
+  }
+
+  Spacer(Modifier.height(18.dp))
+
+  when (state.value) {
+    HireState.Idle, HireState.Failed -> {
+      EmberCta(
+        text = if (state.value == HireState.Failed) "Try Again" else "Sign with Wallet",
+        onClick = onConfirm,
+        modifier = Modifier.fillMaxWidth(),
+      )
+      if (state.value == HireState.Failed) {
+        Spacer(Modifier.height(8.dp))
+        Text(
+          text = errorMessage.value ?: "—",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.danger,
+        )
+      }
+      Spacer(Modifier.height(8.dp))
+      Text(
+        text = "DISMISS",
+        style = ClanWorldTheme.type.monoNano,
+        color = Ink3,
+        modifier = Modifier
+          .fillMaxWidth()
+          .clickable { onDismiss() }
+          .padding(vertical = 10.dp),
+        textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+      )
+    }
+    HireState.Signing -> {
+      Box(
+        Modifier
+          .fillMaxWidth()
+          .height(54.dp)
+          .clip(RoundedCornerShape(6.dp))
+          .drawBehind {
+            drawRoundRect(
+              color = Ink.copy(alpha = 0.10f),
+              cornerRadius = CornerRadius(6.dp.toPx()),
+              style = Stroke(width = 1.dp.toPx()),
+            )
+          },
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          text = "AWAITING THE WALLET'S SEAL…",
+          style = ClanWorldTheme.type.ctaLabel,
+          color = Ink3,
+        )
+      }
+    }
+    HireState.Sealed -> {
+      Box(
+        Modifier
+          .fillMaxWidth()
+          .height(54.dp)
+          .clip(RoundedCornerShape(6.dp))
+          .background(ClanWorldTheme.colors.success.copy(alpha = 0.18f)),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          text = "SEALED ✓",
+          style = ClanWorldTheme.type.ctaLabel,
+          color = ClanWorldTheme.colors.success,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.HireStat(
+  label: String,
+  value: String,
+  color: Color,
+) {
+  Column(Modifier.weight(1f)) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Text(
+      text = value,
+      style = ClanWorldTheme.type.monoData,
+      color = color,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Tabbar.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Tabbar.kt
@@ -36,6 +36,7 @@ import world.clan.app.ui.theme.ClanWorldTheme
 enum class RootTab(val label: String, val drawableRes: Int) {
   Hearth("Hearth", R.drawable.ui_tab_hearth),
   Hall("Hall", R.drawable.ui_tab_hall),
+  Bazaar("Bazaar", R.drawable.ui_tab_bazaar),
   Codex("Codex", R.drawable.ui_tab_codex),
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
@@ -1,0 +1,256 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import world.clan.app.App
+import world.clan.app.data.BazaarListing
+import world.clan.app.ui.components.CrownHeader
+import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.components.StaggeredEntry
+import world.clan.app.ui.components.WaxSeal
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.ui.theme.clanGlyphRes
+import world.clan.app.viewmodel.BazaarUiState
+import world.clan.app.viewmodel.BazaarViewModel
+import world.clan.app.viewmodel.ClanWorldViewModelFactory
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.clanTagline
+
+@Composable
+fun BazaarScreenRoute(
+  app: App,
+  factory: ClanWorldViewModelFactory,
+  onOpenListing: (Int) -> Unit,
+) {
+  val vm: BazaarViewModel = viewModel(factory = factory)
+  val state by vm.state.collectAsState()
+  BazaarScreen(state = state, onOpenListing = onOpenListing)
+}
+
+@Composable
+private fun BazaarScreen(
+  state: BazaarUiState,
+  onOpenListing: (Int) -> Unit,
+) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(horizontal = 22.dp),
+  ) {
+    CrownHeader(
+      screenName = "Bazaar",
+      modifier = Modifier.fillMaxWidth(),
+    )
+
+    StaggeredEntry(index = 0) {
+      BazaarHead(count = state.listings.size)
+    }
+
+    Spacer(Modifier.height(18.dp))
+
+    if (state.isLoading) {
+      Text(
+        text = "the merchants are setting their stalls…",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warmFaint,
+        modifier = Modifier.padding(top = 24.dp),
+      )
+    } else if (state.listings.isEmpty()) {
+      Text(
+        text = state.errorMessage ?: "the bazaar is quiet — no listings posted.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warmFaint,
+        modifier = Modifier.padding(top = 24.dp),
+      )
+    } else {
+      LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+        contentPadding = PaddingValues(bottom = 24.dp),
+      ) {
+        items(state.listings, key = { it.tokenId }) { listing ->
+          StaggeredEntry(index = listing.clanId.coerceAtMost(8)) {
+            ListingCard(
+              listing = listing,
+              onClick = { onOpenListing(listing.clanId) },
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun BazaarHead(count: Int) {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val gold = ClanWorldTheme.colors.gold
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(top = 14.dp, bottom = 4.dp)
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 18f),
+          end = Offset(size.width, size.height + 18f),
+          strokeWidth = 1f,
+        )
+      },
+    verticalAlignment = Alignment.Bottom,
+    horizontalArrangement = Arrangement.SpaceBetween,
+  ) {
+    Column {
+      Text(
+        text = "BAZAAR",
+        style = ClanWorldTheme.type.displayHero,
+        color = parchment,
+      )
+      Text(
+        text = "merchants of the realm — sigils for hire",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = warmDim,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+    Column(horizontalAlignment = Alignment.End) {
+      Text(
+        text = "%02d".format(count),
+        style = ClanWorldTheme.type.monoBig,
+        color = parchment,
+      )
+      Text(
+        text = "listings",
+        style = ClanWorldTheme.type.monoMicro,
+        color = gold,
+      )
+    }
+  }
+}
+
+@Composable
+private fun ListingCard(
+  listing: BazaarListing,
+  onClick: () -> Unit,
+) {
+  ParchmentCard(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { onClick() },
+  ) {
+    val clanCol = clanColor(listing.clanId)
+
+    Row(
+      verticalAlignment = Alignment.Top,
+      horizontalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+      Column(Modifier.weight(1f)) {
+        Text(
+          text = clanDisplayName(listing.clanId),
+          style = ClanWorldTheme.type.letterName,
+          color = Ink,
+        )
+        Text(
+          text = "tkn 0x${"%04x".format(listing.tokenId)} · clan ${roman(listing.clanId).lowercase()}",
+          style = ClanWorldTheme.type.monoMicro,
+          color = Ink3,
+          modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+      WaxSeal(
+        glyph = painterResource(clanGlyphRes(listing.clanId)),
+        clanColor = clanCol,
+      )
+    }
+
+    Spacer(Modifier.height(8.dp))
+
+    Text(
+      text = listing.pitch,
+      style = ClanWorldTheme.type.scriptItalic,
+      color = Ink2,
+    )
+
+    Spacer(Modifier.height(12.dp))
+
+    Box(
+      Modifier
+        .fillMaxWidth()
+        .height(1.dp)
+        .drawBehind {
+          drawLine(
+            color = Ink.copy(alpha = 0.20f),
+            start = Offset(0f, 0f),
+            end = Offset(size.width, 0f),
+            strokeWidth = 1f,
+            pathEffect = PathEffect.dashPathEffect(floatArrayOf(2.dp.toPx(), 2.dp.toPx())),
+          )
+        },
+    )
+
+    Spacer(Modifier.height(12.dp))
+
+    Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+      ListingStat(label = "Price", value = "${listing.pricePerSeason}g/season", color = ClanWorldTheme.colors.gold)
+      ListingStat(label = "Status", value = listing.availability.substringBefore("—").trim(), color = ClanWorldTheme.colors.success)
+      ListingStat(label = "Owner", value = listing.ownerShort, color = Ink3)
+    }
+  }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.ListingStat(
+  label: String,
+  value: String,
+  color: androidx.compose.ui.graphics.Color,
+) {
+  Column(Modifier.weight(1f)) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Text(
+      text = value,
+      style = ClanWorldTheme.type.monoData,
+      color = color,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+private fun roman(n: Int): String = when (n) {
+  1 -> "I"; 2 -> "II"; 3 -> "III"; 4 -> "IV"
+  5 -> "V"; 6 -> "VI"; 7 -> "VII"; 8 -> "VIII"
+  else -> n.toString()
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -79,6 +79,9 @@ fun InftDetailScreenRoute(
   clanId: Int,
   onBack: () -> Unit,
   onEnterCockpit: () -> Unit = {},
+  isBazaar: Boolean = false,
+  hostActivity: androidx.activity.ComponentActivity? = null,
+  onHireConfirmed: (() -> Unit)? = null,
 ) {
   val vm: InftDetailViewModel = viewModel(factory = InftDetailViewModelFactory(app, clanId))
   val state by vm.state.collectAsState()
@@ -88,6 +91,10 @@ fun InftDetailScreenRoute(
     onBack = onBack,
     onSelectDetailTab = vm::selectTab,
     onEnterCockpit = onEnterCockpit,
+    isBazaar = isBazaar,
+    app = app,
+    hostActivity = hostActivity,
+    onHireConfirmed = onHireConfirmed ?: onBack,
   )
 }
 
@@ -98,8 +105,14 @@ private fun InftDetailScreen(
   onBack: () -> Unit,
   onSelectDetailTab: (DetailTab) -> Unit,
   onEnterCockpit: () -> Unit,
+  isBazaar: Boolean = false,
+  app: App? = null,
+  hostActivity: androidx.activity.ComponentActivity? = null,
+  onHireConfirmed: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
+  val showHireModal = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+  Box(modifier = Modifier.fillMaxSize()) {
   Column(
     modifier = Modifier
       .fillMaxSize()
@@ -116,10 +129,10 @@ private fun InftDetailScreen(
 
     Spacer(Modifier.height(14.dp))
 
-    // ── Enter Cockpit CTA — drill into the live game cockpit ───────────
+    // ── Primary CTA: Hire (bazaar mode) or Enter Cockpit (linked mode) ─
     world.clan.app.ui.components.EmberCta(
-      text = "Enter Cockpit",
-      onClick = onEnterCockpit,
+      text = if (isBazaar) "Hire This Sigil" else "Enter Cockpit",
+      onClick = if (isBazaar) ({ showHireModal.value = true }) else onEnterCockpit,
       modifier = Modifier
         .fillMaxWidth()
         .padding(horizontal = 22.dp),
@@ -146,6 +159,24 @@ private fun InftDetailScreen(
 
     Spacer(Modifier.height(40.dp))
   }
+
+  // ── HireModal overlay (bazaar mode only) ────────────────────────────────
+  if (isBazaar && showHireModal.value && app != null && hostActivity != null) {
+    val listing = world.clan.app.data.bazaarListingByClan(clanId)
+    if (listing != null) {
+      world.clan.app.ui.components.HireModal(
+        app = app,
+        hostActivity = hostActivity,
+        listing = listing,
+        onDismiss = { showHireModal.value = false },
+        onConfirmed = {
+          showHireModal.value = false
+          onHireConfirmed()
+        },
+      )
+    }
+  }
+  } // close outer Box
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/BazaarViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/BazaarViewModel.kt
@@ -1,0 +1,28 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import world.clan.app.data.BAZAAR_LISTINGS
+import world.clan.app.data.BazaarListing
+
+data class BazaarUiState(
+  val isLoading: Boolean = false,
+  val listings: List<BazaarListing> = emptyList(),
+  val errorMessage: String? = null,
+)
+
+/**
+ * Slice 4: Bazaar viewmodel. The listings are a static demo list; no Convex
+ * marketplace query exists yet. ViewModel still exists so that the screen
+ * can subscribe through StateFlow like every other screen — when a real
+ * listings query lands, only this file changes.
+ */
+class BazaarViewModel : ViewModel() {
+
+  private val _state = MutableStateFlow(
+    BazaarUiState(listings = BAZAAR_LISTINGS),
+  )
+  val state: StateFlow<BazaarUiState> = _state.asStateFlow()
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -14,6 +14,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     ConnectViewModel::class.java -> ConnectViewModel(app.mwaClient, app.sessionStore)
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
+    BazaarViewModel::class.java -> BazaarViewModel()
     CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")
   } as T

--- a/apps/clan-world-mobile/app/src/main/res/drawable/ui_tab_bazaar.xml
+++ b/apps/clan-world-mobile/app/src/main/res/drawable/ui_tab_bazaar.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <!-- merchant scales — beam + two pans + center post -->
+    <path android:strokeColor="#FFFFFF" android:strokeWidth="1.4"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M12,4 V20 M5,20 H19 M4,7 H20 M9,5.6 L15,5.6"/>
+    <!-- left pan -->
+    <path android:strokeColor="#FFFFFF" android:strokeWidth="1.4"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M3,11 L7,11 M3,11 a4,4 0 0 0 4,0 z"/>
+    <!-- right pan -->
+    <path android:strokeColor="#FFFFFF" android:strokeWidth="1.4"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M17,11 L21,11 M17,11 a4,4 0 0 0 4,0 z"/>
+</vector>


### PR DESCRIPTION
## Summary

Adds the marketplace browse + hire flow per the RN reference. Stacked on top of #61 (Phase 3 cockpit wiring) — once #61 merges, this rebases onto dev cleanly.

- **New Bazaar bottom tab** — 4-tab layout: Hearth / Hall / Bazaar / Codex (was 3)
- **BazaarScreen** — marketplace iNFT list. Reuses ParchmentCard + WaxSeal; stat strip shows price/season + status + owner-short
- **HireModal** — full-screen scrim + parchment confirm card. On Confirm signs a Hire message via existing \`MwaClient.signMessage\`, shows pulsing "Sealed ✓" for 1.4s, dismisses
- **InftDetailScreen** — new \`isBazaar\` mode swaps "Enter Cockpit" CTA for "Hire This Sigil" and overlays HireModal on tap. Linked-mode flow (Hall → InftDetail → Cockpit) is unchanged
- **5 hardcoded listings** for the demo (clans 1, 3, 4, 7, 8 — the unlinked set; 2/5/6 are in \`HearthViewModel.LINKED_CLAN_IDS\`). No real Convex marketplace query exists yet — \`BazaarViewModel\` is the StateFlow seam for when one lands
- **ClanWorldApp.kt** routing — adds \`Routes.Bazaar\` + \`Routes.BazaarInftDetail\`; \`showTabBar\` / \`selectedTab\` / \`navigateTab\` extend cleanly

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 21s.

## Test plan

- [ ] Connect → Hearth → tap Bazaar tab → 5 listings render with correct stat strip
- [ ] Tap a listing → BazaarInftDetail opens with "Hire This Sigil" (NOT "Enter Cockpit")
- [ ] Tap Hire → HireModal overlay shows clan card, price, owner, terms
- [ ] Confirm → MWA wallet sign sheet opens (Phantom)
- [ ] On sign: "Sealed ✓" success state, auto-dismiss 1.4s, back to Bazaar
- [ ] On user-decline: modal returns to idle (Sign with Wallet button visible)
- [ ] Linked-mode: Hall → tap iNFT → "Enter Cockpit" CTA still navigates to cockpit (unchanged)
- [ ] Tab transitions: Bazaar slide direction matches tab order (Hearth=0, Hall=1, Bazaar=2, Codex=3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)