### PR TITLE
feat(android): Phase 4b — BridgeScreen + Whispers inbox

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -62,11 +62,15 @@ object Routes {
   const val Codex = "codex"
   const val InftDetail = "inft/{clanId}"
   const val BazaarInftDetail = "bazaarInft/{clanId}"
+  const val Whispers = "whispers/{clanId}"
+  const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
   const val OwnerComingSoon = "ownerComingSoon/{clanId}"
   fun inftDetail(clanId: Int) = "inft/$clanId"
   fun bazaarInftDetail(clanId: Int) = "bazaarInft/$clanId"
+  fun whispers(clanId: Int) = "whispers/$clanId"
+  fun bridge(clanId: Int) = "bridge/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
 }
@@ -202,7 +206,8 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
     currentRoute == Routes.Bazaar ||
     currentRoute == Routes.Codex ||
     currentRoute?.startsWith("inft/") == true ||
-    currentRoute?.startsWith("bazaarInft/") == true
+    currentRoute?.startsWith("bazaarInft/") == true ||
+    currentRoute?.startsWith("whispers/") == true
   // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
@@ -211,7 +216,9 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
     currentRoute == Routes.Codex -> RootTab.Codex
     currentRoute?.startsWith("inft/") == true -> RootTab.Hall // detail derived from Hall
     currentRoute?.startsWith("bazaarInft/") == true -> RootTab.Bazaar // detail derived from Bazaar
-    currentRoute == Routes.Cockpit ||
+    currentRoute?.startsWith("whispers/") == true -> RootTab.Hall // inbox is a Hall drill-in
+    currentRoute?.startsWith("bridge/") == true ||
+      currentRoute == Routes.Cockpit ||
       currentRoute?.startsWith("ownerSignIn/") == true ||
       currentRoute?.startsWith("ownerComingSoon/") == true -> RootTab.Hall
     else -> RootTab.Hearth
@@ -354,7 +361,8 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
               app = app,
               clanId = clanId,
               onBack = { nav.popBackStack() },
-              onEnterCockpit = { nav.navigate(Routes.Cockpit) },
+              onEnterCockpit = { nav.navigate(Routes.bridge(clanId)) },
+              onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
             )
           }
 
@@ -372,6 +380,7 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
               app = app,
               clanId = clanId,
               onBack = { nav.popBackStack() },
+              onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
               isBazaar = true,
               hostActivity = hostActivity,
               onHireConfirmed = {
@@ -382,7 +391,42 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
             )
           }
 
