### PR TITLE
feat(android): Phase 5 — TreasuryScreen

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -66,6 +66,7 @@ object Routes {
   const val Whispers = "whispers/{clanId}"
   const val SteeringConsole = "steer/{clanId}"
   const val StrategyEditor = "strategy/{clanId}"
+  const val Treasury = "treasury/{clanId}"
   const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
@@ -75,6 +76,7 @@ object Routes {
   fun whispers(clanId: Int) = "whispers/$clanId"
   fun steer(clanId: Int) = "steer/$clanId"
   fun strategy(clanId: Int) = "strategy/$clanId"
+  fun treasury(clanId: Int) = "treasury/$clanId"
   fun bridge(clanId: Int) = "bridge/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
@@ -217,7 +219,8 @@ fun ClanWorldApp(
     currentRoute?.startsWith("inft/") == true ||
     currentRoute?.startsWith("bazaarInft/") == true ||
     currentRoute?.startsWith("whispers/") == true ||
-    currentRoute?.startsWith("strategy/") == true
+    currentRoute?.startsWith("strategy/") == true ||
+    currentRoute?.startsWith("treasury/") == true
   // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
@@ -228,6 +231,7 @@ fun ClanWorldApp(
     currentRoute?.startsWith("bazaarInft/") == true -> RootTab.Bazaar // detail derived from Bazaar
     currentRoute?.startsWith("whispers/") == true -> RootTab.Hall // inbox is a Hall drill-in
     currentRoute?.startsWith("strategy/") == true -> RootTab.Hall // editor is a Hall drill-in
+    currentRoute?.startsWith("treasury/") == true -> RootTab.Hall // treasury is a Hall drill-in
     currentRoute?.startsWith("steer/") == true ||
       currentRoute?.startsWith("bridge/") == true ||
       currentRoute == Routes.Cockpit ||
@@ -376,6 +380,7 @@ fun ClanWorldApp(
               onEnterCockpit = { nav.navigate(Routes.bridge(clanId)) },
               onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
               onEditStrategy = { nav.navigate(Routes.strategy(clanId)) },
+              onOpenTreasury = { nav.navigate(Routes.treasury(clanId)) },
             )
           }
 
@@ -394,6 +399,7 @@ fun ClanWorldApp(
               clanId = clanId,
               onBack = { nav.popBackStack() },
               onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
+              onOpenTreasury = { nav.navigate(Routes.treasury(clanId)) },
               isBazaar = true,
               mwaSender = mwaSender,
               onHireConfirmed = {
@@ -455,6 +461,22 @@ fun ClanWorldApp(
               initialClanId = clanId,
               onBack = { nav.popBackStack() },
               onSent = { nav.popBackStack() },
+            )
+          }
+
+          // ── Treasury (per-iNFT GOLD + resources + movements; from Vault tab) ─
+          composable(
+            route = Routes.Treasury,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            world.clan.app.ui.screens.TreasuryScreenRoute(
+              app = app,
+              clanId = clanId,
+              onBack = { nav.popBackStack() },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -81,6 +81,7 @@ fun InftDetailScreenRoute(
   onEnterCockpit: () -> Unit = {},
   onOpenInbox: () -> Unit = {},
   onEditStrategy: () -> Unit = {},
+  onOpenTreasury: () -> Unit = {},
   isBazaar: Boolean = false,
   mwaSender: com.solana.mobilewalletadapter.clientlib.ActivityResultSender? = null,
   onHireConfirmed: (() -> Unit)? = null,
@@ -95,6 +96,7 @@ fun InftDetailScreenRoute(
     onEnterCockpit = onEnterCockpit,
     onOpenInbox = onOpenInbox,
     onEditStrategy = onEditStrategy,
+    onOpenTreasury = onOpenTreasury,
     isBazaar = isBazaar,
     app = app,
     mwaSender = mwaSender,
@@ -111,6 +113,7 @@ private fun InftDetailScreen(
   onEnterCockpit: () -> Unit,
   onOpenInbox: () -> Unit = {},
   onEditStrategy: () -> Unit = {},
+  onOpenTreasury: () -> Unit = {},
   isBazaar: Boolean = false,
   app: App? = null,
   mwaSender: com.solana.mobilewalletadapter.clientlib.ActivityResultSender? = null,
@@ -160,7 +163,7 @@ private fun InftDetailScreen(
           state.state?.memory.orEmpty(),
           onEditStrategy = if (!isBazaar) onEditStrategy else null,
         )
-        DetailTab.Vault -> VaultPanel(state.vault)
+        DetailTab.Vault -> VaultPanel(state.vault, onOpenTreasury = onOpenTreasury)
         DetailTab.Whispers -> WhispersPanel(state.comms, onOpenInbox = onOpenInbox)
         DetailTab.Bulletin -> BulletinPanel(state.state?.bulletins?.map { it.body } ?: emptyList())
       }
@@ -470,7 +473,11 @@ private fun MemoryPanel(
 }
 
 @Composable
-private fun VaultPanel(vault: List<VaultMovement>) {
+private fun VaultPanel(
+  vault: List<VaultMovement>,
+  onOpenTreasury: () -> Unit = {},
+) {
+  Column {
   PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
     if (vault.isEmpty()) {
       ComingNextSlice("the vault keeps its silence")
@@ -505,6 +512,17 @@ private fun VaultPanel(vault: List<VaultMovement>) {
       }
     }
   }
+  Text(
+    text = "FULL TREASURY →",
+    style = ClanWorldTheme.type.monoMicro,
+    color = ClanWorldTheme.colors.gold,
+    textAlign = TextAlign.Center,
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { onOpenTreasury() }
+      .padding(horizontal = 22.dp, vertical = 14.dp),
+  )
+  } // close outer Column
 }
 
 @Composable

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
@@ -1,0 +1,375 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import world.clan.app.App
+import world.clan.app.R
+import world.clan.app.data.VaultMovement
+import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.viewmodel.ResourceBalance
+import world.clan.app.viewmodel.TreasuryFilter
+import world.clan.app.viewmodel.TreasuryUiState
+import world.clan.app.viewmodel.TreasuryViewModel
+import world.clan.app.viewmodel.TreasuryViewModelFactory
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.filteredMovements
+
+@Composable
+fun TreasuryScreenRoute(
+  app: App,
+  clanId: Int,
+  onBack: () -> Unit,
+) {
+  val vm: TreasuryViewModel = viewModel(factory = TreasuryViewModelFactory(app, clanId))
+  val state by vm.state.collectAsState()
+  TreasuryScreen(
+    state = state,
+    clanId = clanId,
+    onBack = onBack,
+    onSetFilter = vm::setFilter,
+  )
+}
+
+@Composable
+private fun TreasuryScreen(
+  state: TreasuryUiState,
+  clanId: Int,
+  onBack: () -> Unit,
+  onSetFilter: (TreasuryFilter) -> Unit,
+) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    BackBar(text = "back to ${clanDisplayName(clanId).lowercase()}", onBack = onBack)
+
+    Column(modifier = Modifier.padding(horizontal = 22.dp)) {
+      TreasuryHead(clanId = clanId, balance = state.balance)
+      Spacer(Modifier.height(14.dp))
+
+      if (state.isLoading) {
+        Text(
+          text = "the keep is being weighed…",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(top = 18.dp),
+        )
+      } else if (state.errorMessage != null) {
+        Text(
+          text = state.errorMessage,
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.danger,
+          modifier = Modifier.padding(top = 18.dp),
+        )
+      } else {
+        GoldHeroCard(gold = state.balance.gold, clanId = clanId)
+        Spacer(Modifier.height(12.dp))
+        ResourceStripCard(balance = state.balance)
+        Spacer(Modifier.height(18.dp))
+        Text(
+          text = "MOVEMENTS",
+          style = ClanWorldTheme.type.monoNano,
+          color = ClanWorldTheme.colors.warmFaint,
+        )
+        Spacer(Modifier.height(8.dp))
+        FilterRow(active = state.filter, onSelect = onSetFilter)
+        Spacer(Modifier.height(10.dp))
+      }
+    }
+
+    if (!state.isLoading && state.errorMessage == null) {
+      val items = state.filteredMovements()
+      if (items.isEmpty()) {
+        Text(
+          text = "the vault keeps its silence",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
+        )
+      } else {
+        LazyColumn(
+          modifier = Modifier.fillMaxSize(),
+          verticalArrangement = Arrangement.spacedBy(0.dp),
+          contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+        ) {
+          items(items.withIndex().toList(), key = { (i, m) -> "${i}-${m.tick}-${m.resource}" }) { (_, mv) ->
+            MovementRow(mv)
+          }
+          item { Spacer(Modifier.height(40.dp)) }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun BackBar(text: String, onBack: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 14.dp)
+      .clickable { onBack() },
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      painter = painterResource(R.drawable.ui_arrow),
+      contentDescription = "back",
+      tint = ClanWorldTheme.colors.warm,
+      modifier = Modifier.height(16.dp),
+    )
+    Text(
+      text = text,
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+  }
+}
+
+@Composable
+private fun TreasuryHead(clanId: Int, balance: ResourceBalance) {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 14f),
+          end = Offset(size.width, size.height + 14f),
+          strokeWidth = 1f,
+        )
+      },
+    horizontalArrangement = Arrangement.SpaceBetween,
+    verticalAlignment = Alignment.Bottom,
+  ) {
+    Column {
+      Text(
+        text = "TREASURY",
+        style = ClanWorldTheme.type.displayHero,
+        color = parchment,
+      )
+      Text(
+        text = "the keeping of ${clanDisplayName(clanId).lowercase()}",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = warmDim,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+  }
+}
+
+@Composable
+private fun GoldHeroCard(gold: Long, clanId: Int) {
+  ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.SpaceBetween,
+      modifier = Modifier.fillMaxWidth(),
+    ) {
+      Column(modifier = Modifier.weight(1f)) {
+        Text(
+          text = "GOLD",
+          style = ClanWorldTheme.type.monoNano,
+          color = Ink3,
+        )
+        Text(
+          text = formatGold(gold),
+          style = ClanWorldTheme.type.displayHero,
+          color = Ink,
+          modifier = Modifier.padding(top = 4.dp),
+        )
+        Text(
+          text = "stored under ${clanDisplayName(clanId).lowercase()}",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = Ink2,
+          modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+      // accent dot in clan color
+      Box(
+        modifier = Modifier
+          .padding(start = 8.dp)
+          .clip(RoundedCornerShape(50))
+          .background(clanColor(clanId))
+          .padding(8.dp),
+      ) {
+        Text(
+          text = " ",
+          style = ClanWorldTheme.type.monoNano,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun ResourceStripCard(balance: ResourceBalance) {
+  ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+    Text(
+      text = "RESOURCES",
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Spacer(Modifier.height(10.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+      ResourceCell(label = "Wood", value = balance.wood)
+      ResourceCell(label = "Iron", value = balance.iron)
+      ResourceCell(label = "Wheat", value = balance.wheat)
+      ResourceCell(label = "Fish", value = balance.fish)
+    }
+  }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.ResourceCell(label: String, value: Long) {
+  Column(Modifier.weight(1f)) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Text(
+      text = "%,d".format(value),
+      style = ClanWorldTheme.type.monoData,
+      color = Ink,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+@Composable
+private fun FilterRow(active: TreasuryFilter, onSelect: (TreasuryFilter) -> Unit) {
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    FilterChip(label = "All", selected = active == TreasuryFilter.All, onClick = { onSelect(TreasuryFilter.All) })
+    FilterChip(label = "Gold", selected = active == TreasuryFilter.Gold, onClick = { onSelect(TreasuryFilter.Gold) })
+    FilterChip(label = "Resources", selected = active == TreasuryFilter.Resources, onClick = { onSelect(TreasuryFilter.Resources) })
+  }
+}
+
+@Composable
+private fun FilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
+  val bg = if (selected) ClanWorldTheme.colors.iron2 else Color.Transparent
+  val border = if (selected) ClanWorldTheme.colors.hairlineStrong else ClanWorldTheme.colors.hairline
+  val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
+  Box(
+    modifier = Modifier
+      .clip(RoundedCornerShape(4.dp))
+      .background(bg)
+      .drawBehind {
+        drawRoundRect(
+          color = border,
+          cornerRadius = CornerRadius(4.dp.toPx()),
+          style = Stroke(width = 1.dp.toPx()),
+        )
+      }
+      .clickable { onClick() }
+      .padding(horizontal = 12.dp, vertical = 8.dp),
+  ) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoMicro,
+      color = tint,
+    )
+  }
+}
+
+@Composable
+private fun MovementRow(mv: VaultMovement) {
+  val warm = ClanWorldTheme.colors.warm
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val warmFaint = ClanWorldTheme.colors.warmFaint
+  val gold = ClanWorldTheme.colors.gold
+  val danger = ClanWorldTheme.colors.danger
+  val rune = ClanWorldTheme.colors.rune
+  val hairline = ClanWorldTheme.colors.hairline
+
+  val sign = if (mv.type == "spend") "−" else "+"
+  val amountColor = when (mv.type) {
+    "spend" -> danger
+    "transfer" -> rune
+    else -> gold
+  }
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height),
+          end = Offset(size.width, size.height),
+          strokeWidth = 1f,
+        )
+      }
+      .padding(vertical = 12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Text(
+      text = "T %04d".format(mv.tick),
+      style = ClanWorldTheme.type.monoNano,
+      color = warmFaint,
+      modifier = Modifier.padding(end = 4.dp),
+    )
+    Column(modifier = Modifier.weight(1f)) {
+      Text(
+        text = mv.resource.replaceFirstChar { it.uppercase() },
+        style = ClanWorldTheme.type.body,
+        color = warm,
+      )
+      mv.source?.takeIf { it.isNotBlank() }?.let { src ->
+        Text(
+          text = src,
+          style = ClanWorldTheme.type.monoNano,
+          color = warmDim,
+          modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+    }
+    Text(
+      text = "$sign%.2f".format(mv.amount),
+      style = ClanWorldTheme.type.monoData,
+      color = amountColor,
+    )
+  }
+}
+
+private fun formatGold(value: Long): String =
+  if (value >= 1_000_000) "%.1fM".format(value / 1_000_000.0)
+  else if (value >= 1_000) "%.1fk".format(value / 1_000.0)
+  else "%,d".format(value)

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -58,3 +58,13 @@ class StrategyEditorViewModelFactory(
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
     StrategyEditorViewModel(app.convexClient, clanId) as T
 }
+
+/** Per-route factory for Treasury, parameterized by clanId. */
+class TreasuryViewModelFactory(
+  private val app: App,
+  private val clanId: Int,
+) : ViewModelProvider.Factory {
+  @Suppress("UNCHECKED_CAST")
+  override fun <T : ViewModel> create(modelClass: Class<T>): T =
+    TreasuryViewModel(app.convexClient, clanId) as T
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
@@ -1,0 +1,107 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import world.clan.app.data.ClanWorldConvexClient
+import world.clan.app.data.VaultMovement
+import world.clan.app.data.weiToWhole
+
+enum class TreasuryFilter { All, Gold, Resources }
+
+data class ResourceBalance(
+  val gold: Long,
+  val wood: Long,
+  val iron: Long,
+  val wheat: Long,
+  val fish: Long,
+)
+
+data class TreasuryUiState(
+  val isLoading: Boolean = true,
+  val clanId: Int,
+  val balance: ResourceBalance = ResourceBalance(0, 0, 0, 0, 0),
+  val movements: List<VaultMovement> = emptyList(),
+  val filter: TreasuryFilter = TreasuryFilter.All,
+  val errorMessage: String? = null,
+)
+
+/**
+ * Slice 5: per-clan Treasury.
+ *
+ * Aggregates two existing queries in parallel:
+ *   - getSnapshot — to read goldBalance / vaultWood / vaultIron / etc for THIS clan
+ *   - getVaultMovements — recent gains/spends/transfers
+ *
+ * Wei-precision balances (`String?` → `Long`) parsed via existing weiToWhole().
+ * Filtering is client-side over `movements`.
+ */
+class TreasuryViewModel(
+  private val convex: ClanWorldConvexClient,
+  private val clanId: Int,
+) : ViewModel() {
+
+  private val _state = MutableStateFlow(TreasuryUiState(clanId = clanId))
+  val state: StateFlow<TreasuryUiState> = _state.asStateFlow()
+
+  init { refresh() }
+
+  fun refresh() {
+    viewModelScope.launch {
+      _state.update { it.copy(isLoading = true, errorMessage = null) }
+      runCatching {
+        coroutineScope {
+          val snap = async { convex.getSnapshot() }
+          val moves = async {
+            runCatching { convex.getVaultMovements(clanId, limit = 24) }
+              .getOrDefault(emptyList())
+          }
+          snap.await() to moves.await()
+        }
+      }
+        .onSuccess { (snapshot, moves) ->
+          val mine = snapshot.clans.firstOrNull { it.id.toIntOrNull() == clanId }
+          val bal = if (mine == null) ResourceBalance(0, 0, 0, 0, 0)
+          else ResourceBalance(
+            gold = mine.goldBalance.weiToWhole(),
+            wood = mine.vaultWood.weiToWhole(),
+            iron = mine.vaultIron.weiToWhole(),
+            wheat = mine.vaultWheat.weiToWhole(),
+            fish = mine.vaultFish.weiToWhole(),
+          )
+          _state.update {
+            it.copy(
+              isLoading = false,
+              balance = bal,
+              movements = moves,
+              errorMessage = null,
+            )
+          }
+        }
+        .onFailure { e ->
+          _state.update {
+            it.copy(
+              isLoading = false,
+              errorMessage = e.message ?: "Failed to load treasury.",
+            )
+          }
+        }
+    }
+  }
+
+  fun setFilter(f: TreasuryFilter) {
+    _state.update { it.copy(filter = f) }
+  }
+}
+
+fun TreasuryUiState.filteredMovements(): List<VaultMovement> = when (filter) {
+  TreasuryFilter.All -> movements
+  TreasuryFilter.Gold -> movements.filter { it.resource == "gold" }
+  TreasuryFilter.Resources -> movements.filter { it.resource != "gold" }
+}


### PR DESCRIPTION
## Summary

Per-iNFT treasury view, deep route from InftDetail Vault tab.

**TreasuryScreen**
- Hero parchment card showing GOLD balance with \`formatGold\` (k/M/raw)
- Resource strip (Wood / Iron / Wheat / Fish) on a second parchment card
- Movements list with All / Gold / Resources filter chips (client-side)
- Sign-coded amount color: spend=danger, transfer=rune, gain=gold

**TreasuryViewModel**
- Aggregates two existing Convex queries in parallel (async/await):
  - \`getSnapshot\` for wei-precision balances (parsed via existing \`weiToWhole\`)
  - \`getVaultMovements(clanId, limit=24)\` for movement history
- No new server surface

**Wiring**
- New route: \`treasury/{clanId}\` (Hall drill-in; tabbar visible)
- InftDetail Vault tab gets a \"FULL TREASURY →\" link below the inline panel — same pattern as Whispers→Inbox + Memory→Strategy
- \`onOpenTreasury\` threaded through both InftDetail and BazaarInftDetail composable routes

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 12s.

## Test plan

- [ ] Hall → tap iNFT → Vault tab → \"FULL TREASURY →\" → TreasuryScreen with gold balance, resource strip, and movements list
- [ ] Filter chips (All/Gold/Resources) slice the movements list
- [ ] Bazaar → tap listing → Vault tab: \"FULL TREASURY →\" works (informational, even though you're not the owner yet)
- [ ] Tab bar visible during Treasury (Hall selected)
- [ ] Empty movements: shows \"the vault keeps its silence\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)