### PR TITLE
release: dev → main — Phase 3 (cockpit wiring) + Phase 4 (Bazaar/Bridge/Whispers/Steering)

### DIFF
--- a/.github/workflows/chainclient-abi.yml
+++ b/.github/workflows/chainclient-abi.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/App.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/App.kt
@@ -2,6 +2,7 @@ package world.clan.app
 
 import android.app.Application
 import world.clan.app.data.ClanWorldConvexClient
+import world.clan.app.data.LineageStore
 import world.clan.app.data.SessionStore
 import world.clan.app.wallet.DeviceCapabilities
 import world.clan.app.wallet.DeviceClass
@@ -20,5 +21,6 @@ class App : Application() {
   }
   val mwaClient: MwaClient by lazy { MwaClient() }
   val sessionStore: SessionStore by lazy { SessionStore(this) }
+  val lineageStore: LineageStore by lazy { LineageStore(this) }
   val deviceClass: DeviceClass by lazy { DeviceCapabilities.inspect(this) }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/CockpitScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/CockpitScreen.kt
@@ -47,9 +47,13 @@ import world.clan.app.ui.theme.CockpitTokens
 @Composable
 fun CockpitScreen(
   onOwnerControl: (Int) -> Unit,
+  initialClanId: Int = 1,
 ) {
   var collapsed by rememberSaveable { mutableStateOf(false) }
-  var activeClanId by rememberSaveable { mutableStateOf(1) }
+  // Key the saver on initialClanId so navigating into Cockpit for a
+  // different clan resets the active selection instead of stickying the
+  // previous clan's id from process restoration.
+  var activeClanId by rememberSaveable(initialClanId) { mutableStateOf(initialClanId) }
   var bulletinOpen by rememberSaveable { mutableStateOf(false) }
 
   // Singleton-per-screen data source. Survives recompositions, dies with

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/BazaarListing.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/BazaarListing.kt
@@ -1,0 +1,69 @@
+package world.clan.app.data
+
+/**
+ * One row in the Bazaar marketplace. UI-demo data — no on-chain listing
+ * mechanism exists yet, so listings are a static const list seeded from
+ * the unlinked clan set (anything not in HearthViewModel.LINKED_CLAN_IDS).
+ */
+data class BazaarListing(
+  val tokenId: Int,
+  val clanId: Int,
+  /** Hire price in whole gold per season. */
+  val pricePerSeason: Int,
+  /** Display-only owner short label (truncated pubkey). */
+  val ownerShort: String,
+  /** Hire-style availability blurb shown above the price. */
+  val availability: String,
+  /** Single-line flavor copy. */
+  val pitch: String,
+)
+
+/**
+ * Hardcoded listings for the slice 4 Bazaar demo. The five clan IDs not in
+ * `HearthViewModel.LINKED_CLAN_IDS` (1, 3, 4, 7, 8) are listed.
+ */
+val BAZAAR_LISTINGS: List<BazaarListing> = listOf(
+  BazaarListing(
+    tokenId = 0x10A1,
+    clanId = 1,
+    pricePerSeason = 240,
+    ownerShort = "9pK4 · 7vQy",
+    availability = "available — i of i",
+    pitch = "Mountain-bred. Reads winter as plainly as a name.",
+  ),
+  BazaarListing(
+    tokenId = 0x10A3,
+    clanId = 3,
+    pricePerSeason = 320,
+    ownerShort = "Hr8e · q2Fm",
+    availability = "available — i of i",
+    pitch = "Sun-keeper. Coin discipline is its first oath.",
+  ),
+  BazaarListing(
+    tokenId = 0x10A4,
+    clanId = 4,
+    pricePerSeason = 180,
+    ownerShort = "C4ka · M6sz",
+    availability = "available — i of i",
+    pitch = "Of the green country. Patient. Reads weather first.",
+  ),
+  BazaarListing(
+    tokenId = 0x10A7,
+    clanId = 7,
+    pricePerSeason = 360,
+    ownerShort = "B2nv · F1xz",
+    availability = "available — i of i",
+    pitch = "Forge-born. Steady iron over showy gold.",
+  ),
+  BazaarListing(
+    tokenId = 0x10A8,
+    clanId = 8,
+    pricePerSeason = 280,
+    ownerShort = "Tg9q · 4kPx",
+    availability = "available — i of i",
+    pitch = "Walks the longer line. Treats the season as a cipher.",
+  ),
+)
+
+fun bazaarListingByClan(clanId: Int): BazaarListing? =
+  BAZAAR_LISTINGS.firstOrNull { it.clanId == clanId }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/Lineage.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/Lineage.kt
@@ -1,0 +1,75 @@
+package world.clan.app.data
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * One row in the user's local lineage — the things they've signed in this
+ * install. Demo-only persistence (EncryptedSharedPreferences); no on-chain
+ * source-of-truth yet.
+ *
+ * `kind` discriminates which flow produced the row:
+ *   - "forged"      Forge wizard mint
+ *   - "hired"       Bazaar HireModal seal
+ *   - "whispered"   SteeringConsole compose
+ *   - "sealed"      StrategyEditor doctrine save
+ */
+@Serializable
+data class LineageEntry(
+  val kind: String,
+  val clanId: Int,
+  val title: String,
+  val subtitle: String? = null,
+  val tsEpochMs: Long = System.currentTimeMillis(),
+)
+
+/**
+ * Append-only local log of the user's owner actions. Backed by the same
+ * EncryptedSharedPreferences file as SessionStore — distinct file is
+ * unnecessary because the data is just-as-private and the lifetime
+ * matches.
+ *
+ * Capped at 64 entries; older entries roll off when full so the prefs
+ * blob stays small.
+ */
+class LineageStore(context: Context) {
+
+  private val prefs by lazy {
+    val masterKey = MasterKey.Builder(context)
+      .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+      .build()
+    EncryptedSharedPreferences.create(
+      context,
+      "clan-world-lineage.enc",
+      masterKey,
+      EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+      EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+  }
+
+  private val json = Json { encodeDefaults = true; ignoreUnknownKeys = true }
+
+  fun read(): List<LineageEntry> {
+    val raw = prefs.getString("entries", null) ?: return emptyList()
+    return runCatching { json.decodeFromString<List<LineageEntry>>(raw) }
+      .getOrElse { emptyList() }
+  }
+
+  fun append(entry: LineageEntry) {
+    val current = read()
+    val next = (listOf(entry) + current).take(MAX_ENTRIES)
+    prefs.edit().putString("entries", json.encodeToString<List<LineageEntry>>(next)).apply()
+  }
+
+  fun clear() {
+    prefs.edit().clear().apply()
+  }
+
+  companion object {
+    const val MAX_ENTRIES = 64
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -104,6 +104,24 @@ class SessionStore(context: Context) {
     ed.apply()
   }
 
+  // ── Hired clan IDs ────────────────────────────────────────────────────
+  // After a successful Bazaar hire, the clan is added to this set. Hall +
+  // Hearth + Codex union LINKED_CLAN_IDS with this set when displaying
+  // "your" sigils, so a freshly-hired card appears in the user's hall
+  // without a relaunch.
+
+  fun getHiredClanIds(): Set<Int> =
+    prefs.getStringSet("hired:clanIds", emptySet())
+      ?.mapNotNullTo(mutableSetOf()) { it.toIntOrNull() }
+      ?: emptySet()
+
+  fun addHiredClanId(clanId: Int) {
+    val current = getHiredClanIds()
+    if (clanId in current) return
+    val next = (current + clanId).map { it.toString() }.toSet()
+    prefs.edit().putStringSet("hired:clanIds", next).apply()
+  }
+
   // ── One-shot UI flags ─────────────────────────────────────────────────
   // Persisted booleans for onboarding hints / coachmarks. Once a flag is
   // marked seen, it stays seen across reinstalls (within EncryptedShared

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -82,4 +82,25 @@ class SessionStore(context: Context) {
   fun clear() {
     prefs.edit().clear().apply()
   }
+
+  // ── Form-draft persistence ────────────────────────────────────────────
+  //
+  // SteeringConsole / StrategyEditor / Forge text inputs survive process
+  // death + backgrounding. Keys are namespaced "draft:<scope>:<field>".
+  // On successful submit the relevant scope is cleared.
+
+  fun getDraft(scope: String, field: String): String? =
+    prefs.getString("draft:$scope:$field", null)
+
+  fun setDraft(scope: String, field: String, value: String) {
+    prefs.edit().putString("draft:$scope:$field", value).apply()
+  }
+
+  fun clearDrafts(scope: String) {
+    val toRemove = prefs.all.keys.filter { it.startsWith("draft:$scope:") }
+    if (toRemove.isEmpty()) return
+    val ed = prefs.edit()
+    toRemove.forEach { ed.remove(it) }
+    ed.apply()
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -103,4 +103,15 @@ class SessionStore(context: Context) {
     toRemove.forEach { ed.remove(it) }
     ed.apply()
   }
+
+  // ── One-shot UI flags ─────────────────────────────────────────────────
+  // Persisted booleans for onboarding hints / coachmarks. Once a flag is
+  // marked seen, it stays seen across reinstalls (within EncryptedShared
+  // Preferences' device-keystore lifetime).
+
+  fun hasSeenFlag(key: String): Boolean = prefs.getBoolean("flag:$key", false)
+
+  fun markFlagSeen(key: String) {
+    prefs.edit().putBoolean("flag:$key", true).apply()
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -104,22 +104,36 @@ class SessionStore(context: Context) {
     ed.apply()
   }
 
-  // ── Hired clan IDs ────────────────────────────────────────────────────
-  // After a successful Bazaar hire, the clan is added to this set. Hall +
-  // Hearth + Codex union LINKED_CLAN_IDS with this set when displaying
-  // "your" sigils, so a freshly-hired card appears in the user's hall
-  // without a relaunch.
+  // ── Hired / Forged clan IDs ───────────────────────────────────────────
+  // After a successful Bazaar hire OR a Forge wizard mint, the clan is
+  // added to the matching set. Hall + Hearth + Codex union LINKED_CLAN_IDS
+  // with both sets when displaying "your" sigils — a freshly-hired or
+  // freshly-forged card appears in the user's hall without a relaunch.
+  //
+  // Sets are kept separate so Lineage / future analytics can tell forged
+  // from hired; ownership unions read both via getOwnedClanIdsExtra().
 
-  fun getHiredClanIds(): Set<Int> =
-    prefs.getStringSet("hired:clanIds", emptySet())
+  fun getHiredClanIds(): Set<Int> = readClanIdSet("hired:clanIds")
+
+  fun addHiredClanId(clanId: Int) = writeClanIdSet("hired:clanIds", clanId)
+
+  fun getForgedClanIds(): Set<Int> = readClanIdSet("forged:clanIds")
+
+  fun addForgedClanId(clanId: Int) = writeClanIdSet("forged:clanIds", clanId)
+
+  /** Union of hired + forged. LINKED_CLAN_IDS is added by ViewModels. */
+  fun getOwnedClanIdsExtra(): Set<Int> = getHiredClanIds() + getForgedClanIds()
+
+  private fun readClanIdSet(prefKey: String): Set<Int> =
+    prefs.getStringSet(prefKey, emptySet())
       ?.mapNotNullTo(mutableSetOf()) { it.toIntOrNull() }
       ?: emptySet()
 
-  fun addHiredClanId(clanId: Int) {
-    val current = getHiredClanIds()
+  private fun writeClanIdSet(prefKey: String, clanId: Int) {
+    val current = readClanIdSet(prefKey)
     if (clanId in current) return
     val next = (current + clanId).map { it.toString() }.toSet()
-    prefs.edit().putStringSet("hired:clanIds", next).apply()
+    prefs.edit().putStringSet(prefKey, next).apply()
   }
 
   // ── One-shot UI flags ─────────────────────────────────────────────────

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -413,9 +413,16 @@ fun ClanWorldApp(
               isBazaar = true,
               mwaSender = mwaSender,
               onHireConfirmed = {
-                val name = world.clan.app.data.bazaarListingByClan(clanId)
-                  ?.let { l -> "tkn 0x${"%04x".format(l.tokenId)}" }
-                  .orEmpty()
+                val listing = world.clan.app.data.bazaarListingByClan(clanId)
+                val name = listing?.let { "tkn 0x${"%04x".format(it.tokenId)}" }.orEmpty()
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "hired",
+                    clanId = clanId,
+                    title = "Hired ${world.clan.app.viewmodel.clanDisplayName(clanId)}",
+                    subtitle = listing?.let { "${it.pricePerSeason}g · 1 season · $name" } ?: name,
+                  ),
+                )
                 nav.navigate(Routes.forged(clanId, name, "HIRED")) {
                   popUpTo(Routes.Bazaar) { saveState = true }
                 }
@@ -473,7 +480,17 @@ fun ClanWorldApp(
               mwaSender = mwaSender,
               initialClanId = clanId,
               onBack = { nav.popBackStack() },
-              onSent = { nav.popBackStack() },
+              onSent = {
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "whispered",
+                    clanId = clanId,
+                    title = "Whispered to ${world.clan.app.viewmodel.clanDisplayName(clanId)}",
+                    subtitle = "queued for next tick",
+                  ),
+                )
+                nav.popBackStack()
+              },
             )
           }
 
@@ -490,9 +507,15 @@ fun ClanWorldApp(
               mwaSender = mwaSender,
               onBack = { nav.popBackStack() },
               onForged = { clanId, name ->
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "forged",
+                    clanId = clanId,
+                    title = "Forged ${name.ifBlank { "the unnamed seal" }}",
+                    subtitle = world.clan.app.viewmodel.clanDisplayName(clanId),
+                  ),
+                )
                 nav.navigate(Routes.forged(clanId, name, "FORGED")) {
-                  // Replace Forge wizard so back goes to Hall, not the
-                  // wizard's last step.
                   popUpTo(Routes.Forge) { inclusive = true }
                 }
               },
@@ -569,7 +592,17 @@ fun ClanWorldApp(
               mwaSender = mwaSender,
               clanId = clanId,
               onBack = { nav.popBackStack() },
-              onSaved = { nav.popBackStack() },
+              onSaved = {
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "sealed",
+                    clanId = clanId,
+                    title = "Sealed doctrine for ${world.clan.app.viewmodel.clanDisplayName(clanId)}",
+                    subtitle = "the elder will hold this counsel",
+                  ),
+                )
+                nav.popBackStack()
+              },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -66,6 +66,7 @@ object Routes {
   const val Whispers = "whispers/{clanId}"
   const val SteeringConsole = "steer/{clanId}"
   const val StrategyEditor = "strategy/{clanId}"
+  const val Treasury = "treasury/{clanId}"
   const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
@@ -75,6 +76,7 @@ object Routes {
   fun whispers(clanId: Int) = "whispers/$clanId"
   fun steer(clanId: Int) = "steer/$clanId"
   fun strategy(clanId: Int) = "strategy/$clanId"
+  fun treasury(clanId: Int) = "treasury/$clanId"
   fun bridge(clanId: Int) = "bridge/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
@@ -217,7 +219,8 @@ fun ClanWorldApp(
     currentRoute?.startsWith("inft/") == true ||
     currentRoute?.startsWith("bazaarInft/") == true ||
     currentRoute?.startsWith("whispers/") == true ||
-    currentRoute?.startsWith("strategy/") == true
+    currentRoute?.startsWith("strategy/") == true ||
+    currentRoute?.startsWith("treasury/") == true
   // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
@@ -228,6 +231,7 @@ fun ClanWorldApp(
     currentRoute?.startsWith("bazaarInft/") == true -> RootTab.Bazaar // detail derived from Bazaar
     currentRoute?.startsWith("whispers/") == true -> RootTab.Hall // inbox is a Hall drill-in
     currentRoute?.startsWith("strategy/") == true -> RootTab.Hall // editor is a Hall drill-in
+    currentRoute?.startsWith("treasury/") == true -> RootTab.Hall // treasury is a Hall drill-in
     currentRoute?.startsWith("steer/") == true ||
       currentRoute?.startsWith("bridge/") == true ||
       currentRoute == Routes.Cockpit ||
@@ -376,6 +380,7 @@ fun ClanWorldApp(
               onEnterCockpit = { nav.navigate(Routes.bridge(clanId)) },
               onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
               onEditStrategy = { nav.navigate(Routes.strategy(clanId)) },
+              onOpenTreasury = { nav.navigate(Routes.treasury(clanId)) },
             )
           }
 
@@ -394,6 +399,7 @@ fun ClanWorldApp(
               clanId = clanId,
               onBack = { nav.popBackStack() },
               onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
+              onOpenTreasury = { nav.navigate(Routes.treasury(clanId)) },
               isBazaar = true,
               mwaSender = mwaSender,
               onHireConfirmed = {
@@ -455,6 +461,22 @@ fun ClanWorldApp(
               initialClanId = clanId,
               onBack = { nav.popBackStack() },
               onSent = { nav.popBackStack() },
+            )
+          }
+
+          // ── Treasury (per-iNFT GOLD + resources + movements; from Vault tab) ─
+          composable(
+            route = Routes.Treasury,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            world.clan.app.ui.screens.TreasuryScreenRoute(
+              app = app,
+              clanId = clanId,
+              onBack = { nav.popBackStack() },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -423,6 +423,10 @@ fun ClanWorldApp(
                     subtitle = listing?.let { "${it.pricePerSeason}g · 1 season · $name" } ?: name,
                   ),
                 )
+                // Persist that this clan is now in the user's hall — so
+                // it shows up next time HallScreen refreshes (also affects
+                // Hearth leaderboard `isMine` and Codex linked-clans line).
+                app.sessionStore.addHiredClanId(clanId)
                 nav.navigate(Routes.forged(clanId, name, "HIRED")) {
                   popUpTo(Routes.Bazaar) { saveState = true }
                 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -68,6 +68,7 @@ object Routes {
   const val StrategyEditor = "strategy/{clanId}"
   const val Treasury = "treasury/{clanId}"
   const val Forge = "forge"
+  const val Forged = "forged/{clanId}?name={name}&label={label}"
   const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
@@ -78,6 +79,11 @@ object Routes {
   fun steer(clanId: Int) = "steer/$clanId"
   fun strategy(clanId: Int) = "strategy/$clanId"
   fun treasury(clanId: Int) = "treasury/$clanId"
+  fun forged(clanId: Int, name: String = "", label: String = "FORGED"): String {
+    val n = java.net.URLEncoder.encode(name, "UTF-8")
+    val l = java.net.URLEncoder.encode(label, "UTF-8")
+    return "forged/$clanId?name=$n&label=$l"
+  }
   fun bridge(clanId: Int) = "bridge/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
@@ -407,9 +413,12 @@ fun ClanWorldApp(
               isBazaar = true,
               mwaSender = mwaSender,
               onHireConfirmed = {
-                // For now: simply pop back to Bazaar. A future "Hired"
-                // confirmation screen could replace this.
-                nav.popBackStack()
+                val name = world.clan.app.data.bazaarListingByClan(clanId)
+                  ?.let { l -> "tkn 0x${"%04x".format(l.tokenId)}" }
+                  .orEmpty()
+                nav.navigate(Routes.forged(clanId, name, "HIRED")) {
+                  popUpTo(Routes.Bazaar) { saveState = true }
+                }
               },
             )
           }
@@ -480,7 +489,53 @@ fun ClanWorldApp(
               factory = factory,
               mwaSender = mwaSender,
               onBack = { nav.popBackStack() },
-              onForged = { nav.popBackStack() },
+              onForged = { clanId, name ->
+                nav.navigate(Routes.forged(clanId, name, "FORGED")) {
+                  // Replace Forge wizard so back goes to Hall, not the
+                  // wizard's last step.
+                  popUpTo(Routes.Forge) { inclusive = true }
+                }
+              },
+            )
+          }
+
+          // ── Forged (celebration landing for Forge + Hire) ───────────────
+          composable(
+            route = Routes.Forged,
+            arguments = listOf(
+              androidx.navigation.navArgument("clanId") { type = NavType.IntType },
+              androidx.navigation.navArgument("name") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = ""
+              },
+              androidx.navigation.navArgument("label") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = "FORGED"
+              },
+            ),
+            enterTransition = { fadeIn(tween(360, easing = FastOutSlowInEasing)) },
+            popExitTransition = { fadeOut(tween(220, easing = FastOutSlowInEasing)) },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            val name = entry.arguments?.getString("name").orEmpty().let {
+              runCatching { java.net.URLDecoder.decode(it, "UTF-8") }.getOrDefault(it)
+            }
+            val label = (entry.arguments?.getString("label") ?: "FORGED").let {
+              runCatching { java.net.URLDecoder.decode(it, "UTF-8") }.getOrDefault(it)
+            }
+            world.clan.app.ui.screens.ForgedScreen(
+              clanId = clanId,
+              label = label,
+              sigilName = name,
+              onEnterHall = {
+                nav.navigate(Routes.Hall) {
+                  popUpTo(Routes.Hearth) { saveState = true }
+                  launchSingleTop = true
+                  restoreState = true
+                }
+              },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -58,12 +58,15 @@ object Routes {
   const val Connect = "connect"
   const val Hearth = "hearth"
   const val Hall = "hall"
+  const val Bazaar = "bazaar"
   const val Codex = "codex"
   const val InftDetail = "inft/{clanId}"
+  const val BazaarInftDetail = "bazaarInft/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
   const val OwnerComingSoon = "ownerComingSoon/{clanId}"
   fun inftDetail(clanId: Int) = "inft/$clanId"
+  fun bazaarInftDetail(clanId: Int) = "bazaarInft/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
 }
@@ -75,7 +78,8 @@ object Routes {
 private val tabIndex = mapOf(
   Routes.Hearth to 0,
   Routes.Hall to 1,
-  Routes.Codex to 2,
+  Routes.Bazaar to 2,
+  Routes.Codex to 3,
 )
 
 private fun NavBackStackEntry?.tabIdx(): Int? =
@@ -195,14 +199,18 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
   val currentRoute = currentBackStack?.destination?.route
   val showTabBar = currentRoute == Routes.Hearth ||
     currentRoute == Routes.Hall ||
+    currentRoute == Routes.Bazaar ||
     currentRoute == Routes.Codex ||
-    currentRoute?.startsWith("inft/") == true
+    currentRoute?.startsWith("inft/") == true ||
+    currentRoute?.startsWith("bazaarInft/") == true
   // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
     currentRoute == Routes.Hall -> RootTab.Hall
+    currentRoute == Routes.Bazaar -> RootTab.Bazaar
     currentRoute == Routes.Codex -> RootTab.Codex
     currentRoute?.startsWith("inft/") == true -> RootTab.Hall // detail derived from Hall
+    currentRoute?.startsWith("bazaarInft/") == true -> RootTab.Bazaar // detail derived from Bazaar
     currentRoute == Routes.Cockpit ||
       currentRoute?.startsWith("ownerSignIn/") == true ||
       currentRoute?.startsWith("ownerComingSoon/") == true -> RootTab.Hall
@@ -297,6 +305,33 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
           }
 
           composable(
+            route = Routes.Bazaar,
+            enterTransition = { tabEnter() },
+            exitTransition = {
+              if (targetState.destination.route == Routes.BazaarInftDetail)
+                fadeOut(tween(TAB_FADE_OUT_MS, easing = FastOutSlowInEasing))
+              else tabExit()
+            },
+            popEnterTransition = {
+              if (initialState.destination.route == Routes.BazaarInftDetail)
+                fadeIn(
+                  tween(
+                    durationMillis = TAB_FADE_IN_MS,
+                    delayMillis = TAB_FADE_IN_DELAY_MS,
+                    easing = FastOutSlowInEasing,
+                  ),
+                )
+              else tabEnter()
+            },
+          ) {
+            world.clan.app.ui.screens.BazaarScreenRoute(
+              app = app,
+              factory = factory,
+              onOpenListing = { clanId -> nav.navigate(Routes.bazaarInftDetail(clanId)) },
+            )
+          }
+
+          composable(
             route = Routes.Codex,
             enterTransition = { tabEnter() },
             exitTransition = { tabExit() },
@@ -320,6 +355,30 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
               clanId = clanId,
               onBack = { nav.popBackStack() },
               onEnterCockpit = { nav.navigate(Routes.Cockpit) },
+            )
+          }
+
+          // ── Bazaar iNFT detail (preview a hireable sigil; "Hire" instead
+          //    of "Enter Cockpit"). Confirms via HireModal → SIWS sign.
+          composable(
+            route = Routes.BazaarInftDetail,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            InftDetailScreenRoute(
+              app = app,
+              clanId = clanId,
+              onBack = { nav.popBackStack() },
+              isBazaar = true,
+              hostActivity = hostActivity,
+              onHireConfirmed = {
+                // For now: simply pop back to Bazaar. A future "Hired"
+                // confirmation screen could replace this.
+                nav.popBackStack()
+              },
             )
           }
 
@@ -386,6 +445,7 @@ private fun navigateTab(
   val route = when (tab) {
     RootTab.Hearth -> Routes.Hearth
     RootTab.Hall -> Routes.Hall
+    RootTab.Bazaar -> Routes.Bazaar
     RootTab.Codex -> Routes.Codex
   }
   nav.navigate(route) {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -395,7 +395,7 @@ fun ClanWorldApp(
               onBack = { nav.popBackStack() },
               onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
               isBazaar = true,
-              hostActivity = hostActivity,
+              mwaSender = mwaSender,
               onHireConfirmed = {
                 // For now: simply pop back to Bazaar. A future "Hired"
                 // confirmation screen could replace this.
@@ -451,7 +451,7 @@ fun ClanWorldApp(
             val clanId = entry.arguments?.getInt("clanId") ?: 1
             world.clan.app.ui.screens.SteeringConsoleScreenRoute(
               app = app,
-              hostActivity = hostActivity,
+              mwaSender = mwaSender,
               initialClanId = clanId,
               onBack = { nav.popBackStack() },
               onSent = { nav.popBackStack() },
@@ -469,7 +469,7 @@ fun ClanWorldApp(
             val clanId = entry.arguments?.getInt("clanId") ?: 1
             world.clan.app.ui.screens.StrategyEditorScreenRoute(
               app = app,
-              hostActivity = hostActivity,
+              mwaSender = mwaSender,
               clanId = clanId,
               onBack = { nav.popBackStack() },
               onSaved = { nav.popBackStack() },

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -63,6 +63,8 @@ object Routes {
   const val InftDetail = "inft/{clanId}"
   const val BazaarInftDetail = "bazaarInft/{clanId}"
   const val Whispers = "whispers/{clanId}"
+  const val SteeringConsole = "steer/{clanId}"
+  const val StrategyEditor = "strategy/{clanId}"
   const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
@@ -70,6 +72,8 @@ object Routes {
   fun inftDetail(clanId: Int) = "inft/$clanId"
   fun bazaarInftDetail(clanId: Int) = "bazaarInft/$clanId"
   fun whispers(clanId: Int) = "whispers/$clanId"
+  fun steer(clanId: Int) = "steer/$clanId"
+  fun strategy(clanId: Int) = "strategy/$clanId"
   fun bridge(clanId: Int) = "bridge/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
@@ -207,7 +211,8 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
     currentRoute == Routes.Codex ||
     currentRoute?.startsWith("inft/") == true ||
     currentRoute?.startsWith("bazaarInft/") == true ||
-    currentRoute?.startsWith("whispers/") == true
+    currentRoute?.startsWith("whispers/") == true ||
+    currentRoute?.startsWith("strategy/") == true
   // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
@@ -217,7 +222,9 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
     currentRoute?.startsWith("inft/") == true -> RootTab.Hall // detail derived from Hall
     currentRoute?.startsWith("bazaarInft/") == true -> RootTab.Bazaar // detail derived from Bazaar
     currentRoute?.startsWith("whispers/") == true -> RootTab.Hall // inbox is a Hall drill-in
-    currentRoute?.startsWith("bridge/") == true ||
+    currentRoute?.startsWith("strategy/") == true -> RootTab.Hall // editor is a Hall drill-in
+    currentRoute?.startsWith("steer/") == true ||
+      currentRoute?.startsWith("bridge/") == true ||
       currentRoute == Routes.Cockpit ||
       currentRoute?.startsWith("ownerSignIn/") == true ||
       currentRoute?.startsWith("ownerComingSoon/") == true -> RootTab.Hall
@@ -363,6 +370,7 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
               onBack = { nav.popBackStack() },
               onEnterCockpit = { nav.navigate(Routes.bridge(clanId)) },
               onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
+              onEditStrategy = { nav.navigate(Routes.strategy(clanId)) },
             )
           }
 
@@ -423,6 +431,43 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
               app = app,
               clanId = clanId,
               onBack = { nav.popBackStack() },
+              onCompose = { nav.navigate(Routes.steer(clanId)) },
+            )
+          }
+
+          // ── SteeringConsole (whisper composer; deep route from Whispers) ─
+          composable(
+            route = Routes.SteeringConsole,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            world.clan.app.ui.screens.SteeringConsoleScreenRoute(
+              app = app,
+              hostActivity = hostActivity,
+              initialClanId = clanId,
+              onBack = { nav.popBackStack() },
+              onSent = { nav.popBackStack() },
+            )
+          }
+
+          // ── StrategyEditor (per-iNFT doctrine form; deep route from InftDetail) ─
+          composable(
+            route = Routes.StrategyEditor,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            world.clan.app.ui.screens.StrategyEditorScreenRoute(
+              app = app,
+              hostActivity = hostActivity,
+              clanId = clanId,
+              onBack = { nav.popBackStack() },
+              onSaved = { nav.popBackStack() },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -62,11 +62,15 @@ object Routes {
   const val Codex = "codex"
   const val InftDetail = "inft/{clanId}"
   const val BazaarInftDetail = "bazaarInft/{clanId}"
+  const val Whispers = "whispers/{clanId}"
+  const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
   const val OwnerComingSoon = "ownerComingSoon/{clanId}"
   fun inftDetail(clanId: Int) = "inft/$clanId"
   fun bazaarInftDetail(clanId: Int) = "bazaarInft/$clanId"
+  fun whispers(clanId: Int) = "whispers/$clanId"
+  fun bridge(clanId: Int) = "bridge/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
 }
@@ -202,7 +206,8 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
     currentRoute == Routes.Bazaar ||
     currentRoute == Routes.Codex ||
     currentRoute?.startsWith("inft/") == true ||
-    currentRoute?.startsWith("bazaarInft/") == true
+    currentRoute?.startsWith("bazaarInft/") == true ||
+    currentRoute?.startsWith("whispers/") == true
   // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
@@ -211,7 +216,9 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
     currentRoute == Routes.Codex -> RootTab.Codex
     currentRoute?.startsWith("inft/") == true -> RootTab.Hall // detail derived from Hall
     currentRoute?.startsWith("bazaarInft/") == true -> RootTab.Bazaar // detail derived from Bazaar
-    currentRoute == Routes.Cockpit ||
+    currentRoute?.startsWith("whispers/") == true -> RootTab.Hall // inbox is a Hall drill-in
+    currentRoute?.startsWith("bridge/") == true ||
+      currentRoute == Routes.Cockpit ||
       currentRoute?.startsWith("ownerSignIn/") == true ||
       currentRoute?.startsWith("ownerComingSoon/") == true -> RootTab.Hall
     else -> RootTab.Hearth
@@ -354,7 +361,8 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
               app = app,
               clanId = clanId,
               onBack = { nav.popBackStack() },
-              onEnterCockpit = { nav.navigate(Routes.Cockpit) },
+              onEnterCockpit = { nav.navigate(Routes.bridge(clanId)) },
+              onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
             )
           }
 
@@ -372,6 +380,7 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
               app = app,
               clanId = clanId,
               onBack = { nav.popBackStack() },
+              onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
               isBazaar = true,
               hostActivity = hostActivity,
               onHireConfirmed = {
@@ -382,7 +391,42 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
             )
           }
 
-          // ── Cockpit (deep route from InftDetail "Enter Cockpit" CTA) ────
+          // ── Bridge loader (between InftDetail "Enter Cockpit" and Cockpit) ─
+          composable(
+            route = Routes.Bridge,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { fadeIn(tween(280, easing = FastOutSlowInEasing)) },
+            exitTransition = { fadeOut(tween(280, easing = FastOutSlowInEasing)) },
+            popExitTransition = { fadeOut(tween(220, easing = FastOutSlowInEasing)) },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            world.clan.app.ui.screens.BridgeScreen(
+              clanId = clanId,
+              onReady = {
+                nav.navigate(Routes.Cockpit) {
+                  popUpTo(Routes.Bridge) { inclusive = true }
+                }
+              },
+            )
+          }
+
+          // ── Whispers inbox (deep route from InftDetail Whispers tab) ────
+          composable(
+            route = Routes.Whispers,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            world.clan.app.ui.screens.WhispersScreenRoute(
+              app = app,
+              clanId = clanId,
+              onBack = { nav.popBackStack() },
+            )
+          }
+
+          // ── Cockpit (deep route from Bridge after the loader resolves) ──
           composable(
             route = Routes.Cockpit,
             enterTransition = { detailEnter() },

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -35,6 +35,9 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import world.clan.app.App
+import world.clan.app.cockpit.CockpitScreen
+import world.clan.app.owner.OwnerComingSoonScreen
+import world.clan.app.owner.OwnerSignInScreen
 import world.clan.app.ui.components.ClanWorldTabBar
 import world.clan.app.ui.components.LocalOnDisconnect
 import world.clan.app.ui.components.LocalWalletIdentity
@@ -57,7 +60,12 @@ object Routes {
   const val Hall = "hall"
   const val Codex = "codex"
   const val InftDetail = "inft/{clanId}"
+  const val Cockpit = "cockpit"
+  const val OwnerSignIn = "ownerSignIn/{clanId}"
+  const val OwnerComingSoon = "ownerComingSoon/{clanId}"
   fun inftDetail(clanId: Int) = "inft/$clanId"
+  fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
+  fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -189,11 +197,15 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
     currentRoute == Routes.Hall ||
     currentRoute == Routes.Codex ||
     currentRoute?.startsWith("inft/") == true
+  // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
     currentRoute == Routes.Hall -> RootTab.Hall
     currentRoute == Routes.Codex -> RootTab.Codex
     currentRoute?.startsWith("inft/") == true -> RootTab.Hall // detail derived from Hall
+    currentRoute == Routes.Cockpit ||
+      currentRoute?.startsWith("ownerSignIn/") == true ||
+      currentRoute?.startsWith("ownerComingSoon/") == true -> RootTab.Hall
     else -> RootTab.Hearth
   }
 
@@ -305,6 +317,58 @@ fun ClanWorldApp(app: App, hostActivity: ComponentActivity) {
             val clanId = entry.arguments?.getInt("clanId") ?: 1
             InftDetailScreenRoute(
               app = app,
+              clanId = clanId,
+              onBack = { nav.popBackStack() },
+              onEnterCockpit = { nav.navigate(Routes.Cockpit) },
+            )
+          }
+
+          // ── Cockpit (deep route from InftDetail "Enter Cockpit" CTA) ────
+          composable(
+            route = Routes.Cockpit,
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) {
+            CockpitScreen(
+              onOwnerControl = { clanId ->
+                nav.navigate(Routes.ownerSignIn(clanId))
+              },
+            )
+          }
+
+          // ── Owner sign-in (drill-in from CockpitScreen) ─────────────────
+          composable(
+            route = Routes.OwnerSignIn,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            OwnerSignInScreen(
+              clanId = clanId,
+              onSignedIn = {
+                nav.navigate(Routes.ownerComingSoon(clanId)) {
+                  // Replace the sign-in screen so back goes to Cockpit,
+                  // not back through SIWS again.
+                  popUpTo(Routes.OwnerSignIn) { inclusive = true }
+                }
+              },
+              onBack = { nav.popBackStack() },
+            )
+          }
+
+          // ── Owner coming-soon (placeholder after successful SIWS) ───────
+          composable(
+            route = Routes.OwnerComingSoon,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            OwnerComingSoonScreen(
               clanId = clanId,
               onBack = { nav.popBackStack() },
             )

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -67,6 +67,7 @@ object Routes {
   const val SteeringConsole = "steer/{clanId}"
   const val StrategyEditor = "strategy/{clanId}"
   const val Treasury = "treasury/{clanId}"
+  const val Forge = "forge"
   const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
@@ -220,7 +221,8 @@ fun ClanWorldApp(
     currentRoute?.startsWith("bazaarInft/") == true ||
     currentRoute?.startsWith("whispers/") == true ||
     currentRoute?.startsWith("strategy/") == true ||
-    currentRoute?.startsWith("treasury/") == true
+    currentRoute?.startsWith("treasury/") == true ||
+    currentRoute == Routes.Forge
   // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
@@ -232,6 +234,7 @@ fun ClanWorldApp(
     currentRoute?.startsWith("whispers/") == true -> RootTab.Hall // inbox is a Hall drill-in
     currentRoute?.startsWith("strategy/") == true -> RootTab.Hall // editor is a Hall drill-in
     currentRoute?.startsWith("treasury/") == true -> RootTab.Hall // treasury is a Hall drill-in
+    currentRoute == Routes.Forge -> RootTab.Hall // forge wizard surfaces from Hall
     currentRoute?.startsWith("steer/") == true ||
       currentRoute?.startsWith("bridge/") == true ||
       currentRoute == Routes.Cockpit ||
@@ -324,6 +327,7 @@ fun ClanWorldApp(
               app = app,
               factory = factory,
               onOpenInft = { clanId -> nav.navigate(Routes.inftDetail(clanId)) },
+              onForge = { nav.navigate(Routes.Forge) },
             )
           }
 
@@ -461,6 +465,22 @@ fun ClanWorldApp(
               initialClanId = clanId,
               onBack = { nav.popBackStack() },
               onSent = { nav.popBackStack() },
+            )
+          }
+
+          // ── Forge (4-step mint wizard; surfaces from Hall) ──────────────
+          composable(
+            route = Routes.Forge,
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) {
+            world.clan.app.ui.screens.ForgeScreenRoute(
+              app = app,
+              factory = factory,
+              mwaSender = mwaSender,
+              onBack = { nav.popBackStack() },
+              onForged = { nav.popBackStack() },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -70,7 +70,7 @@ object Routes {
   const val Forge = "forge"
   const val Forged = "forged/{clanId}?name={name}&label={label}"
   const val Bridge = "bridge/{clanId}"
-  const val Cockpit = "cockpit"
+  const val Cockpit = "cockpit/{clanId}"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
   const val OwnerComingSoon = "ownerComingSoon/{clanId}"
   fun inftDetail(clanId: Int) = "inft/$clanId"
@@ -85,6 +85,7 @@ object Routes {
     return "forged/$clanId?name=$n&label=$l"
   }
   fun bridge(clanId: Int) = "bridge/$clanId"
+  fun cockpit(clanId: Int) = "cockpit/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
 }
@@ -243,7 +244,7 @@ fun ClanWorldApp(
     currentRoute == Routes.Forge -> RootTab.Hall // forge wizard surfaces from Hall
     currentRoute?.startsWith("steer/") == true ||
       currentRoute?.startsWith("bridge/") == true ||
-      currentRoute == Routes.Cockpit ||
+      currentRoute?.startsWith("cockpit/") == true ||
       currentRoute?.startsWith("ownerSignIn/") == true ||
       currentRoute?.startsWith("ownerComingSoon/") == true -> RootTab.Hall
     else -> RootTab.Hearth
@@ -446,7 +447,7 @@ fun ClanWorldApp(
             world.clan.app.ui.screens.BridgeScreen(
               clanId = clanId,
               onReady = {
-                nav.navigate(Routes.Cockpit) {
+                nav.navigate(Routes.cockpit(clanId)) {
                   popUpTo(Routes.Bridge) { inclusive = true }
                 }
               },
@@ -617,13 +618,16 @@ fun ClanWorldApp(
           // ── Cockpit (deep route from Bridge after the loader resolves) ──
           composable(
             route = Routes.Cockpit,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
             enterTransition = { detailEnter() },
             popExitTransition = { detailPopExit() },
             exitTransition = { tabExit() },
-          ) {
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
             CockpitScreen(
-              onOwnerControl = { clanId ->
-                nav.navigate(Routes.ownerSignIn(clanId))
+              initialClanId = clanId,
+              onOwnerControl = { c ->
+                nav.navigate(Routes.ownerSignIn(c))
               },
             )
           }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -519,6 +519,10 @@ fun ClanWorldApp(
                     subtitle = world.clan.app.viewmodel.clanDisplayName(clanId),
                   ),
                 )
+                // Persist that this clan is now in the user's hall — same
+                // mechanism as Bazaar Hire. Hall + Hearth + Codex unions
+                // pick this up on next refresh.
+                app.sessionStore.addForgedClanId(clanId)
                 nav.navigate(Routes.forged(clanId, name, "FORGED")) {
                   popUpTo(Routes.Forge) { inclusive = true }
                 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/EmptyState.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/EmptyState.kt
@@ -1,0 +1,91 @@
+package world.clan.app.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * Inviting empty state. Renders centered title + body italics, plus an
+ * optional outlined-pill CTA at the bottom. Use when a list is genuinely
+ * empty (no error, just nothing yet) and there's a sensible next action.
+ *
+ * Distinguished from RetryNotice (which is for errors): this is for
+ * "all good, nothing here yet" rather than "something went wrong".
+ */
+@Composable
+fun EmptyState(
+  title: String,
+  body: String,
+  ctaLabel: String? = null,
+  onCta: (() -> Unit)? = null,
+  modifier: Modifier = Modifier,
+) {
+  val warm = ClanWorldTheme.colors.warm
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val parchment = ClanWorldTheme.colors.parchment
+  val gold = ClanWorldTheme.colors.gold
+  val hairlineMid = ClanWorldTheme.colors.hairlineMid
+  val iron2 = ClanWorldTheme.colors.iron2
+
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 32.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Text(
+      text = title,
+      style = ClanWorldTheme.type.scriptItalic,
+      color = warm,
+      textAlign = TextAlign.Center,
+    )
+    Text(
+      text = body,
+      style = ClanWorldTheme.type.scriptItalic,
+      color = warmDim,
+      textAlign = TextAlign.Center,
+    )
+    if (ctaLabel != null && onCta != null) {
+      Spacer(Modifier.height(6.dp))
+      Box(
+        modifier = Modifier
+          .clip(RoundedCornerShape(4.dp))
+          .background(iron2)
+          .drawBehind {
+            drawRoundRect(
+              color = hairlineMid,
+              cornerRadius = CornerRadius(4.dp.toPx()),
+              style = Stroke(width = 1.dp.toPx()),
+            )
+          }
+          .clickable { onCta() }
+          .padding(horizontal = 18.dp, vertical = 10.dp),
+      ) {
+        Text(
+          text = ctaLabel.uppercase(),
+          style = ClanWorldTheme.type.monoMicro,
+          color = gold,
+        )
+      }
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
@@ -1,6 +1,6 @@
 package world.clan.app.ui.components
 
-import androidx.activity.ComponentActivity
+import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -61,7 +61,7 @@ import world.clan.app.wallet.MwaResult
 @Composable
 fun HireModal(
   app: App,
-  hostActivity: ComponentActivity,
+  mwaSender: ActivityResultSender,
   listing: BazaarListing,
   onDismiss: () -> Unit,
   onConfirmed: () -> Unit,
@@ -111,7 +111,7 @@ fun HireModal(
                 return@launch
               }
               val message = "ClanWorld Hire — token 0x${"%04x".format(listing.tokenId)} clan ${listing.clanId}".toByteArray()
-              val result = app.mwaClient.signMessage(hostActivity, token, message)
+              val result = app.mwaClient.signMessage(mwaSender, token, message)
               when (result) {
                 is MwaResult.Ok -> state.value = HireState.Sealed
                 is MwaResult.WalletNotFound -> {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
@@ -1,0 +1,285 @@
+package world.clan.app.ui.components
+
+import androidx.activity.ComponentActivity
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import world.clan.app.App
+import world.clan.app.data.BazaarListing
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.ui.theme.clanGlyphRes
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.wallet.MwaResult
+
+/**
+ * Hire confirmation modal. Renders as a full-screen overlay (scrim + parchment
+ * card centered). On Confirm:
+ *   1. Sign a "Hire" message via MWA (real signMessage call against the
+ *      stored authToken).
+ *   2. Show a pulsing "Sealed ✓" success state for ~1.4s.
+ *   3. Call [onConfirmed] so the host can dismiss + navigate.
+ *
+ * If the user has no auth token (shouldn't happen on this screen — Connect
+ * gates everything), Confirm short-circuits to the success state without
+ * calling MWA.
+ */
+@Composable
+fun HireModal(
+  app: App,
+  hostActivity: ComponentActivity,
+  listing: BazaarListing,
+  onDismiss: () -> Unit,
+  onConfirmed: () -> Unit,
+) {
+  val scope = rememberCoroutineScope()
+  val state = remember { mutableStateOf(HireState.Idle) }
+  val errorMessage = remember { mutableStateOf<String?>(null) }
+
+  // Auto-dismiss after success.
+  LaunchedEffect(state.value) {
+    if (state.value == HireState.Sealed) {
+      delay(1400L)
+      onConfirmed()
+    }
+  }
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .background(Color(0xCC050505)) // scrim
+      .clickable(
+        enabled = state.value == HireState.Idle || state.value == HireState.Failed,
+        onClick = onDismiss,
+      ),
+    contentAlignment = Alignment.Center,
+  ) {
+    // Inner card; consume click so taps inside don't dismiss.
+    Box(
+      modifier = Modifier
+        .padding(horizontal = 28.dp)
+        .clickable(enabled = false) {},
+    ) {
+      ParchmentCard(
+        modifier = Modifier.fillMaxWidth(),
+      ) {
+        HireBody(
+          listing = listing,
+          state = state,
+          errorMessage = errorMessage,
+          onConfirm = {
+            scope.launch {
+              state.value = HireState.Signing
+              errorMessage.value = null
+              val token = app.sessionStore.read()?.mwaAuthToken
+              if (token == null) {
+                state.value = HireState.Sealed
+                return@launch
+              }
+              val message = "ClanWorld Hire — token 0x${"%04x".format(listing.tokenId)} clan ${listing.clanId}".toByteArray()
+              val result = app.mwaClient.signMessage(hostActivity, token, message)
+              when (result) {
+                is MwaResult.Ok -> state.value = HireState.Sealed
+                is MwaResult.WalletNotFound -> {
+                  state.value = HireState.Failed
+                  errorMessage.value = "no wallet found on device."
+                }
+                is MwaResult.UserDeclined -> {
+                  state.value = HireState.Idle
+                }
+                is MwaResult.Error -> {
+                  state.value = HireState.Failed
+                  errorMessage.value = result.cause.message ?: "the wallet refused the seal."
+                }
+              }
+            }
+          },
+          onDismiss = onDismiss,
+        )
+      }
+    }
+  }
+}
+
+private enum class HireState { Idle, Signing, Sealed, Failed }
+
+@Composable
+private fun HireBody(
+  listing: BazaarListing,
+  state: MutableState<HireState>,
+  errorMessage: MutableState<String?>,
+  onConfirm: () -> Unit,
+  onDismiss: () -> Unit,
+) {
+  val clanCol = clanColor(listing.clanId)
+
+  Row(
+    verticalAlignment = Alignment.Top,
+    horizontalArrangement = Arrangement.spacedBy(14.dp),
+  ) {
+    Column(Modifier.weight(1f)) {
+      Text(
+        text = "BIND THE CONTRACT",
+        style = ClanWorldTheme.type.monoMicro,
+        color = Ink3,
+      )
+      Text(
+        text = clanDisplayName(listing.clanId),
+        style = ClanWorldTheme.type.letterName,
+        color = Ink,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+      Text(
+        text = "tkn 0x${"%04x".format(listing.tokenId)}",
+        style = ClanWorldTheme.type.monoMicro,
+        color = Ink3,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+    WaxSeal(
+      glyph = painterResource(clanGlyphRes(listing.clanId)),
+      clanColor = clanCol,
+    )
+  }
+
+  Spacer(Modifier.height(12.dp))
+
+  Text(
+    text = listing.pitch,
+    style = ClanWorldTheme.type.scriptItalic,
+    color = Ink2,
+  )
+
+  Spacer(Modifier.height(14.dp))
+
+  // Stat strip
+  Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+    HireStat(label = "Price", value = "${listing.pricePerSeason}g", color = ClanWorldTheme.colors.gold)
+    HireStat(label = "Term", value = "i season", color = Ink)
+    HireStat(label = "Owner", value = listing.ownerShort, color = Ink3)
+  }
+
+  Spacer(Modifier.height(18.dp))
+
+  when (state.value) {
+    HireState.Idle, HireState.Failed -> {
+      EmberCta(
+        text = if (state.value == HireState.Failed) "Try Again" else "Sign with Wallet",
+        onClick = onConfirm,
+        modifier = Modifier.fillMaxWidth(),
+      )
+      if (state.value == HireState.Failed) {
+        Spacer(Modifier.height(8.dp))
+        Text(
+          text = errorMessage.value ?: "—",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.danger,
+        )
+      }
+      Spacer(Modifier.height(8.dp))
+      Text(
+        text = "DISMISS",
+        style = ClanWorldTheme.type.monoNano,
+        color = Ink3,
+        modifier = Modifier
+          .fillMaxWidth()
+          .clickable { onDismiss() }
+          .padding(vertical = 10.dp),
+        textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+      )
+    }
+    HireState.Signing -> {
+      Box(
+        Modifier
+          .fillMaxWidth()
+          .height(54.dp)
+          .clip(RoundedCornerShape(6.dp))
+          .drawBehind {
+            drawRoundRect(
+              color = Ink.copy(alpha = 0.10f),
+              cornerRadius = CornerRadius(6.dp.toPx()),
+              style = Stroke(width = 1.dp.toPx()),
+            )
+          },
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          text = "AWAITING THE WALLET'S SEAL…",
+          style = ClanWorldTheme.type.ctaLabel,
+          color = Ink3,
+        )
+      }
+    }
+    HireState.Sealed -> {
+      Box(
+        Modifier
+          .fillMaxWidth()
+          .height(54.dp)
+          .clip(RoundedCornerShape(6.dp))
+          .background(ClanWorldTheme.colors.success.copy(alpha = 0.18f)),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          text = "SEALED ✓",
+          style = ClanWorldTheme.type.ctaLabel,
+          color = ClanWorldTheme.colors.success,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.HireStat(
+  label: String,
+  value: String,
+  color: Color,
+) {
+  Column(Modifier.weight(1f)) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Text(
+      text = value,
+      style = ClanWorldTheme.type.monoData,
+      color = color,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/OnboardingHint.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/OnboardingHint.kt
@@ -1,0 +1,134 @@
+package world.clan.app.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import world.clan.app.R
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * One-shot dismissible coachmark for first-time users. Renders a small
+ * parchment-tinted banner with title + body + close icon. Disappears
+ * permanently when dismissed (or on first prevent-show-again signal from
+ * the host).
+ *
+ * Hosts manage the "have they seen it?" flag via SessionStore.hasSeenFlag /
+ * markFlagSeen. The banner shrinks itself out cleanly on dismiss so the
+ * surrounding content reflows without a layout pop.
+ */
+@Composable
+fun OnboardingHint(
+  visible: Boolean,
+  title: String,
+  body: String,
+  onDismiss: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  // Local visibility tracks the parent's `visible` plus an in-flight
+  // dismissal. Without this the parent flag flips synchronously and the
+  // exit animation has nothing to animate.
+  var localVisible by remember(visible) { mutableStateOf(visible) }
+
+  AnimatedVisibility(
+    visible = localVisible,
+    enter = fadeIn(),
+    exit = fadeOut() + shrinkVertically(),
+    modifier = modifier,
+  ) {
+    val gold = ClanWorldTheme.colors.gold
+    val goldDim = ClanWorldTheme.colors.goldDim
+    val warm = ClanWorldTheme.colors.warm
+    val warmDim = ClanWorldTheme.colors.warmDim
+    val iron2 = ClanWorldTheme.colors.iron2
+
+    Row(
+      modifier = Modifier
+        .fillMaxWidth()
+        .clip(RoundedCornerShape(6.dp))
+        .background(
+          Brush.verticalGradient(
+            0f to gold.copy(alpha = 0.10f),
+            1f to gold.copy(alpha = 0.04f),
+          ),
+        )
+        .drawBehind {
+          drawRoundRect(
+            color = goldDim,
+            cornerRadius = CornerRadius(6.dp.toPx()),
+            style = Stroke(width = 1.dp.toPx()),
+          )
+        }
+        .padding(horizontal = 14.dp, vertical = 12.dp),
+      verticalAlignment = Alignment.Top,
+      horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+      // Small ember-pill marker on the left
+      Box(
+        modifier = Modifier
+          .size(8.dp)
+          .clip(RoundedCornerShape(50))
+          .background(gold),
+      )
+      Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+      ) {
+        Text(
+          text = title.uppercase(),
+          style = ClanWorldTheme.type.monoMicro,
+          color = gold,
+        )
+        Text(
+          text = body,
+          style = ClanWorldTheme.type.scriptItalic,
+          color = warm,
+        )
+      }
+      // Dismiss × button
+      Box(
+        modifier = Modifier
+          .clip(RoundedCornerShape(50))
+          .background(iron2)
+          .clickable {
+            localVisible = false
+            onDismiss()
+          }
+          .padding(6.dp),
+      ) {
+        Icon(
+          painter = painterResource(R.drawable.ui_check),
+          contentDescription = "dismiss",
+          tint = warmDim,
+          modifier = Modifier.size(12.dp),
+        )
+      }
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/RefreshableContent.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/RefreshableContent.kt
@@ -1,0 +1,105 @@
+package world.clan.app.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * Pull-to-refresh wrapper using Material3's [PullToRefreshBox].
+ *
+ * Drop-in replacement for `Box(Modifier.fillMaxSize())` around a vertically
+ * scrollable child. Pulls a refresh callback from the host viewmodel.
+ *
+ * Notes:
+ * - The Material3 indicator is themed by ColorScheme; we let it inherit
+ *   from the obsidian color scheme rather than pinning. If the default
+ *   indicator looks wrong, swap to a custom one via `indicator =`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RefreshableContent(
+  isRefreshing: Boolean,
+  onRefresh: () -> Unit,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  PullToRefreshBox(
+    isRefreshing = isRefreshing,
+    onRefresh = onRefresh,
+    modifier = modifier,
+  ) {
+    content()
+  }
+}
+
+/**
+ * Error notice for data-fetch failures. Renders the message + a tap-to-retry
+ * affordance. Same script-italic + danger-color palette as the other
+ * screens' error texts, with an extra CTA button beneath.
+ */
+@Composable
+fun RetryNotice(
+  message: String,
+  onRetry: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val danger = ClanWorldTheme.colors.danger
+  val iron2 = ClanWorldTheme.colors.iron2
+  val hairlineMid = ClanWorldTheme.colors.hairlineMid
+  val parchment = ClanWorldTheme.colors.parchment
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 16.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Text(
+      text = message,
+      style = ClanWorldTheme.type.scriptItalic,
+      color = danger,
+      textAlign = TextAlign.Center,
+    )
+    Box(
+      modifier = Modifier
+        .clip(RoundedCornerShape(4.dp))
+        .background(iron2)
+        .drawBehind {
+          drawRoundRect(
+            color = hairlineMid,
+            cornerRadius = CornerRadius(4.dp.toPx()),
+            style = Stroke(width = 1.dp.toPx()),
+          )
+        }
+        .clickable { onRetry() }
+        .padding(horizontal = 18.dp, vertical = 10.dp),
+    ) {
+      Text(
+        text = "TAP TO RETRY",
+        style = ClanWorldTheme.type.monoMicro,
+        color = parchment,
+      )
+    }
+    Spacer(Modifier.height(4.dp))
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Skeleton.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Skeleton.kt
@@ -1,0 +1,255 @@
+package world.clan.app.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * Sweep a translucent gold band diagonally across the modifier's bounds,
+ * looping every ~1500ms. Apply via .then(rememberShimmer()).
+ *
+ * The sweep is drawn ON TOP of existing content via drawWithContent, so the
+ * caller renders a solid base color first and the shimmer overlays it.
+ */
+@Composable
+fun Modifier.shimmer(): Modifier {
+  val gold = ClanWorldTheme.colors.goldDim
+  val transition = rememberInfiniteTransition(label = "skeleton-shimmer")
+  val sweepX by transition.animateFloat(
+    initialValue = -1f,
+    targetValue = 2f,
+    animationSpec = infiniteRepeatable(
+      animation = tween(durationMillis = 1500, easing = LinearEasing),
+      repeatMode = RepeatMode.Restart,
+    ),
+    label = "shimmer-x",
+  )
+  return this.drawWithContent {
+    drawContent()
+    val w = size.width
+    val band = w * 0.45f
+    val x0 = sweepX * w * 1.5f
+    drawRect(
+      brush = Brush.linearGradient(
+        colors = listOf(
+          Color.Transparent,
+          gold.copy(alpha = 0.18f),
+          Color.Transparent,
+        ),
+        start = Offset(x0, 0f),
+        end = Offset(x0 + band, size.height),
+      ),
+      topLeft = Offset(0f, 0f),
+      size = Size(w, size.height),
+    )
+  }
+}
+
+/**
+ * One rectangular skeleton "bone" — solid iron2 base + gold shimmer sweep.
+ * Building block for every higher-level skeleton card.
+ */
+@Composable
+fun SkeletonBone(
+  width: Dp? = null,
+  height: Dp = 12.dp,
+  cornerRadius: Dp = 4.dp,
+  modifier: Modifier = Modifier,
+) {
+  val base = ClanWorldTheme.colors.iron2
+  val mod = (if (width != null) modifier.width(width) else modifier.fillMaxWidth())
+    .height(height)
+    .clip(RoundedCornerShape(cornerRadius))
+    .background(base)
+    .shimmer()
+  Box(modifier = mod)
+}
+
+/**
+ * Hall list placeholder — mimics LetterCard shape: parchment-toned bg,
+ * round seal area on the right, two text lines on the left, divider, three
+ * stat columns. Renders four of these stacked when called from HallScreen.
+ */
+@Composable
+fun SkeletonLetterCard(modifier: Modifier = Modifier) {
+  val parchmentTint = ClanWorldTheme.colors.parchmentShade.copy(alpha = 0.10f)
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(6.dp))
+      .background(parchmentTint)
+      .padding(horizontal = 16.dp, vertical = 14.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Row(
+      verticalAlignment = androidx.compose.ui.Alignment.Top,
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        SkeletonBone(height = 18.dp)
+        SkeletonBone(height = 10.dp, width = 140.dp)
+      }
+      Box(
+        modifier = Modifier
+          .size(54.dp)
+          .clip(CircleShape)
+          .background(ClanWorldTheme.colors.iron2)
+          .shimmer(),
+      )
+    }
+    SkeletonBone(height = 12.dp)
+    SkeletonBone(height = 12.dp, width = 200.dp)
+    Spacer(Modifier.height(2.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+      repeat(3) {
+        Column(
+          modifier = Modifier.weight(1f),
+          verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+          SkeletonBone(height = 8.dp, width = 50.dp)
+          SkeletonBone(height = 12.dp)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * WhisperRow placeholder — left-edge accent line, meta + body bones.
+ */
+@Composable
+fun SkeletonWhisperRow(modifier: Modifier = Modifier) {
+  Row(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(start = 12.dp, end = 10.dp, top = 6.dp, bottom = 6.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Box(
+      modifier = Modifier
+        .width(2.dp)
+        .height(46.dp)
+        .background(ClanWorldTheme.colors.runeDim),
+    )
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+      SkeletonBone(height = 8.dp, width = 110.dp)
+      SkeletonBone(height = 14.dp)
+      SkeletonBone(height = 14.dp, width = 220.dp)
+    }
+  }
+}
+
+/**
+ * Treasury hero placeholder — gold value bone + clan dot.
+ */
+@Composable
+fun SkeletonTreasuryHero(modifier: Modifier = Modifier) {
+  val parchmentTint = ClanWorldTheme.colors.parchmentShade.copy(alpha = 0.10f)
+  Row(
+    modifier = modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(6.dp))
+      .background(parchmentTint)
+      .padding(horizontal = 16.dp, vertical = 18.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+  ) {
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      SkeletonBone(height = 8.dp, width = 50.dp)
+      SkeletonBone(height = 28.dp, width = 160.dp)
+      SkeletonBone(height = 10.dp, width = 200.dp)
+    }
+    Box(
+      modifier = Modifier
+        .size(28.dp)
+        .clip(CircleShape)
+        .background(ClanWorldTheme.colors.iron2)
+        .shimmer(),
+    )
+  }
+}
+
+/**
+ * Treasury movement row placeholder — tick label + resource + amount.
+ */
+@Composable
+fun SkeletonMovementRow(modifier: Modifier = Modifier) {
+  Row(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(vertical = 12.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+  ) {
+    SkeletonBone(height = 8.dp, width = 36.dp)
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+      SkeletonBone(height = 12.dp, width = 80.dp)
+      SkeletonBone(height = 8.dp, width = 50.dp)
+    }
+    SkeletonBone(height = 14.dp, width = 60.dp)
+  }
+}
+
+/**
+ * Leaderboard row placeholder — rank + name + tagline + value.
+ */
+@Composable
+fun SkeletonLeaderboardRow(modifier: Modifier = Modifier) {
+  Row(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(vertical = 8.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+  ) {
+    SkeletonBone(height = 14.dp, width = 24.dp)
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+      SkeletonBone(height = 14.dp, width = 140.dp)
+      SkeletonBone(height = 8.dp, width = 90.dp)
+    }
+    SkeletonBone(height = 14.dp, width = 64.dp)
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Tabbar.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Tabbar.kt
@@ -36,6 +36,7 @@ import world.clan.app.ui.theme.ClanWorldTheme
 enum class RootTab(val label: String, val drawableRes: Int) {
   Hearth("Hearth", R.drawable.ui_tab_hearth),
   Hall("Hall", R.drawable.ui_tab_hall),
+  Bazaar("Bazaar", R.drawable.ui_tab_bazaar),
   Codex("Codex", R.drawable.ui_tab_codex),
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
@@ -1,0 +1,256 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import world.clan.app.App
+import world.clan.app.data.BazaarListing
+import world.clan.app.ui.components.CrownHeader
+import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.components.StaggeredEntry
+import world.clan.app.ui.components.WaxSeal
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.ui.theme.clanGlyphRes
+import world.clan.app.viewmodel.BazaarUiState
+import world.clan.app.viewmodel.BazaarViewModel
+import world.clan.app.viewmodel.ClanWorldViewModelFactory
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.clanTagline
+
+@Composable
+fun BazaarScreenRoute(
+  app: App,
+  factory: ClanWorldViewModelFactory,
+  onOpenListing: (Int) -> Unit,
+) {
+  val vm: BazaarViewModel = viewModel(factory = factory)
+  val state by vm.state.collectAsState()
+  BazaarScreen(state = state, onOpenListing = onOpenListing)
+}
+
+@Composable
+private fun BazaarScreen(
+  state: BazaarUiState,
+  onOpenListing: (Int) -> Unit,
+) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(horizontal = 22.dp),
+  ) {
+    CrownHeader(
+      screenName = "Bazaar",
+      modifier = Modifier.fillMaxWidth(),
+    )
+
+    StaggeredEntry(index = 0) {
+      BazaarHead(count = state.listings.size)
+    }
+
+    Spacer(Modifier.height(18.dp))
+
+    if (state.isLoading) {
+      Text(
+        text = "the merchants are setting their stalls…",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warmFaint,
+        modifier = Modifier.padding(top = 24.dp),
+      )
+    } else if (state.listings.isEmpty()) {
+      Text(
+        text = state.errorMessage ?: "the bazaar is quiet — no listings posted.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warmFaint,
+        modifier = Modifier.padding(top = 24.dp),
+      )
+    } else {
+      LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+        contentPadding = PaddingValues(bottom = 24.dp),
+      ) {
+        items(state.listings, key = { it.tokenId }) { listing ->
+          StaggeredEntry(index = listing.clanId.coerceAtMost(8)) {
+            ListingCard(
+              listing = listing,
+              onClick = { onOpenListing(listing.clanId) },
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun BazaarHead(count: Int) {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val gold = ClanWorldTheme.colors.gold
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(top = 14.dp, bottom = 4.dp)
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 18f),
+          end = Offset(size.width, size.height + 18f),
+          strokeWidth = 1f,
+        )
+      },
+    verticalAlignment = Alignment.Bottom,
+    horizontalArrangement = Arrangement.SpaceBetween,
+  ) {
+    Column {
+      Text(
+        text = "BAZAAR",
+        style = ClanWorldTheme.type.displayHero,
+        color = parchment,
+      )
+      Text(
+        text = "merchants of the realm — sigils for hire",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = warmDim,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+    Column(horizontalAlignment = Alignment.End) {
+      Text(
+        text = "%02d".format(count),
+        style = ClanWorldTheme.type.monoBig,
+        color = parchment,
+      )
+      Text(
+        text = "listings",
+        style = ClanWorldTheme.type.monoMicro,
+        color = gold,
+      )
+    }
+  }
+}
+
+@Composable
+private fun ListingCard(
+  listing: BazaarListing,
+  onClick: () -> Unit,
+) {
+  ParchmentCard(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { onClick() },
+  ) {
+    val clanCol = clanColor(listing.clanId)
+
+    Row(
+      verticalAlignment = Alignment.Top,
+      horizontalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+      Column(Modifier.weight(1f)) {
+        Text(
+          text = clanDisplayName(listing.clanId),
+          style = ClanWorldTheme.type.letterName,
+          color = Ink,
+        )
+        Text(
+          text = "tkn 0x${"%04x".format(listing.tokenId)} · clan ${roman(listing.clanId).lowercase()}",
+          style = ClanWorldTheme.type.monoMicro,
+          color = Ink3,
+          modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+      WaxSeal(
+        glyph = painterResource(clanGlyphRes(listing.clanId)),
+        clanColor = clanCol,
+      )
+    }
+
+    Spacer(Modifier.height(8.dp))
+
+    Text(
+      text = listing.pitch,
+      style = ClanWorldTheme.type.scriptItalic,
+      color = Ink2,
+    )
+
+    Spacer(Modifier.height(12.dp))
+
+    Box(
+      Modifier
+        .fillMaxWidth()
+        .height(1.dp)
+        .drawBehind {
+          drawLine(
+            color = Ink.copy(alpha = 0.20f),
+            start = Offset(0f, 0f),
+            end = Offset(size.width, 0f),
+            strokeWidth = 1f,
+            pathEffect = PathEffect.dashPathEffect(floatArrayOf(2.dp.toPx(), 2.dp.toPx())),
+          )
+        },
+    )
+
+    Spacer(Modifier.height(12.dp))
+
+    Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+      ListingStat(label = "Price", value = "${listing.pricePerSeason}g/season", color = ClanWorldTheme.colors.gold)
+      ListingStat(label = "Status", value = listing.availability.substringBefore("—").trim(), color = ClanWorldTheme.colors.success)
+      ListingStat(label = "Owner", value = listing.ownerShort, color = Ink3)
+    }
+  }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.ListingStat(
+  label: String,
+  value: String,
+  color: androidx.compose.ui.graphics.Color,
+) {
+  Column(Modifier.weight(1f)) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Text(
+      text = value,
+      style = ClanWorldTheme.type.monoData,
+      color = color,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+private fun roman(n: Int): String = when (n) {
+  1 -> "I"; 2 -> "II"; 3 -> "III"; 4 -> "IV"
+  5 -> "V"; 6 -> "VI"; 7 -> "VII"; 8 -> "VIII"
+  else -> n.toString()
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
@@ -51,6 +51,9 @@ fun BazaarScreenRoute(
 ) {
   val vm: BazaarViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
+  // Re-apply the hired-clan filter on (re-)entry so a freshly-hired
+  // sigil drops out of the listings without an app kill.
+  androidx.compose.runtime.LaunchedEffect(Unit) { vm.refresh() }
   BazaarScreen(state = state, onOpenListing = onOpenListing)
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BridgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BridgeScreen.kt
@@ -1,0 +1,102 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import world.clan.app.ui.components.Sigil
+import world.clan.app.ui.components.bigSigilSpec
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.viewmodel.clanDisplayName
+
+/**
+ * Short loader between InftDetail's "Enter Cockpit" tap and the actual
+ * CockpitScreen mount. Buys ~1.4s for two reasons:
+ *   1. Cockpit data fetches start from a clean state — gives them a
+ *      moment to land before the screen is on-stage.
+ *   2. The transition feels weighty rather than instant — matches the
+ *      "the strait is preparing" copy.
+ *
+ * The screen is intentionally still: a single rotating Sigil with a slow
+ * breathing-fade subtitle. No tap targets — backstack handles cancel.
+ */
+@Composable
+fun BridgeScreen(
+  clanId: Int,
+  onReady: () -> Unit,
+) {
+  // Auto-advance after ~1.4s. If composition is torn down before then
+  // (back-press, etc.), the LaunchedEffect cancels cleanly.
+  LaunchedEffect(clanId) {
+    delay(1400L)
+    onReady()
+  }
+
+  val transition = rememberInfiniteTransition(label = "bridge-pulse")
+  val pulse by transition.animateFloat(
+    initialValue = 0.55f,
+    targetValue = 1f,
+    animationSpec = infiniteRepeatable(
+      animation = tween(durationMillis = 1600, easing = EaseInOut),
+      repeatMode = RepeatMode.Reverse,
+    ),
+    label = "pulse",
+  )
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(horizontal = 22.dp),
+    contentAlignment = Alignment.Center,
+  ) {
+    Column(
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center,
+    ) {
+      Sigil(
+        spec = bigSigilSpec(clanColor(clanId)),
+        modifier = Modifier.size(160.dp),
+      )
+
+      Spacer(Modifier.height(34.dp))
+
+      Text(
+        text = "preparing the strait…",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warm,
+        modifier = Modifier.alpha(pulse),
+        textAlign = TextAlign.Center,
+      )
+
+      Spacer(Modifier.height(8.dp))
+
+      Text(
+        text = clanDisplayName(clanId).uppercase(),
+        style = ClanWorldTheme.type.monoNano,
+        color = ClanWorldTheme.colors.gold,
+        textAlign = TextAlign.Center,
+      )
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
@@ -57,6 +58,9 @@ fun CodexScreenRoute(
 ) {
   val vm: CodexViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
+  // Re-read lineage on each Codex visit so newly-signed actions appear
+  // without a kill/relaunch.
+  androidx.compose.runtime.LaunchedEffect(Unit) { vm.refreshLineage() }
   CodexScreen(state = state)
 }
 
@@ -123,6 +127,19 @@ private fun CodexScreen(
     }
 
     Spacer(Modifier.height(20.dp))
+
+    // ── Lineage ──────────────────────────────────────────────────────
+    if (state.lineage.isNotEmpty()) {
+      StaggeredEntry(index = 9) {
+        SectionHeader(title = "Lineage", showLozenge = false)
+      }
+      StaggeredEntry(index = 10) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          state.lineage.take(12).forEach { entry -> LineageRow(entry) }
+        }
+      }
+      Spacer(Modifier.height(20.dp))
+    }
 
     // ── Share ────────────────────────────────────────────────────────
     StaggeredEntry(index = 5) {
@@ -270,6 +287,79 @@ private fun RowCard(
         )
       }
     }
+  }
+}
+
+@Composable
+private fun LineageRow(entry: world.clan.app.data.LineageEntry) {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warm = ClanWorldTheme.colors.warm
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val warmFaint = ClanWorldTheme.colors.warmFaint
+  val accent = world.clan.app.ui.theme.clanColor(entry.clanId)
+  val kindGlyph = when (entry.kind) {
+    "forged" -> "✦"
+    "hired" -> "◈"
+    "whispered" -> "≈"
+    "sealed" -> "✕"
+    else -> "·"
+  }
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(6.dp))
+      .background(ClanWorldTheme.colors.iron)
+      .border(1.dp, ClanWorldTheme.colors.hairline, RoundedCornerShape(6.dp))
+      .padding(horizontal = 14.dp, vertical = 10.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Box(
+      modifier = Modifier
+        .size(28.dp)
+        .clip(CircleShape)
+        .background(accent.copy(alpha = 0.18f))
+        .border(1.dp, accent.copy(alpha = 0.55f), CircleShape),
+      contentAlignment = Alignment.Center,
+    ) {
+      Text(
+        text = kindGlyph,
+        style = ClanWorldTheme.type.body,
+        color = accent,
+      )
+    }
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+      Text(
+        text = entry.title,
+        style = ClanWorldTheme.type.body,
+        color = parchment,
+      )
+      if (!entry.subtitle.isNullOrBlank()) {
+        Text(
+          text = entry.subtitle,
+          style = ClanWorldTheme.type.scriptItalicSmall,
+          color = warmDim,
+        )
+      }
+    }
+    Text(
+      text = formatRelativeTime(entry.tsEpochMs),
+      style = ClanWorldTheme.type.monoNano,
+      color = warmFaint,
+    )
+  }
+}
+
+private fun formatRelativeTime(tsMs: Long): String {
+  val deltaMs = System.currentTimeMillis() - tsMs
+  return when {
+    deltaMs < 60_000 -> "just now"
+    deltaMs < 60 * 60_000 -> "${deltaMs / 60_000}m"
+    deltaMs < 24 * 60 * 60_000 -> "${deltaMs / (60 * 60_000)}h"
+    else -> "${deltaMs / (24 * 60 * 60_000)}d"
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -98,9 +98,15 @@ private fun CodexScreen(
           copyable = state.solanaPubkey != null,
           copyText = state.solanaPubkey,
         )
+        if (state.walletLabel != null) {
+          RowCard(
+            label = "Wallet account",
+            value = state.walletLabel,
+          )
+        }
         RowCard(
-          label = "Linked clan",
-          value = "Caldris of the Strait — sealed at tick demo.",
+          label = "Linked clans · ${state.linkedClansCount} of viii",
+          value = linkedClansLine(state.linkedClanIds),
           isScript = true,
         )
       }
@@ -118,15 +124,58 @@ private fun CodexScreen(
 
     Spacer(Modifier.height(20.dp))
 
-    // ── About ────────────────────────────────────────────────────────
+    // ── Share ────────────────────────────────────────────────────────
     StaggeredEntry(index = 5) {
-      SectionHeader(title = "About", showLozenge = false)
+      SectionHeader(title = "Share", showLozenge = false)
     }
     StaggeredEntry(index = 6) {
-      RowCard(label = "Build", value = state.build)
+      RowCard(
+        label = "APK download · for friends",
+        value = state.apkShareUrl,
+        copyable = true,
+        copyText = state.apkShareUrl,
+      )
+    }
+
+    Spacer(Modifier.height(20.dp))
+
+    // ── About ────────────────────────────────────────────────────────
+    StaggeredEntry(index = 7) {
+      SectionHeader(title = "About", showLozenge = false)
+    }
+    StaggeredEntry(index = 8) {
+      Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        RowCard(label = "Build", value = state.build)
+        RowCard(
+          label = "Convex deployment",
+          value = state.convexUrl,
+          copyable = true,
+          copyText = state.convexUrl,
+        )
+      }
     }
 
     Spacer(Modifier.height(40.dp))
+  }
+}
+
+private fun linkedClansLine(ids: List<Int>): String {
+  if (ids.isEmpty()) return "no clans linked yet"
+  val names = ids.map { id ->
+    when (id) {
+      1 -> "Storm-Edge"; 2 -> "Tideborne"; 3 -> "Sunhold"; 4 -> "Vale-Ward"
+      5 -> "Twilight"; 6 -> "Ember"; 7 -> "Forge"; 8 -> "Star"
+      else -> "Clan $id"
+    }
+  }
+  return when (names.size) {
+    1 -> "${names[0]} stands under your hand."
+    2 -> "${names[0]} and ${names[1]} stand under your hand."
+    else -> {
+      val head = names.dropLast(1).joinToString(", ")
+      val tail = names.last()
+      "$head, and $tail stand under your hand."
+    }
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -75,7 +75,7 @@ fun ForgeScreenRoute(
   factory: ClanWorldViewModelFactory,
   mwaSender: ActivityResultSender,
   onBack: () -> Unit,
-  onForged: () -> Unit,
+  onForged: (clanId: Int, name: String) -> Unit,
 ) {
   val vm: ForgeViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
@@ -114,7 +114,8 @@ fun ForgeScreenRoute(
   if (state.mintPhase == SendPhase.Queued) {
     androidx.compose.runtime.LaunchedEffect(Unit) {
       delay(1500L)
-      onForged()
+      val cid = state.clanId ?: 1
+      onForged(cid, state.sigilName)
     }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
@@ -271,6 +272,15 @@ private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
       color = ClanWorldTheme.colors.warmFaint,
       modifier = Modifier.padding(horizontal = 22.dp),
     )
+    if (state.ownedClanIds.isNotEmpty()) {
+      Spacer(Modifier.height(4.dp))
+      Text(
+        text = "clans already under your hand can't be re-forged.",
+        style = ClanWorldTheme.type.scriptItalicSmall,
+        color = ClanWorldTheme.colors.warmFaint,
+        modifier = Modifier.padding(horizontal = 22.dp),
+      )
+    }
     Spacer(Modifier.height(10.dp))
     LazyColumn(
       modifier = Modifier.fillMaxSize(),
@@ -278,10 +288,12 @@ private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
       contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
     ) {
       items((1..8).toList()) { clanId ->
+        val owned = clanId in state.ownedClanIds
         ClanCard(
           clanId = clanId,
           selected = state.clanId == clanId,
-          onClick = { onSelect(clanId) },
+          owned = owned,
+          onClick = { if (!owned) onSelect(clanId) },
         )
       }
     }
@@ -289,15 +301,26 @@ private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
 }
 
 @Composable
-private fun ClanCard(clanId: Int, selected: Boolean, onClick: () -> Unit) {
+private fun ClanCard(
+  clanId: Int,
+  selected: Boolean,
+  owned: Boolean,
+  onClick: () -> Unit,
+) {
   val accent = clanColor(clanId)
-  val borderColor = if (selected) accent else ClanWorldTheme.colors.hairline
-  val borderStroke = if (selected) 2.dp else 1.dp
+  val borderColor = when {
+    owned -> ClanWorldTheme.colors.hairline
+    selected -> accent
+    else -> ClanWorldTheme.colors.hairline
+  }
+  val borderStroke = if (selected && !owned) 2.dp else 1.dp
+  val cardAlpha = if (owned) 0.45f else 1f
 
   Box(
     modifier = Modifier
       .fillMaxWidth()
-      .clickable { onClick() }
+      .alpha(cardAlpha)
+      .clickable(enabled = !owned) { onClick() }
       .drawBehind {
         drawRoundRect(
           color = borderColor,
@@ -323,7 +346,7 @@ private fun ClanCard(clanId: Int, selected: Boolean, onClick: () -> Unit) {
             color = Ink,
           )
           Text(
-            text = clanTagline(clanId),
+            text = if (owned) "already under your hand" else clanTagline(clanId),
             style = ClanWorldTheme.type.scriptItalic,
             color = Ink2,
             modifier = Modifier.padding(top = 2.dp),

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -1,0 +1,668 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentTransitionScope.SlideDirection
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import world.clan.app.App
+import world.clan.app.R
+import world.clan.app.ui.components.EmberCta
+import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.components.WaxSeal
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.ui.theme.clanGlyphRes
+import world.clan.app.viewmodel.ClanWorldViewModelFactory
+import world.clan.app.viewmodel.ForgeStep
+import world.clan.app.viewmodel.ForgeUiState
+import world.clan.app.viewmodel.ForgeViewModel
+import world.clan.app.viewmodel.Harness
+import world.clan.app.viewmodel.SendPhase
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.clanTagline
+import world.clan.app.wallet.MwaResult
+
+@Composable
+fun ForgeScreenRoute(
+  app: App,
+  factory: ClanWorldViewModelFactory,
+  mwaSender: ActivityResultSender,
+  onBack: () -> Unit,
+  onForged: () -> Unit,
+) {
+  val vm: ForgeViewModel = viewModel(factory = factory)
+  val state by vm.state.collectAsState()
+  val scope = rememberCoroutineScope()
+
+  ForgeScreen(
+    state = state,
+    onBack = onBack,
+    onSelectClan = vm::setClanId,
+    onSetName = vm::setSigilName,
+    onSetHarness = vm::setHarness,
+    onNext = vm::next,
+    onPrev = vm::back,
+    onForge = {
+      scope.launch {
+        vm.setMintPhase(SendPhase.Signing)
+        val token = app.sessionStore.read()?.mwaAuthToken
+        if (token == null) {
+          vm.setMintPhase(SendPhase.Queued)
+          return@launch
+        }
+        val msg = ("ClanWorld Forge — clan ${state.clanId} | ${state.sigilName} | " +
+          "${state.harness.name}").toByteArray()
+        when (val r = app.mwaClient.signMessage(mwaSender, token, msg)) {
+          is MwaResult.Ok -> vm.setMintPhase(SendPhase.Queued)
+          is MwaResult.UserDeclined -> vm.setMintPhase(SendPhase.Idle)
+          is MwaResult.WalletNotFound ->
+            vm.setMintPhase(SendPhase.Failed, "no wallet found on device.")
+          is MwaResult.Error ->
+            vm.setMintPhase(SendPhase.Failed, r.cause.message ?: "the wallet refused the seal.")
+        }
+      }
+    },
+  )
+
+  if (state.mintPhase == SendPhase.Queued) {
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+      delay(1500L)
+      onForged()
+    }
+  }
+}
+
+@Composable
+private fun ForgeScreen(
+  state: ForgeUiState,
+  onBack: () -> Unit,
+  onSelectClan: (Int) -> Unit,
+  onSetName: (String) -> Unit,
+  onSetHarness: (Harness) -> Unit,
+  onNext: () -> Unit,
+  onPrev: () -> Unit,
+  onForge: () -> Unit,
+) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    BackBar(text = "back to hall", onBack = onBack)
+
+    Column(modifier = Modifier.padding(horizontal = 22.dp)) {
+      ForgeHead()
+      Spacer(Modifier.height(10.dp))
+      ProgressDots(step = state.step)
+      Spacer(Modifier.height(18.dp))
+    }
+
+    AnimatedContent(
+      targetState = state.step,
+      transitionSpec = {
+        val direction = if (targetState.ordinal > initialState.ordinal) SlideDirection.Start else SlideDirection.End
+        (slideIntoContainer(direction, animationSpec = tween(280)) + fadeIn(tween(220))) togetherWith
+          (slideOutOfContainer(direction, animationSpec = tween(280)) + fadeOut(tween(180)))
+      },
+      label = "forge-step",
+      modifier = Modifier.weight(1f),
+    ) { step ->
+      when (step) {
+        ForgeStep.PickClan -> StepPickClan(
+          state = state,
+          onSelect = onSelectClan,
+        )
+        ForgeStep.NameSigil -> StepNameSigil(
+          state = state,
+          onChange = onSetName,
+        )
+        ForgeStep.PickHarness -> StepPickHarness(
+          state = state,
+          onSelect = onSetHarness,
+        )
+        ForgeStep.Confirm -> StepConfirm(
+          state = state,
+          onForge = onForge,
+        )
+      }
+    }
+
+    NavRow(state = state, onNext = onNext, onPrev = onPrev)
+    Spacer(Modifier.height(20.dp))
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Header + progress dots
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun BackBar(text: String, onBack: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 14.dp)
+      .clickable { onBack() },
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      painter = painterResource(R.drawable.ui_arrow),
+      contentDescription = "back",
+      tint = ClanWorldTheme.colors.warm,
+      modifier = Modifier.height(16.dp),
+    )
+    Text(
+      text = text,
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+  }
+}
+
+@Composable
+private fun ForgeHead() {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 14f),
+          end = Offset(size.width, size.height + 14f),
+          strokeWidth = 1f,
+        )
+      },
+  ) {
+    Text(text = "FORGE", style = ClanWorldTheme.type.displayHero, color = parchment)
+    Text(
+      text = "the unmade seal awaits its line",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = warmDim,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+@Composable
+private fun ProgressDots(step: ForgeStep) {
+  val ember = ClanWorldTheme.colors.ember
+  val warmFaint = ClanWorldTheme.colors.warmFaint
+  val total = ForgeStep.values().size
+  val activeIdx = step.ordinal
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    for (i in 0 until total) {
+      val color = if (i <= activeIdx) ember else warmFaint
+      Box(
+        modifier = Modifier
+          .size(8.dp)
+          .clip(RoundedCornerShape(50))
+          .background(color),
+      )
+    }
+    Spacer(Modifier.fillMaxWidth().weight(1f, fill = false))
+    Text(
+      text = "STEP ${activeIdx + 1} OF $total",
+      style = ClanWorldTheme.type.monoNano,
+      color = warmFaint,
+      modifier = Modifier.padding(start = 12.dp),
+    )
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 1 — Pick clan
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    Text(
+      text = "CHOOSE YOUR CLAN",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+      modifier = Modifier.padding(horizontal = 22.dp),
+    )
+    Spacer(Modifier.height(10.dp))
+    LazyColumn(
+      modifier = Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.spacedBy(10.dp),
+      contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+    ) {
+      items((1..8).toList()) { clanId ->
+        ClanCard(
+          clanId = clanId,
+          selected = state.clanId == clanId,
+          onClick = { onSelect(clanId) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun ClanCard(clanId: Int, selected: Boolean, onClick: () -> Unit) {
+  val accent = clanColor(clanId)
+  val borderColor = if (selected) accent else ClanWorldTheme.colors.hairline
+  val borderStroke = if (selected) 2.dp else 1.dp
+
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { onClick() }
+      .drawBehind {
+        drawRoundRect(
+          color = borderColor,
+          cornerRadius = CornerRadius(6.dp.toPx()),
+          style = Stroke(width = borderStroke.toPx()),
+        )
+      },
+  ) {
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+      ) {
+        WaxSeal(
+          glyph = painterResource(clanGlyphRes(clanId)),
+          clanColor = accent,
+          size = 44.dp,
+        )
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            text = clanDisplayName(clanId),
+            style = ClanWorldTheme.type.letterName,
+            color = Ink,
+          )
+          Text(
+            text = clanTagline(clanId),
+            style = ClanWorldTheme.type.scriptItalic,
+            color = Ink2,
+            modifier = Modifier.padding(top = 2.dp),
+          )
+        }
+      }
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 2 — Name the sigil
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepNameSigil(state: ForgeUiState, onChange: (String) -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(horizontal = 22.dp),
+  ) {
+    Text(
+      text = "NAME THE SIGIL",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Spacer(Modifier.height(8.dp))
+    Text(
+      text = "what shall the elders call this iNFT?",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+    Spacer(Modifier.height(14.dp))
+
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Text(
+        text = "NAME",
+        style = ClanWorldTheme.type.monoNano,
+        color = Ink3,
+      )
+      Spacer(Modifier.height(6.dp))
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(48.dp),
+      ) {
+        if (state.sigilName.isEmpty()) {
+          Text(
+            text = "the unnamed seal…",
+            style = ClanWorldTheme.type.scriptItalic.copy(color = Ink3),
+          )
+        }
+        BasicTextField(
+          value = state.sigilName,
+          onValueChange = onChange,
+          singleLine = true,
+          textStyle = LocalTextStyle.current.copy(
+            fontFamily = ClanWorldTheme.type.letterName.fontFamily,
+            fontSize = ClanWorldTheme.type.letterName.fontSize,
+            color = Ink,
+          ),
+          cursorBrush = SolidColor(Ink2),
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+      Spacer(Modifier.height(8.dp))
+      Text(
+        text = "${state.sigilName.length}/32",
+        style = ClanWorldTheme.type.monoNano,
+        color = Ink3,
+        textAlign = TextAlign.End,
+        modifier = Modifier.fillMaxWidth(),
+      )
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 3 — Pick harness
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepPickHarness(state: ForgeUiState, onSelect: (Harness) -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(horizontal = 22.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Text(
+      text = "PICK YOUR HARNESS",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Spacer(Modifier.height(2.dp))
+    Text(
+      text = "the bend the elder will favor",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+    Spacer(Modifier.height(8.dp))
+
+    Harness.values().forEach { h ->
+      HarnessCard(
+        harness = h,
+        selected = state.harness == h,
+        onClick = { onSelect(h) },
+      )
+    }
+  }
+}
+
+@Composable
+private fun HarnessCard(harness: Harness, selected: Boolean, onClick: () -> Unit) {
+  val accent = when (harness) {
+    Harness.Iron -> ClanWorldTheme.colors.rune
+    Harness.Tide -> ClanWorldTheme.colors.gold
+    Harness.Ember -> ClanWorldTheme.colors.ember
+  }
+  val border = if (selected) accent else ClanWorldTheme.colors.hairline
+  val stroke = if (selected) 2.dp else 1.dp
+
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { onClick() }
+      .drawBehind {
+        drawRoundRect(
+          color = border,
+          cornerRadius = CornerRadius(6.dp.toPx()),
+          style = Stroke(width = stroke.toPx()),
+        )
+      },
+  ) {
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        Box(
+          modifier = Modifier
+            .size(14.dp)
+            .clip(RoundedCornerShape(50))
+            .background(accent),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            text = harness.display.uppercase(),
+            style = ClanWorldTheme.type.letterName,
+            color = Ink,
+          )
+          Text(
+            text = harness.tagline,
+            style = ClanWorldTheme.type.scriptItalic,
+            color = Ink2,
+            modifier = Modifier.padding(top = 2.dp),
+          )
+        }
+      }
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 4 — Confirm + sign
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepConfirm(state: ForgeUiState, onForge: () -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(horizontal = 22.dp),
+    verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Text(
+      text = "CONFIRM THE FORGE",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Text(
+      text = "your seal is required before the iNFT goes to your wallet.",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+
+    Spacer(Modifier.height(2.dp))
+
+    val clanId = state.clanId
+    if (clanId == null) {
+      Text(
+        text = "no clan chosen — go back to step 1.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.danger,
+      )
+      return@Column
+    }
+
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Row(
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+      ) {
+        WaxSeal(
+          glyph = painterResource(clanGlyphRes(clanId)),
+          clanColor = clanColor(clanId),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            text = state.sigilName.ifBlank { "the unnamed seal" },
+            style = ClanWorldTheme.type.letterName,
+            color = Ink,
+          )
+          Text(
+            text = clanDisplayName(clanId),
+            style = ClanWorldTheme.type.scriptItalic,
+            color = Ink2,
+            modifier = Modifier.padding(top = 2.dp),
+          )
+        }
+      }
+      Spacer(Modifier.height(12.dp))
+      Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+        ConfirmStat(label = "Clan", value = clanDisplayName(clanId))
+        ConfirmStat(label = "Harness", value = state.harness.display)
+        ConfirmStat(label = "Cost", value = "free • demo")
+      }
+    }
+
+    Spacer(Modifier.height(2.dp))
+
+    when (state.mintPhase) {
+      SendPhase.Idle, SendPhase.Failed -> {
+        EmberCta(
+          text = if (state.mintPhase == SendPhase.Failed) "Try Again" else "Sign and Forge",
+          onClick = onForge,
+          enabled = state.sigilName.isNotBlank(),
+          modifier = Modifier.fillMaxWidth(),
+        )
+        if (state.mintPhase == SendPhase.Failed) {
+          Text(
+            text = state.errorMessage ?: "the seal could not be set.",
+            style = ClanWorldTheme.type.scriptItalic,
+            color = ClanWorldTheme.colors.danger,
+          )
+        }
+      }
+      SendPhase.Signing -> {
+        Text(
+          text = "the wallet is preparing the seal…",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.gold,
+        )
+      }
+      SendPhase.Queued -> {
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .background(ClanWorldTheme.colors.success.copy(alpha = 0.18f))
+            .padding(vertical = 16.dp),
+          contentAlignment = Alignment.Center,
+        ) {
+          Text(
+            text = "FORGED ✓",
+            style = ClanWorldTheme.type.ctaLabel,
+            color = ClanWorldTheme.colors.success,
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.ConfirmStat(label: String, value: String) {
+  Column(Modifier.weight(1f)) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Text(
+      text = value,
+      style = ClanWorldTheme.type.monoData,
+      color = Ink,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Bottom nav row (Back / Next)
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun NavRow(state: ForgeUiState, onNext: () -> Unit, onPrev: () -> Unit) {
+  val isFirst = state.step == ForgeStep.PickClan
+  val isLast = state.step == ForgeStep.Confirm
+  val canAdvance = when (state.step) {
+    ForgeStep.PickClan -> state.clanId != null
+    ForgeStep.NameSigil -> state.sigilName.isNotBlank()
+    ForgeStep.PickHarness -> true
+    ForgeStep.Confirm -> false
+  }
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 8.dp),
+    horizontalArrangement = Arrangement.SpaceBetween,
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    if (!isFirst) {
+      Text(
+        text = "← BACK",
+        style = ClanWorldTheme.type.monoMicro,
+        color = ClanWorldTheme.colors.warmDim,
+        modifier = Modifier
+          .clickable { onPrev() }
+          .padding(horizontal = 8.dp, vertical = 10.dp),
+      )
+    } else {
+      Spacer(Modifier.size(1.dp))
+    }
+    if (!isLast) {
+      val tint = if (canAdvance) ClanWorldTheme.colors.gold else ClanWorldTheme.colors.warmFaint
+      Text(
+        text = "NEXT →",
+        style = ClanWorldTheme.type.monoMicro,
+        color = tint,
+        modifier = Modifier
+          .clickable(enabled = canAdvance) { onNext() }
+          .padding(horizontal = 8.dp, vertical = 10.dp),
+      )
+    } else {
+      Spacer(Modifier.size(1.dp))
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgedScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgedScreen.kt
@@ -1,0 +1,155 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import world.clan.app.ui.components.EmberCta
+import world.clan.app.ui.components.Sigil
+import world.clan.app.ui.components.bigSigilSpec
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.clanTagline
+
+/**
+ * Celebration landing for both Forge mint + Bazaar hire flows.
+ *
+ * Replaces the previous "tiny Sealed ✓ then nav.popBackStack()" UX gap —
+ * after a successful sign, the user lands here for a beat to actually see
+ * the sigil they just bound to their wallet, then taps "Enter Your Hall"
+ * to land in Hall (popUpTo Hall, inclusive=false, so back doesn't bounce
+ * through the wizard).
+ *
+ * Visual hierarchy:
+ *   [LABEL]                       — small mono ("FORGED" or "HIRED")
+ *   <large rotating Sigil>        — clan-color, with breathing halo
+ *   <sigil name>                  — display script
+ *   <clan name>                   — italic
+ *   <tagline>                     — italic, dim
+ *   [Enter Your Hall]             — primary CTA
+ */
+@Composable
+fun ForgedScreen(
+  clanId: Int,
+  label: String,
+  sigilName: String,
+  onEnterHall: () -> Unit,
+) {
+  val accent = clanColor(clanId)
+  val transition = rememberInfiniteTransition(label = "forged-pulse")
+  val haloPulse by transition.animateFloat(
+    initialValue = 0.55f,
+    targetValue = 1f,
+    animationSpec = infiniteRepeatable(
+      animation = tween(durationMillis = 2400, easing = EaseInOut),
+      repeatMode = RepeatMode.Reverse,
+    ),
+    label = "halo",
+  )
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(horizontal = 22.dp),
+  ) {
+    Column(
+      modifier = Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      Text(
+        text = label.uppercase(),
+        style = ClanWorldTheme.type.monoNano,
+        color = accent,
+      )
+
+      Spacer(Modifier.height(20.dp))
+
+      // Sigil with a breathing accent halo behind it.
+      Box(
+        modifier = Modifier.size(200.dp),
+        contentAlignment = Alignment.Center,
+      ) {
+        // Halo
+        Box(
+          modifier = Modifier
+            .size(200.dp)
+            .alpha(haloPulse * 0.40f)
+            .drawBehind {
+              drawCircle(
+                color = accent,
+                radius = size.minDimension / 2f,
+                blendMode = BlendMode.Plus,
+              )
+            },
+        )
+        Sigil(
+          spec = bigSigilSpec(accent),
+          modifier = Modifier.size(160.dp),
+        )
+      }
+
+      Spacer(Modifier.height(28.dp))
+
+      Text(
+        text = sigilName.ifBlank { "the unnamed seal" },
+        style = ClanWorldTheme.type.displayHero,
+        color = ClanWorldTheme.colors.parchment,
+        textAlign = TextAlign.Center,
+      )
+
+      Spacer(Modifier.height(6.dp))
+
+      Text(
+        text = clanDisplayName(clanId),
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warm,
+        textAlign = TextAlign.Center,
+      )
+
+      Spacer(Modifier.height(2.dp))
+
+      Text(
+        text = clanTagline(clanId),
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warmDim,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(horizontal = 28.dp),
+      )
+
+      Spacer(Modifier.height(36.dp))
+
+      Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
+        EmberCta(
+          text = "Enter Your Hall",
+          onClick = onEnterHall,
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -16,6 +16,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -63,11 +66,21 @@ fun HallScreenRoute(
 ) {
   val vm: HallViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
+  // First-launch coachmark: read once from SessionStore, dismiss-on-tap
+  // toggles the local state and writes the persistent flag.
+  val hintFlagKey = "hall.hintSeen"
+  val hintInitial = remember { !app.sessionStore.hasSeenFlag(hintFlagKey) }
+  var hintVisible by remember { mutableStateOf(hintInitial) }
   HallScreen(
     state = state,
     onOpenInft = onOpenInft,
     onForge = onForge,
     onRefresh = vm::refresh,
+    showHint = hintVisible,
+    onDismissHint = {
+      hintVisible = false
+      app.sessionStore.markFlagSeen(hintFlagKey)
+    },
   )
 }
 
@@ -77,6 +90,8 @@ private fun HallScreen(
   onOpenInft: (Int) -> Unit,
   onForge: () -> Unit = {},
   onRefresh: () -> Unit = {},
+  showHint: Boolean = false,
+  onDismissHint: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
   Column(
@@ -93,6 +108,15 @@ private fun HallScreen(
     StaggeredEntry(index = 0) {
       HallHead(count = state.items.size)
     }
+
+    // First-launch coachmark — points new users at the FORGE entry below.
+    Spacer(Modifier.height(14.dp))
+    world.clan.app.ui.components.OnboardingHint(
+      visible = showHint,
+      title = "Begin your line",
+      body = "Tap “+ Forge a new sigil” below to mint your first iNFT.",
+      onDismiss = onDismissHint,
+    )
 
     // Forge entry — sits between the head divider and the list. Always
     // available; an empty hall still wants the option to forge a new one.

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -66,6 +67,15 @@ fun HallScreenRoute(
 ) {
   val vm: HallViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
+  // Refresh on every (re)entry into the Hall route. The HallViewModel is
+  // held by the NavHost across navigations (Hall → Forge/Hire → celebration
+  // → back), so without this LaunchedEffect the user sees a stale list
+  // until pull-to-refresh. SessionStore.add{Forged,Hired}ClanId() are
+  // called before the celebration screen lands, so by the time we pop
+  // back to Hall the extras are already present.
+  LaunchedEffect(Unit) {
+    vm.refresh()
+  }
   // First-launch coachmark: read once from SessionStore, dismiss-on-tap
   // toggles the local state and writes the persistent flag.
   val hintFlagKey = "hall.hintSeen"

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -133,11 +133,11 @@ private fun HallScreen(
         if (state.items.isEmpty()) {
           LazyColumn(modifier = Modifier.fillMaxSize()) {
             item {
-              Text(
-                text = "your hall is quiet — no sigils linked.",
-                style = ClanWorldTheme.type.scriptItalic,
-                color = ClanWorldTheme.colors.warmFaint,
-                modifier = Modifier.padding(top = 24.dp),
+              world.clan.app.ui.components.EmptyState(
+                title = "your hall is quiet",
+                body = "no sigils stand under your hand yet — forge one to begin.",
+                ctaLabel = "+ Forge a sigil",
+                onCta = onForge,
               )
             }
           }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -63,7 +63,12 @@ fun HallScreenRoute(
 ) {
   val vm: HallViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
-  HallScreen(state = state, onOpenInft = onOpenInft, onForge = onForge)
+  HallScreen(
+    state = state,
+    onOpenInft = onOpenInft,
+    onForge = onForge,
+    onRefresh = vm::refresh,
+  )
 }
 
 @Composable
@@ -71,6 +76,7 @@ private fun HallScreen(
   state: HallUiState,
   onOpenInft: (Int) -> Unit,
   onForge: () -> Unit = {},
+  onRefresh: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
   Column(
@@ -111,25 +117,42 @@ private fun HallScreen(
         color = ClanWorldTheme.colors.warmFaint,
         modifier = Modifier.padding(top = 24.dp),
       )
-    } else if (state.items.isEmpty()) {
-      Text(
-        text = state.errorMessage ?: "your hall is quiet — no sigils linked.",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.warmFaint,
-        modifier = Modifier.padding(top = 24.dp),
+    } else if (state.errorMessage != null && state.items.isEmpty()) {
+      world.clan.app.ui.components.RetryNotice(
+        message = state.errorMessage,
+        onRetry = onRefresh,
       )
     } else {
-      LazyColumn(
+      world.clan.app.ui.components.RefreshableContent(
+        isRefreshing = state.isRefreshing,
+        onRefresh = onRefresh,
         modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(14.dp),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 24.dp),
       ) {
-        items(state.items, key = { it.tokenId }) { card ->
-          StaggeredEntry(index = card.tokenId.coerceAtMost(8)) {
-            LetterCard(
-              card = card,
-              onClick = { onOpenInft(card.clanId) },
-            )
+        if (state.items.isEmpty()) {
+          LazyColumn(modifier = Modifier.fillMaxSize()) {
+            item {
+              Text(
+                text = "your hall is quiet — no sigils linked.",
+                style = ClanWorldTheme.type.scriptItalic,
+                color = ClanWorldTheme.colors.warmFaint,
+                modifier = Modifier.padding(top = 24.dp),
+              )
+            }
+          }
+        } else {
+          LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 24.dp),
+          ) {
+            items(state.items, key = { it.tokenId }) { card ->
+              StaggeredEntry(index = card.tokenId.coerceAtMost(8)) {
+                LetterCard(
+                  card = card,
+                  onClick = { onOpenInft(card.clanId) },
+                )
+              }
+            }
           }
         }
       }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -111,12 +111,14 @@ private fun HallScreen(
     Spacer(Modifier.height(10.dp))
 
     if (state.isLoading) {
-      Text(
-        text = "gathering the sigils…",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.warmFaint,
-        modifier = Modifier.padding(top = 24.dp),
-      )
+      Column(
+        modifier = Modifier
+          .fillMaxSize()
+          .padding(top = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+      ) {
+        repeat(3) { world.clan.app.ui.components.SkeletonLetterCard() }
+      }
     } else if (state.errorMessage != null && state.items.isEmpty()) {
       world.clan.app.ui.components.RetryNotice(
         message = state.errorMessage,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -59,16 +59,18 @@ fun HallScreenRoute(
   app: App,
   factory: ClanWorldViewModelFactory,
   onOpenInft: (Int) -> Unit,
+  onForge: () -> Unit = {},
 ) {
   val vm: HallViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
-  HallScreen(state = state, onOpenInft = onOpenInft)
+  HallScreen(state = state, onOpenInft = onOpenInft, onForge = onForge)
 }
 
 @Composable
 private fun HallScreen(
   state: HallUiState,
   onOpenInft: (Int) -> Unit,
+  onForge: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
   Column(
@@ -86,7 +88,21 @@ private fun HallScreen(
       HallHead(count = state.items.size)
     }
 
-    Spacer(Modifier.height(18.dp))
+    // Forge entry — sits between the head divider and the list. Always
+    // available; an empty hall still wants the option to forge a new one.
+    Text(
+      text = "+ FORGE A NEW SIGIL",
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.gold,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(top = 18.dp, bottom = 8.dp)
+        .clickable { onForge() }
+        .padding(vertical = 8.dp),
+      textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+    )
+
+    Spacer(Modifier.height(10.dp))
 
     if (state.isLoading) {
       Text(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
@@ -70,12 +70,13 @@ fun HearthScreenRoute(
 ) {
   val vm: HearthViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
-  HearthScreen(state = state)
+  HearthScreen(state = state, onRefresh = vm::refresh)
 }
 
 @Composable
 private fun HearthScreen(
   state: HearthUiState,
+  onRefresh: () -> Unit = {},
 ) {
   // Background and tab bar are hosted at the app level (ClanWorldApp.kt);
   // this screen is just the page content.
@@ -89,6 +90,19 @@ private fun HearthScreen(
       modifier = Modifier.fillMaxWidth(),
     )
 
+    if (state.errorMessage != null && state.leaderboard.isEmpty()) {
+      world.clan.app.ui.components.RetryNotice(
+        message = state.errorMessage,
+        onRetry = onRefresh,
+      )
+      return@Column
+    }
+
+    world.clan.app.ui.components.RefreshableContent(
+      isRefreshing = state.isRefreshing,
+      onRefresh = onRefresh,
+      modifier = Modifier.fillMaxSize(),
+    ) {
     Column(
       modifier = Modifier
         .fillMaxSize()
@@ -125,6 +139,7 @@ private fun HearthScreen(
         WhispersList(state.recentComms)
       }
     }
+    } // close RefreshableContent
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
@@ -126,7 +126,7 @@ private fun HearthScreen(
             )
           }
           StaggeredEntry(index = 2) {
-            LeaderboardSurface(state.leaderboard)
+            LeaderboardSurface(state.leaderboard, isLoading = state.isLoading)
           }
 
           StaggeredEntry(index = 3) {
@@ -136,7 +136,7 @@ private fun HearthScreen(
             )
           }
       StaggeredEntry(index = 4) {
-        WhispersList(state.recentComms)
+        WhispersList(state.recentComms, isLoading = state.isLoading)
       }
     }
     } // close RefreshableContent
@@ -355,7 +355,10 @@ private fun Int.spelledOut(): String {
 // ─────────────────────────────────────────────────────────────────────────
 
 @Composable
-private fun LeaderboardSurface(rows: List<HearthUiState.LeaderboardRow>) {
+private fun LeaderboardSurface(
+  rows: List<HearthUiState.LeaderboardRow>,
+  isLoading: Boolean = false,
+) {
   val hairline = ClanWorldTheme.colors.hairline
   Column(
     modifier = Modifier
@@ -365,7 +368,17 @@ private fun LeaderboardSurface(rows: List<HearthUiState.LeaderboardRow>) {
       .border(1.dp, hairline, RoundedCornerShape(6.dp)),
     verticalArrangement = Arrangement.spacedBy(1.dp),
   ) {
-    if (rows.isEmpty()) {
+    if (rows.isEmpty() && isLoading) {
+      Column(
+        modifier = Modifier
+          .fillMaxWidth()
+          .background(ClanWorldTheme.colors.iron)
+          .padding(horizontal = 14.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+      ) {
+        repeat(4) { world.clan.app.ui.components.SkeletonLeaderboardRow() }
+      }
+    } else if (rows.isEmpty()) {
       Box(
         Modifier
           .fillMaxWidth()
@@ -401,7 +414,16 @@ private fun LeaderboardSurface(rows: List<HearthUiState.LeaderboardRow>) {
 // ─────────────────────────────────────────────────────────────────────────
 
 @Composable
-private fun WhispersList(comms: List<CombinedComm>) {
+private fun WhispersList(
+  comms: List<CombinedComm>,
+  isLoading: Boolean = false,
+) {
+  if (comms.isEmpty() && isLoading) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+      repeat(2) { world.clan.app.ui.components.SkeletonWhisperRow() }
+    }
+    return
+  }
   if (comms.isEmpty()) {
     Text(
       text = "no whispers in the wind…",

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -78,6 +78,7 @@ fun InftDetailScreenRoute(
   app: App,
   clanId: Int,
   onBack: () -> Unit,
+  onEnterCockpit: () -> Unit = {},
 ) {
   val vm: InftDetailViewModel = viewModel(factory = InftDetailViewModelFactory(app, clanId))
   val state by vm.state.collectAsState()
@@ -86,6 +87,7 @@ fun InftDetailScreenRoute(
     clanId = clanId,
     onBack = onBack,
     onSelectDetailTab = vm::selectTab,
+    onEnterCockpit = onEnterCockpit,
   )
 }
 
@@ -95,6 +97,7 @@ private fun InftDetailScreen(
   clanId: Int,
   onBack: () -> Unit,
   onSelectDetailTab: (DetailTab) -> Unit,
+  onEnterCockpit: () -> Unit,
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
   Column(
@@ -109,6 +112,17 @@ private fun InftDetailScreen(
       clanId = clanId,
       state = state,
       modifier = Modifier.padding(horizontal = 22.dp),
+    )
+
+    Spacer(Modifier.height(14.dp))
+
+    // ── Enter Cockpit CTA — drill into the live game cockpit ───────────
+    world.clan.app.ui.components.EmberCta(
+      text = "Enter Cockpit",
+      onClick = onEnterCockpit,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 22.dp),
     )
 
     Spacer(Modifier.height(22.dp))

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -82,7 +82,7 @@ fun InftDetailScreenRoute(
   onOpenInbox: () -> Unit = {},
   onEditStrategy: () -> Unit = {},
   isBazaar: Boolean = false,
-  hostActivity: androidx.activity.ComponentActivity? = null,
+  mwaSender: com.solana.mobilewalletadapter.clientlib.ActivityResultSender? = null,
   onHireConfirmed: (() -> Unit)? = null,
 ) {
   val vm: InftDetailViewModel = viewModel(factory = InftDetailViewModelFactory(app, clanId))
@@ -97,7 +97,7 @@ fun InftDetailScreenRoute(
     onEditStrategy = onEditStrategy,
     isBazaar = isBazaar,
     app = app,
-    hostActivity = hostActivity,
+    mwaSender = mwaSender,
     onHireConfirmed = onHireConfirmed ?: onBack,
   )
 }
@@ -113,7 +113,7 @@ private fun InftDetailScreen(
   onEditStrategy: () -> Unit = {},
   isBazaar: Boolean = false,
   app: App? = null,
-  hostActivity: androidx.activity.ComponentActivity? = null,
+  mwaSender: com.solana.mobilewalletadapter.clientlib.ActivityResultSender? = null,
   onHireConfirmed: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
@@ -170,12 +170,12 @@ private fun InftDetailScreen(
   }
 
   // ── HireModal overlay (bazaar mode only) ────────────────────────────────
-  if (isBazaar && showHireModal.value && app != null && hostActivity != null) {
+  if (isBazaar && showHireModal.value && app != null && mwaSender != null) {
     val listing = world.clan.app.data.bazaarListingByClan(clanId)
     if (listing != null) {
       world.clan.app.ui.components.HireModal(
         app = app,
-        hostActivity = hostActivity,
+        mwaSender = mwaSender,
         listing = listing,
         onDismiss = { showHireModal.value = false },
         onConfirmed = {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -80,6 +80,7 @@ fun InftDetailScreenRoute(
   onBack: () -> Unit,
   onEnterCockpit: () -> Unit = {},
   onOpenInbox: () -> Unit = {},
+  onEditStrategy: () -> Unit = {},
   isBazaar: Boolean = false,
   hostActivity: androidx.activity.ComponentActivity? = null,
   onHireConfirmed: (() -> Unit)? = null,
@@ -93,6 +94,7 @@ fun InftDetailScreenRoute(
     onSelectDetailTab = vm::selectTab,
     onEnterCockpit = onEnterCockpit,
     onOpenInbox = onOpenInbox,
+    onEditStrategy = onEditStrategy,
     isBazaar = isBazaar,
     app = app,
     hostActivity = hostActivity,
@@ -108,6 +110,7 @@ private fun InftDetailScreen(
   onSelectDetailTab: (DetailTab) -> Unit,
   onEnterCockpit: () -> Unit,
   onOpenInbox: () -> Unit = {},
+  onEditStrategy: () -> Unit = {},
   isBazaar: Boolean = false,
   app: App? = null,
   hostActivity: androidx.activity.ComponentActivity? = null,
@@ -153,7 +156,10 @@ private fun InftDetailScreen(
       label = "detail-tab",
     ) { tab ->
       when (tab) {
-        DetailTab.Memory -> MemoryPanel(state.state?.memory.orEmpty())
+        DetailTab.Memory -> MemoryPanel(
+          state.state?.memory.orEmpty(),
+          onEditStrategy = if (!isBazaar) onEditStrategy else null,
+        )
         DetailTab.Vault -> VaultPanel(state.vault)
         DetailTab.Whispers -> WhispersPanel(state.comms, onOpenInbox = onOpenInbox)
         DetailTab.Bulletin -> BulletinPanel(state.state?.bulletins?.map { it.body } ?: emptyList())
@@ -418,30 +424,47 @@ private val DetailTab.label get() = when (this) {
 // ── Panels ──────────────────────────────────────────────────────────────
 
 @Composable
-private fun MemoryPanel(memory: List<MemoryEntry>) {
-  PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
-    if (memory.isEmpty()) {
-      Box(
-        Modifier
+private fun MemoryPanel(
+  memory: List<MemoryEntry>,
+  onEditStrategy: (() -> Unit)? = null,
+) {
+  Column {
+    PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
+      if (memory.isEmpty()) {
+        Box(
+          Modifier
+            .fillMaxWidth()
+            .padding(20.dp),
+          contentAlignment = Alignment.Center,
+        ) {
+          Text(
+            "no memory written yet",
+            style = ClanWorldTheme.type.scriptItalic,
+            color = ClanWorldTheme.colors.warmFaint,
+          )
+        }
+      } else {
+        memory.take(10).forEach { entry ->
+          MemoryRow(
+            key = entry.key,
+            body = inlineCodeBody(entry.value),
+            stamp = "written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}",
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+      }
+    }
+    if (onEditStrategy != null) {
+      Text(
+        text = "EDIT STRATEGY →",
+        style = ClanWorldTheme.type.monoMicro,
+        color = ClanWorldTheme.colors.gold,
+        textAlign = TextAlign.Center,
+        modifier = Modifier
           .fillMaxWidth()
-          .padding(20.dp),
-        contentAlignment = Alignment.Center,
-      ) {
-        Text(
-          "no memory written yet",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-        )
-      }
-    } else {
-      memory.take(10).forEach { entry ->
-        MemoryRow(
-          key = entry.key,
-          body = inlineCodeBody(entry.value),
-          stamp = "written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}",
-          modifier = Modifier.fillMaxWidth(),
-        )
-      }
+          .clickable { onEditStrategy() }
+          .padding(horizontal = 22.dp, vertical = 14.dp),
+      )
     }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -79,6 +79,9 @@ fun InftDetailScreenRoute(
   clanId: Int,
   onBack: () -> Unit,
   onEnterCockpit: () -> Unit = {},
+  isBazaar: Boolean = false,
+  hostActivity: androidx.activity.ComponentActivity? = null,
+  onHireConfirmed: (() -> Unit)? = null,
 ) {
   val vm: InftDetailViewModel = viewModel(factory = InftDetailViewModelFactory(app, clanId))
   val state by vm.state.collectAsState()
@@ -88,6 +91,10 @@ fun InftDetailScreenRoute(
     onBack = onBack,
     onSelectDetailTab = vm::selectTab,
     onEnterCockpit = onEnterCockpit,
+    isBazaar = isBazaar,
+    app = app,
+    hostActivity = hostActivity,
+    onHireConfirmed = onHireConfirmed ?: onBack,
   )
 }
 
@@ -98,8 +105,14 @@ private fun InftDetailScreen(
   onBack: () -> Unit,
   onSelectDetailTab: (DetailTab) -> Unit,
   onEnterCockpit: () -> Unit,
+  isBazaar: Boolean = false,
+  app: App? = null,
+  hostActivity: androidx.activity.ComponentActivity? = null,
+  onHireConfirmed: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
+  val showHireModal = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+  Box(modifier = Modifier.fillMaxSize()) {
   Column(
     modifier = Modifier
       .fillMaxSize()
@@ -116,10 +129,10 @@ private fun InftDetailScreen(
 
     Spacer(Modifier.height(14.dp))
 
-    // ── Enter Cockpit CTA — drill into the live game cockpit ───────────
+    // ── Primary CTA: Hire (bazaar mode) or Enter Cockpit (linked mode) ─
     world.clan.app.ui.components.EmberCta(
-      text = "Enter Cockpit",
-      onClick = onEnterCockpit,
+      text = if (isBazaar) "Hire This Sigil" else "Enter Cockpit",
+      onClick = if (isBazaar) ({ showHireModal.value = true }) else onEnterCockpit,
       modifier = Modifier
         .fillMaxWidth()
         .padding(horizontal = 22.dp),
@@ -146,6 +159,24 @@ private fun InftDetailScreen(
 
     Spacer(Modifier.height(40.dp))
   }
+
+  // ── HireModal overlay (bazaar mode only) ────────────────────────────────
+  if (isBazaar && showHireModal.value && app != null && hostActivity != null) {
+    val listing = world.clan.app.data.bazaarListingByClan(clanId)
+    if (listing != null) {
+      world.clan.app.ui.components.HireModal(
+        app = app,
+        hostActivity = hostActivity,
+        listing = listing,
+        onDismiss = { showHireModal.value = false },
+        onConfirmed = {
+          showHireModal.value = false
+          onHireConfirmed()
+        },
+      )
+    }
+  }
+  } // close outer Box
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -81,6 +81,7 @@ fun InftDetailScreenRoute(
   onEnterCockpit: () -> Unit = {},
   onOpenInbox: () -> Unit = {},
   onEditStrategy: () -> Unit = {},
+  onOpenTreasury: () -> Unit = {},
   isBazaar: Boolean = false,
   mwaSender: com.solana.mobilewalletadapter.clientlib.ActivityResultSender? = null,
   onHireConfirmed: (() -> Unit)? = null,
@@ -95,6 +96,7 @@ fun InftDetailScreenRoute(
     onEnterCockpit = onEnterCockpit,
     onOpenInbox = onOpenInbox,
     onEditStrategy = onEditStrategy,
+    onOpenTreasury = onOpenTreasury,
     isBazaar = isBazaar,
     app = app,
     mwaSender = mwaSender,
@@ -111,6 +113,7 @@ private fun InftDetailScreen(
   onEnterCockpit: () -> Unit,
   onOpenInbox: () -> Unit = {},
   onEditStrategy: () -> Unit = {},
+  onOpenTreasury: () -> Unit = {},
   isBazaar: Boolean = false,
   app: App? = null,
   mwaSender: com.solana.mobilewalletadapter.clientlib.ActivityResultSender? = null,
@@ -160,7 +163,7 @@ private fun InftDetailScreen(
           state.state?.memory.orEmpty(),
           onEditStrategy = if (!isBazaar) onEditStrategy else null,
         )
-        DetailTab.Vault -> VaultPanel(state.vault)
+        DetailTab.Vault -> VaultPanel(state.vault, onOpenTreasury = onOpenTreasury)
         DetailTab.Whispers -> WhispersPanel(state.comms, onOpenInbox = onOpenInbox)
         DetailTab.Bulletin -> BulletinPanel(state.state?.bulletins?.map { it.body } ?: emptyList())
       }
@@ -470,7 +473,11 @@ private fun MemoryPanel(
 }
 
 @Composable
-private fun VaultPanel(vault: List<VaultMovement>) {
+private fun VaultPanel(
+  vault: List<VaultMovement>,
+  onOpenTreasury: () -> Unit = {},
+) {
+  Column {
   PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
     if (vault.isEmpty()) {
       ComingNextSlice("the vault keeps its silence")
@@ -505,6 +512,17 @@ private fun VaultPanel(vault: List<VaultMovement>) {
       }
     }
   }
+  Text(
+    text = "FULL TREASURY →",
+    style = ClanWorldTheme.type.monoMicro,
+    color = ClanWorldTheme.colors.gold,
+    textAlign = TextAlign.Center,
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { onOpenTreasury() }
+      .padding(horizontal = 22.dp, vertical = 14.dp),
+  )
+  } // close outer Column
 }
 
 @Composable

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -79,6 +79,7 @@ fun InftDetailScreenRoute(
   clanId: Int,
   onBack: () -> Unit,
   onEnterCockpit: () -> Unit = {},
+  onOpenInbox: () -> Unit = {},
   isBazaar: Boolean = false,
   hostActivity: androidx.activity.ComponentActivity? = null,
   onHireConfirmed: (() -> Unit)? = null,
@@ -91,6 +92,7 @@ fun InftDetailScreenRoute(
     onBack = onBack,
     onSelectDetailTab = vm::selectTab,
     onEnterCockpit = onEnterCockpit,
+    onOpenInbox = onOpenInbox,
     isBazaar = isBazaar,
     app = app,
     hostActivity = hostActivity,
@@ -105,6 +107,7 @@ private fun InftDetailScreen(
   onBack: () -> Unit,
   onSelectDetailTab: (DetailTab) -> Unit,
   onEnterCockpit: () -> Unit,
+  onOpenInbox: () -> Unit = {},
   isBazaar: Boolean = false,
   app: App? = null,
   hostActivity: androidx.activity.ComponentActivity? = null,
@@ -152,7 +155,7 @@ private fun InftDetailScreen(
       when (tab) {
         DetailTab.Memory -> MemoryPanel(state.state?.memory.orEmpty())
         DetailTab.Vault -> VaultPanel(state.vault)
-        DetailTab.Whispers -> WhispersPanel(state.comms)
+        DetailTab.Whispers -> WhispersPanel(state.comms, onOpenInbox = onOpenInbox)
         DetailTab.Bulletin -> BulletinPanel(state.state?.bulletins?.map { it.body } ?: emptyList())
       }
     }
@@ -482,7 +485,10 @@ private fun VaultPanel(vault: List<VaultMovement>) {
 }
 
 @Composable
-private fun WhispersPanel(comms: List<world.clan.app.data.CombinedComm>) {
+private fun WhispersPanel(
+  comms: List<world.clan.app.data.CombinedComm>,
+  onOpenInbox: () -> Unit = {},
+) {
   Column(
     modifier = Modifier
       .fillMaxWidth()
@@ -511,6 +517,17 @@ private fun WhispersPanel(comms: List<world.clan.app.data.CombinedComm>) {
           accent = accent,
         )
       }
+      Spacer(Modifier.height(4.dp))
+      Text(
+        text = "OPEN FULL INBOX →",
+        style = ClanWorldTheme.type.monoMicro,
+        color = ClanWorldTheme.colors.gold,
+        modifier = Modifier
+          .fillMaxWidth()
+          .clickable { onOpenInbox() }
+          .padding(vertical = 10.dp),
+        textAlign = TextAlign.Center,
+      )
     }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -432,29 +432,23 @@ private fun MemoryPanel(
   onEditStrategy: (() -> Unit)? = null,
 ) {
   Column {
+    if (memory.isEmpty()) {
+      world.clan.app.ui.components.EmptyState(
+        title = "no doctrine written yet",
+        body = "the elder waits for your first counsel.",
+        ctaLabel = if (onEditStrategy != null) "+ Write doctrine" else null,
+        onCta = onEditStrategy,
+      )
+      return@Column
+    }
     PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
-      if (memory.isEmpty()) {
-        Box(
-          Modifier
-            .fillMaxWidth()
-            .padding(20.dp),
-          contentAlignment = Alignment.Center,
-        ) {
-          Text(
-            "no memory written yet",
-            style = ClanWorldTheme.type.scriptItalic,
-            color = ClanWorldTheme.colors.warmFaint,
-          )
-        }
-      } else {
-        memory.take(10).forEach { entry ->
-          MemoryRow(
-            key = entry.key,
-            body = inlineCodeBody(entry.value),
-            stamp = "written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}",
-            modifier = Modifier.fillMaxWidth(),
-          )
-        }
+      memory.take(10).forEach { entry ->
+        MemoryRow(
+          key = entry.key,
+          body = inlineCodeBody(entry.value),
+          stamp = "written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}",
+          modifier = Modifier.fillMaxWidth(),
+        )
       }
     }
     if (onEditStrategy != null) {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -1,0 +1,348 @@
+package world.clan.app.ui.screens
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import world.clan.app.App
+import world.clan.app.R
+import world.clan.app.ui.components.EmberCta
+import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.ui.theme.clanGlyphRes
+import world.clan.app.viewmodel.HearthViewModel
+import world.clan.app.viewmodel.SendPhase
+import world.clan.app.viewmodel.SteeringConsoleUiState
+import world.clan.app.viewmodel.SteeringConsoleViewModel
+import world.clan.app.viewmodel.SteeringConsoleViewModelFactory
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.wallet.MwaResult
+
+@Composable
+fun SteeringConsoleScreenRoute(
+  app: App,
+  hostActivity: ComponentActivity,
+  initialClanId: Int,
+  onBack: () -> Unit,
+  onSent: () -> Unit,
+) {
+  val vm: SteeringConsoleViewModel =
+    viewModel(factory = SteeringConsoleViewModelFactory(initialClanId))
+  val state by vm.state.collectAsState()
+  val scope = rememberCoroutineScope()
+
+  SteeringConsole(
+    state = state,
+    onBack = onBack,
+    onDraftChange = vm::setDraft,
+    onTargetChange = vm::setTarget,
+    onSend = {
+      scope.launch {
+        vm.setPhase(SendPhase.Signing)
+        val token = app.sessionStore.read()?.mwaAuthToken
+        if (token == null) {
+          vm.setPhase(SendPhase.Queued)
+          return@launch
+        }
+        val msg = "ClanWorld Steer — clan ${state.targetClanId}: ${state.draft}".toByteArray()
+        val result = app.mwaClient.signMessage(hostActivity, token, msg)
+        when (result) {
+          is MwaResult.Ok -> vm.setPhase(SendPhase.Queued)
+          is MwaResult.UserDeclined -> vm.setPhase(SendPhase.Idle)
+          is MwaResult.WalletNotFound ->
+            vm.setPhase(SendPhase.Failed, "no wallet found on device.")
+          is MwaResult.Error ->
+            vm.setPhase(SendPhase.Failed, result.cause.message ?: "the wallet refused the seal.")
+        }
+      }
+    },
+  )
+
+  // Auto-pop after queued state lands.
+  if (state.phase == SendPhase.Queued) {
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+      delay(1300L)
+      onSent()
+    }
+  }
+}
+
+@Composable
+private fun SteeringConsole(
+  state: SteeringConsoleUiState,
+  onBack: () -> Unit,
+  onDraftChange: (String) -> Unit,
+  onTargetChange: (Int) -> Unit,
+  onSend: () -> Unit,
+) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState()),
+  ) {
+    BackBar(text = "back to whispers", onBack = onBack)
+
+    Column(modifier = Modifier.padding(horizontal = 22.dp)) {
+      ConsoleHead()
+      Spacer(Modifier.height(14.dp))
+      TargetClanRow(
+        active = state.targetClanId,
+        onSelect = onTargetChange,
+      )
+      Spacer(Modifier.height(18.dp))
+      DraftCard(
+        draft = state.draft,
+        onChange = onDraftChange,
+        enabled = state.phase == SendPhase.Idle || state.phase == SendPhase.Failed,
+      )
+      Spacer(Modifier.height(14.dp))
+      ConsoleStatus(state)
+      Spacer(Modifier.height(14.dp))
+      EmberCta(
+        text = when (state.phase) {
+          SendPhase.Idle -> "Sign and Send"
+          SendPhase.Signing -> "Awaiting the seal…"
+          SendPhase.Queued -> "Queued ✓"
+          SendPhase.Failed -> "Try Again"
+        },
+        onClick = onSend,
+        enabled = state.draft.isNotBlank() &&
+          (state.phase == SendPhase.Idle || state.phase == SendPhase.Failed),
+        modifier = Modifier.fillMaxWidth(),
+      )
+      Spacer(Modifier.height(40.dp))
+    }
+  }
+}
+
+@Composable
+private fun BackBar(text: String, onBack: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 14.dp)
+      .clickable { onBack() },
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      painter = painterResource(R.drawable.ui_arrow),
+      contentDescription = "back",
+      tint = ClanWorldTheme.colors.warm,
+      modifier = Modifier.height(16.dp),
+    )
+    Text(
+      text = text,
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+  }
+}
+
+@Composable
+private fun ConsoleHead() {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 14f),
+          end = Offset(size.width, size.height + 14f),
+          strokeWidth = 1f,
+        )
+      },
+  ) {
+    Text(
+      text = "STEERING CONSOLE",
+      style = ClanWorldTheme.type.displayHero,
+      color = parchment,
+    )
+    Text(
+      text = "speak to your elder before the next tick",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = warmDim,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+@Composable
+private fun TargetClanRow(active: Int, onSelect: (Int) -> Unit) {
+  Column {
+    Text(
+      text = "TO ELDER",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Spacer(Modifier.height(8.dp))
+    LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+      items(HearthViewModel.LINKED_CLAN_IDS) { clanId ->
+        ClanPill(
+          clanId = clanId,
+          selected = clanId == active,
+          onClick = { onSelect(clanId) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun ClanPill(clanId: Int, selected: Boolean, onClick: () -> Unit) {
+  val accent = clanColor(clanId)
+  val bg = if (selected) accent.copy(alpha = 0.18f) else Color.Transparent
+  val border = if (selected) accent else ClanWorldTheme.colors.hairline
+  val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
+  Row(
+    modifier = Modifier
+      .clip(RoundedCornerShape(4.dp))
+      .background(bg)
+      .drawBehind {
+        drawRoundRect(
+          color = border,
+          cornerRadius = CornerRadius(4.dp.toPx()),
+          style = Stroke(width = 1.dp.toPx()),
+        )
+      }
+      .clickable { onClick() }
+      .padding(horizontal = 12.dp, vertical = 8.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Box(
+      modifier = Modifier
+        .size(10.dp)
+        .clip(RoundedCornerShape(50))
+        .background(accent),
+    )
+    Text(
+      text = clanDisplayName(clanId).uppercase(),
+      style = ClanWorldTheme.type.monoMicro,
+      color = tint,
+    )
+  }
+}
+
+@Composable
+private fun DraftCard(draft: String, onChange: (String) -> Unit, enabled: Boolean) {
+  ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+    Text(
+      text = "STEER",
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Spacer(Modifier.height(6.dp))
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .height(120.dp),
+    ) {
+      if (draft.isEmpty()) {
+        Text(
+          text = "the river runs cold; press for the strait, hold the western shore until the next tick…",
+          style = ClanWorldTheme.type.scriptItalic.copy(color = Ink3),
+        )
+      }
+      BasicTextField(
+        value = draft,
+        onValueChange = if (enabled) onChange else { _ -> },
+        textStyle = LocalTextStyle.current.copy(
+          fontFamily = ClanWorldTheme.type.scriptItalic.fontFamily,
+          fontStyle = ClanWorldTheme.type.scriptItalic.fontStyle,
+          fontSize = ClanWorldTheme.type.scriptItalic.fontSize,
+          color = Ink,
+        ),
+        cursorBrush = SolidColor(Ink2),
+        modifier = Modifier.fillMaxSize(),
+      )
+    }
+    Spacer(Modifier.height(8.dp))
+    Text(
+      text = "${draft.length}/280",
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+      textAlign = TextAlign.End,
+      modifier = Modifier.fillMaxWidth(),
+    )
+  }
+}
+
+@Composable
+private fun ConsoleStatus(state: SteeringConsoleUiState) {
+  when (state.phase) {
+    SendPhase.Idle -> {
+      Text(
+        text = "your seal is required before the message goes to the elder.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warmDim,
+      )
+    }
+    SendPhase.Signing -> {
+      Text(
+        text = "the wallet is preparing the seal…",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.gold,
+      )
+    }
+    SendPhase.Queued -> {
+      Text(
+        text = "queued for next tick — the elder will hear before the heartbeat.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.success,
+      )
+    }
+    SendPhase.Failed -> {
+      Text(
+        text = state.errorMessage ?: "the seal could not be set.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.danger,
+      )
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -1,6 +1,6 @@
 package world.clan.app.ui.screens
 
-import androidx.activity.ComponentActivity
+import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -62,7 +62,7 @@ import world.clan.app.wallet.MwaResult
 @Composable
 fun SteeringConsoleScreenRoute(
   app: App,
-  hostActivity: ComponentActivity,
+  mwaSender: ActivityResultSender,
   initialClanId: Int,
   onBack: () -> Unit,
   onSent: () -> Unit,
@@ -86,7 +86,7 @@ fun SteeringConsoleScreenRoute(
           return@launch
         }
         val msg = "ClanWorld Steer — clan ${state.targetClanId}: ${state.draft}".toByteArray()
-        val result = app.mwaClient.signMessage(hostActivity, token, msg)
+        val result = app.mwaClient.signMessage(mwaSender, token, msg)
         when (result) {
           is MwaResult.Ok -> vm.setPhase(SendPhase.Queued)
           is MwaResult.UserDeclined -> vm.setPhase(SendPhase.Idle)

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -68,7 +68,7 @@ fun SteeringConsoleScreenRoute(
   onSent: () -> Unit,
 ) {
   val vm: SteeringConsoleViewModel =
-    viewModel(factory = SteeringConsoleViewModelFactory(initialClanId))
+    viewModel(factory = SteeringConsoleViewModelFactory(app, initialClanId))
   val state by vm.state.collectAsState()
   val scope = rememberCoroutineScope()
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
@@ -1,0 +1,373 @@
+package world.clan.app.ui.screens
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import world.clan.app.App
+import world.clan.app.R
+import world.clan.app.ui.components.EmberCta
+import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.viewmodel.Posture
+import world.clan.app.viewmodel.SendPhase
+import world.clan.app.viewmodel.StrategyEditorUiState
+import world.clan.app.viewmodel.StrategyEditorViewModel
+import world.clan.app.viewmodel.StrategyEditorViewModelFactory
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.wallet.MwaResult
+
+@Composable
+fun StrategyEditorScreenRoute(
+  app: App,
+  hostActivity: ComponentActivity,
+  clanId: Int,
+  onBack: () -> Unit,
+  onSaved: () -> Unit,
+) {
+  val vm: StrategyEditorViewModel =
+    viewModel(factory = StrategyEditorViewModelFactory(app, clanId))
+  val state by vm.state.collectAsState()
+  val scope = rememberCoroutineScope()
+
+  StrategyEditor(
+    state = state,
+    onBack = onBack,
+    onSetPosture = vm::setPosture,
+    onSetDoctrine = vm::setDoctrine,
+    onSetPinnedKey = vm::setPinnedKey,
+    onSave = {
+      scope.launch {
+        vm.setSavePhase(SendPhase.Signing)
+        val token = app.sessionStore.read()?.mwaAuthToken
+        if (token == null) {
+          vm.setSavePhase(SendPhase.Queued)
+          return@launch
+        }
+        val msg = ("ClanWorld Strategy — clan ${state.clanId} | ${state.posture.name} | " +
+          "${state.pinnedKey} = ${state.doctrine}").toByteArray()
+        when (val r = app.mwaClient.signMessage(hostActivity, token, msg)) {
+          is MwaResult.Ok -> vm.setSavePhase(SendPhase.Queued)
+          is MwaResult.UserDeclined -> vm.setSavePhase(SendPhase.Idle)
+          is MwaResult.WalletNotFound ->
+            vm.setSavePhase(SendPhase.Failed, "no wallet found on device.")
+          is MwaResult.Error ->
+            vm.setSavePhase(SendPhase.Failed, r.cause.message ?: "the wallet refused the seal.")
+        }
+      }
+    },
+  )
+
+  if (state.savePhase == SendPhase.Queued) {
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+      delay(1300L)
+      onSaved()
+    }
+  }
+}
+
+@Composable
+private fun StrategyEditor(
+  state: StrategyEditorUiState,
+  onBack: () -> Unit,
+  onSetPosture: (Posture) -> Unit,
+  onSetDoctrine: (String) -> Unit,
+  onSetPinnedKey: (String) -> Unit,
+  onSave: () -> Unit,
+) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState()),
+  ) {
+    BackBar(text = "back to ${clanDisplayName(state.clanId).lowercase()}", onBack = onBack)
+
+    Column(modifier = Modifier.padding(horizontal = 22.dp)) {
+      EditorHead(state.clanId)
+      Spacer(Modifier.height(14.dp))
+
+      if (state.isLoading) {
+        Text(
+          text = "the elder's last counsel is being read…",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(top = 24.dp),
+        )
+      } else {
+        // ── Posture ───────────────────────────────────────────────────────
+        Text(
+          text = "POSTURE",
+          style = ClanWorldTheme.type.monoNano,
+          color = ClanWorldTheme.colors.warmFaint,
+        )
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          Posture.values().forEach { p ->
+            PosturePill(
+              posture = p,
+              selected = p == state.posture,
+              onClick = { onSetPosture(p) },
+            )
+          }
+        }
+        Spacer(Modifier.height(18.dp))
+
+        // ── Pinned memory key ─────────────────────────────────────────────
+        ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+          Text(
+            text = "PINNED KEY",
+            style = ClanWorldTheme.type.monoNano,
+            color = Ink3,
+          )
+          Spacer(Modifier.height(6.dp))
+          BasicTextField(
+            value = state.pinnedKey,
+            onValueChange = onSetPinnedKey,
+            singleLine = true,
+            textStyle = LocalTextStyle.current.copy(
+              fontFamily = ClanWorldTheme.type.monoData.fontFamily,
+              fontSize = ClanWorldTheme.type.monoData.fontSize,
+              color = Ink,
+            ),
+            cursorBrush = SolidColor(Ink2),
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+
+        Spacer(Modifier.height(14.dp))
+
+        // ── Doctrine ──────────────────────────────────────────────────────
+        ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+          Text(
+            text = "DOCTRINE",
+            style = ClanWorldTheme.type.monoNano,
+            color = Ink3,
+          )
+          Spacer(Modifier.height(6.dp))
+          Box(
+            modifier = Modifier
+              .fillMaxWidth()
+              .height(140.dp),
+          ) {
+            if (state.doctrine.isEmpty()) {
+              Text(
+                text = "what should the elder hold to, even when the season turns?",
+                style = ClanWorldTheme.type.scriptItalic.copy(color = Ink3),
+              )
+            }
+            BasicTextField(
+              value = state.doctrine,
+              onValueChange = onSetDoctrine,
+              textStyle = LocalTextStyle.current.copy(
+                fontFamily = ClanWorldTheme.type.scriptItalic.fontFamily,
+                fontStyle = ClanWorldTheme.type.scriptItalic.fontStyle,
+                fontSize = ClanWorldTheme.type.scriptItalic.fontSize,
+                color = Ink,
+              ),
+              cursorBrush = SolidColor(Ink2),
+              modifier = Modifier.fillMaxSize(),
+            )
+          }
+          Spacer(Modifier.height(8.dp))
+          Text(
+            text = "${state.doctrine.length}/280",
+            style = ClanWorldTheme.type.monoNano,
+            color = Ink3,
+            textAlign = TextAlign.End,
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+
+        Spacer(Modifier.height(14.dp))
+
+        // ── Save status ───────────────────────────────────────────────────
+        EditorStatus(state)
+        Spacer(Modifier.height(14.dp))
+
+        EmberCta(
+          text = when (state.savePhase) {
+            SendPhase.Idle -> "Sign and Seal"
+            SendPhase.Signing -> "Awaiting the seal…"
+            SendPhase.Queued -> "Sealed ✓"
+            SendPhase.Failed -> "Try Again"
+          },
+          onClick = onSave,
+          enabled = state.doctrine.isNotBlank() &&
+            state.pinnedKey.isNotBlank() &&
+            (state.savePhase == SendPhase.Idle || state.savePhase == SendPhase.Failed),
+          modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(Modifier.height(40.dp))
+      }
+    }
+  }
+}
+
+@Composable
+private fun BackBar(text: String, onBack: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 14.dp)
+      .clickable { onBack() },
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      painter = painterResource(R.drawable.ui_arrow),
+      contentDescription = "back",
+      tint = ClanWorldTheme.colors.warm,
+      modifier = Modifier.height(16.dp),
+    )
+    Text(
+      text = text,
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+  }
+}
+
+@Composable
+private fun EditorHead(clanId: Int) {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 14f),
+          end = Offset(size.width, size.height + 14f),
+          strokeWidth = 1f,
+        )
+      },
+  ) {
+    Text(
+      text = "STRATEGY",
+      style = ClanWorldTheme.type.displayHero,
+      color = parchment,
+    )
+    Text(
+      text = "the doctrine kept by ${clanDisplayName(clanId).lowercase()}",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = warmDim,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+@Composable
+private fun PosturePill(posture: Posture, selected: Boolean, onClick: () -> Unit) {
+  val accent = when (posture) {
+    Posture.Defensive -> ClanWorldTheme.colors.rune
+    Posture.Balanced -> ClanWorldTheme.colors.gold
+    Posture.Aggressive -> ClanWorldTheme.colors.ember
+  }
+  val bg = if (selected) accent.copy(alpha = 0.18f) else Color.Transparent
+  val border = if (selected) accent else ClanWorldTheme.colors.hairline
+  val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
+  Row(
+    modifier = Modifier
+      .clip(RoundedCornerShape(4.dp))
+      .background(bg)
+      .drawBehind {
+        drawRoundRect(
+          color = border,
+          cornerRadius = CornerRadius(4.dp.toPx()),
+          style = Stroke(width = 1.dp.toPx()),
+        )
+      }
+      .clickable { onClick() }
+      .padding(horizontal = 14.dp, vertical = 10.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Box(
+      modifier = Modifier
+        .size(8.dp)
+        .clip(RoundedCornerShape(50))
+        .background(accent),
+    )
+    Text(
+      text = posture.name.uppercase(),
+      style = ClanWorldTheme.type.monoMicro,
+      color = tint,
+    )
+  }
+}
+
+@Composable
+private fun EditorStatus(state: StrategyEditorUiState) {
+  when (state.savePhase) {
+    SendPhase.Idle -> {
+      Text(
+        text = "your seal will write the doctrine to the elder's memory.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warmDim,
+      )
+    }
+    SendPhase.Signing -> {
+      Text(
+        text = "the wallet is preparing the seal…",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.gold,
+      )
+    }
+    SendPhase.Queued -> {
+      Text(
+        text = "sealed — the elder will hold this counsel through the next tick.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.success,
+      )
+    }
+    SendPhase.Failed -> {
+      Text(
+        text = state.errorMessage ?: "the seal could not be set.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.danger,
+      )
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
@@ -1,6 +1,6 @@
 package world.clan.app.ui.screens
 
-import androidx.activity.ComponentActivity
+import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -59,7 +59,7 @@ import world.clan.app.wallet.MwaResult
 @Composable
 fun StrategyEditorScreenRoute(
   app: App,
-  hostActivity: ComponentActivity,
+  mwaSender: ActivityResultSender,
   clanId: Int,
   onBack: () -> Unit,
   onSaved: () -> Unit,
@@ -85,7 +85,7 @@ fun StrategyEditorScreenRoute(
         }
         val msg = ("ClanWorld Strategy — clan ${state.clanId} | ${state.posture.name} | " +
           "${state.pinnedKey} = ${state.doctrine}").toByteArray()
-        when (val r = app.mwaClient.signMessage(hostActivity, token, msg)) {
+        when (val r = app.mwaClient.signMessage(mwaSender, token, msg)) {
           is MwaResult.Ok -> vm.setSavePhase(SendPhase.Queued)
           is MwaResult.UserDeclined -> vm.setSavePhase(SendPhase.Idle)
           is MwaResult.WalletNotFound ->

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
@@ -1,0 +1,375 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import world.clan.app.App
+import world.clan.app.R
+import world.clan.app.data.VaultMovement
+import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.viewmodel.ResourceBalance
+import world.clan.app.viewmodel.TreasuryFilter
+import world.clan.app.viewmodel.TreasuryUiState
+import world.clan.app.viewmodel.TreasuryViewModel
+import world.clan.app.viewmodel.TreasuryViewModelFactory
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.filteredMovements
+
+@Composable
+fun TreasuryScreenRoute(
+  app: App,
+  clanId: Int,
+  onBack: () -> Unit,
+) {
+  val vm: TreasuryViewModel = viewModel(factory = TreasuryViewModelFactory(app, clanId))
+  val state by vm.state.collectAsState()
+  TreasuryScreen(
+    state = state,
+    clanId = clanId,
+    onBack = onBack,
+    onSetFilter = vm::setFilter,
+  )
+}
+
+@Composable
+private fun TreasuryScreen(
+  state: TreasuryUiState,
+  clanId: Int,
+  onBack: () -> Unit,
+  onSetFilter: (TreasuryFilter) -> Unit,
+) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    BackBar(text = "back to ${clanDisplayName(clanId).lowercase()}", onBack = onBack)
+
+    Column(modifier = Modifier.padding(horizontal = 22.dp)) {
+      TreasuryHead(clanId = clanId, balance = state.balance)
+      Spacer(Modifier.height(14.dp))
+
+      if (state.isLoading) {
+        Text(
+          text = "the keep is being weighed…",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(top = 18.dp),
+        )
+      } else if (state.errorMessage != null) {
+        Text(
+          text = state.errorMessage,
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.danger,
+          modifier = Modifier.padding(top = 18.dp),
+        )
+      } else {
+        GoldHeroCard(gold = state.balance.gold, clanId = clanId)
+        Spacer(Modifier.height(12.dp))
+        ResourceStripCard(balance = state.balance)
+        Spacer(Modifier.height(18.dp))
+        Text(
+          text = "MOVEMENTS",
+          style = ClanWorldTheme.type.monoNano,
+          color = ClanWorldTheme.colors.warmFaint,
+        )
+        Spacer(Modifier.height(8.dp))
+        FilterRow(active = state.filter, onSelect = onSetFilter)
+        Spacer(Modifier.height(10.dp))
+      }
+    }
+
+    if (!state.isLoading && state.errorMessage == null) {
+      val items = state.filteredMovements()
+      if (items.isEmpty()) {
+        Text(
+          text = "the vault keeps its silence",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
+        )
+      } else {
+        LazyColumn(
+          modifier = Modifier.fillMaxSize(),
+          verticalArrangement = Arrangement.spacedBy(0.dp),
+          contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+        ) {
+          items(items.withIndex().toList(), key = { (i, m) -> "${i}-${m.tick}-${m.resource}" }) { (_, mv) ->
+            MovementRow(mv)
+          }
+          item { Spacer(Modifier.height(40.dp)) }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun BackBar(text: String, onBack: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 14.dp)
+      .clickable { onBack() },
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      painter = painterResource(R.drawable.ui_arrow),
+      contentDescription = "back",
+      tint = ClanWorldTheme.colors.warm,
+      modifier = Modifier.height(16.dp),
+    )
+    Text(
+      text = text,
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+  }
+}
+
+@Composable
+private fun TreasuryHead(clanId: Int, balance: ResourceBalance) {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 14f),
+          end = Offset(size.width, size.height + 14f),
+          strokeWidth = 1f,
+        )
+      },
+    horizontalArrangement = Arrangement.SpaceBetween,
+    verticalAlignment = Alignment.Bottom,
+  ) {
+    Column {
+      Text(
+        text = "TREASURY",
+        style = ClanWorldTheme.type.displayHero,
+        color = parchment,
+      )
+      Text(
+        text = "the keeping of ${clanDisplayName(clanId).lowercase()}",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = warmDim,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+  }
+}
+
+@Composable
+private fun GoldHeroCard(gold: Long, clanId: Int) {
+  ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.SpaceBetween,
+      modifier = Modifier.fillMaxWidth(),
+    ) {
+      Column(modifier = Modifier.weight(1f)) {
+        Text(
+          text = "GOLD",
+          style = ClanWorldTheme.type.monoNano,
+          color = Ink3,
+        )
+        Text(
+          text = formatGold(gold),
+          style = ClanWorldTheme.type.displayHero,
+          color = Ink,
+          modifier = Modifier.padding(top = 4.dp),
+        )
+        Text(
+          text = "stored under ${clanDisplayName(clanId).lowercase()}",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = Ink2,
+          modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+      // accent dot in clan color
+      Box(
+        modifier = Modifier
+          .padding(start = 8.dp)
+          .clip(RoundedCornerShape(50))
+          .background(clanColor(clanId))
+          .padding(8.dp),
+      ) {
+        Text(
+          text = " ",
+          style = ClanWorldTheme.type.monoNano,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun ResourceStripCard(balance: ResourceBalance) {
+  ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+    Text(
+      text = "RESOURCES",
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Spacer(Modifier.height(10.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+      ResourceCell(label = "Wood", value = balance.wood)
+      ResourceCell(label = "Iron", value = balance.iron)
+      ResourceCell(label = "Wheat", value = balance.wheat)
+      ResourceCell(label = "Fish", value = balance.fish)
+    }
+  }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.ResourceCell(label: String, value: Long) {
+  Column(Modifier.weight(1f)) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Text(
+      text = "%,d".format(value),
+      style = ClanWorldTheme.type.monoData,
+      color = Ink,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+@Composable
+private fun FilterRow(active: TreasuryFilter, onSelect: (TreasuryFilter) -> Unit) {
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    FilterChip(label = "All", selected = active == TreasuryFilter.All, onClick = { onSelect(TreasuryFilter.All) })
+    FilterChip(label = "Gold", selected = active == TreasuryFilter.Gold, onClick = { onSelect(TreasuryFilter.Gold) })
+    FilterChip(label = "Resources", selected = active == TreasuryFilter.Resources, onClick = { onSelect(TreasuryFilter.Resources) })
+  }
+}
+
+@Composable
+private fun FilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
+  val bg = if (selected) ClanWorldTheme.colors.iron2 else Color.Transparent
+  val border = if (selected) ClanWorldTheme.colors.hairlineStrong else ClanWorldTheme.colors.hairline
+  val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
+  Box(
+    modifier = Modifier
+      .clip(RoundedCornerShape(4.dp))
+      .background(bg)
+      .drawBehind {
+        drawRoundRect(
+          color = border,
+          cornerRadius = CornerRadius(4.dp.toPx()),
+          style = Stroke(width = 1.dp.toPx()),
+        )
+      }
+      .clickable { onClick() }
+      .padding(horizontal = 12.dp, vertical = 8.dp),
+  ) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoMicro,
+      color = tint,
+    )
+  }
+}
+
+@Composable
+private fun MovementRow(mv: VaultMovement) {
+  val warm = ClanWorldTheme.colors.warm
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val warmFaint = ClanWorldTheme.colors.warmFaint
+  val gold = ClanWorldTheme.colors.gold
+  val danger = ClanWorldTheme.colors.danger
+  val rune = ClanWorldTheme.colors.rune
+  val hairline = ClanWorldTheme.colors.hairline
+
+  val sign = if (mv.type == "spend") "−" else "+"
+  val amountColor = when (mv.type) {
+    "spend" -> danger
+    "transfer" -> rune
+    else -> gold
+  }
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height),
+          end = Offset(size.width, size.height),
+          strokeWidth = 1f,
+        )
+      }
+      .padding(vertical = 12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Text(
+      text = "T %04d".format(mv.tick),
+      style = ClanWorldTheme.type.monoNano,
+      color = warmFaint,
+      modifier = Modifier.padding(end = 4.dp),
+    )
+    Column(modifier = Modifier.weight(1f)) {
+      Text(
+        text = mv.resource.replaceFirstChar { it.uppercase() },
+        style = ClanWorldTheme.type.body,
+        color = warm,
+      )
+      mv.source?.takeIf { it.isNotBlank() }?.let { src ->
+        Text(
+          text = src,
+          style = ClanWorldTheme.type.monoNano,
+          color = warmDim,
+          modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+    }
+    Text(
+      text = "$sign%.2f".format(mv.amount),
+      style = ClanWorldTheme.type.monoData,
+      color = amountColor,
+    )
+  }
+}
+
+private fun formatGold(value: Long): String =
+  if (value >= 1_000_000) "%.1fM".format(value / 1_000_000.0)
+  else if (value >= 1_000) "%.1fk".format(value / 1_000.0)
+  else "%,d".format(value)

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
@@ -61,6 +61,7 @@ fun TreasuryScreenRoute(
     clanId = clanId,
     onBack = onBack,
     onSetFilter = vm::setFilter,
+    onRefresh = vm::refresh,
   )
 }
 
@@ -70,6 +71,7 @@ private fun TreasuryScreen(
   clanId: Int,
   onBack: () -> Unit,
   onSetFilter: (TreasuryFilter) -> Unit,
+  onRefresh: () -> Unit = {},
 ) {
   Column(modifier = Modifier.fillMaxSize()) {
     BackBar(text = "back to ${clanDisplayName(clanId).lowercase()}", onBack = onBack)
@@ -86,11 +88,9 @@ private fun TreasuryScreen(
           modifier = Modifier.padding(top = 18.dp),
         )
       } else if (state.errorMessage != null) {
-        Text(
-          text = state.errorMessage,
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.danger,
-          modifier = Modifier.padding(top = 18.dp),
+        world.clan.app.ui.components.RetryNotice(
+          message = state.errorMessage,
+          onRetry = onRefresh,
         )
       } else {
         GoldHeroCard(gold = state.balance.gold, clanId = clanId)
@@ -110,23 +110,33 @@ private fun TreasuryScreen(
 
     if (!state.isLoading && state.errorMessage == null) {
       val items = state.filteredMovements()
-      if (items.isEmpty()) {
-        Text(
-          text = "the vault keeps its silence",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-          modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
-        )
-      } else {
-        LazyColumn(
-          modifier = Modifier.fillMaxSize(),
-          verticalArrangement = Arrangement.spacedBy(0.dp),
-          contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
-        ) {
-          items(items.withIndex().toList(), key = { (i, m) -> "${i}-${m.tick}-${m.resource}" }) { (_, mv) ->
-            MovementRow(mv)
+      world.clan.app.ui.components.RefreshableContent(
+        isRefreshing = state.isLoading,
+        onRefresh = onRefresh,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        if (items.isEmpty()) {
+          LazyColumn(modifier = Modifier.fillMaxSize()) {
+            item {
+              Text(
+                text = "the vault keeps its silence",
+                style = ClanWorldTheme.type.scriptItalic,
+                color = ClanWorldTheme.colors.warmFaint,
+                modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
+              )
+            }
           }
-          item { Spacer(Modifier.height(40.dp)) }
+        } else {
+          LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(0.dp),
+            contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+          ) {
+            items(items.withIndex().toList(), key = { (i, m) -> "${i}-${m.tick}-${m.resource}" }) { (_, mv) ->
+              MovementRow(mv)
+            }
+            item { Spacer(Modifier.height(40.dp)) }
+          }
         }
       }
     }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
@@ -81,12 +81,11 @@ private fun TreasuryScreen(
       Spacer(Modifier.height(14.dp))
 
       if (state.isLoading) {
-        Text(
-          text = "the keep is being weighed…",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-          modifier = Modifier.padding(top = 18.dp),
-        )
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+          world.clan.app.ui.components.SkeletonTreasuryHero()
+          Spacer(Modifier.height(2.dp))
+          repeat(5) { world.clan.app.ui.components.SkeletonMovementRow() }
+        }
       } else if (state.errorMessage != null) {
         world.clan.app.ui.components.RetryNotice(
           message = state.errorMessage,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -95,12 +95,12 @@ private fun WhispersScreen(
     val items = state.filtered()
     when {
       state.isLoading -> {
-        Text(
-          text = "the whispers gather…",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
-        )
+        Column(
+          modifier = Modifier.padding(horizontal = 22.dp, vertical = 8.dp),
+          verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+          repeat(5) { world.clan.app.ui.components.SkeletonWhisperRow() }
+        }
       }
       state.errorMessage != null && items.isEmpty() -> {
         world.clan.app.ui.components.RetryNotice(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -1,0 +1,257 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import world.clan.app.App
+import world.clan.app.R
+import world.clan.app.data.CombinedComm
+import world.clan.app.ui.components.WhisperAccent
+import world.clan.app.ui.components.WhisperRow
+import world.clan.app.ui.components.boldedMeta
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.viewmodel.WhispersFilter
+import world.clan.app.viewmodel.WhispersUiState
+import world.clan.app.viewmodel.WhispersViewModel
+import world.clan.app.viewmodel.WhispersViewModelFactory
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.filtered
+
+@Composable
+fun WhispersScreenRoute(
+  app: App,
+  clanId: Int,
+  onBack: () -> Unit,
+) {
+  val vm: WhispersViewModel = viewModel(factory = WhispersViewModelFactory(app, clanId))
+  val state by vm.state.collectAsState()
+  WhispersScreen(
+    state = state,
+    clanId = clanId,
+    onBack = onBack,
+    onSetFilter = vm::setFilter,
+  )
+}
+
+@Composable
+private fun WhispersScreen(
+  state: WhispersUiState,
+  clanId: Int,
+  onBack: () -> Unit,
+  onSetFilter: (WhispersFilter) -> Unit,
+) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    InboxBackBar(clanId = clanId, onBack = onBack)
+
+    Column(modifier = Modifier.padding(horizontal = 22.dp)) {
+      InboxHead(clanId = clanId, count = state.filtered().size)
+      Spacer(Modifier.height(12.dp))
+      FilterRow(active = state.filter, onSelect = onSetFilter)
+      Spacer(Modifier.height(14.dp))
+    }
+
+    val items = state.filtered()
+    when {
+      state.isLoading -> {
+        Text(
+          text = "the whispers gather…",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+        )
+      }
+      state.errorMessage != null -> {
+        Text(
+          text = state.errorMessage,
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.danger,
+          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+        )
+      }
+      items.isEmpty() -> {
+        Text(
+          text = "no whispers carry this kind.",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+        )
+      }
+      else -> {
+        LazyColumn(
+          modifier = Modifier.fillMaxSize(),
+          verticalArrangement = Arrangement.spacedBy(10.dp),
+          contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+        ) {
+          items(items.withIndex().toList(), key = { (i, c) -> "${i}-${c.tick ?: c.timestamp ?: 0}" }) { (_, c) ->
+            InboxRow(comm = c)
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun InboxBackBar(clanId: Int, onBack: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 14.dp)
+      .clickable { onBack() },
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      painter = painterResource(R.drawable.ui_arrow),
+      contentDescription = "back",
+      tint = ClanWorldTheme.colors.warm,
+      modifier = Modifier.height(16.dp),
+    )
+    Text(
+      text = "back to ${clanDisplayName(clanId).lowercase()}",
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+  }
+}
+
+@Composable
+private fun InboxHead(clanId: Int, count: Int) {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val gold = ClanWorldTheme.colors.gold
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(top = 4.dp, bottom = 4.dp)
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 14f),
+          end = Offset(size.width, size.height + 14f),
+          strokeWidth = 1f,
+        )
+      },
+    verticalAlignment = Alignment.Bottom,
+    horizontalArrangement = Arrangement.SpaceBetween,
+  ) {
+    Column {
+      Text(
+        text = "INBOX",
+        style = ClanWorldTheme.type.displayHero,
+        color = parchment,
+      )
+      Text(
+        text = "whispers heard at ${clanDisplayName(clanId).lowercase()}",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = warmDim,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+    Column(horizontalAlignment = Alignment.End) {
+      Text(
+        text = "%02d".format(count),
+        style = ClanWorldTheme.type.monoBig,
+        color = parchment,
+      )
+      Text(
+        text = "shown",
+        style = ClanWorldTheme.type.monoMicro,
+        color = gold,
+      )
+    }
+  }
+}
+
+@Composable
+private fun FilterRow(active: WhispersFilter, onSelect: (WhispersFilter) -> Unit) {
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    FilterChip(label = "All", selected = active == WhispersFilter.All, onClick = { onSelect(WhispersFilter.All) })
+    FilterChip(label = "Peers", selected = active == WhispersFilter.Whisper, onClick = { onSelect(WhispersFilter.Whisper) })
+    FilterChip(label = "Orch", selected = active == WhispersFilter.Orch, onClick = { onSelect(WhispersFilter.Orch) })
+    FilterChip(label = "Owner", selected = active == WhispersFilter.Human, onClick = { onSelect(WhispersFilter.Human) })
+  }
+}
+
+@Composable
+private fun FilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
+  val bg = if (selected) ClanWorldTheme.colors.iron2 else Color.Transparent
+  val border = if (selected) ClanWorldTheme.colors.hairlineStrong else ClanWorldTheme.colors.hairline
+  val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
+  Box(
+    modifier = Modifier
+      .clip(RoundedCornerShape(4.dp))
+      .background(bg)
+      .drawBehind {
+        drawLine(
+          color = border,
+          start = Offset(0f, 0f),
+          end = Offset(size.width, 0f),
+          strokeWidth = 1f,
+        )
+        drawLine(
+          color = border,
+          start = Offset(0f, size.height),
+          end = Offset(size.width, size.height),
+          strokeWidth = 1f,
+        )
+      }
+      .clickable { onClick() }
+      .padding(horizontal = 12.dp, vertical = 8.dp),
+  ) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoMicro,
+      color = tint,
+    )
+  }
+}
+
+@Composable
+private fun InboxRow(comm: CombinedComm) {
+  val accent = when (comm.kind) {
+    "whisper" -> WhisperAccent.Rune
+    "orch" -> WhisperAccent.Gold
+    "human" -> WhisperAccent.Ember
+    else -> WhisperAccent.Default
+  }
+  val from = comm.fromClan?.let { clanDisplayName(it) }
+    ?: comm.speaker
+    ?: when (comm.kind) {
+      "orch" -> "Orchestrator"; "human" -> "Owner"; else -> "—"
+    }
+  val tickStr = comm.tick?.let { "%04d".format(it) } ?: "—"
+  WhisperRow(
+    meta = boldedMeta("*$from* · $tickStr".uppercase()),
+    body = comm.body,
+    accent = accent,
+  )
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -117,11 +117,13 @@ private fun WhispersScreen(
           if (items.isEmpty()) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
               item {
-                Text(
-                  text = "no whispers carry this kind.",
-                  style = ClanWorldTheme.type.scriptItalic,
-                  color = ClanWorldTheme.colors.warmFaint,
-                  modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+                val isFiltered = state.filter != WhispersFilter.All
+                world.clan.app.ui.components.EmptyState(
+                  title = if (isFiltered) "no whispers carry this kind" else "the inbox is silent",
+                  body = if (isFiltered) "try another filter, or compose one yourself."
+                  else "no whispers heard yet — be the first to speak.",
+                  ctaLabel = if (isFiltered) null else "+ New whisper",
+                  onCta = if (isFiltered) null else onCompose,
                 )
               }
             }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -58,6 +58,7 @@ fun WhispersScreenRoute(
     onBack = onBack,
     onSetFilter = vm::setFilter,
     onCompose = onCompose,
+    onRefresh = vm::refresh,
   )
 }
 
@@ -68,6 +69,7 @@ private fun WhispersScreen(
   onBack: () -> Unit,
   onSetFilter: (WhispersFilter) -> Unit,
   onCompose: () -> Unit = {},
+  onRefresh: () -> Unit = {},
 ) {
   Column(modifier = Modifier.fillMaxSize()) {
     InboxBackBar(clanId = clanId, onBack = onBack)
@@ -100,30 +102,39 @@ private fun WhispersScreen(
           modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
         )
       }
-      state.errorMessage != null -> {
-        Text(
-          text = state.errorMessage,
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.danger,
-          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
-        )
-      }
-      items.isEmpty() -> {
-        Text(
-          text = "no whispers carry this kind.",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+      state.errorMessage != null && items.isEmpty() -> {
+        world.clan.app.ui.components.RetryNotice(
+          message = state.errorMessage,
+          onRetry = onRefresh,
         )
       }
       else -> {
-        LazyColumn(
+        world.clan.app.ui.components.RefreshableContent(
+          isRefreshing = state.isLoading,
+          onRefresh = onRefresh,
           modifier = Modifier.fillMaxSize(),
-          verticalArrangement = Arrangement.spacedBy(10.dp),
-          contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
         ) {
-          items(items.withIndex().toList(), key = { (i, c) -> "${i}-${c.tick ?: c.timestamp ?: 0}" }) { (_, c) ->
-            InboxRow(comm = c)
+          if (items.isEmpty()) {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+              item {
+                Text(
+                  text = "no whispers carry this kind.",
+                  style = ClanWorldTheme.type.scriptItalic,
+                  color = ClanWorldTheme.colors.warmFaint,
+                  modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+                )
+              }
+            }
+          } else {
+            LazyColumn(
+              modifier = Modifier.fillMaxSize(),
+              verticalArrangement = Arrangement.spacedBy(10.dp),
+              contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+            ) {
+              items(items.withIndex().toList(), key = { (i, c) -> "${i}-${c.tick ?: c.timestamp ?: 0}" }) { (_, c) ->
+                InboxRow(comm = c)
+              }
+            }
           }
         }
       }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -48,6 +48,7 @@ fun WhispersScreenRoute(
   app: App,
   clanId: Int,
   onBack: () -> Unit,
+  onCompose: () -> Unit = {},
 ) {
   val vm: WhispersViewModel = viewModel(factory = WhispersViewModelFactory(app, clanId))
   val state by vm.state.collectAsState()
@@ -56,6 +57,7 @@ fun WhispersScreenRoute(
     clanId = clanId,
     onBack = onBack,
     onSetFilter = vm::setFilter,
+    onCompose = onCompose,
   )
 }
 
@@ -65,6 +67,7 @@ private fun WhispersScreen(
   clanId: Int,
   onBack: () -> Unit,
   onSetFilter: (WhispersFilter) -> Unit,
+  onCompose: () -> Unit = {},
 ) {
   Column(modifier = Modifier.fillMaxSize()) {
     InboxBackBar(clanId = clanId, onBack = onBack)
@@ -73,7 +76,18 @@ private fun WhispersScreen(
       InboxHead(clanId = clanId, count = state.filtered().size)
       Spacer(Modifier.height(12.dp))
       FilterRow(active = state.filter, onSelect = onSetFilter)
-      Spacer(Modifier.height(14.dp))
+      Spacer(Modifier.height(10.dp))
+      Text(
+        text = "+ NEW WHISPER",
+        style = ClanWorldTheme.type.monoMicro,
+        color = ClanWorldTheme.colors.gold,
+        modifier = Modifier
+          .fillMaxWidth()
+          .clickable { onCompose() }
+          .padding(vertical = 8.dp),
+        textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+      )
+      Spacer(Modifier.height(8.dp))
     }
 
     val items = state.filtered()

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/BazaarViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/BazaarViewModel.kt
@@ -1,0 +1,28 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import world.clan.app.data.BAZAAR_LISTINGS
+import world.clan.app.data.BazaarListing
+
+data class BazaarUiState(
+  val isLoading: Boolean = false,
+  val listings: List<BazaarListing> = emptyList(),
+  val errorMessage: String? = null,
+)
+
+/**
+ * Slice 4: Bazaar viewmodel. The listings are a static demo list; no Convex
+ * marketplace query exists yet. ViewModel still exists so that the screen
+ * can subscribe through StateFlow like every other screen — when a real
+ * listings query lands, only this file changes.
+ */
+class BazaarViewModel : ViewModel() {
+
+  private val _state = MutableStateFlow(
+    BazaarUiState(listings = BAZAAR_LISTINGS),
+  )
+  val state: StateFlow<BazaarUiState> = _state.asStateFlow()
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/BazaarViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/BazaarViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import world.clan.app.data.BAZAAR_LISTINGS
 import world.clan.app.data.BazaarListing
+import world.clan.app.data.SessionStore
 
 data class BazaarUiState(
   val isLoading: Boolean = false,
@@ -14,15 +16,24 @@ data class BazaarUiState(
 )
 
 /**
- * Slice 4: Bazaar viewmodel. The listings are a static demo list; no Convex
- * marketplace query exists yet. ViewModel still exists so that the screen
- * can subscribe through StateFlow like every other screen — when a real
- * listings query lands, only this file changes.
+ * Bazaar viewmodel. Listings are a static demo set; no Convex marketplace
+ * query exists yet. Filters out clans already hired (so a hired sigil
+ * can't be hired again in the same install).
  */
-class BazaarViewModel : ViewModel() {
+class BazaarViewModel(
+  private val sessionStore: SessionStore? = null,
+) : ViewModel() {
 
-  private val _state = MutableStateFlow(
-    BazaarUiState(listings = BAZAAR_LISTINGS),
-  )
+  private val _state = MutableStateFlow(BazaarUiState(listings = currentListings()))
   val state: StateFlow<BazaarUiState> = _state.asStateFlow()
+
+  /** Re-read hired set + reapply filter — call when re-entering the screen. */
+  fun refresh() {
+    _state.update { it.copy(listings = currentListings()) }
+  }
+
+  private fun currentListings(): List<BazaarListing> {
+    val hired = sessionStore?.getHiredClanIds().orEmpty()
+    return BAZAAR_LISTINGS.filter { it.clanId !in hired }
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -15,7 +15,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
     BazaarViewModel::class.java -> BazaarViewModel()
-    ForgeViewModel::class.java -> ForgeViewModel()
+    ForgeViewModel::class.java -> ForgeViewModel(app.sessionStore)
     CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")
   } as T
@@ -43,11 +43,12 @@ class WhispersViewModelFactory(
 
 /** Per-route factory for SteeringConsole, parameterized by the initial target clan. */
 class SteeringConsoleViewModelFactory(
+  private val app: App,
   private val initialClanId: Int,
 ) : ViewModelProvider.Factory {
   @Suppress("UNCHECKED_CAST")
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
-    SteeringConsoleViewModel(initialClanId) as T
+    SteeringConsoleViewModel(initialClanId, app.sessionStore) as T
 }
 
 /** Per-route factory for StrategyEditor, parameterized by clanId. */
@@ -57,7 +58,7 @@ class StrategyEditorViewModelFactory(
 ) : ViewModelProvider.Factory {
   @Suppress("UNCHECKED_CAST")
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
-    StrategyEditorViewModel(app.convexClient, clanId) as T
+    StrategyEditorViewModel(app.convexClient, clanId, app.sessionStore) as T
 }
 
 /** Per-route factory for Treasury, parameterized by clanId. */

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -58,3 +58,13 @@ class StrategyEditorViewModelFactory(
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
     StrategyEditorViewModel(app.convexClient, clanId) as T
 }
+
+/** Per-route factory for Treasury, parameterized by clanId. */
+class TreasuryViewModelFactory(
+  private val app: App,
+  private val clanId: Int,
+) : ViewModelProvider.Factory {
+  @Suppress("UNCHECKED_CAST")
+  override fun <T : ViewModel> create(modelClass: Class<T>): T =
+    TreasuryViewModel(app.convexClient, clanId) as T
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -14,7 +14,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     ConnectViewModel::class.java -> ConnectViewModel(app.mwaClient, app.sessionStore)
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
-    BazaarViewModel::class.java -> BazaarViewModel()
+    BazaarViewModel::class.java -> BazaarViewModel(app.sessionStore)
     ForgeViewModel::class.java -> ForgeViewModel(app.sessionStore)
     CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.lineageStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -29,3 +29,13 @@ class InftDetailViewModelFactory(
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
     InftDetailViewModel(app.convexClient, clanId) as T
 }
+
+/** Per-route factory for Whispers, which depends on a clanId. */
+class WhispersViewModelFactory(
+  private val app: App,
+  private val clanId: Int,
+) : ViewModelProvider.Factory {
+  @Suppress("UNCHECKED_CAST")
+  override fun <T : ViewModel> create(modelClass: Class<T>): T =
+    WhispersViewModel(app.convexClient, clanId) as T
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -39,3 +39,22 @@ class WhispersViewModelFactory(
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
     WhispersViewModel(app.convexClient, clanId) as T
 }
+
+/** Per-route factory for SteeringConsole, parameterized by the initial target clan. */
+class SteeringConsoleViewModelFactory(
+  private val initialClanId: Int,
+) : ViewModelProvider.Factory {
+  @Suppress("UNCHECKED_CAST")
+  override fun <T : ViewModel> create(modelClass: Class<T>): T =
+    SteeringConsoleViewModel(initialClanId) as T
+}
+
+/** Per-route factory for StrategyEditor, parameterized by clanId. */
+class StrategyEditorViewModelFactory(
+  private val app: App,
+  private val clanId: Int,
+) : ViewModelProvider.Factory {
+  @Suppress("UNCHECKED_CAST")
+  override fun <T : ViewModel> create(modelClass: Class<T>): T =
+    StrategyEditorViewModel(app.convexClient, clanId) as T
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -16,7 +16,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
     BazaarViewModel::class.java -> BazaarViewModel()
     ForgeViewModel::class.java -> ForgeViewModel(app.sessionStore)
-    CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.deviceClass)
+    CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.lineageStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")
   } as T
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -14,6 +14,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     ConnectViewModel::class.java -> ConnectViewModel(app.mwaClient, app.sessionStore)
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
+    BazaarViewModel::class.java -> BazaarViewModel()
     CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")
   } as T

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -15,6 +15,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
     BazaarViewModel::class.java -> BazaarViewModel()
+    ForgeViewModel::class.java -> ForgeViewModel()
     CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")
   } as T

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import world.clan.app.BuildConfig
+import world.clan.app.data.LineageEntry
+import world.clan.app.data.LineageStore
 import world.clan.app.data.SessionStore
 import world.clan.app.wallet.DeviceClass
 
@@ -17,14 +19,16 @@ data class CodexUiState(
   val linkedClansCount: Int,
   val linkedClanIds: List<Int>,
   val apkShareUrl: String,
+  val lineage: List<LineageEntry> = emptyList(),
 )
 
 /**
- * Codex — read-only identity / device / about summary. Powered by
- * BuildConfig + SessionStore.
+ * Codex — read-only identity / device / about / lineage summary. Powered
+ * by BuildConfig + SessionStore + LineageStore.
  */
 class CodexViewModel(
   private val sessionStore: SessionStore,
+  private val lineageStore: LineageStore,
   deviceClass: DeviceClass,
 ) : ViewModel() {
 
@@ -40,10 +44,16 @@ class CodexViewModel(
         linkedClansCount = HearthViewModel.LINKED_CLAN_IDS.size,
         linkedClanIds = HearthViewModel.LINKED_CLAN_IDS,
         apkShareUrl = "https://shared.claude.do/public/clanworld-mobile-slice-1.apk",
+        lineage = lineageStore.read(),
       )
     },
   )
   val state: StateFlow<CodexUiState> = _state.asStateFlow()
+
+  /** Re-read lineage when the screen is re-entered after a successful sign. */
+  fun refreshLineage() {
+    _state.value = _state.value.copy(lineage = lineageStore.read())
+  }
 
   fun disconnect() {
     sessionStore.clear()

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -35,7 +35,7 @@ class CodexViewModel(
   private val _state = MutableStateFlow(
     run {
       val s = sessionStore.read()
-      val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+      val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).distinct()
       CodexUiState(
         deviceClass = deviceClass,
         solanaPubkey = s?.solanaPubkeyBase58,
@@ -56,7 +56,7 @@ class CodexViewModel(
    * and freshly-hired sigils appear in Codex without an app kill.
    */
   fun refreshLineage() {
-    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).distinct()
     _state.value = _state.value.copy(
       lineage = lineageStore.read(),
       linkedClansCount = owned.size,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -35,14 +35,15 @@ class CodexViewModel(
   private val _state = MutableStateFlow(
     run {
       val s = sessionStore.read()
+      val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
       CodexUiState(
         deviceClass = deviceClass,
         solanaPubkey = s?.solanaPubkeyBase58,
         walletLabel = s?.walletLabel,
         build = "v ${BuildConfig.VERSION_NAME} · build ${BuildConfig.VERSION_CODE}",
         convexUrl = BuildConfig.CONVEX_URL,
-        linkedClansCount = HearthViewModel.LINKED_CLAN_IDS.size,
-        linkedClanIds = HearthViewModel.LINKED_CLAN_IDS,
+        linkedClansCount = owned.size,
+        linkedClanIds = owned,
         apkShareUrl = "https://shared.claude.do/public/clanworld-mobile-slice-1.apk",
         lineage = lineageStore.read(),
       )
@@ -50,9 +51,17 @@ class CodexViewModel(
   )
   val state: StateFlow<CodexUiState> = _state.asStateFlow()
 
-  /** Re-read lineage when the screen is re-entered after a successful sign. */
+  /**
+   * Re-read lineage + hired clans on (re-)entry so newly-signed actions
+   * and freshly-hired sigils appear in Codex without an app kill.
+   */
   fun refreshLineage() {
-    _state.value = _state.value.copy(lineage = lineageStore.read())
+    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+    _state.value = _state.value.copy(
+      lineage = lineageStore.read(),
+      linkedClansCount = owned.size,
+      linkedClanIds = owned,
+    )
   }
 
   fun disconnect() {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -4,19 +4,24 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import world.clan.app.BuildConfig
 import world.clan.app.data.SessionStore
 import world.clan.app.wallet.DeviceClass
 
 data class CodexUiState(
   val deviceClass: DeviceClass,
   val solanaPubkey: String?,
+  val walletLabel: String?,
   val build: String,
+  val convexUrl: String,
+  val linkedClansCount: Int,
+  val linkedClanIds: List<Int>,
+  val apkShareUrl: String,
 )
 
 /**
- * Slice 1 Codex screen — read-only summary of identity + device + about.
- * No EVM paste, no profile selector, no validation. The Solana pubkey is
- * the only identifier this app cares about.
+ * Codex — read-only identity / device / about summary. Powered by
+ * BuildConfig + SessionStore.
  */
 class CodexViewModel(
   private val sessionStore: SessionStore,
@@ -24,16 +29,24 @@ class CodexViewModel(
 ) : ViewModel() {
 
   private val _state = MutableStateFlow(
-    CodexUiState(
-      deviceClass = deviceClass,
-      solanaPubkey = sessionStore.read()?.solanaPubkeyBase58,
-      build = "v 0.1.0 · slice I",
-    ),
+    run {
+      val s = sessionStore.read()
+      CodexUiState(
+        deviceClass = deviceClass,
+        solanaPubkey = s?.solanaPubkeyBase58,
+        walletLabel = s?.walletLabel,
+        build = "v ${BuildConfig.VERSION_NAME} · build ${BuildConfig.VERSION_CODE}",
+        convexUrl = BuildConfig.CONVEX_URL,
+        linkedClansCount = HearthViewModel.LINKED_CLAN_IDS.size,
+        linkedClanIds = HearthViewModel.LINKED_CLAN_IDS,
+        apkShareUrl = "https://shared.claude.do/public/clanworld-mobile-slice-1.apk",
+      )
+    },
   )
   val state: StateFlow<CodexUiState> = _state.asStateFlow()
 
   fun disconnect() {
     sessionStore.clear()
-    _state.value = _state.value.copy(solanaPubkey = null)
+    _state.value = _state.value.copy(solanaPubkey = null, walletLabel = null)
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import world.clan.app.data.SessionStore
 
 enum class ForgeStep { PickClan, NameSigil, PickHarness, Confirm }
 
@@ -35,14 +36,41 @@ data class ForgeUiState(
  * No real on-chain mint exists. The MWA sign at the end is the seam —
  * a future on-chain mint replaces only the screen-level send call.
  */
-class ForgeViewModel : ViewModel() {
+class ForgeViewModel(
+  private val sessionStore: SessionStore? = null,
+) : ViewModel() {
 
-  private val _state = MutableStateFlow(ForgeUiState())
+  private val draftScope = "forge"
+
+  private val _state = MutableStateFlow(initial())
   val state: StateFlow<ForgeUiState> = _state.asStateFlow()
 
-  fun setClanId(clanId: Int) = _state.update { it.copy(clanId = clanId) }
-  fun setSigilName(name: String) = _state.update { it.copy(sigilName = name.take(32)) }
-  fun setHarness(h: Harness) = _state.update { it.copy(harness = h) }
+  private fun initial(): ForgeUiState {
+    val draftClan = sessionStore?.getDraft(draftScope, "clanId")?.toIntOrNull()
+    val draftName = sessionStore?.getDraft(draftScope, "sigilName").orEmpty()
+    val draftHarness = sessionStore?.getDraft(draftScope, "harness")
+      ?.let { runCatching { Harness.valueOf(it) }.getOrNull() }
+      ?: Harness.Tide
+    return ForgeUiState(
+      clanId = draftClan,
+      sigilName = draftName,
+      harness = draftHarness,
+    )
+  }
+
+  fun setClanId(clanId: Int) {
+    _state.update { it.copy(clanId = clanId) }
+    sessionStore?.setDraft(draftScope, "clanId", clanId.toString())
+  }
+  fun setSigilName(name: String) {
+    val capped = name.take(32)
+    _state.update { it.copy(sigilName = capped) }
+    sessionStore?.setDraft(draftScope, "sigilName", capped)
+  }
+  fun setHarness(h: Harness) {
+    _state.update { it.copy(harness = h) }
+    sessionStore?.setDraft(draftScope, "harness", h.name)
+  }
 
   fun goTo(step: ForgeStep) = _state.update { it.copy(step = step) }
 
@@ -66,6 +94,8 @@ class ForgeViewModel : ViewModel() {
     it.copy(step = prv)
   }
 
-  fun setMintPhase(phase: SendPhase, error: String? = null) =
+  fun setMintPhase(phase: SendPhase, error: String? = null) {
     _state.update { it.copy(mintPhase = phase, errorMessage = error) }
+    if (phase == SendPhase.Queued) sessionStore?.clearDrafts(draftScope)
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
@@ -1,0 +1,71 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+enum class ForgeStep { PickClan, NameSigil, PickHarness, Confirm }
+
+/**
+ * Themed harness choices for a freshly forged sigil.
+ *  - Iron   → defensive bias
+ *  - Tide   → balanced bias
+ *  - Ember  → aggressive bias
+ */
+enum class Harness(val display: String, val tagline: String) {
+  Iron("Iron", "hold the line; trade no ground without weight"),
+  Tide("Tide", "read the strait; move when both shores agree"),
+  Ember("Ember", "forge ahead; the season favors the bold"),
+}
+
+data class ForgeUiState(
+  val step: ForgeStep = ForgeStep.PickClan,
+  val clanId: Int? = null,
+  val sigilName: String = "",
+  val harness: Harness = Harness.Tide,
+  val mintPhase: SendPhase = SendPhase.Idle,
+  val errorMessage: String? = null,
+)
+
+/**
+ * Slice 6: Forge. Four-step mint wizard.
+ *
+ * No real on-chain mint exists. The MWA sign at the end is the seam —
+ * a future on-chain mint replaces only the screen-level send call.
+ */
+class ForgeViewModel : ViewModel() {
+
+  private val _state = MutableStateFlow(ForgeUiState())
+  val state: StateFlow<ForgeUiState> = _state.asStateFlow()
+
+  fun setClanId(clanId: Int) = _state.update { it.copy(clanId = clanId) }
+  fun setSigilName(name: String) = _state.update { it.copy(sigilName = name.take(32)) }
+  fun setHarness(h: Harness) = _state.update { it.copy(harness = h) }
+
+  fun goTo(step: ForgeStep) = _state.update { it.copy(step = step) }
+
+  fun next() = _state.update {
+    val nxt = when (it.step) {
+      ForgeStep.PickClan -> ForgeStep.NameSigil
+      ForgeStep.NameSigil -> ForgeStep.PickHarness
+      ForgeStep.PickHarness -> ForgeStep.Confirm
+      ForgeStep.Confirm -> ForgeStep.Confirm
+    }
+    it.copy(step = nxt)
+  }
+
+  fun back() = _state.update {
+    val prv = when (it.step) {
+      ForgeStep.PickClan -> ForgeStep.PickClan
+      ForgeStep.NameSigil -> ForgeStep.PickClan
+      ForgeStep.PickHarness -> ForgeStep.NameSigil
+      ForgeStep.Confirm -> ForgeStep.PickHarness
+    }
+    it.copy(step = prv)
+  }
+
+  fun setMintPhase(phase: SendPhase, error: String? = null) =
+    _state.update { it.copy(mintPhase = phase, errorMessage = error) }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
@@ -28,6 +28,8 @@ data class ForgeUiState(
   val harness: Harness = Harness.Tide,
   val mintPhase: SendPhase = SendPhase.Idle,
   val errorMessage: String? = null,
+  /** Clans the user already owns — disabled in step 1 (PickClan). */
+  val ownedClanIds: Set<Int> = emptySet(),
 )
 
 /**
@@ -51,14 +53,22 @@ class ForgeViewModel(
     val draftHarness = sessionStore?.getDraft(draftScope, "harness")
       ?.let { runCatching { Harness.valueOf(it) }.getOrNull() }
       ?: Harness.Tide
+    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore?.getOwnedClanIdsExtra().orEmpty()).toSet()
+    // If the persisted draftClan was a clan you've since acquired, drop
+    // it so step 1 doesn't preselect a now-disabled card.
+    val safeClanId = draftClan?.takeIf { it !in owned }
     return ForgeUiState(
-      clanId = draftClan,
+      clanId = safeClanId,
       sigilName = draftName,
       harness = draftHarness,
+      ownedClanIds = owned,
     )
   }
 
   fun setClanId(clanId: Int) {
+    // Defensive: ignore taps on already-owned clans (step 1 should already
+    // tap-disable them, but the VM is the source of truth).
+    if (clanId in _state.value.ownedClanIds) return
     _state.update { it.copy(clanId = clanId) }
     sessionStore?.setDraft(draftScope, "clanId", clanId.toString())
   }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
@@ -62,7 +62,7 @@ class HallViewModel(
   fun refresh() {
     viewModelScope.launch {
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
-      val ownedClanIds = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+      val ownedClanIds = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).distinct()
       runCatching {
         coroutineScope {
           ownedClanIds

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
@@ -46,15 +46,15 @@ data class HallCard(
  */
 class HallViewModel(
   private val convex: ClanWorldConvexClient,
-  sessionStore: SessionStore,
+  private val sessionStore: SessionStore,
 ) : ViewModel() {
 
-  private val _state = MutableStateFlow(initial(sessionStore))
+  private val _state = MutableStateFlow(initial())
   val state: StateFlow<HallUiState> = _state.asStateFlow()
 
   init { refresh() }
 
-  private fun initial(sessionStore: SessionStore): HallUiState {
+  private fun initial(): HallUiState {
     val s = sessionStore.read()
     return HallUiState(walletShort = s?.solanaPubkeyBase58?.shortenPubkey().orEmpty())
   }
@@ -62,9 +62,10 @@ class HallViewModel(
   fun refresh() {
     viewModelScope.launch {
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
+      val ownedClanIds = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
       runCatching {
         coroutineScope {
-          HearthViewModel.LINKED_CLAN_IDS
+          ownedClanIds
             .map { clanId -> async { runCatching { convex.getInftDemoState(clanId) }.getOrNull() to clanId } }
             .awaitAll()
         }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -58,7 +58,7 @@ class HearthViewModel(
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
       val session = sessionStore.read()
       val selectedClan = session?.selectedClanId ?: DEFAULT_LINKED_CLAN
-      val ownedClanIds = (LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).toSet()
+      val ownedClanIds = (LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).toSet()
       runCatching {
         val snap = convex.getSnapshot()
         val comms = runCatching { convex.getCombinedComms(selectedClan, limit = 3) }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -58,6 +58,7 @@ class HearthViewModel(
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
       val session = sessionStore.read()
       val selectedClan = session?.selectedClanId ?: DEFAULT_LINKED_CLAN
+      val ownedClanIds = (LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).toSet()
       runCatching {
         val snap = convex.getSnapshot()
         val comms = runCatching { convex.getCombinedComms(selectedClan, limit = 3) }
@@ -65,7 +66,7 @@ class HearthViewModel(
         snap to comms
       }.onSuccess { (snap, comms) ->
         _state.update { _ ->
-          project(snap, selectedClan, comms, session?.solanaPubkeyBase58.orEmpty())
+          project(snap, selectedClan, comms, session?.solanaPubkeyBase58.orEmpty(), ownedClanIds)
         }
       }.onFailure { e ->
         _state.update {
@@ -84,6 +85,7 @@ class HearthViewModel(
     selectedClanId: Int,
     comms: List<CombinedComm>,
     solanaPubkey: String,
+    ownedClanIds: Set<Int>,
   ): HearthUiState {
     // Sort clans by goldBalance (wei → whole), descending. Empty / null
     // gold goes last.
@@ -103,7 +105,7 @@ class HearthViewModel(
         tagline = clanTagline(p.clanId),
         gold = p.gold,
         delta = 0L, // no delta data in snapshot — keep at 0 for v0; UI shows "—"
-        isMine = LINKED_CLAN_IDS.contains(p.clanId),
+        isMine = ownedClanIds.contains(p.clanId),
       )
     }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
@@ -1,0 +1,46 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+enum class SendPhase { Idle, Signing, Queued, Failed }
+
+data class SteeringConsoleUiState(
+  val targetClanId: Int,
+  val draft: String = "",
+  val phase: SendPhase = SendPhase.Idle,
+  val errorMessage: String? = null,
+)
+
+/**
+ * Slice 4c: SteeringConsole. The owner's whisper composer — drafts a
+ * single-line steering message addressed to one of their elders.
+ *
+ * No real Convex mutation exists yet (per BUILD_PLAN — whisper send
+ * needs a backend mutation that doesn't exist). This view-model holds
+ * draft state; the screen handles the MWA sign + the (stubbed) send.
+ */
+class SteeringConsoleViewModel(
+  initialClanId: Int,
+) : ViewModel() {
+
+  private val _state = MutableStateFlow(
+    SteeringConsoleUiState(targetClanId = initialClanId),
+  )
+  val state: StateFlow<SteeringConsoleUiState> = _state.asStateFlow()
+
+  fun setDraft(text: String) {
+    _state.update { it.copy(draft = text) }
+  }
+
+  fun setTarget(clanId: Int) {
+    _state.update { it.copy(targetClanId = clanId) }
+  }
+
+  fun setPhase(p: SendPhase, error: String? = null) {
+    _state.update { it.copy(phase = p, errorMessage = error) }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import world.clan.app.data.SessionStore
 
 enum class SendPhase { Idle, Signing, Queued, Failed }
 
@@ -19,21 +20,31 @@ data class SteeringConsoleUiState(
  * Slice 4c: SteeringConsole. The owner's whisper composer — drafts a
  * single-line steering message addressed to one of their elders.
  *
+ * Drafts are persisted through process death via SessionStore (key
+ * "draft:steer:<clanId>"); cleared on successful submit (Queued phase).
+ *
  * No real Convex mutation exists yet (per BUILD_PLAN — whisper send
  * needs a backend mutation that doesn't exist). This view-model holds
  * draft state; the screen handles the MWA sign + the (stubbed) send.
  */
 class SteeringConsoleViewModel(
   initialClanId: Int,
+  private val sessionStore: SessionStore? = null,
 ) : ViewModel() {
 
+  private val draftScope = "steer:$initialClanId"
+
   private val _state = MutableStateFlow(
-    SteeringConsoleUiState(targetClanId = initialClanId),
+    SteeringConsoleUiState(
+      targetClanId = initialClanId,
+      draft = sessionStore?.getDraft(draftScope, "body").orEmpty(),
+    ),
   )
   val state: StateFlow<SteeringConsoleUiState> = _state.asStateFlow()
 
   fun setDraft(text: String) {
     _state.update { it.copy(draft = text) }
+    sessionStore?.setDraft(draftScope, "body", text)
   }
 
   fun setTarget(clanId: Int) {
@@ -42,5 +53,6 @@ class SteeringConsoleViewModel(
 
   fun setPhase(p: SendPhase, error: String? = null) {
     _state.update { it.copy(phase = p, errorMessage = error) }
+    if (p == SendPhase.Queued) sessionStore?.clearDrafts(draftScope)
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/StrategyEditorViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/StrategyEditorViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import world.clan.app.data.ClanWorldConvexClient
+import world.clan.app.data.SessionStore
 
 enum class Posture { Defensive, Balanced, Aggressive }
 
@@ -33,7 +34,10 @@ data class StrategyEditorUiState(
 class StrategyEditorViewModel(
   private val convex: ClanWorldConvexClient,
   clanId: Int,
+  private val sessionStore: SessionStore? = null,
 ) : ViewModel() {
+
+  private val draftScope = "strategy:$clanId"
 
   private val _state = MutableStateFlow(StrategyEditorUiState(clanId = clanId))
   val state: StateFlow<StrategyEditorUiState> = _state.asStateFlow()
@@ -42,14 +46,20 @@ class StrategyEditorViewModel(
 
   private fun hydrate(clanId: Int) {
     viewModelScope.launch {
+      val draftDoctrine = sessionStore?.getDraft(draftScope, "doctrine")
+      val draftPinned = sessionStore?.getDraft(draftScope, "pinnedKey")
+      val draftPosture = sessionStore?.getDraft(draftScope, "posture")
+        ?.let { runCatching { Posture.valueOf(it) }.getOrNull() }
+
       runCatching { convex.getInftDemoState(clanId) }
         .onSuccess { demo ->
           val firstMem = demo.memory.firstOrNull()
           _state.update {
             it.copy(
               isLoading = false,
-              doctrine = firstMem?.value?.take(180) ?: defaultDoctrine(clanId),
-              pinnedKey = firstMem?.key ?: "policy:default",
+              doctrine = draftDoctrine ?: firstMem?.value?.take(180) ?: defaultDoctrine(clanId),
+              pinnedKey = draftPinned ?: firstMem?.key ?: "policy:default",
+              posture = draftPosture ?: it.posture,
             )
           }
         }
@@ -57,19 +67,33 @@ class StrategyEditorViewModel(
           _state.update {
             it.copy(
               isLoading = false,
-              doctrine = defaultDoctrine(clanId),
-              pinnedKey = "policy:default",
+              doctrine = draftDoctrine ?: defaultDoctrine(clanId),
+              pinnedKey = draftPinned ?: "policy:default",
+              posture = draftPosture ?: it.posture,
             )
           }
         }
     }
   }
 
-  fun setPosture(p: Posture) = _state.update { it.copy(posture = p) }
-  fun setDoctrine(text: String) = _state.update { it.copy(doctrine = text.take(280)) }
-  fun setPinnedKey(text: String) = _state.update { it.copy(pinnedKey = text.take(64)) }
-  fun setSavePhase(phase: SendPhase, error: String? = null) =
+  fun setPosture(p: Posture) {
+    _state.update { it.copy(posture = p) }
+    sessionStore?.setDraft(draftScope, "posture", p.name)
+  }
+  fun setDoctrine(text: String) {
+    val capped = text.take(280)
+    _state.update { it.copy(doctrine = capped) }
+    sessionStore?.setDraft(draftScope, "doctrine", capped)
+  }
+  fun setPinnedKey(text: String) {
+    val capped = text.take(64)
+    _state.update { it.copy(pinnedKey = capped) }
+    sessionStore?.setDraft(draftScope, "pinnedKey", capped)
+  }
+  fun setSavePhase(phase: SendPhase, error: String? = null) {
     _state.update { it.copy(savePhase = phase, errorMessage = error) }
+    if (phase == SendPhase.Queued) sessionStore?.clearDrafts(draftScope)
+  }
 
   private fun defaultDoctrine(clanId: Int): String = when (clanId) {
     1 -> "Hold the high pass. Trade no ground without iron."

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/StrategyEditorViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/StrategyEditorViewModel.kt
@@ -1,0 +1,85 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import world.clan.app.data.ClanWorldConvexClient
+
+enum class Posture { Defensive, Balanced, Aggressive }
+
+data class StrategyEditorUiState(
+  val isLoading: Boolean = true,
+  val clanId: Int,
+  val posture: Posture = Posture.Balanced,
+  val doctrine: String = "",
+  val pinnedKey: String = "",
+  val savePhase: SendPhase = SendPhase.Idle,
+  val errorMessage: String? = null,
+)
+
+/**
+ * Slice 4c: per-iNFT strategy form.
+ *
+ * No real strategy mutation exists yet. We seed initial draft state from
+ * the clan's first memory entry (best-effort) and call sign-only on save,
+ * then surface a "Sealed" state for ~1.3s before pop. When the backend
+ * mutation lands, the only change is swapping the no-op send for a real
+ * convex.setStrategy(...) call inside the screen.
+ */
+class StrategyEditorViewModel(
+  private val convex: ClanWorldConvexClient,
+  clanId: Int,
+) : ViewModel() {
+
+  private val _state = MutableStateFlow(StrategyEditorUiState(clanId = clanId))
+  val state: StateFlow<StrategyEditorUiState> = _state.asStateFlow()
+
+  init { hydrate(clanId) }
+
+  private fun hydrate(clanId: Int) {
+    viewModelScope.launch {
+      runCatching { convex.getInftDemoState(clanId) }
+        .onSuccess { demo ->
+          val firstMem = demo.memory.firstOrNull()
+          _state.update {
+            it.copy(
+              isLoading = false,
+              doctrine = firstMem?.value?.take(180) ?: defaultDoctrine(clanId),
+              pinnedKey = firstMem?.key ?: "policy:default",
+            )
+          }
+        }
+        .onFailure {
+          _state.update {
+            it.copy(
+              isLoading = false,
+              doctrine = defaultDoctrine(clanId),
+              pinnedKey = "policy:default",
+            )
+          }
+        }
+    }
+  }
+
+  fun setPosture(p: Posture) = _state.update { it.copy(posture = p) }
+  fun setDoctrine(text: String) = _state.update { it.copy(doctrine = text.take(280)) }
+  fun setPinnedKey(text: String) = _state.update { it.copy(pinnedKey = text.take(64)) }
+  fun setSavePhase(phase: SendPhase, error: String? = null) =
+    _state.update { it.copy(savePhase = phase, errorMessage = error) }
+
+  private fun defaultDoctrine(clanId: Int): String = when (clanId) {
+    1 -> "Hold the high pass. Trade no ground without iron."
+    2 -> "Read the strait. Move only when both shores agree."
+    3 -> "Coin discipline first. Spend gold the way a hawk spends wing."
+    4 -> "Tend the green country. Refuse winter; outlast it."
+    5 -> "Watch the signs. The first move is rarely the right one."
+    6 -> "Forge before all. Steel pays for itself."
+    7 -> "The iron that holds. Build slow; break later."
+    8 -> "Walk the longer line. The season is a cipher; read it twice."
+    else -> "—"
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
@@ -1,0 +1,107 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import world.clan.app.data.ClanWorldConvexClient
+import world.clan.app.data.VaultMovement
+import world.clan.app.data.weiToWhole
+
+enum class TreasuryFilter { All, Gold, Resources }
+
+data class ResourceBalance(
+  val gold: Long,
+  val wood: Long,
+  val iron: Long,
+  val wheat: Long,
+  val fish: Long,
+)
+
+data class TreasuryUiState(
+  val isLoading: Boolean = true,
+  val clanId: Int,
+  val balance: ResourceBalance = ResourceBalance(0, 0, 0, 0, 0),
+  val movements: List<VaultMovement> = emptyList(),
+  val filter: TreasuryFilter = TreasuryFilter.All,
+  val errorMessage: String? = null,
+)
+
+/**
+ * Slice 5: per-clan Treasury.
+ *
+ * Aggregates two existing queries in parallel:
+ *   - getSnapshot — to read goldBalance / vaultWood / vaultIron / etc for THIS clan
+ *   - getVaultMovements — recent gains/spends/transfers
+ *
+ * Wei-precision balances (`String?` → `Long`) parsed via existing weiToWhole().
+ * Filtering is client-side over `movements`.
+ */
+class TreasuryViewModel(
+  private val convex: ClanWorldConvexClient,
+  private val clanId: Int,
+) : ViewModel() {
+
+  private val _state = MutableStateFlow(TreasuryUiState(clanId = clanId))
+  val state: StateFlow<TreasuryUiState> = _state.asStateFlow()
+
+  init { refresh() }
+
+  fun refresh() {
+    viewModelScope.launch {
+      _state.update { it.copy(isLoading = true, errorMessage = null) }
+      runCatching {
+        coroutineScope {
+          val snap = async { convex.getSnapshot() }
+          val moves = async {
+            runCatching { convex.getVaultMovements(clanId, limit = 24) }
+              .getOrDefault(emptyList())
+          }
+          snap.await() to moves.await()
+        }
+      }
+        .onSuccess { (snapshot, moves) ->
+          val mine = snapshot.clans.firstOrNull { it.id.toIntOrNull() == clanId }
+          val bal = if (mine == null) ResourceBalance(0, 0, 0, 0, 0)
+          else ResourceBalance(
+            gold = mine.goldBalance.weiToWhole(),
+            wood = mine.vaultWood.weiToWhole(),
+            iron = mine.vaultIron.weiToWhole(),
+            wheat = mine.vaultWheat.weiToWhole(),
+            fish = mine.vaultFish.weiToWhole(),
+          )
+          _state.update {
+            it.copy(
+              isLoading = false,
+              balance = bal,
+              movements = moves,
+              errorMessage = null,
+            )
+          }
+        }
+        .onFailure { e ->
+          _state.update {
+            it.copy(
+              isLoading = false,
+              errorMessage = e.message ?: "Failed to load treasury.",
+            )
+          }
+        }
+    }
+  }
+
+  fun setFilter(f: TreasuryFilter) {
+    _state.update { it.copy(filter = f) }
+  }
+}
+
+fun TreasuryUiState.filteredMovements(): List<VaultMovement> = when (filter) {
+  TreasuryFilter.All -> movements
+  TreasuryFilter.Gold -> movements.filter { it.resource == "gold" }
+  TreasuryFilter.Resources -> movements.filter { it.resource != "gold" }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/WhispersViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/WhispersViewModel.kt
@@ -1,0 +1,70 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import world.clan.app.data.ClanWorldConvexClient
+import world.clan.app.data.CombinedComm
+
+enum class WhispersFilter { All, Whisper, Orch, Human }
+
+data class WhispersUiState(
+  val isLoading: Boolean = true,
+  val items: List<CombinedComm> = emptyList(),
+  val filter: WhispersFilter = WhispersFilter.All,
+  val errorMessage: String? = null,
+)
+
+/**
+ * Inbox view-model for the per-clan whispers screen. Reuses the existing
+ * `comms:getCombinedComms` query — no new server-side surface needed.
+ *
+ * Filtering is client-side: the server returns the combined feed and the
+ * filter chips just slice the local list.
+ */
+class WhispersViewModel(
+  private val convex: ClanWorldConvexClient,
+  private val clanId: Int,
+) : ViewModel() {
+
+  private val _state = MutableStateFlow(WhispersUiState())
+  val state: StateFlow<WhispersUiState> = _state.asStateFlow()
+
+  init { refresh() }
+
+  fun refresh() {
+    viewModelScope.launch {
+      _state.update { it.copy(isLoading = true, errorMessage = null) }
+      runCatching { convex.getCombinedComms(clanId, limit = 80) }
+        .onSuccess { comms ->
+          _state.update {
+            it.copy(isLoading = false, items = comms, errorMessage = null)
+          }
+        }
+        .onFailure { e ->
+          _state.update {
+            it.copy(
+              isLoading = false,
+              errorMessage = e.message ?: "Failed to load whispers.",
+            )
+          }
+        }
+    }
+  }
+
+  fun setFilter(f: WhispersFilter) {
+    _state.update { it.copy(filter = f) }
+  }
+}
+
+/** Apply the active filter to the loaded items. */
+fun WhispersUiState.filtered(): List<CombinedComm> = when (filter) {
+  WhispersFilter.All -> items
+  WhispersFilter.Whisper -> items.filter { it.kind == "whisper" }
+  WhispersFilter.Orch -> items.filter { it.kind == "orch" }
+  WhispersFilter.Human -> items.filter { it.kind == "human" }
+}

--- a/apps/clan-world-mobile/app/src/main/res/drawable/ui_tab_bazaar.xml
+++ b/apps/clan-world-mobile/app/src/main/res/drawable/ui_tab_bazaar.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <!-- merchant scales — beam + two pans + center post -->
+    <path android:strokeColor="#FFFFFF" android:strokeWidth="1.4"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M12,4 V20 M5,20 H19 M4,7 H20 M9,5.6 L15,5.6"/>
+    <!-- left pan -->
+    <path android:strokeColor="#FFFFFF" android:strokeWidth="1.4"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M3,11 L7,11 M3,11 a4,4 0 0 0 4,0 z"/>
+    <!-- right pan -->
+    <path android:strokeColor="#FFFFFF" android:strokeWidth="1.4"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M17,11 L21,11 M17,11 a4,4 0 0 0 4,0 z"/>
+</vector>

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -693,7 +693,8 @@ export const pollLogs = internalAction({
     return await ctx.runMutation(indexerApi.ingestEvents, {
       events,
       blockNumber: Number(toBlock),
-      txHash: events.at(-1)?.transactionHash ?? checkpoint?.lastTxHash,
+      txHash:
+        events[events.length - 1]?.transactionHash ?? checkpoint?.lastTxHash,
       advanceCheckpoint: true,
     });
   },
@@ -703,5 +704,23 @@ export const readCheckpoint = internalQuery({
   args: {},
   handler: async (ctx) => {
     return await ctx.db.query("eventCheckpoint").first();
+  },
+});
+
+/**
+ * Demo-day operational reset. Used after redeploying the diamond at a new
+ * address to point the indexer at a block just before the new deployment so
+ * pollLogs backfills the new diamond's events instead of stale ones.
+ */
+export const resetCheckpoint = internalMutation({
+  args: { lastBlock: v.number() },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.query("eventCheckpoint").first();
+    if (existing) await ctx.db.delete(existing._id);
+    await ctx.db.insert("eventCheckpoint", {
+      lastBlock: args.lastBlock,
+      lastSeenAt: Date.now(),
+    });
+    return { lastBlock: args.lastBlock };
   },
 });

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -923,6 +923,10 @@ export function WorldMap() {
       clan: ClanDef;
       baseY: number;
       phaseOffset: number;
+      /** Natural scale.y captured at relayout (after sprite.height = baseSize).
+       *  Breathing animation multiplies this — never assigns scale.y directly,
+       *  which would clobber the height-fit ratio and stretch bases ~3x tall. */
+      baseScaleY: number;
     }[];
     /** Floating "Lv N" badge beside each base. */
     levelBadges: { bg: Graphics; label: Text; clan: ClanDef }[];
@@ -1498,11 +1502,14 @@ export function WorldMap() {
             // the painted rooflines. phaseOffset keeps bases out of sync.
             // zIndex is already set during relayout (base.baseY is static between
             // relayouts), so no need to reassign each tick.
-            const scaleY = 1 + Math.sin((now + base.phaseOffset) * Math.PI / 2000) * 0.03;
+            // IMPORTANT: multiply by baseScaleY (the natural scale captured at
+            // relayout). Setting scale.y directly would clobber the
+            // sprite.height=baseSize sizing and stretch the sprite ~3x tall.
+            const breath = 1 + Math.sin((now + base.phaseOffset) * Math.PI / 2000) * 0.03;
             if (base.sprite) {
-              base.sprite.scale.y = scaleY;
+              base.sprite.scale.y = base.baseScaleY * breath;
             } else {
-              base.fallback.scale.y = scaleY;
+              base.fallback.scale.y = base.baseScaleY * breath;
             }
           });
           updateLiveClansmanPositions();
@@ -1769,6 +1776,10 @@ export function WorldMap() {
         clan: ClanDef;
         baseY: number;
         phaseOffset: number;
+        // Natural scale.y at relayout, BEFORE breathing animation. The breathing
+        // tick multiplies this — without it, scale.y would clobber the
+        // sprite.height=baseSize sizing and stretch the base ~3x tall.
+        baseScaleY: number;
       } = {
         container,
         sprite: null,
@@ -1777,6 +1788,7 @@ export function WorldMap() {
         clan,
         baseY: 0,
         phaseOffset: 0,
+        baseScaleY: 1,
       };
       drawn.bases.push(entry);
 
@@ -2566,6 +2578,14 @@ export function WorldMap() {
           sprite.x = 0;
           sprite.y = 0; // anchor=bottom-center; parent sits slightly below region center
           sprite.alpha = 1;
+          // Cache the natural scale.y so the breathing tick can multiply, not
+          // clobber. sprite.height = baseSize internally sets scale.y to
+          // baseSize/texture.height (often ~0.3-0.5); the breathing animation
+          // must preserve that ratio.
+          entry.baseScaleY = sprite.scale.y;
+        } else {
+          // Fallback Graphics is drawn at native coords (scale.y === 1).
+          entry.baseScaleY = 1;
         }
         glow.clear();
         glow.circle(0, -baseSize * 0.8, Math.max(6, 8 * cappedSizeScale));

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -86,6 +86,487 @@ export interface Deps {
   chain: IChainClient;
 }
 
+// ---------------------------------------------------------------------------
+// Help text
+//
+// Hand-rolled (per packages/agents/AGENTS.md "Argv parsing is hand-rolled (no
+// commander), keep deps minimal"). Each subcommand has its own help block so
+// `elder <cmd> --help` prints the same level of detail as `elder --help`.
+// ---------------------------------------------------------------------------
+
+const TOP_LEVEL_HELP = `elder — Clan World CLI for Elder agents
+
+USAGE:
+  elder <command> [...]
+
+COMMANDS:
+  world snapshot                              Read current world state (tick, season, all clans)
+  clan view <clanId>                          Read full state of one clan (resources, clansmen, missions)
+  clan submit-orders <ordersJsonFile>         Submit pending mission orders for your clan
+  memory recall <topic>                       Read your saved memory by key
+  memory save <key> <value>                   Persist memory across context wipes
+  peer whisper <toClanId> <msg>               Send a whisper to another clan's inbox
+  peer inbox                                  Read your unread whispers
+  ack-clear                                   Signal runner you're ready for context wipe
+  rules                                       Print game rules + capacity constants + action codes
+
+OPTIONS:
+  --help, -h                                  Show help for a command
+  --version, -v                               Show CLI version
+
+EXAMPLES:
+  elder world snapshot
+  elder clan view 1
+  elder clan submit-orders /tmp/my-orders.json
+  elder memory save active-strategy "T19. Food-first; trade iron for wheat with clan 4."
+  elder peer whisper 2 "Iron-for-wheat at 1:2, T20+. Confirm?"
+  elder rules
+
+For per-command help: elder <command> --help
+`;
+
+const SUBMIT_ORDERS_HELP = `elder clan submit-orders <ordersJsonFile>
+
+Submit pending mission orders for your clan. Reads orders from a JSON file.
+
+JSON SCHEMA:
+{
+  "clanId": "<your clan ID as string>",
+  "orders": [
+    {
+      "kind": "mission",                        // REQUIRED. Wave 0 only supports "mission".
+      "payload": {                              // REQUIRED nested object — fields below.
+        "clansmanId": <number>,                 // 1..N within your clan
+        "gotoRegion": <number>,                 // destination region 0..8 (see 'elder rules')
+        "action": <number>,                     // ACTION_CODE 1..14 (see 'elder rules')
+        "targetClanId": <number>,               // (optional, for DefendBase/combat; default 0)
+        "marketToken": "<address>",             // (optional, for MarketBuy; default zero address)
+        "marketAmount": "<bigint string>",      // (optional, for MarketSell; default "0")
+        "maxGoldIn": "<bigint string>",         // (optional, for MarketBuy; default "0")
+        "withdrawResources": {                  // (optional, for WithdrawResources; default all "0")
+          "wood": "<bigint string>",
+          "iron": "<bigint string>",
+          "wheat": "<bigint string>",
+          "fish": "<bigint string>"
+        }
+      }
+    }
+  ]
+}
+
+EXAMPLES:
+
+1. Send clansman 1 to Forest (region 1) to chop wood (action 1 = ChopWood):
+
+   cat > /tmp/orders.json <<'EOF'
+   {
+     "clanId": "1",
+     "orders": [
+       { "kind": "mission",
+         "payload": { "clansmanId": 1, "gotoRegion": 1, "action": 1 } }
+     ]
+   }
+   EOF
+   elder clan submit-orders /tmp/orders.json
+
+2. Send clansman 1 home to deposit (action 6 = DepositResources). Use your clan's
+   home base region as gotoRegion:
+
+   cat > /tmp/deposit.json <<'EOF'
+   {
+     "clanId": "1",
+     "orders": [
+       { "kind": "mission",
+         "payload": { "clansmanId": 1, "gotoRegion": 1, "action": 6 } }
+     ]
+   }
+   EOF
+   elder clan submit-orders /tmp/deposit.json
+
+3. Submit four missions in one call (one per clansman, four resources):
+
+   cat > /tmp/spread.json <<'EOF'
+   {
+     "clanId": "1",
+     "orders": [
+       { "kind": "mission", "payload": { "clansmanId": 1, "gotoRegion": 1, "action": 1 } },
+       { "kind": "mission", "payload": { "clansmanId": 2, "gotoRegion": 2, "action": 2 } },
+       { "kind": "mission", "payload": { "clansmanId": 3, "gotoRegion": 4, "action": 5 } },
+       { "kind": "mission", "payload": { "clansmanId": 4, "gotoRegion": 6, "action": 3 } }
+     ]
+   }
+   EOF
+   elder clan submit-orders /tmp/spread.json
+
+COMMON ERRORS:
+  "missing required payload fields (clansmanId, gotoRegion, action)"
+        payload is REQUIRED. Don't put fields at the top level — wrap in
+        "payload": { ... }.
+
+  "no valid mission orders to submit"
+        all orders had kind != "mission". Set kind: "mission".
+
+  "Cannot destructure 'clansmanId' of 'order.payload' as it is undefined"
+        payload key was missing entirely. Wrap fields in payload: { ... }.
+
+  "ClanWorld: clan dead"
+        your clan is dead this season. Try \`elder world snapshot\` to confirm
+        season state and your ClanState.
+
+  "Wave 0 only supports 'mission' kind, N skipped"
+        non-mission orders are silently dropped today.
+
+See \`elder rules\` for the full action-code table and region map.
+`;
+
+const WORLD_SNAPSHOT_HELP = `elder world snapshot
+
+Read the current world state. Returns JSON to stdout containing:
+  - tick (current tick number)
+  - tickEpoch (when the current tick started + tick duration)
+  - regions (all regions with owners)
+  - clans (all clans with treasury / state)
+
+EXAMPLES:
+  elder world snapshot
+  elder world snapshot | jq '.tick'
+`;
+
+const CLAN_VIEW_HELP = `elder clan view <clanId>
+
+Read full chain state of one clan. Returns JSON to stdout containing:
+  - clan (id, name, treasury, ClanState — ACTIVE or DEAD)
+  - controlledRegions (regions this clan owns / occupies)
+  - pendingOrders (orders submitted for the next tick)
+  - whispers (recent inbound whispers from peers)
+
+EXAMPLES:
+  elder clan view 1
+  elder clan view 1 | jq '.clan.treasury'
+`;
+
+const MEMORY_RECALL_HELP = `elder memory recall <topic>
+
+Read a saved memory entry by key. Memory is local to your elder process and
+persists across context wipes. Requires ELDER_N env var.
+
+EXAMPLES:
+  elder memory recall active-strategy
+  elder memory recall trade-partners
+`;
+
+const MEMORY_SAVE_HELP = `elder memory save <key> <value...>
+
+Persist a memory entry across context wipes. The value can be multiple words —
+they are joined with single spaces. Requires ELDER_N env var.
+
+EXAMPLES:
+  elder memory save active-strategy "T19. Food-first; trade iron for wheat with clan 4."
+  elder memory save trade-partners "clan-2 (iron->wheat 1:2), clan-4 (wood->fish 1:1)"
+`;
+
+const PEER_WHISPER_HELP = `elder peer whisper <toClanId> <msg...>
+
+Send a whisper to another clan's inbox. The msg can be multiple words; they are
+joined with single spaces and stored as a single message. Requires ELDER_N env
+var (used as the sender ID).
+
+EXAMPLES:
+  elder peer whisper 2 "Iron-for-wheat at 1:2, T20+. Confirm?"
+  elder peer whisper 4 "Defending east farms this tick — keep clansmen home."
+
+NOTE:
+  Whisper writes to elder-<toClanId>.jsonl. Inbox reads by ELDER_N. Round-trip
+  works only when clanId == String(ELDER_N) (S2 default 1:1 mapping). See
+  issue #94.
+`;
+
+const PEER_INBOX_HELP = `elder peer inbox
+
+Read all unread whispers in your inbox. Requires ELDER_N env var. Output is one
+line per whisper:
+
+  [<iso-ts>] from=<senderElderN> to=<recipientClanId>: <msg>
+
+EXAMPLES:
+  elder peer inbox
+`;
+
+const ACK_CLEAR_HELP = `elder ack-clear
+
+Signal the runner that you've finished processing this tick and are ready for a
+context wipe. Writes a flag file at ~/.world/clanworld-runner/state/elder-<N>-ack.flag.
+Requires ELDER_N env var.
+
+EXAMPLES:
+  elder ack-clear
+`;
+
+const RULES_HELP = `elder rules
+
+Print canonical game rules + capacity constants + action codes. Read this once
+on first boot and after any rule change.
+
+EXAMPLES:
+  elder rules
+  elder rules | grep -A5 'ACTION CODES'
+`;
+
+const SUBCOMMAND_HELP: Record<string, string> = {
+  'world snapshot': WORLD_SNAPSHOT_HELP,
+  'clan view': CLAN_VIEW_HELP,
+  'clan submit-orders': SUBMIT_ORDERS_HELP,
+  'memory recall': MEMORY_RECALL_HELP,
+  'memory save': MEMORY_SAVE_HELP,
+  'peer whisper': PEER_WHISPER_HELP,
+  'peer inbox': PEER_INBOX_HELP,
+  'ack-clear': ACK_CLEAR_HELP,
+  rules: RULES_HELP,
+  // also handle bare-namespace help
+  world: WORLD_SNAPSHOT_HELP,
+  clan: `elder clan <subcommand>
+
+Subcommands:
+  view <clanId>                        Read full state of one clan
+  submit-orders <ordersJsonFile>       Submit pending mission orders
+
+For per-subcommand help: elder clan <subcommand> --help
+`,
+  memory: `elder memory <subcommand>
+
+Subcommands:
+  recall <topic>                       Read saved memory by key
+  save <key> <value...>                Persist memory across context wipes
+
+For per-subcommand help: elder memory <subcommand> --help
+`,
+  peer: `elder peer <subcommand>
+
+Subcommands:
+  whisper <toClanId> <msg...>          Send whisper to another clan
+  inbox                                Read your unread whispers
+
+For per-subcommand help: elder peer <subcommand> --help
+`,
+};
+
+// ---------------------------------------------------------------------------
+// Rules text — canonical game rules.
+//
+// Values are sourced from packages/shared/src/generated/constants.ts (which is
+// generated from packages/contracts/src/diamond/lib/Lib*.sol via
+// scripts/gen-constants.mjs). When constants change, this text drifts; future
+// improvement is to import them at runtime, but for hackathon we hardcode +
+// reference the canonical source here.
+//
+// Action codes mirror packages/shared/src/generated/enums.ts (ActionType).
+// Region codes mirror generated/constants.ts (REGION_*).
+// ---------------------------------------------------------------------------
+
+const RULES_TEXT = `CLAN WORLD — RULES & CONSTANTS
+(canonical source: packages/shared/src/generated/{enums,constants}.ts)
+
+================================================================
+ACTION CODES (set as 'action' field in mission payload)
+================================================================
+  0  = None                  (no-op; do not submit)
+  1  = ChopWood              gather wood from a forest region
+  2  = MineIron              gather iron from a mountain region
+  3  = FishDocks             fish from a docks region (lower yield, safer)
+  4  = FishDeepSea           fish from deep sea (higher yield, riskier)
+  5  = HarvestWheat          harvest a wheat plot in a farm region
+  6  = DepositResources      drop carried resources into your clan vault
+                             (must travel to your home base first)
+  7  = UpgradeWall           spend wood/iron at home base to upgrade wall
+  8  = UpgradeBase           spend wood/iron/wheat at home base to upgrade
+  9  = UpgradeMonument       spend wood/iron/wheat/blueprint to upgrade monument
+                             (UNICORN TOWN only)
+  10 = DefendBase            stand on home base to defend vs. bandits
+                             (set targetClanId for cross-clan defense; 0 = self)
+  11 = MarketBuy             buy gold-token at Unicorn Town
+                             (set marketToken + maxGoldIn)
+  12 = MarketSell            sell resource at Unicorn Town
+                             (set marketAmount)
+  13 = Wait                  remain in current region (no action)
+  14 = WithdrawResources     withdraw from clan vault to clansman's wheelbarrow
+                             (must be at home base; set withdrawResources)
+
+================================================================
+REGION CODES (set as 'gotoRegion' field in mission payload)
+================================================================
+  0 = REGION_NOOP            (sentinel — do not travel)
+  1 = Forest                 ChopWood (action 1)
+  2 = Mountains              MineIron (action 2)
+  3 = Unicorn Town           Market actions (11/12), monument (9)
+  4 = West Farms             HarvestWheat (action 5)
+  5 = East Farms             HarvestWheat (action 5)
+  6 = West Docks             FishDocks (action 3)
+  7 = East Docks             FishDocks (action 3)
+  8 = Deep Sea               FishDeepSea (action 4)
+
+NOTE: each clan also has a home-base region used as gotoRegion for
+DepositResources / UpgradeBase / DefendBase / WithdrawResources. Read your
+home base from \`elder clan view <clanId>\` (controlledRegions[0] or similar).
+
+================================================================
+WHEELBARROW & VAULT CAPACITIES
+================================================================
+  CLANSMAN_CARRY_CAP   =  10 (per resource — clansman wheelbarrow limit)
+  WOOD_CAP             =  15 (clan vault wood cap)
+  IRON_CAP             =   5 (clan vault iron cap)
+  WHEAT_CAP            =  40 (clan vault wheat cap)
+  FISH_CAP             =   8 (clan vault fish cap)
+
+(All caps are in tokens — i.e. divided by 1e18 from the on-chain wei value.)
+
+================================================================
+RESOURCE YIELDS (per tick of work)
+================================================================
+  WOOD_YIELD_PER_TICK    = 1     (per ChopWood tick)
+  WOOD_CRIT_BPS          = 1000  (10% chance of crit; doubles tick yield)
+  IRON_BASE_YIELD        = 0.5   (per MineIron tick)
+  WHEAT_YIELD_PER_TICK   = 5     (per HarvestWheat tick)
+  FISH_YIELD_PER_TICK    = 0.25  (base; modified by docks/deep-sea bps below)
+  FISH_DOCKS_BPS         = 2500  (25% multiplier at docks)
+  FISH_DEEP_BPS          = 7500  (75% multiplier at deep sea)
+
+(All yields in tokens — divide on-chain value by 1e18.)
+
+================================================================
+TIMING
+================================================================
+  HEARTBEAT_INTERVAL_SECONDS = 60   (one tick = ~60s real time)
+  CLANSMAN_COOLDOWN_SECONDS  = 60   (after action, clansman idles 1 tick)
+  WHEAT_PLOT_REGROW_TICKS    = 4    (a plot you harvested regrows in 4 ticks)
+  Travel time:                       quoteTravel(src, dst) returns travelTicks.
+                                     Use \`elder clan view <clanId>\` to read
+                                     each clansman's current region first.
+
+================================================================
+SEASON & WINTER
+================================================================
+  SEASON_DURATION_TICKS         = 360
+  WINTER_START_TICK             = 110  (relative to season start)
+  WINTER_DURATION_TICKS         = 10
+  WINTER_PERIOD_TICKS           = 110  (winter recurs every N ticks)
+  WHEAT_UPKEEP_PER_CLANSMAN     = 1    (per tick — clansmen eat wheat)
+  FISH_UPKEEP_PER_CLANSMAN      = 0.1  (per tick — alt food source)
+  WINTER_WOOD_BURN_PER_CLANSMAN = 0.5  (per tick during winter)
+  WINTER_WOOD_BURN_PER_BASE     = 1    (per tick during winter)
+  WINTER_UPKEEP_MULTIPLIER_BPS  = 20000 (winter doubles upkeep)
+  COLD_DAMAGE_PER_WALL_DEGRADATION = 2  (cold ticks per wall degrade)
+  COLD_DAMAGE_PER_CLANSMAN_DEATH   = 2  (cold ticks per clansman death)
+
+================================================================
+BANDITS
+================================================================
+  BANDIT_COOLDOWN_TICKS         = 10
+  BANDIT_CAMP_TICKS             = 3   (bandit camps for N ticks before attacking)
+  BANDIT_REST_TICKS             = 2   (rest between attacks)
+  BANDIT_MAX_ATTACK_ATTEMPTS    = 6
+  BANDIT_BASE_STEAL_BPS         = 2000 (steal 20% on success)
+  BANDIT_DROP_TO_DEFENDERS_BPS  = 5000 (defenders recover 50% on kill)
+
+================================================================
+COMMON PATTERNS
+================================================================
+
+1. Gather wood (or iron / wheat / fish):
+   - Send clansman to a region matching the action.
+   - Wait until wheelbarrow is full (CLANSMAN_CARRY_CAP / yield-per-tick ticks).
+   - Send the same clansman home (action 6 = DepositResources, gotoRegion = home).
+   - Repeat.
+
+2. Trade iron for wheat with peer clan:
+   - elder peer whisper <peer> "iron-for-wheat at 1:2, T20+. Confirm?"
+   - When peer confirms, both submit MarketSell + MarketBuy at Unicorn Town
+     (region 3) with the agreed marketToken + amount.
+
+3. Defend against bandits:
+   - When \`elder world snapshot\` shows bandit near your region, submit
+     action 10 (DefendBase) with your home base as gotoRegion. targetClanId=0
+     means defend self.
+
+================================================================
+CLAN DEATH CONDITIONS
+================================================================
+  - Starvation: clan vault wheat + fish runs out during upkeep.
+  - Cold: insufficient wood during winter -> wall degrades -> clansmen die.
+  - Settlement: lose all clansmen.
+  - Once dead (ClanState=DEAD, code 1) you cannot submit orders this season.
+
+================================================================
+ERROR CODES (from generated/enums.ts StatusCode)
+================================================================
+  0  = OK                      success
+  1  = ERR_CLAN_DEAD           your clan is dead this season
+  2  = ERR_CLAN_NOT_OWNED      clansman not owned by submitter
+  3  = ERR_CLANSMAN_DEAD
+  4  = ERR_INVALID_CLANSMAN
+  5  = ERR_INVALID_REGION
+  6  = ERR_INVALID_ACTION
+  7  = ERR_INVALID_TARGET
+  8  = ERR_COOLDOWN_ACTIVE     clansman acted last tick; wait 1 tick
+  9  = ERR_NOT_WAITING         clansman is mid-action / mid-travel
+  10 = ERR_NOT_IN_UNICORN_TOWN MarketBuy/Sell requires region 3
+  11 = ERR_NOT_AT_HOMEBASE     DepositResources/UpgradeBase need home region
+  12 = ERR_NOT_AT_TARGET_BASE
+  13 = ERR_NOT_DEFENDABLE
+  14 = ERR_MISSING_RESOURCES
+  15 = ERR_EMPTY_CARGO         DepositResources with empty wheelbarrow
+  16 = ERR_PLOT_NOT_READY      wheat plot still regrowing
+  17 = ERR_PLOT_EMPTY
+  18 = ERR_MARKET_ZERO_AMOUNT
+  19 = ERR_MARKET_UNSUPPORTED_TOKEN
+  20 = ERR_IMMEDIATE_MARKET_NOT_ELIGIBLE
+  21 = ERR_MARKET_BUY_OVER_CAPACITY
+  22 = ERR_MAX_GOLD_IN_EXCEEDED
+  23 = ERR_WORLD_TICK_MISMATCH
+  24 = ERR_NO_ACTIVE_BANDIT
+  25 = ERR_SEASON_ENDED
+  26 = ERR_NOT_ENOUGH_GOLD
+  27 = ERR_CARRY_FULL          wheelbarrow already full; deposit first
+  28 = ERR_WINTER_LOCKED       wheat plots locked during winter
+  29 = ERR_MUST_SETTLE_FIRST
+  30 = ERR_LIQUIDITY_INSUFFICIENT
+  31 = ERR_SLIPPAGE_REQUIRED
+`;
+
+// ---------------------------------------------------------------------------
+// Argv parsing — detect --help / -h before positional consumption.
+// ---------------------------------------------------------------------------
+
+function isHelpFlag(arg: string | undefined): boolean {
+  return arg === '--help' || arg === '-h';
+}
+
+function isVersionFlag(arg: string | undefined): boolean {
+  return arg === '--version' || arg === '-v';
+}
+
+/**
+ * Inspect argv for a --help/-h flag in any position. Returns the help text for
+ * the matched (sub)command, or undefined if no help was requested.
+ *
+ * Must be called BEFORE positional consumption so `--help` is never mistaken
+ * for an `<ordersJsonFile>` (the bug elder-1 hit).
+ */
+export function resolveHelp(args: string[]): string | undefined {
+  const hasHelpFlag = args.some(isHelpFlag);
+  if (!hasHelpFlag && args.length === 0) return TOP_LEVEL_HELP;
+  if (!hasHelpFlag) return undefined;
+
+  const positional = args.filter((a) => !a.startsWith('-'));
+  if (positional.length === 0) return TOP_LEVEL_HELP;
+
+  // try two-word match (e.g. "clan submit-orders") then one-word
+  const two = positional.slice(0, 2).join(' ');
+  if (SUBCOMMAND_HELP[two]) return SUBCOMMAND_HELP[two];
+  const one = positional[0];
+  if (SUBCOMMAND_HELP[one]) return SUBCOMMAND_HELP[one];
+  return TOP_LEVEL_HELP;
+}
+
 export async function runCommand(
   ns: string | undefined,
   cmd: string | undefined,
@@ -187,6 +668,10 @@ export async function runCommand(
     return 'ack cleared\n';
   }
 
+  if (ns === 'rules') {
+    return RULES_TEXT;
+  }
+
   throw new UsageError(
     'usage:\n' +
       '  elder world snapshot\n' +
@@ -196,12 +681,42 @@ export async function runCommand(
       '  elder memory save <key> <value>\n' +
       '  elder peer whisper <clanId> <msg>\n' +
       '  elder peer inbox\n' +
-      '  elder ack-clear\n',
+      '  elder ack-clear\n' +
+      '  elder rules\n' +
+      '\nFor full help: elder --help\n',
   );
 }
 
+async function readPackageVersion(): Promise<string> {
+  // package.json sits two levels up from src/cli.ts
+  try {
+    const pkgPath = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
 async function main(argv: string[]): Promise<void> {
-  const [, , ns, cmd, ...rest] = argv;
+  const args = argv.slice(2);
+
+  // Pre-parse --help / -h BEFORE positional consumption (this is the bug
+  // elder-1 hit: `elder clan submit-orders --help` tried to read --help as a
+  // file path).
+  const help = resolveHelp(args);
+  if (help !== undefined) {
+    process.stdout.write(help);
+    return;
+  }
+
+  if (args.some(isVersionFlag)) {
+    const v = await readPackageVersion();
+    process.stdout.write(`elder ${v}\n`);
+    return;
+  }
+
+  const [ns, cmd, ...rest] = args;
   const deps: Deps = {
     convex: createConvexClient(),
     chain: createChainClient(),

--- a/packages/agents/test/cli.test.ts
+++ b/packages/agents/test/cli.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { IConvexClient, IChainClient } from '@clan-world/shared/adapters';
 import type { WorldSnapshot, ClanFullView, Whisper, Tick } from '@clan-world/shared';
-import { runCommand, UsageError, inboxFile, recipientInboxFile, ackFile } from '../src/cli.js';
+import { runCommand, UsageError, inboxFile, recipientInboxFile, ackFile, resolveHelp } from '../src/cli.js';
 
 // ---------------------------------------------------------------------------
 // Stub data
@@ -270,6 +270,109 @@ describe('unknown command', () => {
       expect(err).toBeInstanceOf(UsageError);
       expect((err as UsageError).message).toContain('usage:');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rules subcommand
+// ---------------------------------------------------------------------------
+
+describe('rules subcommand', () => {
+  it('returns rules text containing canonical action codes', async () => {
+    const out = await runCommand('rules', undefined, [], deps, {}, tmpDir);
+    expect(out).toContain('ACTION CODES');
+    expect(out).toContain('1  = ChopWood');
+    expect(out).toContain('6  = DepositResources');
+    expect(out).toContain('14 = WithdrawResources');
+  });
+
+  it('rules text references the generated source file', async () => {
+    const out = await runCommand('rules', undefined, [], deps, {}, tmpDir);
+    expect(out).toContain('generated/');
+  });
+
+  it('rules text covers regions, capacities, timing, error codes', async () => {
+    const out = await runCommand('rules', undefined, [], deps, {}, tmpDir);
+    expect(out).toContain('REGION CODES');
+    expect(out).toContain('Forest');
+    expect(out).toContain('CLANSMAN_CARRY_CAP');
+    expect(out).toContain('SEASON_DURATION_TICKS');
+    expect(out).toContain('ERR_CLAN_DEAD');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveHelp — argv parsing for --help / -h before positional consumption
+// ---------------------------------------------------------------------------
+
+describe('resolveHelp', () => {
+  it('returns top-level help for empty argv', () => {
+    const out = resolveHelp([]);
+    expect(out).toBeDefined();
+    expect(out).toContain('elder — Clan World CLI for Elder agents');
+    expect(out).toContain('clan submit-orders');
+  });
+
+  it('returns top-level help for --help', () => {
+    expect(resolveHelp(['--help'])).toContain('Clan World CLI for Elder agents');
+  });
+
+  it('returns top-level help for -h', () => {
+    expect(resolveHelp(['-h'])).toContain('Clan World CLI for Elder agents');
+  });
+
+  it('returns submit-orders help for `clan submit-orders --help` (the bug elder-1 hit)', () => {
+    const out = resolveHelp(['clan', 'submit-orders', '--help']);
+    expect(out).toBeDefined();
+    expect(out).toContain('elder clan submit-orders <ordersJsonFile>');
+    expect(out).toContain('JSON SCHEMA');
+    expect(out).toContain('"kind": "mission"');
+    expect(out).toContain('"payload":');
+    expect(out).toContain('clansmanId');
+    expect(out).toContain('COMMON ERRORS');
+  });
+
+  it('returns clan-namespace help for `clan --help`', () => {
+    const out = resolveHelp(['clan', '--help']);
+    expect(out).toBeDefined();
+    expect(out).toContain('elder clan <subcommand>');
+  });
+
+  it('returns world-snapshot help for `world snapshot --help`', () => {
+    const out = resolveHelp(['world', 'snapshot', '--help']);
+    expect(out).toBeDefined();
+    expect(out).toContain('elder world snapshot');
+    expect(out).toContain('tick');
+  });
+
+  it('returns rules help for `rules --help`', () => {
+    const out = resolveHelp(['rules', '--help']);
+    expect(out).toBeDefined();
+    expect(out).toContain('elder rules');
+  });
+
+  it('returns peer-whisper help for `peer whisper --help`', () => {
+    const out = resolveHelp(['peer', 'whisper', '--help']);
+    expect(out).toBeDefined();
+    expect(out).toContain('elder peer whisper');
+  });
+
+  it('returns memory-save help for `memory save --help`', () => {
+    const out = resolveHelp(['memory', 'save', '--help']);
+    expect(out).toBeDefined();
+    expect(out).toContain('elder memory save');
+  });
+
+  it('returns ack-clear help for `ack-clear --help`', () => {
+    const out = resolveHelp(['ack-clear', '--help']);
+    expect(out).toBeDefined();
+    expect(out).toContain('elder ack-clear');
+  });
+
+  it('returns undefined when no --help flag and args present (let runCommand take over)', () => {
+    expect(resolveHelp(['world', 'snapshot'])).toBeUndefined();
+    expect(resolveHelp(['clan', 'view', '1'])).toBeUndefined();
+    expect(resolveHelp(['clan', 'submit-orders', '/tmp/orders.json'])).toBeUndefined();
   });
 });
 

--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -82,52 +82,18 @@ contract DeployDiamond is Script {
 
         IDiamondCut(address(diamond))
             .diamondCut(
-                _coreFacetCuts(
+                _bootstrapFacetCuts(
                     address(loupeFacet),
                     address(adminOwnershipFacet),
-                    address(heartbeatFacet),
-                    address(heartbeatConfigFacet),
-                    address(worldPauseFacet),
-                    address(finalizeSeasonFacet),
-                    address(rawWorldViewsFacet),
-                    address(rawTreasuryViewsFacet),
-                    address(rawClanViewsFacet),
-                    address(rawBanditViewsFacet),
-                    address(lifecycleFacet)
-                ),
-                address(0),
-                ""
-            );
-        IDiamondCut(address(diamond))
-            .diamondCut(
-                _orderFacetCuts(
-                    address(submitOrdersFacet),
-                    address(clanOwnershipFacet),
                     address(treasuryFacet),
-                    address(settlementFacet),
-                    address(directTransfersFacet)
-                ),
-                address(0),
-                ""
-            );
-        IDiamondCut(address(diamond))
-            .diamondCut(
-                _viewFacetCuts(
-                    address(derivedViewsFacet),
-                    address(marketViewsFacet),
-                    address(banditViewsFacet),
-                    address(regionViewsFacet),
-                    address(snapshotViewsFacet),
-                    address(clanFullViewFacet),
-                    address(quoteViewsFacet),
-                    address(scoringViewsFacet)
+                    address(rawWorldViewsFacet),
+                    address(rawTreasuryViewsFacet)
                 ),
                 address(init),
                 abi.encodeCall(ClanWorldDiamondInit.init, ())
             );
 
         IClanWorld game = IClanWorld(address(diamond));
-        ClanWorldLens lens = new ClanWorldLens(game);
 
         MinimalERC20 wood = new MinimalERC20("Wood", "WOOD");
         MinimalERC20 iron = new MinimalERC20("Iron", "IRON");
@@ -173,6 +139,42 @@ contract DeployDiamond is Script {
             })
         );
 
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                _gameplayFacetCuts(
+                    address(heartbeatFacet),
+                    address(heartbeatConfigFacet),
+                    address(worldPauseFacet),
+                    address(finalizeSeasonFacet),
+                    address(rawClanViewsFacet),
+                    address(rawBanditViewsFacet),
+                    address(lifecycleFacet),
+                    address(submitOrdersFacet),
+                    address(clanOwnershipFacet),
+                    address(settlementFacet),
+                    address(directTransfersFacet)
+                ),
+                address(0),
+                ""
+            );
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                _viewFacetCuts(
+                    address(derivedViewsFacet),
+                    address(marketViewsFacet),
+                    address(banditViewsFacet),
+                    address(regionViewsFacet),
+                    address(snapshotViewsFacet),
+                    address(clanFullViewFacet),
+                    address(quoteViewsFacet),
+                    address(scoringViewsFacet)
+                ),
+                address(0),
+                ""
+            );
+
+        ClanWorldLens lens = new ClanWorldLens(game);
+
         console.log("CLAN_WORLD_DIAMOND_ADDRESS:       ", address(diamond));
         console.log("CLAN_WORLD_LENS_ADDRESS:          ", address(lens));
         console.log("WOOD_TOKEN_ADDRESS:               ", address(wood));
@@ -215,20 +217,14 @@ contract DeployDiamond is Script {
         vm.stopBroadcast();
     }
 
-    function _coreFacetCuts(
+    function _bootstrapFacetCuts(
         address loupeFacet,
         address adminOwnershipFacet,
-        address heartbeatFacet,
-        address heartbeatConfigFacet,
-        address worldPauseFacet,
-        address finalizeSeasonFacet,
+        address treasuryFacet,
         address rawWorldViewsFacet,
-        address rawTreasuryViewsFacet,
-        address rawClanViewsFacet,
-        address rawBanditViewsFacet,
-        address lifecycleFacet
+        address rawTreasuryViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](11);
+        cut = new IDiamondCut.FacetCut[](5);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -240,81 +236,87 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.ownershipFacetSelectors()
         });
         cut[2] = IDiamondCut.FacetCut({
-            facetAddress: heartbeatFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.heartbeatSelectors()
-        });
-        cut[3] = IDiamondCut.FacetCut({
-            facetAddress: heartbeatConfigFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.heartbeatConfigSelectors()
-        });
-        cut[4] = IDiamondCut.FacetCut({
-            facetAddress: worldPauseFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.worldPauseSelectors()
-        });
-        cut[5] = IDiamondCut.FacetCut({
-            facetAddress: finalizeSeasonFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.seasonSelectors()
-        });
-        cut[6] = IDiamondCut.FacetCut({
-            facetAddress: rawWorldViewsFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.rawWorldViewsSelectors()
-        });
-        cut[7] = IDiamondCut.FacetCut({
-            facetAddress: rawTreasuryViewsFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.rawTreasuryViewsSelectors()
-        });
-        cut[8] = IDiamondCut.FacetCut({
-            facetAddress: rawClanViewsFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.rawClanViewsSelectors()
-        });
-        cut[9] = IDiamondCut.FacetCut({
-            facetAddress: rawBanditViewsFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.rawBanditViewsSelectors()
-        });
-        cut[10] = IDiamondCut.FacetCut({
-            facetAddress: lifecycleFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.lifecycleSelectors()
-        });
-    }
-
-    function _orderFacetCuts(
-        address submitOrdersFacet,
-        address clanOwnershipFacet,
-        address treasuryFacet,
-        address settlementFacet,
-        address directTransfersFacet
-    ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](5);
-        cut[0] = IDiamondCut.FacetCut({
-            facetAddress: submitOrdersFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.submitOrdersSelectors()
-        });
-        cut[1] = IDiamondCut.FacetCut({
-            facetAddress: clanOwnershipFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.ownershipSelectors()
-        });
-        cut[2] = IDiamondCut.FacetCut({
             facetAddress: treasuryFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.treasurySelectors()
         });
         cut[3] = IDiamondCut.FacetCut({
+            facetAddress: rawWorldViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.rawWorldViewsSelectors()
+        });
+        cut[4] = IDiamondCut.FacetCut({
+            facetAddress: rawTreasuryViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.rawTreasuryViewsSelectors()
+        });
+    }
+
+    function _gameplayFacetCuts(
+        address heartbeatFacet,
+        address heartbeatConfigFacet,
+        address worldPauseFacet,
+        address finalizeSeasonFacet,
+        address rawClanViewsFacet,
+        address rawBanditViewsFacet,
+        address lifecycleFacet,
+        address submitOrdersFacet,
+        address clanOwnershipFacet,
+        address settlementFacet,
+        address directTransfersFacet
+    ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](11);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: heartbeatFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.heartbeatSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: heartbeatConfigFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.heartbeatConfigSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: worldPauseFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.worldPauseSelectors()
+        });
+        cut[3] = IDiamondCut.FacetCut({
+            facetAddress: finalizeSeasonFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.seasonSelectors()
+        });
+        cut[4] = IDiamondCut.FacetCut({
+            facetAddress: rawClanViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.rawClanViewsSelectors()
+        });
+        cut[5] = IDiamondCut.FacetCut({
+            facetAddress: rawBanditViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.rawBanditViewsSelectors()
+        });
+        cut[6] = IDiamondCut.FacetCut({
+            facetAddress: lifecycleFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.lifecycleSelectors()
+        });
+        cut[7] = IDiamondCut.FacetCut({
+            facetAddress: submitOrdersFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.submitOrdersSelectors()
+        });
+        cut[8] = IDiamondCut.FacetCut({
+            facetAddress: clanOwnershipFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.ownershipSelectors()
+        });
+        cut[9] = IDiamondCut.FacetCut({
             facetAddress: settlementFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.settlementSelectors()
         });
-        cut[4] = IDiamondCut.FacetCut({
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: directTransfersFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.directTransferSelectors()

--- a/packages/contracts/src/diamond/lib/LibSettlement.sol
+++ b/packages/contracts/src/diamond/lib/LibSettlement.sol
@@ -59,6 +59,12 @@ library LibSettlement {
         uint256 fishDelta,
         uint64 atTick
     );
+    event ClanEliminated(uint32 indexed clanId, uint64 indexed tick);
+    event ClanDied(uint32 indexed clanId, uint64 tick, string reason);
+    event ClanStarvationChanged(uint32 indexed clanId, bool isStarving, uint64 atTick);
+    event ClanColdShortage(uint32 indexed clanId, uint64 tick, uint256 woodShort);
+    event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint64 tick);
+    event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint64 tick);
     // BanditEscaped + BanditTargetDied moved to LibBanditCombat (canonical
     // emitter post-dedup). Same event signatures; ABI consumers unaffected.
 
@@ -67,6 +73,22 @@ library LibSettlement {
         ResourcesGathered,
         ResourcesDeposited,
         ResourcesWithdrawn
+    }
+
+    enum UpkeepLogKind {
+        None,
+        ClanStarvationChanged,
+        ClanColdShortage,
+        WallDegradedByCold,
+        ClansmanColdDeath,
+        ClanEliminated,
+        ClanDied
+    }
+
+    enum ClanDeathReason {
+        None,
+        Starvation,
+        Cold
     }
 
     struct SettlementLog {
@@ -81,13 +103,25 @@ library LibSettlement {
         uint64 tick;
     }
 
+    struct UpkeepLog {
+        UpkeepLogKind kind;
+        uint32 clansmanId;
+        uint64 tick;
+        uint256 amount;
+        uint8 level;
+        bool flag;
+        ClanDeathReason reason;
+    }
+
     struct SettlementSimulation {
         Clan clan;
         Clansman[] clansmen;
         Mission[] missions;
         WheatPlot[2] wheatPlots;
         SettlementLog[] logs;
+        UpkeepLog[] upkeepLogs;
         uint256 logCount;
+        uint256 upkeepLogCount;
         uint64[11] simMonumentReachedAt;
         bool[] simWallReservationCleared;
         bool[] simBaseReservationCleared;
@@ -147,7 +181,9 @@ library LibSettlement {
         if (toTick > fromTick + LibGameRules.MAX_LAZY_SETTLE_BACKLOG) {
             toTick = fromTick + LibGameRules.MAX_LAZY_SETTLE_BACKLOG;
         }
-        sim.logs = new SettlementLog[](sim.clansmen.length * (toTick - fromTick));
+        uint256 tickCount = toTick - fromTick;
+        sim.logs = new SettlementLog[](sim.clansmen.length * tickCount);
+        sim.upkeepLogs = new UpkeepLog[]((sim.clansmen.length + 6) * tickCount);
 
         for (uint64 tick = fromTick; tick < toTick; tick++) {
             applyUpkeep(s, sim, tick);
@@ -172,6 +208,8 @@ library LibSettlement {
         s.clans[clanId] = sim.clan;
         s.wheatPlots[clanId][0] = sim.wheatPlots[0];
         s.wheatPlots[clanId][1] = sim.wheatPlots[1];
+
+        emitUpkeepLogs(sim);
 
         for (uint256 i = 0; i < sim.clansmen.length; i++) {
             uint32 clansmanId = sim.clansmen[i].clansmanId;
@@ -215,6 +253,25 @@ library LibSettlement {
         for (uint8 level = 1; level < sim.simMonumentReachedAt.length; level++) {
             if (sim.simMonumentReachedAt[level] != 0 && s.monumentLevelReachedAt[clanId][level] == 0) {
                 s.monumentLevelReachedAt[clanId][level] = sim.simMonumentReachedAt[level];
+            }
+        }
+    }
+
+    function emitUpkeepLogs(SettlementSimulation memory sim) internal {
+        for (uint256 i = 0; i < sim.upkeepLogCount; i++) {
+            UpkeepLog memory entry = sim.upkeepLogs[i];
+            if (entry.kind == UpkeepLogKind.ClanStarvationChanged) {
+                emit ClanStarvationChanged(sim.clan.clanId, entry.flag, entry.tick);
+            } else if (entry.kind == UpkeepLogKind.ClanColdShortage) {
+                emit ClanColdShortage(sim.clan.clanId, entry.tick, entry.amount);
+            } else if (entry.kind == UpkeepLogKind.WallDegradedByCold) {
+                emit WallDegradedByCold(sim.clan.clanId, entry.level, entry.tick);
+            } else if (entry.kind == UpkeepLogKind.ClansmanColdDeath) {
+                emit ClansmanColdDeath(sim.clan.clanId, entry.clansmanId, entry.tick);
+            } else if (entry.kind == UpkeepLogKind.ClanEliminated) {
+                emit ClanEliminated(sim.clan.clanId, entry.tick);
+            } else if (entry.kind == UpkeepLogKind.ClanDied) {
+                emit ClanDied(sim.clan.clanId, entry.tick, deathReasonString(entry.reason));
             }
         }
     }
@@ -273,6 +330,34 @@ library LibSettlement {
         });
     }
 
+    function recordUpkeepLog(
+        SettlementSimulation memory sim,
+        UpkeepLogKind kind,
+        uint32 clansmanId,
+        uint64 tick,
+        uint256 amount,
+        uint8 level,
+        bool flag,
+        ClanDeathReason reason
+    ) internal pure {
+        if (sim.upkeepLogCount >= sim.upkeepLogs.length) return;
+        sim.upkeepLogs[sim.upkeepLogCount++] = UpkeepLog({
+            kind: kind,
+            clansmanId: clansmanId,
+            tick: tick,
+            amount: amount,
+            level: level,
+            flag: flag,
+            reason: reason
+        });
+    }
+
+    function deathReasonString(ClanDeathReason reason) internal pure returns (string memory) {
+        if (reason == ClanDeathReason.Starvation) return "starvation";
+        if (reason == ClanDeathReason.Cold) return "cold";
+        return "unknown";
+    }
+
     function applyUpkeep(LibStorage.AppStorage storage s, SettlementSimulation memory sim, uint64 tick) internal view {
         bool winter = LibSeason.isWinterActiveAt(tick);
         if (!winter && tick > 0 && LibSeason.isWinterActiveAt(tick - 1)) {
@@ -302,8 +387,28 @@ library LibSettlement {
         bool starving = !hadEnoughWheat || !hadEnoughFish;
         if (starving && sim.clan.starvationStartsAtTick == 0) {
             sim.clan.starvationStartsAtTick = tick + 1;
+            recordUpkeepLog(
+                sim,
+                UpkeepLogKind.ClanStarvationChanged,
+                0,
+                tick + 1,
+                0,
+                0,
+                true,
+                ClanDeathReason.None
+            );
         } else if (!starving && sim.clan.starvationStartsAtTick != 0) {
             sim.clan.starvationStartsAtTick = 0;
+            recordUpkeepLog(
+                sim,
+                UpkeepLogKind.ClanStarvationChanged,
+                0,
+                tick,
+                0,
+                0,
+                false,
+                ClanDeathReason.None
+            );
         }
 
         uint8 livingBeforeStarvation = sim.clan.livingClansmen;
@@ -313,7 +418,7 @@ library LibSettlement {
                 ? sim.clan.starvationStartsAtTick
                 : winterStartsAtTick;
             if (effectiveStarvationStartsAtTick < tick) {
-                killNextClansmanFromStarvation(s, sim);
+                killNextClansmanFromStarvation(s, sim, tick);
             }
         }
         if (sim.clan.clanState == ClanState.DEAD) return;
@@ -326,11 +431,22 @@ library LibSettlement {
             if (spendableWood >= woodNeeded) {
                 sim.clan.vaultWood -= woodNeeded;
             } else {
+                uint256 woodShort = woodNeeded - spendableWood;
                 sim.clan.vaultWood -= spendableWood;
                 uint16 oldColdDamage = sim.clan.coldDamage;
                 if (sim.clan.coldDamage < type(uint16).max) {
                     sim.clan.coldDamage += 1;
                 }
+                recordUpkeepLog(
+                    sim,
+                    UpkeepLogKind.ClanColdShortage,
+                    0,
+                    tick,
+                    woodShort,
+                    0,
+                    false,
+                    ClanDeathReason.None
+                );
                 applyColdDamageConsequence(s, sim, tick, oldColdDamage);
             }
         }
@@ -352,6 +468,16 @@ library LibSettlement {
             ) return;
 
             sim.clan.wallLevel--;
+            recordUpkeepLog(
+                sim,
+                UpkeepLogKind.WallDegradedByCold,
+                0,
+                tick,
+                0,
+                sim.clan.wallLevel,
+                false,
+                ClanDeathReason.None
+            );
             return;
         }
 
@@ -395,14 +521,24 @@ library LibSettlement {
             }
 
             markClansmanDead(s, sim, i);
+            recordUpkeepLog(
+                sim,
+                UpkeepLogKind.ClansmanColdDeath,
+                sim.clansmen[i].clansmanId,
+                tick,
+                0,
+                0,
+                false,
+                ClanDeathReason.None
+            );
             if (sim.clan.livingClansmen == 0) {
-                markClanDead(s, sim);
+                markClanDead(s, sim, ClanDeathReason.Cold, tick);
             }
             return;
         }
     }
 
-    function killNextClansmanFromStarvation(LibStorage.AppStorage storage s, SettlementSimulation memory sim)
+    function killNextClansmanFromStarvation(LibStorage.AppStorage storage s, SettlementSimulation memory sim, uint64 tick)
         internal
         view
     {
@@ -413,7 +549,7 @@ library LibSettlement {
 
             markClansmanDead(s, sim, i);
             if (sim.clan.livingClansmen == 0) {
-                markClanDead(s, sim);
+                markClanDead(s, sim, ClanDeathReason.Starvation, tick);
             }
             return;
         }
@@ -439,7 +575,12 @@ library LibSettlement {
         }
     }
 
-    function markClanDead(LibStorage.AppStorage storage s, SettlementSimulation memory sim) internal view {
+    function markClanDead(
+        LibStorage.AppStorage storage s,
+        SettlementSimulation memory sim,
+        ClanDeathReason reason,
+        uint64 tick
+    ) internal view {
         if (sim.clan.clanId == ClanWorldConstants.CLAN_ID_NULL || sim.clan.clanState == ClanState.DEAD) return;
 
         sim.clan.clanState = ClanState.DEAD;
@@ -462,6 +603,26 @@ library LibSettlement {
             }
         }
         sim.simClanDied = true;
+        recordUpkeepLog(
+            sim,
+            UpkeepLogKind.ClanEliminated,
+            0,
+            tick,
+            0,
+            0,
+            false,
+            ClanDeathReason.None
+        );
+        recordUpkeepLog(
+            sim,
+            UpkeepLogKind.ClanDied,
+            0,
+            tick,
+            0,
+            0,
+            false,
+            reason
+        );
     }
 
     function regrowWheatPlots(SettlementSimulation memory sim, uint64 tick) internal pure {
@@ -825,12 +986,10 @@ library LibSettlement {
             return true;
         }
         if (held.fromLevel != sim.clan.wallLevel) {
-            if (held.fromLevel < sim.clan.wallLevel) {
-                clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeWall);
-                sim.reservedWood = LibSettlementMath.subtractHeld(sim.reservedWood, held.woodCost);
-                sim.reservedIron = LibSettlementMath.subtractHeld(sim.reservedIron, held.ironCost);
-            }
-            return false;
+            clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeWall);
+            sim.reservedWood = LibSettlementMath.subtractHeld(sim.reservedWood, held.woodCost);
+            sim.reservedIron = LibSettlementMath.subtractHeld(sim.reservedIron, held.ironCost);
+            return true;
         }
 
         (uint256 woodCost, uint256 ironCost) = LibGameRules.wallUpgradeCost(sim.clan.wallLevel);

--- a/packages/contracts/test/diamond/PublicDemoBlockers.t.sol
+++ b/packages/contracts/test/diamond/PublicDemoBlockers.t.sol
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {DiamondSelectors} from "../../script/DiamondSelectors.sol";
+import {Diamond} from "../../src/diamond/Diamond.sol";
+import {ClanWorldDiamondInit} from "../../src/diamond/ClanWorldDiamondInit.sol";
+import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
+import {IDiamondLoupe} from "../../src/diamond/IDiamondLoupe.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {OwnershipFacet} from "../../src/diamond/facets/OwnershipFacet.sol";
+import {RawWorldViewsFacet} from "../../src/diamond/facets/RawWorldViewsFacet.sol";
+import {RawTreasuryViewsFacet} from "../../src/diamond/facets/RawTreasuryViewsFacet.sol";
+import {RawClanViewsFacet} from "../../src/diamond/facets/RawClanViewsFacet.sol";
+import {TreasuryFacet} from "../../src/diamond/facets/TreasuryFacet.sol";
+import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.sol";
+import {HeartbeatFacet} from "../../src/diamond/facets/HeartbeatFacet.sol";
+import {SettlementFacet} from "../../src/diamond/facets/SettlementFacet.sol";
+import {SubmitOrdersFacet} from "../../src/diamond/facets/SubmitOrdersFacet.sol";
+import {LibStorage} from "../../src/diamond/lib/LibStorage.sol";
+import {MinimalERC20} from "../../src/MinimalERC20.sol";
+import {StubPool} from "../../src/StubPool.sol";
+import {
+    ActionType,
+    Clan,
+    ClanOrder,
+    ClanWorldConstants,
+    IClanWorld,
+    PoolSeedConfig,
+    StatusCode,
+    WithdrawResourcesData
+} from "../../src/IClanWorld.sol";
+
+interface IPublicDemoHarness {
+    function setCurrentTick(uint64 tick) external;
+    function setClanUpkeepState(
+        uint32 clanId,
+        uint64 lastSettledTick,
+        uint256 vaultWood,
+        uint256 vaultWheat,
+        uint256 vaultFish,
+        uint16 coldDamage
+    ) external;
+    function setClanWallLevel(uint32 clanId, uint8 wallLevel) external;
+    function setVault(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external;
+    function wallReservation(uint32 clansmanId)
+        external
+        view
+        returns (bool active, uint8 fromLevel, uint256 woodCost, uint256 ironCost);
+    function pendingWallUpgrades(uint32 clanId) external view returns (uint8);
+    function reservedWood(uint32 clanId) external view returns (uint256);
+    function reservedIron(uint32 clanId) external view returns (uint256);
+}
+
+contract PublicDemoHarnessFacet {
+    function setCurrentTick(uint64 tick) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        bytes32 tickSeed = bytes32(uint256(tick));
+        s.world.currentTick = tick;
+        s.world.nextHeartbeatAtTick = tick + 1;
+        s.world.nextHeartbeatAtTs = 0;
+        s.world.currentTickSeed = tickSeed;
+        s.tickSeeds[tick] = tickSeed;
+    }
+
+    function setClanUpkeepState(
+        uint32 clanId,
+        uint64 lastSettledTick,
+        uint256 vaultWood,
+        uint256 vaultWheat,
+        uint256 vaultFish,
+        uint16 coldDamage
+    ) external {
+        Clan storage clan = LibStorage.appStorage().clans[clanId];
+        clan.lastSettledTick = lastSettledTick;
+        clan.vaultWood = vaultWood;
+        clan.vaultWheat = vaultWheat;
+        clan.vaultFish = vaultFish;
+        clan.starvationStartsAtTick = 0;
+        clan.coldDamage = coldDamage;
+    }
+
+    function setClanWallLevel(uint32 clanId, uint8 wallLevel) external {
+        LibStorage.appStorage().clans[clanId].wallLevel = wallLevel;
+    }
+
+    function setVault(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        Clan storage clan = LibStorage.appStorage().clans[clanId];
+        clan.vaultWood = wood;
+        clan.vaultIron = iron;
+        clan.vaultWheat = wheat;
+        clan.vaultFish = fish;
+    }
+
+    function wallReservation(uint32 clansmanId)
+        external
+        view
+        returns (bool active, uint8 fromLevel, uint256 woodCost, uint256 ironCost)
+    {
+        LibStorage.WallUpgradeReservation storage r = LibStorage.appStorage().wallUpgradeReservations[clansmanId];
+        return (r.active, r.fromLevel, r.woodCost, r.ironCost);
+    }
+
+    function pendingWallUpgrades(uint32 clanId) external view returns (uint8) {
+        return LibStorage.appStorage().pendingWallUpgradesByClan[clanId];
+    }
+
+    function reservedWood(uint32 clanId) external view returns (uint256) {
+        return LibStorage.appStorage().reservedWoodByClan[clanId];
+    }
+
+    function reservedIron(uint32 clanId) external view returns (uint256) {
+        return LibStorage.appStorage().reservedIronByClan[clanId];
+    }
+}
+
+contract PublicDemoBlockersTest is Test {
+    event ClanColdShortage(uint32 indexed clanId, uint64 tick, uint256 woodShort);
+    event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint64 tick);
+    event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint64 tick);
+    event ClanEliminated(uint32 indexed clanId, uint64 indexed tick);
+    event ClanDied(uint32 indexed clanId, uint64 tick, string reason);
+
+    address private elder = address(0xA11CE);
+
+    function test_bootstrapSelectorsHideGameplayUntilTreasurySeeded() public {
+        Diamond diamond = _newDiamond();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond)).diamondCut(_bootstrapCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        assertEq(loupe.facetAddress(IClanWorld.initTreasury.selector) != address(0), true, "treasury selector");
+        assertEq(loupe.facetAddress(IClanWorld.seedPools.selector) != address(0), true, "seed selector");
+        assertEq(loupe.facetAddress(IClanWorld.mintClan.selector), address(0), "mint hidden");
+        assertEq(loupe.facetAddress(IClanWorld.heartbeat.selector), address(0), "heartbeat hidden");
+        assertEq(loupe.facetAddress(IClanWorld.submitClanOrders.selector), address(0), "orders hidden");
+        assertEq(loupe.facetAddress(IClanWorld.settleClan.selector), address(0), "settlement hidden");
+
+        _initAndSeedTreasury(IClanWorld(address(diamond)));
+
+        IDiamondCut(address(diamond)).diamondCut(_gameplayCut(), address(0), "");
+        assertEq(loupe.facetAddress(IClanWorld.mintClan.selector) != address(0), true, "mint live");
+        assertEq(loupe.facetAddress(IClanWorld.heartbeat.selector) != address(0), true, "heartbeat live");
+        assertEq(loupe.facetAddress(IClanWorld.submitClanOrders.selector) != address(0), true, "orders live");
+        assertEq(loupe.facetAddress(IClanWorld.settleClan.selector) != address(0), true, "settlement live");
+    }
+
+    function test_settlementUpkeepEmitsWinterColdAndDeathEvents() public {
+        IClanWorld world = _deploySettlementDiamond();
+        IPublicDemoHarness harness = IPublicDemoHarness(address(world));
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+
+        uint32 coldShortClan = _mint(world);
+        harness.setCurrentTick(winterStart + 1);
+        harness.setClanUpkeepState(coldShortClan, winterStart, 1e18, 100e18, 100e18, 0);
+        vm.expectEmit(true, false, false, true, address(world));
+        emit ClanColdShortage(coldShortClan, winterStart, 2e18);
+        world.settleClan(coldShortClan);
+
+        uint32 wallClan = _mint(world);
+        harness.setCurrentTick(winterStart + 1);
+        harness.setClanWallLevel(wallClan, 2);
+        harness.setClanUpkeepState(wallClan, winterStart, 0, 100e18, 100e18, 1);
+        vm.expectEmit(true, false, false, true, address(world));
+        emit WallDegradedByCold(wallClan, 1, winterStart);
+        world.settleClan(wallClan);
+
+        uint32 coldDeathClan = _mint(world);
+        harness.setCurrentTick(winterStart + 1);
+        harness.setClanUpkeepState(coldDeathClan, winterStart, 0, 100e18, 100e18, 1);
+        vm.recordLogs();
+        world.settleClan(coldDeathClan);
+        assertEq(_countLogs(vm.getRecordedLogs(), keccak256("ClansmanColdDeath(uint32,uint32,uint64)")), 1);
+
+        uint32 starvedClan = _mint(world);
+        harness.setCurrentTick(winterStart + 6);
+        harness.setClanUpkeepState(starvedClan, winterStart, 100e18, 0, 0, 0);
+        vm.expectEmit(true, true, false, true, address(world));
+        emit ClanEliminated(starvedClan, winterStart + 5);
+        vm.expectEmit(true, false, false, true, address(world));
+        emit ClanDied(starvedClan, winterStart + 5, "starvation");
+        world.settleClan(starvedClan);
+    }
+
+    function test_wallUpgradeReservationClearsWhenColdDegradesWallBeforeCompletion() public {
+        IClanWorld world = _deploySettlementDiamond();
+        IPublicDemoHarness harness = IPublicDemoHarness(address(world));
+        uint32 clanId = _mint(world);
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        harness.setClanWallLevel(clanId, 1);
+        harness.setVault(clanId, 100e18, 100e18, 100e18, 100e18);
+
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: clansmanId,
+            gotoRegion: world.getClan(clanId).baseRegion,
+            action: ActionType.UpgradeWall,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
+        });
+        vm.prank(elder);
+        assertEq(uint8(world.submitClanOrders(clanId, orders)[0].status), uint8(StatusCode.OK), "upgrade queued");
+        (bool active, uint8 fromLevel, uint256 woodCost, uint256 ironCost) = harness.wallReservation(clansmanId);
+        assertTrue(active, "reservation active");
+        assertEq(fromLevel, 1, "from level");
+        assertEq(harness.pendingWallUpgrades(clanId), 1, "pending wall");
+        assertEq(harness.reservedWood(clanId), woodCost, "reserved wood");
+        assertEq(harness.reservedIron(clanId), ironCost, "reserved iron");
+
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        harness.setCurrentTick(winterStart + 1);
+        harness.setClanUpkeepState(clanId, winterStart, 0, 100e18, 100e18, 1);
+        world.settleClan(clanId);
+
+        (active,,,) = harness.wallReservation(clansmanId);
+        assertFalse(active, "reservation cleared");
+        assertEq(harness.pendingWallUpgrades(clanId), 0, "pending cleared");
+        assertEq(harness.reservedWood(clanId), 0, "wood released");
+        assertEq(harness.reservedIron(clanId), 0, "iron released");
+        assertEq(uint8(world.getActiveMission(clansmanId).action), uint8(ActionType.UpgradeWall), "mission action retained");
+        assertFalse(world.getActiveMission(clansmanId).active, "mission completed");
+    }
+
+    function _deploySettlementDiamond() private returns (IClanWorld world) {
+        Diamond diamond = _newDiamond();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+        IDiamondCut(address(diamond)).diamondCut(_settlementCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        return IClanWorld(address(diamond));
+    }
+
+    function _newDiamond() private returns (Diamond) {
+        DiamondCutFacet cutFacet = new DiamondCutFacet();
+        return new Diamond(address(this), address(cutFacet));
+    }
+
+    function _mint(IClanWorld world) private returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
+    }
+
+    function _initAndSeedTreasury(IClanWorld world) private {
+        address[6] memory tokens = [
+            address(new MinimalERC20("Wood", "WOOD")),
+            address(new MinimalERC20("Iron", "IRON")),
+            address(new MinimalERC20("Wheat", "WHEAT")),
+            address(new MinimalERC20("Fish", "FISH")),
+            address(new MinimalERC20("Gold", "GOLD")),
+            address(new MinimalERC20("Blueprint", "BPRT"))
+        ];
+        address[4] memory pools = [
+            address(new StubPool(tokens[0], tokens[4], address(world))),
+            address(new StubPool(tokens[2], tokens[4], address(world))),
+            address(new StubPool(tokens[3], tokens[4], address(world))),
+            address(new StubPool(tokens[1], tokens[4], address(world)))
+        ];
+        PoolSeedConfig memory cfg = PoolSeedConfig({
+            woodSeed: 100e18,
+            wheatSeed: 100e18,
+            fishSeed: 100e18,
+            ironSeed: 100e18,
+            goldSeedForWood: 100e18,
+            goldSeedForWheat: 100e18,
+            goldSeedForFish: 100e18,
+            goldSeedForIron: 100e18
+        });
+
+        world.initTreasury(tokens, pools);
+        MinimalERC20(tokens[0]).seedTreasury(address(this), cfg.woodSeed);
+        MinimalERC20(tokens[1]).seedTreasury(address(this), cfg.ironSeed);
+        MinimalERC20(tokens[2]).seedTreasury(address(this), cfg.wheatSeed);
+        MinimalERC20(tokens[3]).seedTreasury(address(this), cfg.fishSeed);
+        MinimalERC20(tokens[4]).seedTreasury(
+            address(this), cfg.goldSeedForWood + cfg.goldSeedForWheat + cfg.goldSeedForFish + cfg.goldSeedForIron
+        );
+        for (uint256 i = 0; i < 5; i++) {
+            MinimalERC20(tokens[i]).approve(address(world), type(uint256).max);
+        }
+        world.seedPools(cfg);
+    }
+
+    function _bootstrapCut() private returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](5);
+        cut[0] = _facetCut(address(new DiamondLoupeFacet()), DiamondSelectors.loupeSelectors());
+        cut[1] = _facetCut(address(new OwnershipFacet()), DiamondSelectors.ownershipFacetSelectors());
+        cut[2] = _facetCut(address(new TreasuryFacet()), DiamondSelectors.treasurySelectors());
+        cut[3] = _facetCut(address(new RawWorldViewsFacet()), DiamondSelectors.rawWorldViewsSelectors());
+        cut[4] = _facetCut(address(new RawTreasuryViewsFacet()), DiamondSelectors.rawTreasuryViewsSelectors());
+    }
+
+    function _gameplayCut() private returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](5);
+        cut[0] = _facetCut(address(new ClanLifecycleFacet()), DiamondSelectors.lifecycleSelectors());
+        cut[1] = _facetCut(address(new SubmitOrdersFacet()), DiamondSelectors.submitOrdersSelectors());
+        cut[2] = _facetCut(address(new SettlementFacet()), DiamondSelectors.settlementSelectors());
+        cut[3] = _facetCut(address(new RawClanViewsFacet()), DiamondSelectors.rawClanViewsSelectors());
+        cut[4] = _facetCut(address(new HeartbeatFacet()), DiamondSelectors.heartbeatSelectors());
+    }
+
+    function _settlementCut() private returns (IDiamondCut.FacetCut[] memory cut) {
+        bytes4[] memory harnessSelectors = new bytes4[](8);
+        harnessSelectors[0] = PublicDemoHarnessFacet.setCurrentTick.selector;
+        harnessSelectors[1] = PublicDemoHarnessFacet.setClanUpkeepState.selector;
+        harnessSelectors[2] = PublicDemoHarnessFacet.setClanWallLevel.selector;
+        harnessSelectors[3] = PublicDemoHarnessFacet.setVault.selector;
+        harnessSelectors[4] = PublicDemoHarnessFacet.wallReservation.selector;
+        harnessSelectors[5] = PublicDemoHarnessFacet.pendingWallUpgrades.selector;
+        harnessSelectors[6] = PublicDemoHarnessFacet.reservedWood.selector;
+        harnessSelectors[7] = PublicDemoHarnessFacet.reservedIron.selector;
+
+        cut = new IDiamondCut.FacetCut[](6);
+        cut[0] = _facetCut(address(new RawWorldViewsFacet()), DiamondSelectors.rawWorldViewsSelectors());
+        cut[1] = _facetCut(address(new RawClanViewsFacet()), DiamondSelectors.rawClanViewsSelectors());
+        cut[2] = _facetCut(address(new ClanLifecycleFacet()), DiamondSelectors.lifecycleSelectors());
+        cut[3] = _facetCut(address(new SubmitOrdersFacet()), DiamondSelectors.submitOrdersSelectors());
+        cut[4] = _facetCut(address(new SettlementFacet()), DiamondSelectors.settlementSelectors());
+        cut[5] = _facetCut(address(new PublicDemoHarnessFacet()), harnessSelectors);
+    }
+
+    function _facetCut(address facet, bytes4[] memory selectors) private pure returns (IDiamondCut.FacetCut memory) {
+        return IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: selectors
+        });
+    }
+
+    function _countLogs(Vm.Log[] memory logs, bytes32 topic0) private pure returns (uint256 count) {
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics.length > 0 && logs[i].topics[0] == topic0) count++;
+        }
+    }
+}


### PR DESCRIPTION
## What's in this release

Brings the Phase 3 + Phase 4 mobile feature work into main for the next demo APK tag (v0.1.17+).

### Phase 3 (#61) — `8c57049`
- Wires `CockpitScreen` + `OwnerSignInScreen` + `OwnerComingSoonScreen` back into `ClanWorldApp.kt` NavHost (3 deep routes from InftDetail).
- Adds "Enter Cockpit" `EmberCta` on InftDetailScreen between hero and tab strip.
- Tabbar hides on Cockpit / OwnerSignIn / OwnerComingSoon.

### Phase 4a (#68) — `1ad548e`
- Bazaar tab: hire-out clansmen as listings other clans can browse + accept.
- HireModal: tap a listing → invoke owner-side flow.
- Note: Gemini flagged a few medium-priority items (DPI scaling on raw px offset, fragile string parsing for availability status, duplicated `roman` helper, missing `remember(clanId)` for `bazaarListingByClan`). All deferred per hackathon-mode default.

### Phase 4b (#63) — `8dfe8a4`
- BridgeScreen: clan ↔ clan resource bridge UI.
- Whispers inbox: clan-to-clan message feed.
- Gemini noted `state.filtered()` re-computed without `remember` + unstable indexed key in LazyColumn. Deferred.

### Phase 4c (#66) — `e7041a7`
- SteeringConsole + StrategyEditor (clan strategy authoring UI).
- No Gemini comments.

### Sync — `a151e60`
- Merge of `main` (which has the v0.1.15 → v0.1.16 Connect-crash fix #64) back into `dev` so the dev branch carries the fix.

## What's NOT in this release

- The v0.1.15 → v0.1.16 ActivityResultSender fix (#64) is already on main from earlier today; this PR does NOT re-apply it (the merge commit `a151e60` carries the equivalent state forward in both directions).
- Cockpit clanId routing: Gemini flagged the cockpit deep-route currently defaults to first clan instead of using the iNFT detail's `clanId`. Defer post-demo (medium priority).

## Test plan

- [x] Build green (each PR built green individually pre-merge)
- [ ] Visual UAT — install upcoming v0.1.17 APK once Liam is ready to flash
- [ ] Cloud reviewer pass (Gemini + Copilot will auto-attach)

## Reviewers consulted (per-PR, pre-merge)

- All 4 phase PRs: gemini-code-assist commented, all medium-priority style/perf — deferred per hackathon-mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)