### PR TITLE
fix(indexer): unblock convex deploy + add resetCheckpoint

### DIFF
--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -693,7 +693,8 @@ export const pollLogs = internalAction({
     return await ctx.runMutation(indexerApi.ingestEvents, {
       events,
       blockNumber: Number(toBlock),
-      txHash: events.at(-1)?.transactionHash ?? checkpoint?.lastTxHash,
+      txHash:
+        events[events.length - 1]?.transactionHash ?? checkpoint?.lastTxHash,
       advanceCheckpoint: true,
     });
   },
@@ -703,5 +704,23 @@ export const readCheckpoint = internalQuery({
   args: {},
   handler: async (ctx) => {
     return await ctx.db.query("eventCheckpoint").first();
+  },
+});
+
+/**
+ * Demo-day operational reset. Used after redeploying the diamond at a new
+ * address to point the indexer at a block just before the new deployment so
+ * pollLogs backfills the new diamond's events instead of stale ones.
+ */
+export const resetCheckpoint = internalMutation({
+  args: { lastBlock: v.number() },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.query("eventCheckpoint").first();
+    if (existing) await ctx.db.delete(existing._id);
+    await ctx.db.insert("eventCheckpoint", {
+      lastBlock: args.lastBlock,
+      lastSeenAt: Date.now(),
+    });
+    return { lastBlock: args.lastBlock };
   },
 });


### PR DESCRIPTION
## Summary

Demo-day operational fix. Convex `refreshSnapshot` was failing with a JS Number overflow ("Number ...n is not in safe integer range") when decoding `getWorldSnapshot()` from the new diamond at `0xAd0301...`. Initial diagnosis pointed at an ABI mismatch (deployed contract had extra fields the TS ABI didn't know about), but the local ABI in `packages/contracts/abi/IClanWorld.json` actually matches the deployed contract perfectly — `cast call` decodes cleanly.

The real bug was that the cloud Convex deployment (`dev:valuable-kudu-985`) was running stale code. `npx convex dev --once` was silently failing tsc:

```
convex/indexer.ts:696:22 - error TS2550: Property 'at' does not exist on type 'ParsedIndexerEvent[]'.
```

Convex compiles with `lib: ["ES2021", "dom"]`, which doesn't include `Array.prototype.at`. Whoever added `events.at(-1)?.transactionHash` did so locally where it works, but Convex deploys were blocked. So the old indexer kept running with whatever ABI shape it was bundled with at last successful deploy — producing the overflow.

### Changes
1. `events.at(-1)` → `events[events.length - 1]` in `pollLogs` — unblocks tsc + Convex push.
2. New `resetCheckpoint` `internalMutation` — operational tool for re-pointing the indexer when the diamond is redeployed at a new address. Replaces ad-hoc dashboard surgery.

## Verification

After this PR's commit pushed via `convex dev --once`:

```bash
$ npx convex run indexer:refreshSnapshot '{}'
{ "clans": 12, "tick": 18 }

$ cast call $DIAMOND 'getWorldState()(...)' --rpc-url $RPC
(16, 0, 360, false, 1, 17, ...)   # currentTick=16 → 18 by demo time, season=1, end=360

$ tmux capture-pane -t elder-1 -p | grep TICK | tail
❯ TICK 17 Started
❯ TICK 18 Started
```

Convex `worldSnapshot.tick` now matches on-chain `currentTick`. Elder-1 / elder-3 receiving heartbeats. Elder-2 / elder-4 quiet for unrelated reasons (separate from indexer issue).

## Out of scope (pre-existing)

`pollLogs` fails on Alchemy free tier — Alchemy caps `eth_getLogs` to 10-block ranges on the free plan, but `MAX_LOG_BLOCK_RANGE = 9_999n`. Error surfaces as cryptic `InvalidRequestRpcError: JSON is not a valid request object`. Either upgrade Alchemy plan, switch RPC, or chunk requests to ≤10 blocks. Filed separately if not already tracked.

## Test plan

- [x] `convex dev --once` deploys cleanly (no tsc errors)
- [x] `refreshSnapshot` succeeds, returns matching tick
- [x] `resetCheckpoint` mutation callable, sets `eventCheckpoint.lastBlock`
- [x] Convex `worldSnapshot.tick` matches on-chain `getWorldState().currentTick`
- [x] Elder REPLs (1,3) receiving heartbeat ticks