-          // ── Cockpit (deep route from InftDetail "Enter Cockpit" CTA) ────
+          // ── Bridge loader (between InftDetail "Enter Cockpit" and Cockpit) ─
+          composable(
+            route = Routes.Bridge,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { fadeIn(tween(280, easing = FastOutSlowInEasing)) },
+            exitTransition = { fadeOut(tween(280, easing = FastOutSlowInEasing)) },
+            popExitTransition = { fadeOut(tween(220, easing = FastOutSlowInEasing)) },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            world.clan.app.ui.screens.BridgeScreen(
+              clanId = clanId,
+              onReady = {
+                nav.navigate(Routes.Cockpit) {
+                  popUpTo(Routes.Bridge) { inclusive = true }
+                }
+              },
+            )
+          }
+
+          // ── Whispers inbox (deep route from InftDetail Whispers tab) ────
+          composable(
+            route = Routes.Whispers,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            world.clan.app.ui.screens.WhispersScreenRoute(
+              app = app,
+              clanId = clanId,
+              onBack = { nav.popBackStack() },
+            )
+          }
+
+          // ── Cockpit (deep route from Bridge after the loader resolves) ──
           composable(
             route = Routes.Cockpit,
             enterTransition = { detailEnter() },

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BridgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BridgeScreen.kt
@@ -1,0 +1,102 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import world.clan.app.ui.components.Sigil
+import world.clan.app.ui.components.bigSigilSpec
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.viewmodel.clanDisplayName
+
+/**
+ * Short loader between InftDetail's "Enter Cockpit" tap and the actual
+ * CockpitScreen mount. Buys ~1.4s for two reasons:
+ *   1. Cockpit data fetches start from a clean state — gives them a
+ *      moment to land before the screen is on-stage.
+ *   2. The transition feels weighty rather than instant — matches the
+ *      "the strait is preparing" copy.
+ *
+ * The screen is intentionally still: a single rotating Sigil with a slow
+ * breathing-fade subtitle. No tap targets — backstack handles cancel.
+ */
+@Composable
+fun BridgeScreen(
+  clanId: Int,
+  onReady: () -> Unit,
+) {
+  // Auto-advance after ~1.4s. If composition is torn down before then
+  // (back-press, etc.), the LaunchedEffect cancels cleanly.
+  LaunchedEffect(clanId) {
+    delay(1400L)
+    onReady()
+  }
+
+  val transition = rememberInfiniteTransition(label = "bridge-pulse")
+  val pulse by transition.animateFloat(
+    initialValue = 0.55f,
+    targetValue = 1f,
+    animationSpec = infiniteRepeatable(
+      animation = tween(durationMillis = 1600, easing = EaseInOut),
+      repeatMode = RepeatMode.Reverse,
+    ),
+    label = "pulse",
+  )
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(horizontal = 22.dp),
+    contentAlignment = Alignment.Center,
+  ) {
+    Column(
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center,
+    ) {
+      Sigil(
+        spec = bigSigilSpec(clanColor(clanId)),
+        modifier = Modifier.size(160.dp),
+      )
+
+      Spacer(Modifier.height(34.dp))
+
+      Text(
+        text = "preparing the strait…",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warm,
+        modifier = Modifier.alpha(pulse),
+        textAlign = TextAlign.Center,
+      )
+
+      Spacer(Modifier.height(8.dp))
+
+      Text(
+        text = clanDisplayName(clanId).uppercase(),
+        style = ClanWorldTheme.type.monoNano,
+        color = ClanWorldTheme.colors.gold,
+        textAlign = TextAlign.Center,
+      )
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -79,6 +79,7 @@ fun InftDetailScreenRoute(
   clanId: Int,
   onBack: () -> Unit,
   onEnterCockpit: () -> Unit = {},
+  onOpenInbox: () -> Unit = {},
   isBazaar: Boolean = false,
   hostActivity: androidx.activity.ComponentActivity? = null,
   onHireConfirmed: (() -> Unit)? = null,
@@ -91,6 +92,7 @@ fun InftDetailScreenRoute(
     onBack = onBack,
     onSelectDetailTab = vm::selectTab,
     onEnterCockpit = onEnterCockpit,
+    onOpenInbox = onOpenInbox,
     isBazaar = isBazaar,
     app = app,
     hostActivity = hostActivity,
@@ -105,6 +107,7 @@ private fun InftDetailScreen(
   onBack: () -> Unit,
   onSelectDetailTab: (DetailTab) -> Unit,
   onEnterCockpit: () -> Unit,
+  onOpenInbox: () -> Unit = {},
   isBazaar: Boolean = false,
   app: App? = null,
   hostActivity: androidx.activity.ComponentActivity? = null,
@@ -152,7 +155,7 @@ private fun InftDetailScreen(
       when (tab) {
         DetailTab.Memory -> MemoryPanel(state.state?.memory.orEmpty())
         DetailTab.Vault -> VaultPanel(state.vault)
-        DetailTab.Whispers -> WhispersPanel(state.comms)
+        DetailTab.Whispers -> WhispersPanel(state.comms, onOpenInbox = onOpenInbox)
         DetailTab.Bulletin -> BulletinPanel(state.state?.bulletins?.map { it.body } ?: emptyList())
       }
     }
@@ -482,7 +485,10 @@ private fun VaultPanel(vault: List<VaultMovement>) {
 }
 
 @Composable
-private fun WhispersPanel(comms: List<world.clan.app.data.CombinedComm>) {
+private fun WhispersPanel(
+  comms: List<world.clan.app.data.CombinedComm>,
+  onOpenInbox: () -> Unit = {},
+) {
   Column(
     modifier = Modifier
       .fillMaxWidth()
@@ -511,6 +517,17 @@ private fun WhispersPanel(comms: List<world.clan.app.data.CombinedComm>) {
           accent = accent,
         )
       }
+      Spacer(Modifier.height(4.dp))
+      Text(
+        text = "OPEN FULL INBOX →",
+        style = ClanWorldTheme.type.monoMicro,
+        color = ClanWorldTheme.colors.gold,
+        modifier = Modifier
+          .fillMaxWidth()
+          .clickable { onOpenInbox() }
+          .padding(vertical = 10.dp),
+        textAlign = TextAlign.Center,
+      )
     }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -1,0 +1,257 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import world.clan.app.App
+import world.clan.app.R
+import world.clan.app.data.CombinedComm
+import world.clan.app.ui.components.WhisperAccent
+import world.clan.app.ui.components.WhisperRow
+import world.clan.app.ui.components.boldedMeta
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.viewmodel.WhispersFilter
+import world.clan.app.viewmodel.WhispersUiState
+import world.clan.app.viewmodel.WhispersViewModel
+import world.clan.app.viewmodel.WhispersViewModelFactory
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.filtered
+
+@Composable
+fun WhispersScreenRoute(
+  app: App,
+  clanId: Int,
+  onBack: () -> Unit,
+) {
+  val vm: WhispersViewModel = viewModel(factory = WhispersViewModelFactory(app, clanId))
+  val state by vm.state.collectAsState()
+  WhispersScreen(
+    state = state,
+    clanId = clanId,
+    onBack = onBack,
+    onSetFilter = vm::setFilter,
+  )
+}
+
+@Composable
+private fun WhispersScreen(
+  state: WhispersUiState,
+  clanId: Int,
+  onBack: () -> Unit,
+  onSetFilter: (WhispersFilter) -> Unit,
+) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    InboxBackBar(clanId = clanId, onBack = onBack)
+
+    Column(modifier = Modifier.padding(horizontal = 22.dp)) {
+      InboxHead(clanId = clanId, count = state.filtered().size)
+      Spacer(Modifier.height(12.dp))
+      FilterRow(active = state.filter, onSelect = onSetFilter)
+      Spacer(Modifier.height(14.dp))
+    }
+
+    val items = state.filtered()
+    when {
+      state.isLoading -> {
+        Text(
+          text = "the whispers gather…",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+        )
+      }
+      state.errorMessage != null -> {
+        Text(
+          text = state.errorMessage,
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.danger,
+          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+        )
+      }
+      items.isEmpty() -> {
+        Text(
+          text = "no whispers carry this kind.",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+        )
+      }
+      else -> {
+        LazyColumn(
+          modifier = Modifier.fillMaxSize(),
+          verticalArrangement = Arrangement.spacedBy(10.dp),
+          contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+        ) {
+          items(items.withIndex().toList(), key = { (i, c) -> "${i}-${c.tick ?: c.timestamp ?: 0}" }) { (_, c) ->
+            InboxRow(comm = c)
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun InboxBackBar(clanId: Int, onBack: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 14.dp)
+      .clickable { onBack() },
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      painter = painterResource(R.drawable.ui_arrow),
+      contentDescription = "back",
+      tint = ClanWorldTheme.colors.warm,
+      modifier = Modifier.height(16.dp),
+    )
+    Text(
+      text = "back to ${clanDisplayName(clanId).lowercase()}",
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+  }
+}
+
+@Composable
+private fun InboxHead(clanId: Int, count: Int) {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val gold = ClanWorldTheme.colors.gold
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(top = 4.dp, bottom = 4.dp)
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 14f),
+          end = Offset(size.width, size.height + 14f),
+          strokeWidth = 1f,
+        )
+      },
+    verticalAlignment = Alignment.Bottom,
+    horizontalArrangement = Arrangement.SpaceBetween,
+  ) {
+    Column {
+      Text(
+        text = "INBOX",
+        style = ClanWorldTheme.type.displayHero,
+        color = parchment,
+      )
+      Text(
+        text = "whispers heard at ${clanDisplayName(clanId).lowercase()}",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = warmDim,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+    Column(horizontalAlignment = Alignment.End) {
+      Text(
+        text = "%02d".format(count),
+        style = ClanWorldTheme.type.monoBig,
+        color = parchment,
+      )
+      Text(
+        text = "shown",
+        style = ClanWorldTheme.type.monoMicro,
+        color = gold,
+      )
+    }
+  }
+}
+
+@Composable
+private fun FilterRow(active: WhispersFilter, onSelect: (WhispersFilter) -> Unit) {
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    FilterChip(label = "All", selected = active == WhispersFilter.All, onClick = { onSelect(WhispersFilter.All) })
+    FilterChip(label = "Peers", selected = active == WhispersFilter.Whisper, onClick = { onSelect(WhispersFilter.Whisper) })
+    FilterChip(label = "Orch", selected = active == WhispersFilter.Orch, onClick = { onSelect(WhispersFilter.Orch) })
+    FilterChip(label = "Owner", selected = active == WhispersFilter.Human, onClick = { onSelect(WhispersFilter.Human) })
+  }
+}
+
+@Composable
+private fun FilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
+  val bg = if (selected) ClanWorldTheme.colors.iron2 else Color.Transparent
+  val border = if (selected) ClanWorldTheme.colors.hairlineStrong else ClanWorldTheme.colors.hairline
+  val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
+  Box(
+    modifier = Modifier
+      .clip(RoundedCornerShape(4.dp))
+      .background(bg)
+      .drawBehind {
+        drawLine(
+          color = border,
+          start = Offset(0f, 0f),
+          end = Offset(size.width, 0f),
+          strokeWidth = 1f,
+        )
+        drawLine(
+          color = border,
+          start = Offset(0f, size.height),
+          end = Offset(size.width, size.height),
+          strokeWidth = 1f,
+        )
+      }
+      .clickable { onClick() }
+      .padding(horizontal = 12.dp, vertical = 8.dp),
+  ) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoMicro,
+      color = tint,
+    )
+  }
+}
+
+@Composable
+private fun InboxRow(comm: CombinedComm) {
+  val accent = when (comm.kind) {
+    "whisper" -> WhisperAccent.Rune
+    "orch" -> WhisperAccent.Gold
+    "human" -> WhisperAccent.Ember
+    else -> WhisperAccent.Default
+  }
+  val from = comm.fromClan?.let { clanDisplayName(it) }
+    ?: comm.speaker
+    ?: when (comm.kind) {
+      "orch" -> "Orchestrator"; "human" -> "Owner"; else -> "—"
+    }
+  val tickStr = comm.tick?.let { "%04d".format(it) } ?: "—"
+  WhisperRow(
+    meta = boldedMeta("*$from* · $tickStr".uppercase()),
+    body = comm.body,
+    accent = accent,
+  )
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -29,3 +29,13 @@ class InftDetailViewModelFactory(
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
     InftDetailViewModel(app.convexClient, clanId) as T
 }
+
+/** Per-route factory for Whispers, which depends on a clanId. */
+class WhispersViewModelFactory(
+  private val app: App,
+  private val clanId: Int,
+) : ViewModelProvider.Factory {
+  @Suppress("UNCHECKED_CAST")
+  override fun <T : ViewModel> create(modelClass: Class<T>): T =
+    WhispersViewModel(app.convexClient, clanId) as T
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/WhispersViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/WhispersViewModel.kt
@@ -1,0 +1,70 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import world.clan.app.data.ClanWorldConvexClient
+import world.clan.app.data.CombinedComm
+
+enum class WhispersFilter { All, Whisper, Orch, Human }
+
+data class WhispersUiState(
+  val isLoading: Boolean = true,
+  val items: List<CombinedComm> = emptyList(),
+  val filter: WhispersFilter = WhispersFilter.All,
+  val errorMessage: String? = null,
+)
+
+/**
+ * Inbox view-model for the per-clan whispers screen. Reuses the existing
+ * `comms:getCombinedComms` query — no new server-side surface needed.
+ *
+ * Filtering is client-side: the server returns the combined feed and the
+ * filter chips just slice the local list.
+ */
+class WhispersViewModel(
+  private val convex: ClanWorldConvexClient,
+  private val clanId: Int,
+) : ViewModel() {
+
+  private val _state = MutableStateFlow(WhispersUiState())
+  val state: StateFlow<WhispersUiState> = _state.asStateFlow()
+
+  init { refresh() }
+
+  fun refresh() {
+    viewModelScope.launch {
+      _state.update { it.copy(isLoading = true, errorMessage = null) }
+      runCatching { convex.getCombinedComms(clanId, limit = 80) }
+        .onSuccess { comms ->
+          _state.update {
+            it.copy(isLoading = false, items = comms, errorMessage = null)
+          }
+        }
+        .onFailure { e ->
+          _state.update {
+            it.copy(
+              isLoading = false,
+              errorMessage = e.message ?: "Failed to load whispers.",
+            )
+          }
+        }
+    }
+  }
+
+  fun setFilter(f: WhispersFilter) {
+    _state.update { it.copy(filter = f) }
+  }
+}
+
+/** Apply the active filter to the loaded items. */
+fun WhispersUiState.filtered(): List<CombinedComm> = when (filter) {
+  WhispersFilter.All -> items
+  WhispersFilter.Whisper -> items.filter { it.kind == "whisper" }
+  WhispersFilter.Orch -> items.filter { it.kind == "orch" }
+  WhispersFilter.Human -> items.filter { it.kind == "human" }
+}


### PR DESCRIPTION
## Summary

Stacked on #62. Adds two RN-reference screens as deep routes from InftDetail:

**BridgeScreen** — short loader between "Enter Cockpit" and CockpitScreen mount
- ~1.4s auto-advance via LaunchedEffect; back-press cancels via composition teardown
- One rotating Sigil + breathing "preparing the strait…" copy in the clan's accent color
- Inserted into the existing cockpit flow: InftDetail → bridge/{clanId} → cockpit

**WhispersScreen** — full per-clan whispers inbox
- Reuses existing \`comms:getCombinedComms\` (limit=80, no new server surface)
- Filter chips: All / Peers / Orch / Owner — filtering is client-side over the loaded list
- Same visual language as the inline WhispersPanel (WhisperRow + boldedMeta)
- Accessed via new "OPEN FULL INBOX →" link on the inline Whispers panel of InftDetail

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 24s.

## Test plan

- [ ] Connect → Hall → tap iNFT → Enter Cockpit → BridgeScreen shows for ~1.4s with rotating sigil → auto-routes to CockpitScreen
- [ ] Press back during Bridge: cancels cleanly, no orphan navigation
- [ ] InftDetail → Whispers tab → tap "OPEN FULL INBOX →" → WhispersScreen with filter chips renders
- [ ] Tap each filter chip — Peers/Orch/Owner — list slices accordingly
- [ ] Inbox back button returns to InftDetail with Whispers tab still selected
- [ ] Tab bar stays visible during Whispers (Hall selected); hidden during Bridge

## Stacked
This PR is stacked on #62 (Phase 4a — Bazaar). Once #61 → #62 merges, GitHub will retarget to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)