### PR TITLE
fix(web): base building stretch — clamp scale to equal x/y

### DIFF
--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -923,6 +923,10 @@ export function WorldMap() {
       clan: ClanDef;
       baseY: number;
       phaseOffset: number;
+      /** Natural scale.y captured at relayout (after sprite.height = baseSize).
+       *  Breathing animation multiplies this — never assigns scale.y directly,
+       *  which would clobber the height-fit ratio and stretch bases ~3x tall. */
+      baseScaleY: number;
     }[];
     /** Floating "Lv N" badge beside each base. */
     levelBadges: { bg: Graphics; label: Text; clan: ClanDef }[];
@@ -1498,11 +1502,14 @@ export function WorldMap() {
             // the painted rooflines. phaseOffset keeps bases out of sync.
             // zIndex is already set during relayout (base.baseY is static between
             // relayouts), so no need to reassign each tick.
-            const scaleY = 1 + Math.sin((now + base.phaseOffset) * Math.PI / 2000) * 0.03;
+            // IMPORTANT: multiply by baseScaleY (the natural scale captured at
+            // relayout). Setting scale.y directly would clobber the
+            // sprite.height=baseSize sizing and stretch the sprite ~3x tall.
+            const breath = 1 + Math.sin((now + base.phaseOffset) * Math.PI / 2000) * 0.03;
             if (base.sprite) {
-              base.sprite.scale.y = scaleY;
+              base.sprite.scale.y = base.baseScaleY * breath;
             } else {
-              base.fallback.scale.y = scaleY;
+              base.fallback.scale.y = base.baseScaleY * breath;
             }
           });
           updateLiveClansmanPositions();
@@ -1769,6 +1776,10 @@ export function WorldMap() {
         clan: ClanDef;
         baseY: number;
         phaseOffset: number;
+        // Natural scale.y at relayout, BEFORE breathing animation. The breathing
+        // tick multiplies this — without it, scale.y would clobber the
+        // sprite.height=baseSize sizing and stretch the base ~3x tall.
+        baseScaleY: number;
       } = {
         container,
         sprite: null,
@@ -1777,6 +1788,7 @@ export function WorldMap() {
         clan,
         baseY: 0,
         phaseOffset: 0,
+        baseScaleY: 1,
       };
       drawn.bases.push(entry);
 
@@ -2566,6 +2578,14 @@ export function WorldMap() {
           sprite.x = 0;
           sprite.y = 0; // anchor=bottom-center; parent sits slightly below region center
           sprite.alpha = 1;
+          // Cache the natural scale.y so the breathing tick can multiply, not
+          // clobber. sprite.height = baseSize internally sets scale.y to
+          // baseSize/texture.height (often ~0.3-0.5); the breathing animation
+          // must preserve that ratio.
+          entry.baseScaleY = sprite.scale.y;
+        } else {
+          // Fallback Graphics is drawn at native coords (scale.y === 1).
+          entry.baseScaleY = 1;
         }
         glow.clear();
         glow.circle(0, -baseSize * 0.8, Math.max(6, 8 * cappedSizeScale));


### PR DESCRIPTION
## Summary

Fixes the "elongated narrow pillar" base regression visible on `dev` (screenshot: `/tmp/base-stretching-bug.jpg` — wheat barn rendered ~3x taller than NPC houses around it).

## Root cause

PR #5 / commit `b862054` replaced the old choppy y-translation bob with a `scaleY` breathing animation. Round-2 commit `029f93c` extended it to the fallback Graphics. **Both write the scale absolutely:**

```ts
sprite.scale.y = 1 + Math.sin(...) * 0.03;  // ≈ 1.03 each tick
```

But base sprites are sized at relayout via `sprite.height = baseSize` (WorldMap.tsx:2564-2565), which Pixi internally compiles to `scale.y = baseSize / texture.height` — typically `~0.3-0.5` for our 1024px-tall PNGs against a `~101px` base size.

Setting `scale.y = 1.03` each tick **clobbers that height-fit ratio**, blowing the sprite up to 2-3x its proper height. That matches the screenshot exactly.

The fallback Graphics path was unaffected visually (its native scale.y is 1), but the same code path was wrong-by-construction.

## Fix

Cache the natural scale.y as `baseScaleY` on the bases entry after the relayout sizes the sprite, then multiply during the breathing tick:

```ts
const breath = 1 + Math.sin((now + base.phaseOffset) * Math.PI / 2000) * 0.03;
base.sprite.scale.y = base.baseScaleY * breath;
```

- For loaded sprites: `baseScaleY` captures the post-`sprite.height = baseSize` scale (e.g. 0.32).
- For fallback Graphics: `baseScaleY` stays at the default `1` (Graphics is drawn at native coords).
- Updated the canonical `bases[]` type at WorldMap.tsx:918 to add the field — tsc errors without it.

3% breath amplitude + 4s period preserved.

## Test plan

- [ ] `tsc --noEmit -p apps/web` clean (verified locally).
- [ ] Load `https://app-dev.clan-world.com` after merge — bases render at correct height, breathing reads as alive (subtle vertical pulse, no skew).
- [ ] Confirm fallback rect (when sprite still loading) still breathes.
- [ ] Confirm rooflines aren't visibly skewed at peak breath.

## Notes

- Time-boxed; I did not run a full `pnpm --filter @clan-world/web build` (worktree node_modules missing; full install would have eaten too much demo-clock). Typecheck against the original repo's installed deps was clean. HMR on the dev tmux should validate visually within seconds of merge.
- No backwards-compat shim needed (per ClanWorld no-backcompat policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)