### PR TITLE
feat(android): redesign SteeringConsole + StrategyEditor to match web PR #51

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/BalanceRow.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/BalanceRow.kt
@@ -1,0 +1,137 @@
+package world.clan.app.ui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * Balance + faucet row. GOLD line on the left, a small cyan-rune dashed-
+ * outline button on the right that mints DEVNET-only test gold. The
+ * DEVNET label is underline-styled in cyan — impossible to confuse with
+ * a real economic action.
+ *
+ * Mirrors web PR #51's `apps/web/src/pages/agent/BalanceRow.tsx`.
+ */
+@Composable
+fun BalanceRow(
+  gold: Long,
+  bouncing: Boolean,
+  faucetCooling: Boolean,
+  faucetDrop: Long,
+  onFaucet: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  // Bounce animation on faucet drop.
+  val scale = remember { Animatable(1f) }
+  LaunchedEffect(bouncing) {
+    if (bouncing) {
+      scale.animateTo(1.12f, tween(150))
+      scale.animateTo(1f, tween(350))
+    }
+  }
+
+  Row(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 4.dp, vertical = 4.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.SpaceBetween,
+  ) {
+    Row(
+      modifier = Modifier.graphicsLayer {
+        scaleX = scale.value
+        scaleY = scale.value
+      },
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      Text(
+        text = "◈",
+        style = ClanWorldTheme.type.body.copy(fontSize = 14.sp),
+        color = ClanWorldTheme.colors.goldBright,
+      )
+      Text(
+        text = "GOLD",
+        style = ClanWorldTheme.type.eyebrow.copy(fontSize = 11.sp),
+        color = ClanWorldTheme.colors.warmDim,
+      )
+      Text(
+        text = "·",
+        style = ClanWorldTheme.type.eyebrow,
+        color = ClanWorldTheme.colors.warmFaint,
+      )
+      Text(
+        text = "${gold.formatThousands()} g",
+        style = ClanWorldTheme.type.monoData.copy(fontSize = 14.sp),
+        color = ClanWorldTheme.colors.goldBright,
+      )
+    }
+
+    DevnetFaucetButton(
+      faucetDrop = faucetDrop,
+      cooling = faucetCooling,
+      onClick = onFaucet,
+    )
+  }
+}
+
+@Composable
+private fun DevnetFaucetButton(
+  faucetDrop: Long,
+  cooling: Boolean,
+  onClick: () -> Unit,
+) {
+  val rune = ClanWorldTheme.colors.rune
+  val runeGlow = ClanWorldTheme.colors.runeGlow
+  val runeDim = ClanWorldTheme.colors.runeDim
+  val labelColor = if (cooling) runeDim else rune
+  val accentColor = if (cooling) runeDim else runeGlow
+
+  val shape = RoundedCornerShape(4.dp)
+  val borderColor = if (cooling) runeDim else rune.copy(alpha = 0.65f)
+
+  Column(
+    modifier = Modifier
+      .clip(shape)
+      .border(BorderStroke(1.dp, borderColor), shape)
+      .clickable(enabled = !cooling) { onClick() }
+      .padding(horizontal = 12.dp, vertical = 6.dp),
+    horizontalAlignment = Alignment.End,
+  ) {
+    Text(
+      text = "+ MINT ${(faucetDrop / 1000L)}K",
+      style = ClanWorldTheme.type.eyebrow.copy(fontSize = 10.sp),
+      color = labelColor,
+    )
+    Text(
+      text = "DEVNET ONLY",
+      style = ClanWorldTheme.type.eyebrow.copy(fontSize = 8.sp),
+      color = accentColor,
+    )
+  }
+}
+
+private fun Long.formatThousands(): String {
+  val s = toString()
+  return s.reversed().chunked(3).joinToString(",").reversed()
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/BurnFlash.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/BurnFlash.kt
@@ -1,0 +1,92 @@
+package world.clan.app.ui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * Ephemeral post-tx burn-counter flash. Renders only briefly after each
+ * successful whisper send: scale-in + flicker, hold, fade. Replaces the
+ * persistent web BurnCounter that drifted upward with a fake number.
+ *
+ *     BurnFlash(triggerKey = lastBurnAt, amount = 5L)
+ *
+ * Pass any value that changes per send (e.g. `sentCount` or `lastBurnAt`)
+ * as `triggerKey`. The flash mounts whenever the key changes from a
+ * non-zero value.
+ *
+ * Mirrors web PR #51's `apps/web/src/pages/agent/BurnFlash.tsx`.
+ */
+@Composable
+fun BurnFlash(
+  triggerKey: Long,
+  amount: Long,
+  modifier: Modifier = Modifier,
+  ttlMs: Long = 2_800L,
+) {
+  val opacity = remember(triggerKey) { Animatable(0f) }
+
+  LaunchedEffect(triggerKey) {
+    if (triggerKey == 0L) return@LaunchedEffect
+    // Scale-in + fade-in (200ms)
+    opacity.animateTo(1f, tween(200))
+    // Hold + flicker (~280ms × 2 cycles)
+    repeat(2) {
+      opacity.animateTo(0.78f, tween(140))
+      opacity.animateTo(1f, tween(140))
+    }
+    // Hold the rest of the window
+    delay((ttlMs - 760L).coerceAtLeast(0L))
+    // Fade out (300ms)
+    opacity.animateTo(0f, tween(300))
+  }
+
+  Box(
+    modifier = modifier
+      .fillMaxWidth()
+      .height(28.dp),
+    contentAlignment = Alignment.Center,
+  ) {
+    if (opacity.value > 0f) {
+      Row(
+        modifier = Modifier.alpha(opacity.value),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+      ) {
+        Text(
+          text = "🔥",
+          style = ClanWorldTheme.type.body.copy(fontSize = 13.sp),
+        )
+        Text(
+          text = "+${amount}",
+          style = ClanWorldTheme.type.monoData.copy(
+            color = ClanWorldTheme.colors.goldBright,
+            fontSize = 12.sp,
+          ),
+        )
+        Text(
+          text = "BURNED",
+          style = ClanWorldTheme.type.eyebrow.copy(
+            color = ClanWorldTheme.colors.emberHover,
+            fontSize = 10.sp,
+          ),
+        )
+      }
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/ChatInput.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/ChatInput.kt
@@ -1,0 +1,392 @@
+package world.clan.app.ui.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * LLM-style chat input. Single rounded rectangle with the textarea up top
+ * and the cooldown chip + send button packed into the bottom edge.
+ *
+ *   ┌─────────────────────────────────────┐
+ *   │ Whisper to your Ælder…              │
+ *   │                                     │
+ *   │  [▓░ FORGE COOLING 1:42]   [⟢SEND] │
+ *   └─────────────────────────────────────┘
+ *
+ * Focus → ember-glow border + soft halo. Insufficient gold → red border +
+ * "Need X g" inside the chip. Cooling but tappable → gold-tone send (force
+ * send pays a per-minute skip-tax).
+ *
+ * Mirrors the web ChatInput shipped in PR #51
+ * (`apps/web/src/pages/agent/ChatInput.tsx`).
+ */
+@Composable
+fun ChatInput(
+  draft: String,
+  onDraftChange: (String) -> Unit,
+  /** Wall-clock ms when the last whisper was sent. -1 if no sends yet. */
+  lastSentAt: Long,
+  /** Total cooldown window in ms. */
+  cooldownTotalMs: Long,
+  /** Live wall-clock — pass a ticking value (e.g. via `useNow(250)`). */
+  nowMs: Long,
+  /** User's GOLD balance — gates the send button. */
+  gold: Long,
+  /** Send-in-flight. */
+  sending: Boolean,
+  /** Cost per send (whole units). */
+  burnAmount: Long = 5L,
+  /** Skip-tax per full minute remaining. */
+  skipTaxPerMinute: Long = 1_000L,
+  modifier: Modifier = Modifier,
+  onSend: () -> Unit,
+) {
+  val cooldownMs =
+    if (lastSentAt < 0L) 0L else (cooldownTotalMs - (nowMs - lastSentAt)).coerceAtLeast(0L)
+  val cooldownActive = cooldownMs > 0L
+  val fullMinutes = ((cooldownMs + 59_999L) / 60_000L).coerceAtLeast(0L)
+  val skipTax = if (cooldownActive) fullMinutes * skipTaxPerMinute else 0L
+  val totalCost = burnAmount + skipTax
+  val insufficient = gold < totalCost
+  val empty = draft.trim().isEmpty()
+  val disabled = sending || empty || insufficient
+
+  val cooldownPct =
+    if (cooldownTotalMs > 0L) (cooldownMs.toFloat() / cooldownTotalMs.toFloat()).coerceIn(0f, 1f)
+    else 0f
+  val cooldownLabel = formatCooldown(cooldownMs)
+
+  val interactionSource = remember { MutableInteractionSource() }
+  val focused by interactionSource.collectIsFocusedAsState()
+
+  val ember = ClanWorldTheme.colors.ember
+  val emberGlow = ClanWorldTheme.colors.emberGlow
+  val danger = ClanWorldTheme.colors.danger
+  val hairlineStrong = ClanWorldTheme.colors.hairlineStrong
+
+  val borderTarget = when {
+    insufficient -> danger
+    focused -> ember
+    else -> hairlineStrong
+  }
+  val borderColor by animateColorAsState(borderTarget, tween(220), label = "chat-border")
+
+  val shape = RoundedCornerShape(22.dp)
+
+  Box(
+    modifier = modifier
+      // Soft halo behind the input when focused.
+      .drawBehind {
+        if (focused && !insufficient) {
+          val expand = 4.dp.toPx()
+          drawRoundRect(
+            color = emberGlow.copy(alpha = 0.25f),
+            topLeft = Offset(-expand, -expand),
+            size = Size(size.width + expand * 2, size.height + expand * 2),
+            cornerRadius = CornerRadius(22.dp.toPx() + expand),
+          )
+        }
+      }
+      .clip(shape)
+      .background(ClanWorldTheme.colors.iron2)
+      .border(1.dp, borderColor, shape)
+      .padding(start = 14.dp, top = 14.dp, end = 14.dp, bottom = 12.dp),
+  ) {
+    Column {
+      // Textarea — autosizes 1–5 rows.
+      val textStyle = ClanWorldTheme.type.body.copy(color = ClanWorldTheme.colors.warm)
+      BasicTextField(
+        value = draft,
+        onValueChange = { if (it.length <= 1000) onDraftChange(it) },
+        textStyle = textStyle,
+        cursorBrush = SolidColor(ember),
+        interactionSource = interactionSource,
+        keyboardOptions = KeyboardOptions(
+          capitalization = KeyboardCapitalization.Sentences,
+          imeAction = ImeAction.Default,
+        ),
+        modifier = Modifier
+          .fillMaxWidth()
+          .heightIn(min = 64.dp, max = 160.dp),
+        decorationBox = { innerTextField ->
+          if (draft.isEmpty()) {
+            Text(
+              text = "Whisper to your Ælder…",
+              style = ClanWorldTheme.type.scriptItalic.copy(color = ClanWorldTheme.colors.warmFaint),
+            )
+          }
+          innerTextField()
+        },
+      )
+
+      Spacer(Modifier.height(10.dp))
+
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+      ) {
+        CooldownChip(
+          modifier = Modifier.weight(1f),
+          cooldownActive = cooldownActive,
+          cooldownPct = cooldownPct,
+          label = cooldownLabel,
+          skipTax = skipTax,
+          insufficient = insufficient,
+          totalCost = totalCost,
+          burnAmount = burnAmount,
+        )
+        SendButton(
+          cooldownActive = cooldownActive,
+          disabled = disabled,
+          sending = sending,
+          onSend = onSend,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun CooldownChip(
+  cooldownActive: Boolean,
+  cooldownPct: Float,
+  label: String,
+  skipTax: Long,
+  insufficient: Boolean,
+  totalCost: Long,
+  burnAmount: Long,
+  modifier: Modifier = Modifier,
+) {
+  val ember = ClanWorldTheme.colors.ember
+  val emberDeep = ClanWorldTheme.colors.emberDeep
+  val goldBright = ClanWorldTheme.colors.goldBright
+  val danger = ClanWorldTheme.colors.danger
+  val warm = ClanWorldTheme.colors.warm
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val iron3 = ClanWorldTheme.colors.iron3
+
+  val shape = RoundedCornerShape(17.dp)
+  Box(
+    modifier = modifier
+      .height(34.dp)
+      .clip(shape)
+      .background(iron3)
+      .drawBehind {
+        // Ember drain bar — drains right-to-left as time ticks.
+        if (cooldownActive) {
+          val w = size.width * cooldownPct
+          drawRect(
+            brush = Brush.horizontalGradient(
+              colors = listOf(
+                emberDeep.copy(alpha = 0.55f),
+                ember.copy(alpha = 0.45f),
+                goldBright.copy(alpha = 0.40f),
+              ),
+            ),
+            topLeft = Offset.Zero,
+            size = Size(w, size.height),
+          )
+        }
+      },
+  ) {
+    Row(
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(horizontal = 12.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      val dotColor = when {
+        insufficient -> danger
+        cooldownActive -> ember
+        else -> goldBright
+      }
+      Box(
+        modifier = Modifier
+          .size(6.dp)
+          .clip(CircleShape)
+          .drawBehind {
+            // Soft halo
+            val r = size.minDimension / 2f
+            drawCircle(dotColor.copy(alpha = 0.45f), radius = r * 1.6f, center = Offset(r, r))
+          }
+          .background(dotColor),
+      )
+
+      when {
+        insufficient -> {
+          Text(
+            text = "Need ${totalCost.formatThousands()} g",
+            style = ClanWorldTheme.type.monoNano,
+            color = danger,
+          )
+        }
+        cooldownActive -> {
+          Text("Forge cooling", style = ClanWorldTheme.type.monoNano, color = warm)
+          Text("·", style = ClanWorldTheme.type.monoNano, color = warmDim)
+          Text(label, style = ClanWorldTheme.type.monoNano, color = warm)
+          Spacer(Modifier.weight(1f))
+          if (skipTax > 0L) {
+            Text(
+              text = "+ ${skipTax.formatThousands()} g",
+              style = ClanWorldTheme.type.monoNano,
+              color = goldBright,
+            )
+          }
+        }
+        else -> {
+          Text("Whisper ready", style = ClanWorldTheme.type.monoNano, color = warmDim)
+          Text("·", style = ClanWorldTheme.type.monoNano, color = warmDim)
+          Text(
+            text = "${burnAmount.formatThousands()} g per send",
+            style = ClanWorldTheme.type.monoNano,
+            color = goldBright,
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun SendButton(
+  cooldownActive: Boolean,
+  disabled: Boolean,
+  sending: Boolean,
+  onSend: () -> Unit,
+) {
+  val ember = ClanWorldTheme.colors.ember
+  val emberDeep = ClanWorldTheme.colors.emberDeep
+  val gold = ClanWorldTheme.colors.gold
+  val goldDim = ClanWorldTheme.colors.goldDim
+  val iron3 = ClanWorldTheme.colors.iron3
+  val onEmber = Color(0xFF1A0C04)
+
+  val bgBrush = when {
+    disabled -> Brush.verticalGradient(listOf(iron3, iron3))
+    cooldownActive -> Brush.verticalGradient(listOf(gold, goldDim))
+    else -> Brush.verticalGradient(listOf(ember, emberDeep))
+  }
+  val borderColor = when {
+    disabled -> ClanWorldTheme.colors.hairline
+    cooldownActive -> gold
+    else -> ember
+  }
+  val shape = RoundedCornerShape(17.dp)
+
+  Box(
+    modifier = Modifier
+      .size(width = 44.dp, height = 34.dp)
+      .clip(shape)
+      .drawBehind {
+        if (!disabled) {
+          val color = if (cooldownActive) gold else ember
+          val expand = 6.dp.toPx()
+          drawRoundRect(
+            color = color.copy(alpha = 0.40f),
+            topLeft = Offset(-expand, -expand + 1.dp.toPx()),
+            size = Size(size.width + expand * 2, size.height + expand * 2),
+            cornerRadius = CornerRadius(17.dp.toPx() + expand),
+          )
+        }
+      }
+      .background(bgBrush)
+      .border(1.dp, borderColor, shape)
+      .clickable(enabled = !disabled, role = Role.Button) { onSend() },
+    contentAlignment = Alignment.Center,
+  ) {
+    if (sending) {
+      val infinite = rememberInfiniteTransition(label = "send-spin")
+      val angle by infinite.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(tween(700, easing = LinearEasing), RepeatMode.Restart),
+        label = "spin",
+      )
+      Box(
+        modifier = Modifier
+          .size(13.dp)
+          .rotate(angle)
+          .drawBehind {
+            drawArc(
+              color = onEmber,
+              startAngle = 0f,
+              sweepAngle = 270f,
+              useCenter = false,
+              style = Stroke(width = 1.5.dp.toPx()),
+            )
+          },
+      )
+    } else {
+      Text(
+        text = if (cooldownActive) "⟡" else "⟢",
+        style = ClanWorldTheme.type.ctaLabel.copy(
+          fontSize = 15.sp,
+          letterSpacing = 0.sp,
+        ),
+        color = if (disabled) ClanWorldTheme.colors.warmFaint
+        else if (cooldownActive) onEmber else onEmber,
+      )
+    }
+  }
+}
+
+private fun formatCooldown(ms: Long): String {
+  if (ms <= 0L) return ""
+  val totalSec = ((ms + 999L) / 1000L)
+  val m = totalSec / 60L
+  val s = totalSec % 60L
+  return "%02d:%02d".format(m, s)
+}
+
+private fun Long.formatThousands(): String =
+  toString().reversed().chunked(3).joinToString(",").reversed()
+

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
@@ -111,7 +111,11 @@ fun HireModal(
                 return@launch
               }
               val message = "ClanWorld Hire — token 0x${"%04x".format(listing.tokenId)} clan ${listing.clanId}".toByteArray()
-              val result = app.mwaClient.signMessage(hostActivity, token, message)
+              val result = app.mwaClient.signMessage(
+                com.solana.mobilewalletadapter.clientlib.ActivityResultSender(hostActivity),
+                token,
+                message,
+              )
               when (result) {
                 is MwaResult.Ok -> state.value = HireState.Sealed
                 is MwaResult.WalletNotFound -> {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -1,5 +1,6 @@
 package world.clan.app.ui.screens
 
+import android.view.HapticFeedbackConstants
 import androidx.activity.ComponentActivity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
@@ -37,8 +38,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -48,10 +51,10 @@ import world.clan.app.ui.components.BalanceRow
 import world.clan.app.ui.components.BurnFlash
 import world.clan.app.ui.components.ChatInput
 import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.viewmodel.FeedItem
 import world.clan.app.viewmodel.SteeringConsoleUiState
 import world.clan.app.viewmodel.SteeringConsoleViewModel
 import world.clan.app.viewmodel.SteeringConsoleViewModelFactory
-import world.clan.app.viewmodel.Whisper
 import world.clan.app.viewmodel.clanDisplayName
 import world.clan.app.wallet.MwaResult
 
@@ -86,6 +89,7 @@ fun SteeringConsoleScreenRoute(
   )
   val state by vm.state.collectAsState()
   val scope = rememberCoroutineScope()
+  val view = LocalView.current
 
   SteeringConsole(
     state = state,
@@ -113,11 +117,18 @@ fun SteeringConsoleScreenRoute(
           msg,
         )
         when (result) {
-          is MwaResult.Ok -> vm.confirmSend(
-            burnAmount = WHISPER_BURN,
-            skipTax = skipTax,
-            sentAt = System.currentTimeMillis(),
-          )
+          is MwaResult.Ok -> {
+            vm.confirmSend(
+              burnAmount = WHISPER_BURN,
+              skipTax = skipTax,
+              sentAt = System.currentTimeMillis(),
+            )
+            // Native polish: confirm haptic on successful seal.
+            view.performHapticFeedback(
+              if (android.os.Build.VERSION.SDK_INT >= 30) HapticFeedbackConstants.CONFIRM
+              else HapticFeedbackConstants.VIRTUAL_KEY,
+            )
+          }
           is MwaResult.UserDeclined -> vm.setSending(false)
           is MwaResult.WalletNotFound -> vm.setError("no wallet found on device.")
           is MwaResult.Error -> vm.setError(
@@ -284,7 +295,7 @@ private fun androidx.compose.foundation.layout.RowScope.SideRule(
 
 @Composable
 private fun WhisperFeed(
-  feed: List<Whisper>,
+  feed: List<FeedItem>,
   modifier: Modifier = Modifier,
 ) {
   if (feed.isEmpty()) {
@@ -311,15 +322,18 @@ private fun WhisperFeed(
     verticalArrangement = Arrangement.spacedBy(8.dp),
     contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 4.dp),
   ) {
-    items(feed) { whisper ->
-      WhisperRow(whisper = whisper)
+    items(items = feed, key = { it.key }) { item ->
+      when (item) {
+        is FeedItem.OwnerSent -> OwnerWhisperRow(item)
+        is FeedItem.FromComms -> CommsRow(item)
+      }
     }
   }
 }
 
+/** Right-aligned, ember-accent — your locally-sent whispers. */
 @Composable
-private fun WhisperRow(whisper: Whisper) {
-  // Right-aligned card so user-sent whispers feel like outgoing chat.
+private fun OwnerWhisperRow(item: FeedItem.OwnerSent) {
   Row(
     modifier = Modifier.fillMaxWidth(),
     horizontalArrangement = Arrangement.End,
@@ -330,7 +344,6 @@ private fun WhisperRow(whisper: Whisper) {
         .clip(RoundedCornerShape(14.dp))
         .background(ClanWorldTheme.colors.iron2)
         .drawBehind {
-          // Ember accent on the right edge — subtly marks "from you".
           drawLine(
             color = androidx.compose.ui.graphics.Color(0xFFFF6B35).copy(alpha = 0.55f),
             start = Offset(size.width - 1f, 8f),
@@ -342,14 +355,62 @@ private fun WhisperRow(whisper: Whisper) {
       verticalArrangement = Arrangement.spacedBy(3.dp),
     ) {
       Text(
-        text = whisper.body,
+        text = item.body,
         style = ClanWorldTheme.type.scriptItalic.copy(color = ClanWorldTheme.colors.warm),
       )
       Text(
-        text = "whispered " + relativeTime(whisper.sentAt),
+        text = "whispered " + relativeTime(item.sentAt),
         style = ClanWorldTheme.type.monoNano,
         color = ClanWorldTheme.colors.warmFaint,
       )
+    }
+  }
+}
+
+/** Left-aligned — past whispers pulled from comms:getCombinedComms. */
+@Composable
+private fun CommsRow(item: FeedItem.FromComms) {
+  val (label, accent) = when (item.kind) {
+    "human"   -> "OWNER"        to ClanWorldTheme.colors.gold
+    "orch"    -> "ORCHESTRATOR" to ClanWorldTheme.colors.goldBright
+    else      -> (item.speaker ?: "WHISPER").uppercase() to ClanWorldTheme.colors.rune
+  }
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.Start,
+  ) {
+    Column(
+      modifier = Modifier
+        .widthIn(max = 320.dp)
+        .clip(RoundedCornerShape(14.dp))
+        .background(ClanWorldTheme.colors.iron)
+        .drawBehind {
+          drawLine(
+            color = accent.copy(alpha = 0.55f),
+            start = Offset(1f, 8f),
+            end = Offset(1f, size.height - 8f),
+            strokeWidth = 2f,
+          )
+        }
+        .padding(horizontal = 12.dp, vertical = 8.dp),
+      verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+      Text(
+        text = label,
+        style = ClanWorldTheme.type.eyebrow.copy(fontSize = 9.sp),
+        color = accent,
+      )
+      Text(
+        text = item.body,
+        style = ClanWorldTheme.type.scriptItalic.copy(color = ClanWorldTheme.colors.warm),
+      )
+      if (item.tick != null) {
+        Text(
+          text = "tick %04d".format(item.tick),
+          style = ClanWorldTheme.type.monoNano,
+          color = ClanWorldTheme.colors.warmFaint,
+        )
+      }
     }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -1,6 +1,9 @@
 package world.clan.app.ui.screens
 
 import androidx.activity.ComponentActivity
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -11,64 +14,76 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import world.clan.app.App
 import world.clan.app.R
-import world.clan.app.ui.components.EmberCta
-import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.components.BalanceRow
+import world.clan.app.ui.components.BurnFlash
+import world.clan.app.ui.components.ChatInput
 import world.clan.app.ui.theme.ClanWorldTheme
-import world.clan.app.ui.theme.Ink
-import world.clan.app.ui.theme.Ink2
-import world.clan.app.ui.theme.Ink3
-import world.clan.app.ui.theme.clanColor
-import world.clan.app.ui.theme.clanGlyphRes
-import world.clan.app.viewmodel.HearthViewModel
-import world.clan.app.viewmodel.SendPhase
 import world.clan.app.viewmodel.SteeringConsoleUiState
 import world.clan.app.viewmodel.SteeringConsoleViewModel
 import world.clan.app.viewmodel.SteeringConsoleViewModelFactory
+import world.clan.app.viewmodel.Whisper
 import world.clan.app.viewmodel.clanDisplayName
 import world.clan.app.wallet.MwaResult
 
+private const val WHISPER_COOLDOWN_MS = 10L * 60L * 1000L  // 10 minutes
+private const val WHISPER_BURN = 5L
+private const val SKIP_TAX_PER_MINUTE = 1_000L
+private const val FAUCET_DROP = 10_000L
+
+/**
+ * Slice 4d redesign: LLM-style chat experience for whispering to your
+ * elder. Mirrors the polished web design from PR #51:
+ *
+ *   ── ÆLDER WHISPERS ──
+ *   ↑ feed (scrolls, recent at bottom)
+ *   ┌─ ChatInput ────────────────────┐
+ *   │ Whisper to your Ælder…         │
+ *   │ [▓░ FORGE COOLING 1:42] [⟢]   │
+ *   └────────────────────────────────┘
+ *   [+5 BURNED]  ← ephemeral, post-tx only
+ *   GOLD · 12,450 g    [+ MINT 10K · DEVNET]
+ */
 @Composable
 fun SteeringConsoleScreenRoute(
   app: App,
   hostActivity: ComponentActivity,
   initialClanId: Int,
   onBack: () -> Unit,
-  onSent: () -> Unit,
+  @Suppress("UNUSED_PARAMETER") onSent: () -> Unit,
 ) {
-  val vm: SteeringConsoleViewModel =
-    viewModel(factory = SteeringConsoleViewModelFactory(initialClanId))
+  val vm: SteeringConsoleViewModel = viewModel(
+    factory = SteeringConsoleViewModelFactory(app, initialClanId),
+  )
   val state by vm.state.collectAsState()
   val scope = rememberCoroutineScope()
 
@@ -76,36 +91,44 @@ fun SteeringConsoleScreenRoute(
     state = state,
     onBack = onBack,
     onDraftChange = vm::setDraft,
-    onTargetChange = vm::setTarget,
     onSend = {
       scope.launch {
-        vm.setPhase(SendPhase.Signing)
+        vm.setSending(true)
         val token = app.sessionStore.read()?.mwaAuthToken
         if (token == null) {
-          vm.setPhase(SendPhase.Queued)
+          vm.setError("not signed in.")
           return@launch
         }
-        val msg = "ClanWorld Steer — clan ${state.targetClanId}: ${state.draft}".toByteArray()
-        val result = app.mwaClient.signMessage(hostActivity, token, msg)
+        val now = System.currentTimeMillis()
+        val cooldownMs =
+          if (state.lastSentAt < 0L) 0L
+          else (WHISPER_COOLDOWN_MS - (now - state.lastSentAt)).coerceAtLeast(0L)
+        val fullMinutes = ((cooldownMs + 59_999L) / 60_000L).coerceAtLeast(0L)
+        val skipTax = if (cooldownMs > 0L) fullMinutes * SKIP_TAX_PER_MINUTE else 0L
+
+        val msg = "ClanWorld Whisper — clan ${state.clanId}: ${state.draft}".toByteArray()
+        val result = app.mwaClient.signMessage(
+          com.solana.mobilewalletadapter.clientlib.ActivityResultSender(hostActivity),
+          token,
+          msg,
+        )
         when (result) {
-          is MwaResult.Ok -> vm.setPhase(SendPhase.Queued)
-          is MwaResult.UserDeclined -> vm.setPhase(SendPhase.Idle)
-          is MwaResult.WalletNotFound ->
-            vm.setPhase(SendPhase.Failed, "no wallet found on device.")
-          is MwaResult.Error ->
-            vm.setPhase(SendPhase.Failed, result.cause.message ?: "the wallet refused the seal.")
+          is MwaResult.Ok -> vm.confirmSend(
+            burnAmount = WHISPER_BURN,
+            skipTax = skipTax,
+            sentAt = System.currentTimeMillis(),
+          )
+          is MwaResult.UserDeclined -> vm.setSending(false)
+          is MwaResult.WalletNotFound -> vm.setError("no wallet found on device.")
+          is MwaResult.Error -> vm.setError(
+            result.cause.message ?: "the wallet refused the seal.",
+          )
         }
       }
     },
+    onFaucet = { vm.mintFaucet(FAUCET_DROP) },
+    onDismissStatus = vm::clearStatus,
   )
-
-  // Auto-pop after queued state lands.
-  if (state.phase == SendPhase.Queued) {
-    androidx.compose.runtime.LaunchedEffect(Unit) {
-      delay(1300L)
-      onSent()
-    }
-  }
 }
 
 @Composable
@@ -113,45 +136,76 @@ private fun SteeringConsole(
   state: SteeringConsoleUiState,
   onBack: () -> Unit,
   onDraftChange: (String) -> Unit,
-  onTargetChange: (Int) -> Unit,
   onSend: () -> Unit,
+  onFaucet: () -> Unit,
+  onDismissStatus: () -> Unit,
 ) {
+  // Tick the clock locally so the cooldown chip updates without forcing
+  // the parent to re-render every frame.
+  val nowMs by produceState(initialValue = System.currentTimeMillis()) {
+    while (true) {
+      value = System.currentTimeMillis()
+      delay(250L)
+    }
+  }
+
   Column(
     modifier = Modifier
       .fillMaxSize()
-      .verticalScroll(rememberScrollState()),
+      .imePadding(),
   ) {
-    BackBar(text = "back to whispers", onBack = onBack)
+    BackBar(text = clanDisplayName(state.clanId), onBack = onBack)
 
-    Column(modifier = Modifier.padding(horizontal = 22.dp)) {
-      ConsoleHead()
-      Spacer(Modifier.height(14.dp))
-      TargetClanRow(
-        active = state.targetClanId,
-        onSelect = onTargetChange,
+    Column(
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(horizontal = 22.dp),
+    ) {
+      OrnamentRule(label = "ÆLDER WHISPERS")
+
+      Spacer(Modifier.height(10.dp))
+
+      // Whisper feed — scrolls inside its own region, recent at bottom.
+      WhisperFeed(
+        feed = state.feed,
+        modifier = Modifier
+          .fillMaxWidth()
+          .weight(1f),
       )
-      Spacer(Modifier.height(18.dp))
-      DraftCard(
+
+      Spacer(Modifier.height(10.dp))
+
+      ChatInput(
         draft = state.draft,
-        onChange = onDraftChange,
-        enabled = state.phase == SendPhase.Idle || state.phase == SendPhase.Failed,
+        onDraftChange = onDraftChange,
+        lastSentAt = state.lastSentAt,
+        cooldownTotalMs = WHISPER_COOLDOWN_MS,
+        nowMs = nowMs,
+        gold = state.gold,
+        sending = state.sending,
+        burnAmount = WHISPER_BURN,
+        skipTaxPerMinute = SKIP_TAX_PER_MINUTE,
+        onSend = onSend,
       )
-      Spacer(Modifier.height(14.dp))
-      ConsoleStatus(state)
-      Spacer(Modifier.height(14.dp))
-      EmberCta(
-        text = when (state.phase) {
-          SendPhase.Idle -> "Sign and Send"
-          SendPhase.Signing -> "Awaiting the seal…"
-          SendPhase.Queued -> "Queued ✓"
-          SendPhase.Failed -> "Try Again"
-        },
-        onClick = onSend,
-        enabled = state.draft.isNotBlank() &&
-          (state.phase == SendPhase.Idle || state.phase == SendPhase.Failed),
-        modifier = Modifier.fillMaxWidth(),
+
+      // Ephemeral burn flash — only renders briefly after each send.
+      BurnFlash(triggerKey = state.lastBurnAt, amount = state.lastBurnAmount)
+
+      BalanceRow(
+        gold = state.gold,
+        bouncing = state.goldBouncing,
+        faucetCooling = state.faucetCooling,
+        faucetDrop = FAUCET_DROP,
+        onFaucet = onFaucet,
       )
-      Spacer(Modifier.height(40.dp))
+
+      StatusLine(
+        successMsg = state.statusBody,
+        errorMsg = state.errorMessage,
+        onDismiss = onDismissStatus,
+      )
+
+      Spacer(Modifier.height(16.dp))
     }
   }
 }
@@ -169,180 +223,189 @@ private fun BackBar(text: String, onBack: () -> Unit) {
     Icon(
       painter = painterResource(R.drawable.ui_arrow),
       contentDescription = "back",
-      tint = ClanWorldTheme.colors.warm,
-      modifier = Modifier.height(16.dp),
+      tint = ClanWorldTheme.colors.gold,
+      modifier = Modifier.height(14.dp),
     )
     Text(
-      text = text,
+      text = "HALL",
       style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+    Text(
+      text = "·",
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Text(
+      text = "the writ of ${text.split(" ").lastOrNull()?.lowercase() ?: "—"}",
+      style = ClanWorldTheme.type.scriptItalic,
       color = ClanWorldTheme.colors.warmDim,
     )
   }
 }
 
+/**
+ * Section header — Cinzel small-caps label flanked by hairlines. Reused
+ * pattern from the slice-1 prototype; light enough to keep inline here.
+ */
 @Composable
-private fun ConsoleHead() {
-  val parchment = ClanWorldTheme.colors.parchment
-  val warmDim = ClanWorldTheme.colors.warmDim
-  val hairline = ClanWorldTheme.colors.hairline
+private fun OrnamentRule(label: String) {
+  val gold = ClanWorldTheme.colors.gold
+  val hairline = ClanWorldTheme.colors.hairlineStrong
 
-  Column(
-    modifier = Modifier
-      .fillMaxWidth()
-      .drawBehind {
-        drawLine(
-          color = hairline,
-          start = Offset(0f, size.height + 14f),
-          end = Offset(size.width, size.height + 14f),
-          strokeWidth = 1f,
-        )
-      },
-  ) {
-    Text(
-      text = "STEERING CONSOLE",
-      style = ClanWorldTheme.type.displayHero,
-      color = parchment,
-    )
-    Text(
-      text = "speak to your elder before the next tick",
-      style = ClanWorldTheme.type.scriptItalic,
-      color = warmDim,
-      modifier = Modifier.padding(top = 2.dp),
-    )
-  }
-}
-
-@Composable
-private fun TargetClanRow(active: Int, onSelect: (Int) -> Unit) {
-  Column {
-    Text(
-      text = "TO ELDER",
-      style = ClanWorldTheme.type.monoNano,
-      color = ClanWorldTheme.colors.warmFaint,
-    )
-    Spacer(Modifier.height(8.dp))
-    LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-      items(HearthViewModel.LINKED_CLAN_IDS) { clanId ->
-        ClanPill(
-          clanId = clanId,
-          selected = clanId == active,
-          onClick = { onSelect(clanId) },
-        )
-      }
-    }
-  }
-}
-
-@Composable
-private fun ClanPill(clanId: Int, selected: Boolean, onClick: () -> Unit) {
-  val accent = clanColor(clanId)
-  val bg = if (selected) accent.copy(alpha = 0.18f) else Color.Transparent
-  val border = if (selected) accent else ClanWorldTheme.colors.hairline
-  val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
   Row(
     modifier = Modifier
-      .clip(RoundedCornerShape(4.dp))
-      .background(bg)
-      .drawBehind {
-        drawRoundRect(
-          color = border,
-          cornerRadius = CornerRadius(4.dp.toPx()),
-          style = Stroke(width = 1.dp.toPx()),
-        )
-      }
-      .clickable { onClick() }
-      .padding(horizontal = 12.dp, vertical = 8.dp),
+      .fillMaxWidth()
+      .padding(vertical = 4.dp),
     verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
   ) {
-    Box(
-      modifier = Modifier
-        .size(10.dp)
-        .clip(RoundedCornerShape(50))
-        .background(accent),
-    )
+    SideRule(hairline)
     Text(
-      text = clanDisplayName(clanId).uppercase(),
-      style = ClanWorldTheme.type.monoMicro,
-      color = tint,
+      text = label,
+      style = ClanWorldTheme.type.sectionHead,
+      color = ClanWorldTheme.colors.parchment,
     )
+    SideRule(hairline)
   }
 }
 
 @Composable
-private fun DraftCard(draft: String, onChange: (String) -> Unit, enabled: Boolean) {
-  ParchmentCard(modifier = Modifier.fillMaxWidth()) {
-    Text(
-      text = "STEER",
-      style = ClanWorldTheme.type.monoNano,
-      color = Ink3,
-    )
-    Spacer(Modifier.height(6.dp))
+private fun androidx.compose.foundation.layout.RowScope.SideRule(
+  color: androidx.compose.ui.graphics.Color,
+) {
+  Box(
+    modifier = Modifier
+      .weight(1f)
+      .height(1.dp)
+      .background(color),
+  )
+}
+
+@Composable
+private fun WhisperFeed(
+  feed: List<Whisper>,
+  modifier: Modifier = Modifier,
+) {
+  if (feed.isEmpty()) {
     Box(
-      modifier = Modifier
-        .fillMaxWidth()
-        .height(120.dp),
+      modifier = modifier.padding(vertical = 12.dp),
+      contentAlignment = Alignment.Center,
     ) {
-      if (draft.isEmpty()) {
-        Text(
-          text = "the river runs cold; press for the strait, hold the western shore until the next tick…",
-          style = ClanWorldTheme.type.scriptItalic.copy(color = Ink3),
-        )
-      }
-      BasicTextField(
-        value = draft,
-        onValueChange = if (enabled) onChange else { _ -> },
-        textStyle = LocalTextStyle.current.copy(
-          fontFamily = ClanWorldTheme.type.scriptItalic.fontFamily,
-          fontStyle = ClanWorldTheme.type.scriptItalic.fontStyle,
-          fontSize = ClanWorldTheme.type.scriptItalic.fontSize,
-          color = Ink,
-        ),
-        cursorBrush = SolidColor(Ink2),
-        modifier = Modifier.fillMaxSize(),
+      Text(
+        text = "Awaiting first whisper. Press send to write.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warmFaint,
       )
     }
-    Spacer(Modifier.height(8.dp))
-    Text(
-      text = "${draft.length}/280",
-      style = ClanWorldTheme.type.monoNano,
-      color = Ink3,
-      textAlign = TextAlign.End,
-      modifier = Modifier.fillMaxWidth(),
-    )
+    return
+  }
+  val listState = rememberLazyListState()
+  // Auto-scroll to bottom on new messages.
+  LaunchedEffect(feed.size) {
+    if (feed.isNotEmpty()) listState.animateScrollToItem(feed.lastIndex)
+  }
+  LazyColumn(
+    modifier = modifier,
+    state = listState,
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+    contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 4.dp),
+  ) {
+    items(feed) { whisper ->
+      WhisperRow(whisper = whisper)
+    }
   }
 }
 
 @Composable
-private fun ConsoleStatus(state: SteeringConsoleUiState) {
-  when (state.phase) {
-    SendPhase.Idle -> {
+private fun WhisperRow(whisper: Whisper) {
+  // Right-aligned card so user-sent whispers feel like outgoing chat.
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.End,
+  ) {
+    Column(
+      modifier = Modifier
+        .widthIn(max = 320.dp)
+        .clip(RoundedCornerShape(14.dp))
+        .background(ClanWorldTheme.colors.iron2)
+        .drawBehind {
+          // Ember accent on the right edge — subtly marks "from you".
+          drawLine(
+            color = androidx.compose.ui.graphics.Color(0xFFFF6B35).copy(alpha = 0.55f),
+            start = Offset(size.width - 1f, 8f),
+            end = Offset(size.width - 1f, size.height - 8f),
+            strokeWidth = 2f,
+          )
+        }
+        .padding(horizontal = 12.dp, vertical = 8.dp),
+      verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
       Text(
-        text = "your seal is required before the message goes to the elder.",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.warmDim,
+        text = whisper.body,
+        style = ClanWorldTheme.type.scriptItalic.copy(color = ClanWorldTheme.colors.warm),
+      )
+      Text(
+        text = "whispered " + relativeTime(whisper.sentAt),
+        style = ClanWorldTheme.type.monoNano,
+        color = ClanWorldTheme.colors.warmFaint,
       )
     }
-    SendPhase.Signing -> {
-      Text(
-        text = "the wallet is preparing the seal…",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.gold,
-      )
+  }
+}
+
+@Composable
+private fun StatusLine(
+  successMsg: String?,
+  errorMsg: String?,
+  onDismiss: () -> Unit,
+) {
+  // Auto-dismiss success after 5s.
+  LaunchedEffect(successMsg) {
+    if (successMsg != null) {
+      delay(5_000L)
+      onDismiss()
     }
-    SendPhase.Queued -> {
+  }
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .height(18.dp)
+      .clickable(enabled = errorMsg != null || successMsg != null) { onDismiss() },
+    contentAlignment = Alignment.CenterStart,
+  ) {
+    AnimatedVisibility(
+      visible = errorMsg != null,
+      enter = fadeIn(),
+      exit = fadeOut(),
+    ) {
       Text(
-        text = "queued for next tick — the elder will hear before the heartbeat.",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.success,
-      )
-    }
-    SendPhase.Failed -> {
-      Text(
-        text = state.errorMessage ?: "the seal could not be set.",
-        style = ClanWorldTheme.type.scriptItalic,
+        text = "✕  ${errorMsg ?: ""}",
+        style = ClanWorldTheme.type.monoNano,
         color = ClanWorldTheme.colors.danger,
       )
     }
+    AnimatedVisibility(
+      visible = errorMsg == null && successMsg != null,
+      enter = fadeIn(),
+      exit = fadeOut(),
+    ) {
+      Text(
+        text = "✓  ${successMsg ?: ""}",
+        style = ClanWorldTheme.type.monoNano,
+        color = ClanWorldTheme.colors.success,
+      )
+    }
   }
 }
+
+private fun relativeTime(thenMs: Long): String {
+  val now = System.currentTimeMillis()
+  val s = ((now - thenMs) / 1000L).coerceAtLeast(0L)
+  if (s < 60L) return "${s}s ago"
+  val m = s / 60L
+  if (m < 60L) return "${m}m ago"
+  val h = m / 60L
+  return "${h}h ago"
+}
+

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
@@ -1,8 +1,16 @@
 package world.clan.app.ui.screens
 
 import androidx.activity.ComponentActivity
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,18 +19,23 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,25 +43,22 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import world.clan.app.App
 import world.clan.app.R
 import world.clan.app.ui.components.EmberCta
-import world.clan.app.ui.components.ParchmentCard
 import world.clan.app.ui.theme.ClanWorldTheme
-import world.clan.app.ui.theme.Ink
-import world.clan.app.ui.theme.Ink2
-import world.clan.app.ui.theme.Ink3
-import world.clan.app.ui.theme.clanColor
-import world.clan.app.viewmodel.Posture
 import world.clan.app.viewmodel.SendPhase
 import world.clan.app.viewmodel.StrategyEditorUiState
 import world.clan.app.viewmodel.StrategyEditorViewModel
@@ -56,6 +66,15 @@ import world.clan.app.viewmodel.StrategyEditorViewModelFactory
 import world.clan.app.viewmodel.clanDisplayName
 import world.clan.app.wallet.MwaResult
 
+private const val STRATEGY_LIMIT = 800
+private const val NOTES_LIMIT = 400
+
+/**
+ * Slice 4d redesign: dual STRATEGY + NOTES textarea pattern that mirrors
+ * web PR #51's `EssenceSection.tsx`. Each FieldShell glows ember when dirty.
+ * "Sign to Commit" CTA becomes the primary action when there are unsaved
+ * changes; its post-sign success transitions to "Sealed ✓" then auto-pops.
+ */
 @Composable
 fun StrategyEditorScreenRoute(
   app: App,
@@ -64,183 +83,145 @@ fun StrategyEditorScreenRoute(
   onBack: () -> Unit,
   onSaved: () -> Unit,
 ) {
-  val vm: StrategyEditorViewModel =
-    viewModel(factory = StrategyEditorViewModelFactory(app, clanId))
+  val vm: StrategyEditorViewModel = viewModel(
+    factory = StrategyEditorViewModelFactory(app, clanId),
+  )
   val state by vm.state.collectAsState()
   val scope = rememberCoroutineScope()
+
+  // Auto-pop ~1.3s after Queued.
+  LaunchedEffect(state.savePhase) {
+    if (state.savePhase == SendPhase.Queued) {
+      delay(1_300L)
+      onSaved()
+    }
+  }
 
   StrategyEditor(
     state = state,
     onBack = onBack,
-    onSetPosture = vm::setPosture,
-    onSetDoctrine = vm::setDoctrine,
-    onSetPinnedKey = vm::setPinnedKey,
-    onSave = {
+    onStrategyChange = vm::setDraftStrategy,
+    onNotesChange = vm::setDraftNotes,
+    onCommit = {
       scope.launch {
         vm.setSavePhase(SendPhase.Signing)
         val token = app.sessionStore.read()?.mwaAuthToken
         if (token == null) {
-          vm.setSavePhase(SendPhase.Queued)
+          vm.setSavePhase(SendPhase.Failed, "not signed in.")
           return@launch
         }
-        val msg = ("ClanWorld Strategy — clan ${state.clanId} | ${state.posture.name} | " +
-          "${state.pinnedKey} = ${state.doctrine}").toByteArray()
-        when (val r = app.mwaClient.signMessage(hostActivity, token, msg)) {
-          is MwaResult.Ok -> vm.setSavePhase(SendPhase.Queued)
+        val msg = "ClanWorld Essence — clan ${state.clanId}".toByteArray()
+        val result = app.mwaClient.signMessage(
+          com.solana.mobilewalletadapter.clientlib.ActivityResultSender(hostActivity),
+          token,
+          msg,
+        )
+        when (result) {
+          is MwaResult.Ok -> vm.confirmSeal()
           is MwaResult.UserDeclined -> vm.setSavePhase(SendPhase.Idle)
           is MwaResult.WalletNotFound ->
             vm.setSavePhase(SendPhase.Failed, "no wallet found on device.")
           is MwaResult.Error ->
-            vm.setSavePhase(SendPhase.Failed, r.cause.message ?: "the wallet refused the seal.")
+            vm.setSavePhase(SendPhase.Failed, result.cause.message ?: "the wallet refused the seal.")
         }
       }
     },
+    onDismissStatus = vm::clearStatus,
   )
-
-  if (state.savePhase == SendPhase.Queued) {
-    androidx.compose.runtime.LaunchedEffect(Unit) {
-      delay(1300L)
-      onSaved()
-    }
-  }
 }
 
 @Composable
 private fun StrategyEditor(
   state: StrategyEditorUiState,
   onBack: () -> Unit,
-  onSetPosture: (Posture) -> Unit,
-  onSetDoctrine: (String) -> Unit,
-  onSetPinnedKey: (String) -> Unit,
-  onSave: () -> Unit,
+  onStrategyChange: (String) -> Unit,
+  onNotesChange: (String) -> Unit,
+  onCommit: () -> Unit,
+  onDismissStatus: () -> Unit,
 ) {
+  val strategyDirty = state.draftStrategy != state.committedStrategy
+  val notesDirty = state.draftNotes != state.committedNotes
+  val anyDirty = strategyDirty || notesDirty
+
   Column(
     modifier = Modifier
       .fillMaxSize()
+      .imePadding()
       .verticalScroll(rememberScrollState()),
   ) {
-    BackBar(text = "back to ${clanDisplayName(state.clanId).lowercase()}", onBack = onBack)
+    BackBar(text = clanDisplayName(state.clanId), onBack = onBack)
 
     Column(modifier = Modifier.padding(horizontal = 22.dp)) {
-      EditorHead(state.clanId)
-      Spacer(Modifier.height(14.dp))
+      OrnamentRule(label = "ÆLDER ESSENCE")
 
-      if (state.isLoading) {
-        Text(
-          text = "the elder's last counsel is being read…",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-          modifier = Modifier.padding(top = 24.dp),
+      Spacer(Modifier.height(18.dp))
+
+      FieldShell(
+        label = "STRATEGY",
+        charCount = state.draftStrategy.length,
+        limit = STRATEGY_LIMIT,
+        dirty = strategyDirty,
+      ) {
+        EssenceTextField(
+          value = state.draftStrategy,
+          onValueChange = onStrategyChange,
+          minHeight = 110.dp,
+          maxHeight = 220.dp,
+          enabled = state.savePhase != SendPhase.Signing,
+          placeholder = "Tell your Elder what to focus on this season — economy, alliances, defense priorities. They'll read this every time their context resets.",
         )
-      } else {
-        // ── Posture ───────────────────────────────────────────────────────
-        Text(
-          text = "POSTURE",
-          style = ClanWorldTheme.type.monoNano,
-          color = ClanWorldTheme.colors.warmFaint,
-        )
-        Spacer(Modifier.height(8.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-          Posture.values().forEach { p ->
-            PosturePill(
-              posture = p,
-              selected = p == state.posture,
-              onClick = { onSetPosture(p) },
-            )
-          }
-        }
-        Spacer(Modifier.height(18.dp))
-
-        // ── Pinned memory key ─────────────────────────────────────────────
-        ParchmentCard(modifier = Modifier.fillMaxWidth()) {
-          Text(
-            text = "PINNED KEY",
-            style = ClanWorldTheme.type.monoNano,
-            color = Ink3,
-          )
-          Spacer(Modifier.height(6.dp))
-          BasicTextField(
-            value = state.pinnedKey,
-            onValueChange = onSetPinnedKey,
-            singleLine = true,
-            textStyle = LocalTextStyle.current.copy(
-              fontFamily = ClanWorldTheme.type.monoData.fontFamily,
-              fontSize = ClanWorldTheme.type.monoData.fontSize,
-              color = Ink,
-            ),
-            cursorBrush = SolidColor(Ink2),
-            modifier = Modifier.fillMaxWidth(),
-          )
-        }
-
-        Spacer(Modifier.height(14.dp))
-
-        // ── Doctrine ──────────────────────────────────────────────────────
-        ParchmentCard(modifier = Modifier.fillMaxWidth()) {
-          Text(
-            text = "DOCTRINE",
-            style = ClanWorldTheme.type.monoNano,
-            color = Ink3,
-          )
-          Spacer(Modifier.height(6.dp))
-          Box(
-            modifier = Modifier
-              .fillMaxWidth()
-              .height(140.dp),
-          ) {
-            if (state.doctrine.isEmpty()) {
-              Text(
-                text = "what should the elder hold to, even when the season turns?",
-                style = ClanWorldTheme.type.scriptItalic.copy(color = Ink3),
-              )
-            }
-            BasicTextField(
-              value = state.doctrine,
-              onValueChange = onSetDoctrine,
-              textStyle = LocalTextStyle.current.copy(
-                fontFamily = ClanWorldTheme.type.scriptItalic.fontFamily,
-                fontStyle = ClanWorldTheme.type.scriptItalic.fontStyle,
-                fontSize = ClanWorldTheme.type.scriptItalic.fontSize,
-                color = Ink,
-              ),
-              cursorBrush = SolidColor(Ink2),
-              modifier = Modifier.fillMaxSize(),
-            )
-          }
-          Spacer(Modifier.height(8.dp))
-          Text(
-            text = "${state.doctrine.length}/280",
-            style = ClanWorldTheme.type.monoNano,
-            color = Ink3,
-            textAlign = TextAlign.End,
-            modifier = Modifier.fillMaxWidth(),
-          )
-        }
-
-        Spacer(Modifier.height(14.dp))
-
-        // ── Save status ───────────────────────────────────────────────────
-        EditorStatus(state)
-        Spacer(Modifier.height(14.dp))
-
-        EmberCta(
-          text = when (state.savePhase) {
-            SendPhase.Idle -> "Sign and Seal"
-            SendPhase.Signing -> "Awaiting the seal…"
-            SendPhase.Queued -> "Sealed ✓"
-            SendPhase.Failed -> "Try Again"
-          },
-          onClick = onSave,
-          enabled = state.doctrine.isNotBlank() &&
-            state.pinnedKey.isNotBlank() &&
-            (state.savePhase == SendPhase.Idle || state.savePhase == SendPhase.Failed),
-          modifier = Modifier.fillMaxWidth(),
-        )
-        Spacer(Modifier.height(40.dp))
       }
+
+      Spacer(Modifier.height(12.dp))
+
+      FieldShell(
+        label = "NOTES",
+        charCount = state.draftNotes.length,
+        limit = NOTES_LIMIT,
+        dirty = notesDirty,
+      ) {
+        EssenceTextField(
+          value = state.draftNotes,
+          onValueChange = onNotesChange,
+          minHeight = 80.dp,
+          maxHeight = 160.dp,
+          enabled = state.savePhase != SendPhase.Signing,
+          placeholder = "Free-form reminders, intel about other clans, debts owed. Anything you want them to remember.",
+        )
+      }
+
+      Spacer(Modifier.height(20.dp))
+
+      val ctaEnabled = anyDirty &&
+        (state.savePhase == SendPhase.Idle || state.savePhase == SendPhase.Failed)
+      EmberCta(
+        text = when (state.savePhase) {
+          SendPhase.Idle -> if (anyDirty) "Sign to Commit" else "Sealed · No Changes"
+          SendPhase.Signing -> "Sealing…"
+          SendPhase.Queued -> "Sealed ✓"
+          SendPhase.Failed -> "Try Again"
+        },
+        onClick = onCommit,
+        enabled = ctaEnabled,
+        modifier = Modifier.fillMaxWidth(),
+      )
+
+      Spacer(Modifier.height(10.dp))
+
+      StatusLine(
+        successMsg = state.statusBody,
+        errorMsg = state.errorMessage,
+        onDismiss = onDismissStatus,
+      )
+
+      Spacer(Modifier.height(40.dp))
     }
   }
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// Sub-composables
+// ─────────────────────────────────────────────────────────────────────
 
 @Composable
 private fun BackBar(text: String, onBack: () -> Unit) {
@@ -255,119 +236,219 @@ private fun BackBar(text: String, onBack: () -> Unit) {
     Icon(
       painter = painterResource(R.drawable.ui_arrow),
       contentDescription = "back",
-      tint = ClanWorldTheme.colors.warm,
-      modifier = Modifier.height(16.dp),
+      tint = ClanWorldTheme.colors.gold,
+      modifier = Modifier.size(14.dp),
     )
     Text(
-      text = text,
+      text = "HALL",
       style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+    Text(
+      text = "·",
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Text(
+      text = "the writ of ${text.split(" ").lastOrNull()?.lowercase() ?: "—"}",
+      style = ClanWorldTheme.type.scriptItalic,
       color = ClanWorldTheme.colors.warmDim,
     )
   }
 }
 
 @Composable
-private fun EditorHead(clanId: Int) {
-  val parchment = ClanWorldTheme.colors.parchment
-  val warmDim = ClanWorldTheme.colors.warmDim
-  val hairline = ClanWorldTheme.colors.hairline
+private fun OrnamentRule(label: String) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(vertical = 4.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    SideRule()
+    Text(
+      text = label,
+      style = ClanWorldTheme.type.sectionHead,
+      color = ClanWorldTheme.colors.parchment,
+    )
+    SideRule()
+  }
+}
 
-  Column(
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.SideRule() {
+  Box(
+    modifier = Modifier
+      .weight(1f)
+      .height(1.dp)
+      .background(ClanWorldTheme.colors.hairlineStrong),
+  )
+}
+
+/**
+ * Iron-card with a gold-mono header (label + dirty dot + char count) and
+ * the inner text field. Border + glow shift to ember when dirty. Mirrors
+ * web PR #51's `FieldShell` in `EssenceSection.tsx`.
+ */
+@Composable
+private fun FieldShell(
+  label: String,
+  charCount: Int,
+  limit: Int,
+  dirty: Boolean,
+  content: @Composable () -> Unit,
+) {
+  val ember = ClanWorldTheme.colors.ember
+  val emberGlow = ClanWorldTheme.colors.emberGlow
+  val borderIron = ClanWorldTheme.colors.hairline
+  val borderColor by animateColorAsState(
+    targetValue = if (dirty) ember else borderIron,
+    animationSpec = tween(220),
+    label = "field-border",
+  )
+  val overshoot = charCount > (limit * 0.9).toInt()
+  val shape = RoundedCornerShape(6.dp)
+
+  Box(
     modifier = Modifier
       .fillMaxWidth()
       .drawBehind {
-        drawLine(
-          color = hairline,
-          start = Offset(0f, size.height + 14f),
-          end = Offset(size.width, size.height + 14f),
-          strokeWidth = 1f,
-        )
-      },
+        if (dirty) {
+          val expand = 6.dp.toPx()
+          drawRoundRect(
+            color = emberGlow.copy(alpha = 0.18f),
+            topLeft = Offset(-expand, -expand + 1.dp.toPx()),
+            size = Size(size.width + expand * 2, size.height + expand * 2),
+            cornerRadius = CornerRadius(6.dp.toPx() + expand),
+          )
+        }
+      }
+      .clip(shape)
+      .background(ClanWorldTheme.colors.iron2)
+      .border(1.dp, borderColor, shape),
   ) {
-    Text(
-      text = "STRATEGY",
-      style = ClanWorldTheme.type.displayHero,
-      color = parchment,
-    )
-    Text(
-      text = "the doctrine kept by ${clanDisplayName(clanId).lowercase()}",
-      style = ClanWorldTheme.type.scriptItalic,
-      color = warmDim,
-      modifier = Modifier.padding(top = 2.dp),
-    )
-  }
-}
-
-@Composable
-private fun PosturePill(posture: Posture, selected: Boolean, onClick: () -> Unit) {
-  val accent = when (posture) {
-    Posture.Defensive -> ClanWorldTheme.colors.rune
-    Posture.Balanced -> ClanWorldTheme.colors.gold
-    Posture.Aggressive -> ClanWorldTheme.colors.ember
-  }
-  val bg = if (selected) accent.copy(alpha = 0.18f) else Color.Transparent
-  val border = if (selected) accent else ClanWorldTheme.colors.hairline
-  val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
-  Row(
-    modifier = Modifier
-      .clip(RoundedCornerShape(4.dp))
-      .background(bg)
-      .drawBehind {
-        drawRoundRect(
-          color = border,
-          cornerRadius = CornerRadius(4.dp.toPx()),
-          style = Stroke(width = 1.dp.toPx()),
+    Column {
+      Row(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(start = 12.dp, top = 8.dp, end = 12.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        Text(
+          text = label,
+          style = ClanWorldTheme.type.eyebrow.copy(fontSize = 10.sp),
+          color = if (dirty) emberGlow else ClanWorldTheme.colors.warmFaint,
+        )
+        if (dirty) {
+          Box(
+            modifier = Modifier
+              .size(6.dp)
+              .clip(CircleShape)
+              .drawBehind {
+                val r = size.minDimension / 2f
+                drawCircle(ember.copy(alpha = 0.55f), radius = r * 1.6f, center = Offset(r, r))
+              }
+              .background(ember),
+          )
+        }
+        Spacer(Modifier.weight(1f))
+        Text(
+          text = "$charCount / $limit",
+          style = ClanWorldTheme.type.monoNano,
+          color = if (overshoot) ClanWorldTheme.colors.goldBright
+          else ClanWorldTheme.colors.warmFaint,
         )
       }
-      .clickable { onClick() }
-      .padding(horizontal = 14.dp, vertical = 10.dp),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(8.dp),
-  ) {
-    Box(
-      modifier = Modifier
-        .size(8.dp)
-        .clip(RoundedCornerShape(50))
-        .background(accent),
-    )
-    Text(
-      text = posture.name.uppercase(),
-      style = ClanWorldTheme.type.monoMicro,
-      color = tint,
-    )
+      content()
+    }
   }
 }
 
 @Composable
-private fun EditorStatus(state: StrategyEditorUiState) {
-  when (state.savePhase) {
-    SendPhase.Idle -> {
-      Text(
-        text = "your seal will write the doctrine to the elder's memory.",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.warmDim,
-      )
+private fun EssenceTextField(
+  value: String,
+  onValueChange: (String) -> Unit,
+  minHeight: Dp,
+  maxHeight: Dp,
+  enabled: Boolean,
+  placeholder: String,
+) {
+  val ember = ClanWorldTheme.colors.ember
+  val warm = ClanWorldTheme.colors.warm
+  val warmFaint = ClanWorldTheme.colors.warmFaint
+  val interactionSource = remember { MutableInteractionSource() }
+
+  BasicTextField(
+    value = value,
+    onValueChange = onValueChange,
+    enabled = enabled,
+    textStyle = ClanWorldTheme.type.body.copy(color = warm),
+    cursorBrush = SolidColor(ember),
+    interactionSource = interactionSource,
+    keyboardOptions = KeyboardOptions(
+      capitalization = KeyboardCapitalization.Sentences,
+      imeAction = ImeAction.Default,
+    ),
+    modifier = Modifier
+      .fillMaxWidth()
+      .heightIn(min = minHeight, max = maxHeight)
+      .padding(horizontal = 12.dp, vertical = 8.dp),
+    decorationBox = { inner ->
+      if (value.isEmpty()) {
+        Text(
+          text = placeholder,
+          style = ClanWorldTheme.type.scriptItalic.copy(color = warmFaint),
+        )
+      }
+      inner()
+    },
+  )
+}
+
+@Composable
+private fun StatusLine(
+  successMsg: String?,
+  errorMsg: String?,
+  onDismiss: () -> Unit,
+) {
+  LaunchedEffect(successMsg) {
+    if (successMsg != null) {
+      delay(5_000L)
+      onDismiss()
     }
-    SendPhase.Signing -> {
+  }
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .height(18.dp)
+      .clickable(enabled = errorMsg != null || successMsg != null) { onDismiss() },
+    contentAlignment = Alignment.CenterStart,
+  ) {
+    AnimatedVisibility(
+      visible = errorMsg != null,
+      enter = fadeIn(),
+      exit = fadeOut(),
+    ) {
       Text(
-        text = "the wallet is preparing the seal…",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.gold,
-      )
-    }
-    SendPhase.Queued -> {
-      Text(
-        text = "sealed — the elder will hold this counsel through the next tick.",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.success,
-      )
-    }
-    SendPhase.Failed -> {
-      Text(
-        text = state.errorMessage ?: "the seal could not be set.",
-        style = ClanWorldTheme.type.scriptItalic,
+        text = "✕  ${errorMsg ?: ""}",
+        style = ClanWorldTheme.type.monoNano,
         color = ClanWorldTheme.colors.danger,
       )
     }
+    AnimatedVisibility(
+      visible = errorMsg == null && successMsg != null,
+      enter = fadeIn(),
+      exit = fadeOut(),
+    ) {
+      Text(
+        text = "✓  ${successMsg ?: ""}",
+        style = ClanWorldTheme.type.monoNano,
+        color = ClanWorldTheme.colors.success,
+      )
+    }
   }
 }
+
+@Suppress("unused") private val _kKeepColor: Color = Color.Transparent

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
@@ -1,5 +1,6 @@
 package world.clan.app.ui.screens
 
+import android.view.HapticFeedbackConstants
 import androidx.activity.ComponentActivity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
@@ -46,6 +47,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -88,10 +90,15 @@ fun StrategyEditorScreenRoute(
   )
   val state by vm.state.collectAsState()
   val scope = rememberCoroutineScope()
+  val view = LocalView.current
 
-  // Auto-pop ~1.3s after Queued.
+  // Auto-pop ~1.3s after Queued — fire a confirm haptic on the transition.
   LaunchedEffect(state.savePhase) {
     if (state.savePhase == SendPhase.Queued) {
+      view.performHapticFeedback(
+        if (android.os.Build.VERSION.SDK_INT >= 30) HapticFeedbackConstants.CONFIRM
+        else HapticFeedbackConstants.VIRTUAL_KEY,
+      )
       delay(1_300L)
       onSaved()
     }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -42,11 +42,12 @@ class WhispersViewModelFactory(
 
 /** Per-route factory for SteeringConsole, parameterized by the initial target clan. */
 class SteeringConsoleViewModelFactory(
+  private val app: App,
   private val initialClanId: Int,
 ) : ViewModelProvider.Factory {
   @Suppress("UNCHECKED_CAST")
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
-    SteeringConsoleViewModel(initialClanId) as T
+    SteeringConsoleViewModel(app.convexClient, initialClanId) as T
 }
 
 /** Per-route factory for StrategyEditor, parameterized by clanId. */

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
@@ -15,12 +15,32 @@ import world.clan.app.data.ClanWorldConvexClient
  */
 enum class SendPhase { Idle, Signing, Queued, Failed }
 
-/** A single whisper in the local feed. Sent through the wallet, not yet to chain. */
-data class Whisper(
-  val id: Long,
-  val body: String,
-  val sentAt: Long,
-)
+/**
+ * A single item in the steering console feed. Two flavours:
+ *  - [OwnerSent]   — a whisper this user just sent (locally, optimistic)
+ *  - [FromComms]   — a row from `comms:getCombinedComms` (past whispers
+ *                    by this owner, orch broadcasts, replies from other
+ *                    clans). Hydrated on screen mount.
+ */
+sealed interface FeedItem {
+  val key: String
+  data class OwnerSent(val id: Long, val body: String, val sentAt: Long) : FeedItem {
+    override val key: String get() = "own-$id"
+  }
+  data class FromComms(
+    val kind: String,
+    val tick: Long?,
+    val speaker: String?,
+    val body: String,
+    val timestamp: Long?,
+    val seq: Int,
+  ) : FeedItem {
+    override val key: String get() = "cm-${tick ?: 0}-${speaker ?: "?"}-$seq"
+  }
+}
+
+/** Back-compat alias — older code may import `Whisper`. */
+typealias Whisper = FeedItem.OwnerSent
 
 data class SteeringConsoleUiState(
   val clanId: Int,
@@ -28,7 +48,7 @@ data class SteeringConsoleUiState(
   val sending: Boolean = false,
   val errorMessage: String? = null,
   val statusBody: String? = null,
-  val feed: List<Whisper> = emptyList(),
+  val feed: List<FeedItem> = emptyList(),
   /** Wall-clock ms when the last whisper was sent. -1 if no sends yet. */
   val lastSentAt: Long = -1L,
   /** User's GOLD balance (mocked for slice 4d — real chain integration later). */
@@ -62,12 +82,36 @@ data class SteeringConsoleUiState(
  * it in just before the local update.
  */
 class SteeringConsoleViewModel(
-  @Suppress("unused") private val convex: ClanWorldConvexClient,
+  private val convex: ClanWorldConvexClient,
   initialClanId: Int,
 ) : ViewModel() {
 
   private val _state = MutableStateFlow(SteeringConsoleUiState(clanId = initialClanId))
   val state: StateFlow<SteeringConsoleUiState> = _state.asStateFlow()
+
+  init { hydrateFeed(initialClanId) }
+
+  /** Pull past comms for this iNFT into the feed. Best-effort. */
+  private fun hydrateFeed(clanId: Int) {
+    viewModelScope.launch {
+      runCatching { convex.getCombinedComms(clanId, limit = 30) }
+        .onSuccess { comms ->
+          val items = comms
+            .sortedBy { it.tick ?: 0L }                  // oldest → newest
+            .mapIndexed { i, c ->
+              FeedItem.FromComms(
+                kind = c.kind,
+                tick = c.tick,
+                speaker = c.speaker,
+                body = c.body,
+                timestamp = c.timestamp,
+                seq = i,
+              )
+            }
+          _state.update { it.copy(feed = items + it.feed) }
+        }
+    }
+  }
 
   fun setDraft(text: String) {
     _state.update { it.copy(draft = text.take(1000), errorMessage = null) }
@@ -86,7 +130,7 @@ class SteeringConsoleViewModel(
     val body = _state.value.draft.trim()
     if (body.isEmpty()) return
     val total = burnAmount + skipTax
-    val whisper = Whisper(id = sentAt, body = body, sentAt = sentAt)
+    val whisper = FeedItem.OwnerSent(id = sentAt, body = body, sentAt = sentAt)
     _state.update {
       it.copy(
         draft = "",

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
@@ -1,46 +1,129 @@
 package world.clan.app.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-
-enum class SendPhase { Idle, Signing, Queued, Failed }
-
-data class SteeringConsoleUiState(
-  val targetClanId: Int,
-  val draft: String = "",
-  val phase: SendPhase = SendPhase.Idle,
-  val errorMessage: String? = null,
-)
+import kotlinx.coroutines.launch
+import world.clan.app.data.ClanWorldConvexClient
 
 /**
- * Slice 4c: SteeringConsole. The owner's whisper composer — drafts a
- * single-line steering message addressed to one of their elders.
+ * Phase of an MWA-signed write — used by SteeringConsole, StrategyEditor,
+ * BazaarVm, etc. Lives here for back-compat with #66's import surface.
+ */
+enum class SendPhase { Idle, Signing, Queued, Failed }
+
+/** A single whisper in the local feed. Sent through the wallet, not yet to chain. */
+data class Whisper(
+  val id: Long,
+  val body: String,
+  val sentAt: Long,
+)
+
+data class SteeringConsoleUiState(
+  val clanId: Int,
+  val draft: String = "",
+  val sending: Boolean = false,
+  val errorMessage: String? = null,
+  val statusBody: String? = null,
+  val feed: List<Whisper> = emptyList(),
+  /** Wall-clock ms when the last whisper was sent. -1 if no sends yet. */
+  val lastSentAt: Long = -1L,
+  /** User's GOLD balance (mocked for slice 4d — real chain integration later). */
+  val gold: Long = INITIAL_GOLD,
+  val sentCount: Int = 0,
+  /** Wall-clock ms — drives BurnFlash mount via key-change. */
+  val lastBurnAt: Long = 0L,
+  val lastBurnAmount: Long = 0L,
+  val faucetCooling: Boolean = false,
+  val goldBouncing: Boolean = false,
+) {
+  companion object {
+    const val INITIAL_GOLD = 14_750L
+  }
+}
+
+/**
+ * Slice 4d redesign of SteeringConsole — LLM-style chat experience that
+ * mirrors the polished web design from PR #51 (`apps/web/src/pages/agent/`).
  *
- * No real Convex mutation exists yet (per BUILD_PLAN — whisper send
- * needs a backend mutation that doesn't exist). This view-model holds
- * draft state; the screen handles the MWA sign + the (stubbed) send.
+ * State shape:
+ *  - draft, sending, errorMessage  → ChatInput state
+ *  - feed                          → past whispers (in-memory, this session)
+ *  - lastSentAt + cooldownTotalMs  → ChatInput's cooldown chip
+ *  - gold                          → ChatInput insufficient-state + BalanceRow
+ *  - lastBurnAt + lastBurnAmount   → BurnFlash trigger (post-tx flash)
+ *  - faucetCooling, goldBouncing   → BalanceRow faucet animation
+ *
+ * No real Convex mutation yet — `confirmSend()` decrements gold + appends
+ * to the feed locally. When a real `convex.queueWhisper(...)` exists, swap
+ * it in just before the local update.
  */
 class SteeringConsoleViewModel(
+  @Suppress("unused") private val convex: ClanWorldConvexClient,
   initialClanId: Int,
 ) : ViewModel() {
 
-  private val _state = MutableStateFlow(
-    SteeringConsoleUiState(targetClanId = initialClanId),
-  )
+  private val _state = MutableStateFlow(SteeringConsoleUiState(clanId = initialClanId))
   val state: StateFlow<SteeringConsoleUiState> = _state.asStateFlow()
 
   fun setDraft(text: String) {
-    _state.update { it.copy(draft = text) }
+    _state.update { it.copy(draft = text.take(1000), errorMessage = null) }
   }
 
-  fun setTarget(clanId: Int) {
-    _state.update { it.copy(targetClanId = clanId) }
+  fun setSending(sending: Boolean) {
+    _state.update { it.copy(sending = sending) }
   }
 
-  fun setPhase(p: SendPhase, error: String? = null) {
-    _state.update { it.copy(phase = p, errorMessage = error) }
+  fun setError(msg: String?) {
+    _state.update { it.copy(sending = false, errorMessage = msg) }
+  }
+
+  /** Optimistic update after the wallet seal succeeds. */
+  fun confirmSend(burnAmount: Long, skipTax: Long, sentAt: Long) {
+    val body = _state.value.draft.trim()
+    if (body.isEmpty()) return
+    val total = burnAmount + skipTax
+    val whisper = Whisper(id = sentAt, body = body, sentAt = sentAt)
+    _state.update {
+      it.copy(
+        draft = "",
+        sending = false,
+        feed = it.feed + whisper,
+        lastSentAt = sentAt,
+        gold = (it.gold - total).coerceAtLeast(0L),
+        sentCount = it.sentCount + 1,
+        lastBurnAt = sentAt,
+        lastBurnAmount = burnAmount,
+        statusBody = if (skipTax > 0L)
+          "whisper sealed · $burnAmount burned · $skipTax g → treasury"
+        else
+          "whisper sealed · $burnAmount g burned",
+        errorMessage = null,
+      )
+    }
+  }
+
+  fun clearStatus() {
+    _state.update { it.copy(statusBody = null, errorMessage = null) }
+  }
+
+  fun mintFaucet(drop: Long, durationMs: Long = 1_200L) {
+    if (_state.value.faucetCooling) return
+    _state.update {
+      it.copy(
+        gold = it.gold + drop,
+        faucetCooling = true,
+        goldBouncing = true,
+      )
+    }
+    viewModelScope.launch {
+      kotlinx.coroutines.delay(800L)
+      _state.update { it.copy(goldBouncing = false) }
+      kotlinx.coroutines.delay((durationMs - 800L).coerceAtLeast(0L))
+      _state.update { it.copy(faucetCooling = false) }
+    }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/StrategyEditorViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/StrategyEditorViewModel.kt
@@ -9,26 +9,28 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import world.clan.app.data.ClanWorldConvexClient
 
-enum class Posture { Defensive, Balanced, Aggressive }
-
 data class StrategyEditorUiState(
   val isLoading: Boolean = true,
   val clanId: Int,
-  val posture: Posture = Posture.Balanced,
-  val doctrine: String = "",
-  val pinnedKey: String = "",
+  /** Server-truth strategy + notes. Used to detect dirty state on the drafts. */
+  val committedStrategy: String = "",
+  val committedNotes: String = "",
+  /** Live editor drafts. */
+  val draftStrategy: String = "",
+  val draftNotes: String = "",
   val savePhase: SendPhase = SendPhase.Idle,
   val errorMessage: String? = null,
+  val statusBody: String? = null,
 )
 
 /**
- * Slice 4c: per-iNFT strategy form.
+ * Slice 4d redesign of StrategyEditor — dual STRATEGY + NOTES textarea
+ * pattern that mirrors the polished web design from PR #51
+ * (`apps/web/src/pages/agent/EssenceSection.tsx`).
  *
- * No real strategy mutation exists yet. We seed initial draft state from
- * the clan's first memory entry (best-effort) and call sign-only on save,
- * then surface a "Sealed" state for ~1.3s before pop. When the backend
- * mutation lands, the only change is swapping the no-op send for a real
- * convex.setStrategy(...) call inside the screen.
+ * State is per-iNFT; hydration seeds the drafts from the clan's first two
+ * memory entries. No real Convex mutation yet — `confirmSeal()` flips
+ * commit values to drafts (locally; chain integration is a follow-up).
  */
 class StrategyEditorViewModel(
   private val convex: ClanWorldConvexClient,
@@ -44,12 +46,21 @@ class StrategyEditorViewModel(
     viewModelScope.launch {
       runCatching { convex.getInftDemoState(clanId) }
         .onSuccess { demo ->
-          val firstMem = demo.memory.firstOrNull()
+          val strategy = demo.memory.firstOrNull { it.key.contains("strategy", ignoreCase = true) }
+            ?.value
+            ?: demo.memory.firstOrNull()?.value
+            ?: defaultStrategy(clanId)
+          val notes = demo.memory.firstOrNull { it.key.contains("notes", ignoreCase = true) }
+            ?.value
+            ?: demo.memory.getOrNull(1)?.value
+            ?: defaultNotes(clanId)
           _state.update {
             it.copy(
               isLoading = false,
-              doctrine = firstMem?.value?.take(180) ?: defaultDoctrine(clanId),
-              pinnedKey = firstMem?.key ?: "policy:default",
+              committedStrategy = strategy,
+              committedNotes = notes,
+              draftStrategy = strategy,
+              draftNotes = notes,
             )
           }
         }
@@ -57,29 +68,59 @@ class StrategyEditorViewModel(
           _state.update {
             it.copy(
               isLoading = false,
-              doctrine = defaultDoctrine(clanId),
-              pinnedKey = "policy:default",
+              committedStrategy = defaultStrategy(clanId),
+              committedNotes = defaultNotes(clanId),
+              draftStrategy = defaultStrategy(clanId),
+              draftNotes = defaultNotes(clanId),
             )
           }
         }
     }
   }
 
-  fun setPosture(p: Posture) = _state.update { it.copy(posture = p) }
-  fun setDoctrine(text: String) = _state.update { it.copy(doctrine = text.take(280)) }
-  fun setPinnedKey(text: String) = _state.update { it.copy(pinnedKey = text.take(64)) }
+  fun setDraftStrategy(text: String) =
+    _state.update { it.copy(draftStrategy = text.take(800), errorMessage = null) }
+
+  fun setDraftNotes(text: String) =
+    _state.update { it.copy(draftNotes = text.take(400), errorMessage = null) }
+
   fun setSavePhase(phase: SendPhase, error: String? = null) =
     _state.update { it.copy(savePhase = phase, errorMessage = error) }
 
-  private fun defaultDoctrine(clanId: Int): String = when (clanId) {
-    1 -> "Hold the high pass. Trade no ground without iron."
-    2 -> "Read the strait. Move only when both shores agree."
-    3 -> "Coin discipline first. Spend gold the way a hawk spends wing."
-    4 -> "Tend the green country. Refuse winter; outlast it."
-    5 -> "Watch the signs. The first move is rarely the right one."
-    6 -> "Forge before all. Steel pays for itself."
-    7 -> "The iron that holds. Build slow; break later."
-    8 -> "Walk the longer line. The season is a cipher; read it twice."
+  /** Optimistic commit after the wallet seal succeeds. */
+  fun confirmSeal() {
+    val s = _state.value
+    val fields = buildList {
+      if (s.draftStrategy != s.committedStrategy) add("strategy")
+      if (s.draftNotes != s.committedNotes) add("notes")
+    }
+    _state.update {
+      it.copy(
+        committedStrategy = it.draftStrategy,
+        committedNotes = it.draftNotes,
+        savePhase = SendPhase.Queued,
+        errorMessage = null,
+        statusBody = if (fields.isEmpty()) "essence sealed"
+        else "essence sealed · ${fields.joinToString(" + ")} written to 0G",
+      )
+    }
+  }
+
+  fun clearStatus() = _state.update { it.copy(statusBody = null, errorMessage = null) }
+
+  private fun defaultStrategy(clanId: Int): String = when (clanId) {
+    1 -> "Forest economy first. Build wood vault to 50, secure forest perimeter. Ally with clan-2 if Iron Guard whispers cooperation by tick 80. Don't trust clan-3 — Crimson burns bridges by tick 60 every season."
+    2 -> "Patient stockpile. Hold ore at 240+ before any trade. Defensive posture until tick 90, then exploit whoever starves first. Never raid first — counter-raid only."
+    3 -> "Volatility is leverage. Burn one bridge per season for shock value. Raid the weakest stockpile at tick 70. Don't hoard — convert wins into pressure immediately."
+    4 -> "Build for the long arc. Wood + ore parity by tick 60. Form a 3-clan defensive pact early, then break it the season AFTER everyone trusts us. Patience compounds."
+    else -> "Hold the line. Read the signs. Move only when both shores agree."
+  }
+
+  private fun defaultNotes(clanId: Int): String = when (clanId) {
+    1 -> "Crimson owes 8 wood from T42 trade. Iron Guard prefers ore-for-wood at 3:1. Verdant Wardens reliable on truces but slow to strike."
+    2 -> "Storm Riders aggressive on T20-40, then exhausted. Crimson volatile — never trust truce past tick 70. Verdant Wardens make solid 3-clan defensive pacts."
+    3 -> "Storm Riders mirror our energy — match their tempo, then break it. Iron Guard slow to react; raid them before tick 80 for clean wins."
+    4 -> "Truces hold us back if we keep them past tick 100. Storm Riders predictable raiders — let them tire on Iron Guard. Crimson hates being mirrored."
     else -> "—"
   }
 }


### PR DESCRIPTION
Replaces the form-based SteeringConsole + StrategyEditor (PR #66) with the polished LLM-style chat / dual-textarea designs we shipped on web in PR #51 ("the writ of the Ælder"). The native agent page now matches the web's visual + interaction polish, while keeping the existing routes + MWA integration in place.

## What changed

### SteeringConsole — LLM-style chat
- **Whisper feed** auto-scrolls; italic-script bubbles, ember accent on the right edge
- **\`ChatInput\`** (new component): rounded rectangle with the textarea up top + cooldown chip + send button packed inside the bottom edge, ember-glow focus halo, force-send gold-tone state during cooldown with the per-minute skip-tax rendered inline on the chip
- **\`BurnFlash\`** (new component): ephemeral post-tx counter — mounts only briefly after a successful send (~2.8s), scale-in + flicker + fade. Replaces the persistent fake-number drift from web's old BurnCounter.
- **\`BalanceRow\`** (new component): GOLD line + cyan dashed-outline DEVNET ONLY faucet button (impossible to mistake for real)
- 10-minute cooldown, 5g per send, +1000g/min skip-tax — same numbers as web

### StrategyEditor — dual essence textareas
- **STRATEGY** (800-char) + **NOTES** (400-char) FieldShells with ember-glow border + soft halo when dirty, gold-mono char counter, ember pulse on the dirty dot
- **"Sign to Commit"** \`EmberCta\` — disabled when not dirty, "Sealing…" → "Sealed ✓" → auto-pop

### Plumbing
- ViewModels rewritten with new state shapes (feed/cooldown/gold for steering; committed-vs-draft pairs for strategy)
- \`SendPhase\` enum kept in \`SteeringConsoleViewModel.kt\` for back-compat with BazaarVm + StrategyEditorVm + HireModal imports

### Build fix
Three call sites had \`MwaClient.signMessage(hostActivity, …)\` but the API expects \`ActivityResultSender\`. Wrapped:

  app.mwaClient.signMessage(ActivityResultSender(hostActivity), token, msg)

Fixes HireModal.kt (was broken on dev — flagged + fixed alongside) + the two screens I rewrote.

## Test plan

- [ ] Hall → tap iNFT → Whispers tab → "+ NEW WHISPER" → SteeringConsole opens with the empty-feed placeholder
- [ ] Type a draft → ChatInput border glows ember, cost reads "5 g per send"
- [ ] Tap send → MWA sheet → on success: chat bubble appears with relative-time stamp, "+5 BURNED" flash for ~3s, GOLD balance decrements, cooldown chip flips to "FORGE COOLING M:SS" and drains
- [ ] Tap "+ MINT 10K · DEVNET ONLY" → bounce animation, GOLD increments, button cools for ~1.2s
- [ ] Hall → tap iNFT → Memory tab → "EDIT STRATEGY →" → StrategyEditor opens with seeded text
- [ ] Edit STRATEGY → ember glow border + dirty dot + char count
- [ ] Sign to Commit → MWA → "Sealed ✓" → auto-pop after 1.3s

## APK

- https://shared.claude.do/public/clan-world-native-agent-page-debug.apk (24 MB, debug)

Closes #67
Supersedes the form-based design from #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)