### PR TITLE
fix(android): thread mwaSender to Phase 4 MWA-signing screens

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -395,7 +395,7 @@ fun ClanWorldApp(
               onBack = { nav.popBackStack() },
               onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
               isBazaar = true,
-              hostActivity = hostActivity,
+              mwaSender = mwaSender,
               onHireConfirmed = {
                 // For now: simply pop back to Bazaar. A future "Hired"
                 // confirmation screen could replace this.
@@ -451,7 +451,7 @@ fun ClanWorldApp(
             val clanId = entry.arguments?.getInt("clanId") ?: 1
             world.clan.app.ui.screens.SteeringConsoleScreenRoute(
               app = app,
-              hostActivity = hostActivity,
+              mwaSender = mwaSender,
               initialClanId = clanId,
               onBack = { nav.popBackStack() },
               onSent = { nav.popBackStack() },
@@ -469,7 +469,7 @@ fun ClanWorldApp(
             val clanId = entry.arguments?.getInt("clanId") ?: 1
             world.clan.app.ui.screens.StrategyEditorScreenRoute(
               app = app,
-              hostActivity = hostActivity,
+              mwaSender = mwaSender,
               clanId = clanId,
               onBack = { nav.popBackStack() },
               onSaved = { nav.popBackStack() },

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
@@ -1,6 +1,6 @@
 package world.clan.app.ui.components
 
-import androidx.activity.ComponentActivity
+import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -61,7 +61,7 @@ import world.clan.app.wallet.MwaResult
 @Composable
 fun HireModal(
   app: App,
-  hostActivity: ComponentActivity,
+  mwaSender: ActivityResultSender,
   listing: BazaarListing,
   onDismiss: () -> Unit,
   onConfirmed: () -> Unit,
@@ -111,7 +111,7 @@ fun HireModal(
                 return@launch
               }
               val message = "ClanWorld Hire — token 0x${"%04x".format(listing.tokenId)} clan ${listing.clanId}".toByteArray()
-              val result = app.mwaClient.signMessage(hostActivity, token, message)
+              val result = app.mwaClient.signMessage(mwaSender, token, message)
               when (result) {
                 is MwaResult.Ok -> state.value = HireState.Sealed
                 is MwaResult.WalletNotFound -> {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -82,7 +82,7 @@ fun InftDetailScreenRoute(
   onOpenInbox: () -> Unit = {},
   onEditStrategy: () -> Unit = {},
   isBazaar: Boolean = false,
-  hostActivity: androidx.activity.ComponentActivity? = null,
+  mwaSender: com.solana.mobilewalletadapter.clientlib.ActivityResultSender? = null,
   onHireConfirmed: (() -> Unit)? = null,
 ) {
   val vm: InftDetailViewModel = viewModel(factory = InftDetailViewModelFactory(app, clanId))
@@ -97,7 +97,7 @@ fun InftDetailScreenRoute(
     onEditStrategy = onEditStrategy,
     isBazaar = isBazaar,
     app = app,
-    hostActivity = hostActivity,
+    mwaSender = mwaSender,
     onHireConfirmed = onHireConfirmed ?: onBack,
   )
 }
@@ -113,7 +113,7 @@ private fun InftDetailScreen(
   onEditStrategy: () -> Unit = {},
   isBazaar: Boolean = false,
   app: App? = null,
-  hostActivity: androidx.activity.ComponentActivity? = null,
+  mwaSender: com.solana.mobilewalletadapter.clientlib.ActivityResultSender? = null,
   onHireConfirmed: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
@@ -170,12 +170,12 @@ private fun InftDetailScreen(
   }
 
   // ── HireModal overlay (bazaar mode only) ────────────────────────────────
-  if (isBazaar && showHireModal.value && app != null && hostActivity != null) {
+  if (isBazaar && showHireModal.value && app != null && mwaSender != null) {
     val listing = world.clan.app.data.bazaarListingByClan(clanId)
     if (listing != null) {
       world.clan.app.ui.components.HireModal(
         app = app,
-        hostActivity = hostActivity,
+        mwaSender = mwaSender,
         listing = listing,
         onDismiss = { showHireModal.value = false },
         onConfirmed = {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -1,6 +1,6 @@
 package world.clan.app.ui.screens
 
-import androidx.activity.ComponentActivity
+import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -62,7 +62,7 @@ import world.clan.app.wallet.MwaResult
 @Composable
 fun SteeringConsoleScreenRoute(
   app: App,
-  hostActivity: ComponentActivity,
+  mwaSender: ActivityResultSender,
   initialClanId: Int,
   onBack: () -> Unit,
   onSent: () -> Unit,
@@ -86,7 +86,7 @@ fun SteeringConsoleScreenRoute(
           return@launch
         }
         val msg = "ClanWorld Steer — clan ${state.targetClanId}: ${state.draft}".toByteArray()
-        val result = app.mwaClient.signMessage(hostActivity, token, msg)
+        val result = app.mwaClient.signMessage(mwaSender, token, msg)
         when (result) {
           is MwaResult.Ok -> vm.setPhase(SendPhase.Queued)
           is MwaResult.UserDeclined -> vm.setPhase(SendPhase.Idle)

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
@@ -1,6 +1,6 @@
 package world.clan.app.ui.screens
 
-import androidx.activity.ComponentActivity
+import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -59,7 +59,7 @@ import world.clan.app.wallet.MwaResult
 @Composable
 fun StrategyEditorScreenRoute(
   app: App,
-  hostActivity: ComponentActivity,
+  mwaSender: ActivityResultSender,
   clanId: Int,
   onBack: () -> Unit,
   onSaved: () -> Unit,
@@ -85,7 +85,7 @@ fun StrategyEditorScreenRoute(
         }
         val msg = ("ClanWorld Strategy — clan ${state.clanId} | ${state.posture.name} | " +
           "${state.pinnedKey} = ${state.doctrine}").toByteArray()
-        when (val r = app.mwaClient.signMessage(hostActivity, token, msg)) {
+        when (val r = app.mwaClient.signMessage(mwaSender, token, msg)) {
           is MwaResult.Ok -> vm.setSavePhase(SendPhase.Queued)
           is MwaResult.UserDeclined -> vm.setSavePhase(SendPhase.Idle)
           is MwaResult.WalletNotFound ->


### PR DESCRIPTION
## Summary

dev was failing to compile after Phase 4c (#66) merged on top of #64.

PR #64 changed \`MwaClient.signMessage\` to take \`ActivityResultSender\`, but four screens authored in #62/#66 still passed \`ComponentActivity\`:

\`\`\`
e: HireModal.kt:114, SteeringConsoleScreen.kt:89, StrategyEditorScreen.kt:88
Argument type mismatch: actual type is 'androidx.activity.ComponentActivity',
but 'com.solana.mobilewalletadapter.clientlib.ActivityResultSender' was expected.
\`\`\`

This converts all four screens to take \`mwaSender: ActivityResultSender\` and updates the ClanWorldApp call sites to pass the hoisted sender instead of \`hostActivity\` — same pattern as \`ConnectScreenRoute\`.

## Files changed
- \`ui/components/HireModal.kt\`
- \`ui/screens/InftDetailScreen.kt\` (threads sender to HireModal)
- \`ui/screens/SteeringConsoleScreen.kt\`
- \`ui/screens/StrategyEditorScreen.kt\`
- \`ui/ClanWorldApp.kt\` (3 call sites updated)

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 35s.

## Test plan

- [ ] dev compiles cleanly post-merge
- [ ] Bazaar → tap listing → Hire This Sigil → MWA wallet sheet opens (Phantom)
- [ ] InftDetail → Whispers tab → Open Full Inbox → +NEW WHISPER → SteeringConsole → Sign and Send → MWA opens
- [ ] InftDetail → Memory tab → EDIT STRATEGY → StrategyEditor → Sign and Seal → MWA opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)