### PR TITLE
feat(android): Phase 6 — ForgeScreen 4-step mint wizard

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -67,6 +67,7 @@ object Routes {
   const val SteeringConsole = "steer/{clanId}"
   const val StrategyEditor = "strategy/{clanId}"
   const val Treasury = "treasury/{clanId}"
+  const val Forge = "forge"
   const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
@@ -220,7 +221,8 @@ fun ClanWorldApp(
     currentRoute?.startsWith("bazaarInft/") == true ||
     currentRoute?.startsWith("whispers/") == true ||
     currentRoute?.startsWith("strategy/") == true ||
-    currentRoute?.startsWith("treasury/") == true
+    currentRoute?.startsWith("treasury/") == true ||
+    currentRoute == Routes.Forge
   // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
@@ -232,6 +234,7 @@ fun ClanWorldApp(
     currentRoute?.startsWith("whispers/") == true -> RootTab.Hall // inbox is a Hall drill-in
     currentRoute?.startsWith("strategy/") == true -> RootTab.Hall // editor is a Hall drill-in
     currentRoute?.startsWith("treasury/") == true -> RootTab.Hall // treasury is a Hall drill-in
+    currentRoute == Routes.Forge -> RootTab.Hall // forge wizard surfaces from Hall
     currentRoute?.startsWith("steer/") == true ||
       currentRoute?.startsWith("bridge/") == true ||
       currentRoute == Routes.Cockpit ||
@@ -324,6 +327,7 @@ fun ClanWorldApp(
               app = app,
               factory = factory,
               onOpenInft = { clanId -> nav.navigate(Routes.inftDetail(clanId)) },
+              onForge = { nav.navigate(Routes.Forge) },
             )
           }
 
@@ -461,6 +465,22 @@ fun ClanWorldApp(
               initialClanId = clanId,
               onBack = { nav.popBackStack() },
               onSent = { nav.popBackStack() },
+            )
+          }
+
+          // ── Forge (4-step mint wizard; surfaces from Hall) ──────────────
+          composable(
+            route = Routes.Forge,
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) {
+            world.clan.app.ui.screens.ForgeScreenRoute(
+              app = app,
+              factory = factory,
+              mwaSender = mwaSender,
+              onBack = { nav.popBackStack() },
+              onForged = { nav.popBackStack() },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -1,0 +1,668 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentTransitionScope.SlideDirection
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import world.clan.app.App
+import world.clan.app.R
+import world.clan.app.ui.components.EmberCta
+import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.components.WaxSeal
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.ui.theme.clanGlyphRes
+import world.clan.app.viewmodel.ClanWorldViewModelFactory
+import world.clan.app.viewmodel.ForgeStep
+import world.clan.app.viewmodel.ForgeUiState
+import world.clan.app.viewmodel.ForgeViewModel
+import world.clan.app.viewmodel.Harness
+import world.clan.app.viewmodel.SendPhase
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.clanTagline
+import world.clan.app.wallet.MwaResult
+
+@Composable
+fun ForgeScreenRoute(
+  app: App,
+  factory: ClanWorldViewModelFactory,
+  mwaSender: ActivityResultSender,
+  onBack: () -> Unit,
+  onForged: () -> Unit,
+) {
+  val vm: ForgeViewModel = viewModel(factory = factory)
+  val state by vm.state.collectAsState()
+  val scope = rememberCoroutineScope()
+
+  ForgeScreen(
+    state = state,
+    onBack = onBack,
+    onSelectClan = vm::setClanId,
+    onSetName = vm::setSigilName,
+    onSetHarness = vm::setHarness,
+    onNext = vm::next,
+    onPrev = vm::back,
+    onForge = {
+      scope.launch {
+        vm.setMintPhase(SendPhase.Signing)
+        val token = app.sessionStore.read()?.mwaAuthToken
+        if (token == null) {
+          vm.setMintPhase(SendPhase.Queued)
+          return@launch
+        }
+        val msg = ("ClanWorld Forge — clan ${state.clanId} | ${state.sigilName} | " +
+          "${state.harness.name}").toByteArray()
+        when (val r = app.mwaClient.signMessage(mwaSender, token, msg)) {
+          is MwaResult.Ok -> vm.setMintPhase(SendPhase.Queued)
+          is MwaResult.UserDeclined -> vm.setMintPhase(SendPhase.Idle)
+          is MwaResult.WalletNotFound ->
+            vm.setMintPhase(SendPhase.Failed, "no wallet found on device.")
+          is MwaResult.Error ->
+            vm.setMintPhase(SendPhase.Failed, r.cause.message ?: "the wallet refused the seal.")
+        }
+      }
+    },
+  )
+
+  if (state.mintPhase == SendPhase.Queued) {
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+      delay(1500L)
+      onForged()
+    }
+  }
+}
+
+@Composable
+private fun ForgeScreen(
+  state: ForgeUiState,
+  onBack: () -> Unit,
+  onSelectClan: (Int) -> Unit,
+  onSetName: (String) -> Unit,
+  onSetHarness: (Harness) -> Unit,
+  onNext: () -> Unit,
+  onPrev: () -> Unit,
+  onForge: () -> Unit,
+) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    BackBar(text = "back to hall", onBack = onBack)
+
+    Column(modifier = Modifier.padding(horizontal = 22.dp)) {
+      ForgeHead()
+      Spacer(Modifier.height(10.dp))
+      ProgressDots(step = state.step)
+      Spacer(Modifier.height(18.dp))
+    }
+
+    AnimatedContent(
+      targetState = state.step,
+      transitionSpec = {
+        val direction = if (targetState.ordinal > initialState.ordinal) SlideDirection.Start else SlideDirection.End
+        (slideIntoContainer(direction, animationSpec = tween(280)) + fadeIn(tween(220))) togetherWith
+          (slideOutOfContainer(direction, animationSpec = tween(280)) + fadeOut(tween(180)))
+      },
+      label = "forge-step",
+      modifier = Modifier.weight(1f),
+    ) { step ->
+      when (step) {
+        ForgeStep.PickClan -> StepPickClan(
+          state = state,
+          onSelect = onSelectClan,
+        )
+        ForgeStep.NameSigil -> StepNameSigil(
+          state = state,
+          onChange = onSetName,
+        )
+        ForgeStep.PickHarness -> StepPickHarness(
+          state = state,
+          onSelect = onSetHarness,
+        )
+        ForgeStep.Confirm -> StepConfirm(
+          state = state,
+          onForge = onForge,
+        )
+      }
+    }
+
+    NavRow(state = state, onNext = onNext, onPrev = onPrev)
+    Spacer(Modifier.height(20.dp))
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Header + progress dots
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun BackBar(text: String, onBack: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 14.dp)
+      .clickable { onBack() },
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      painter = painterResource(R.drawable.ui_arrow),
+      contentDescription = "back",
+      tint = ClanWorldTheme.colors.warm,
+      modifier = Modifier.height(16.dp),
+    )
+    Text(
+      text = text,
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+  }
+}
+
+@Composable
+private fun ForgeHead() {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 14f),
+          end = Offset(size.width, size.height + 14f),
+          strokeWidth = 1f,
+        )
+      },
+  ) {
+    Text(text = "FORGE", style = ClanWorldTheme.type.displayHero, color = parchment)
+    Text(
+      text = "the unmade seal awaits its line",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = warmDim,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+@Composable
+private fun ProgressDots(step: ForgeStep) {
+  val ember = ClanWorldTheme.colors.ember
+  val warmFaint = ClanWorldTheme.colors.warmFaint
+  val total = ForgeStep.values().size
+  val activeIdx = step.ordinal
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    for (i in 0 until total) {
+      val color = if (i <= activeIdx) ember else warmFaint
+      Box(
+        modifier = Modifier
+          .size(8.dp)
+          .clip(RoundedCornerShape(50))
+          .background(color),
+      )
+    }
+    Spacer(Modifier.fillMaxWidth().weight(1f, fill = false))
+    Text(
+      text = "STEP ${activeIdx + 1} OF $total",
+      style = ClanWorldTheme.type.monoNano,
+      color = warmFaint,
+      modifier = Modifier.padding(start = 12.dp),
+    )
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 1 — Pick clan
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    Text(
+      text = "CHOOSE YOUR CLAN",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+      modifier = Modifier.padding(horizontal = 22.dp),
+    )
+    Spacer(Modifier.height(10.dp))
+    LazyColumn(
+      modifier = Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.spacedBy(10.dp),
+      contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+    ) {
+      items((1..8).toList()) { clanId ->
+        ClanCard(
+          clanId = clanId,
+          selected = state.clanId == clanId,
+          onClick = { onSelect(clanId) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun ClanCard(clanId: Int, selected: Boolean, onClick: () -> Unit) {
+  val accent = clanColor(clanId)
+  val borderColor = if (selected) accent else ClanWorldTheme.colors.hairline
+  val borderStroke = if (selected) 2.dp else 1.dp
+
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { onClick() }
+      .drawBehind {
+        drawRoundRect(
+          color = borderColor,
+          cornerRadius = CornerRadius(6.dp.toPx()),
+          style = Stroke(width = borderStroke.toPx()),
+        )
+      },
+  ) {
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+      ) {
+        WaxSeal(
+          glyph = painterResource(clanGlyphRes(clanId)),
+          clanColor = accent,
+          size = 44.dp,
+        )
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            text = clanDisplayName(clanId),
+            style = ClanWorldTheme.type.letterName,
+            color = Ink,
+          )
+          Text(
+            text = clanTagline(clanId),
+            style = ClanWorldTheme.type.scriptItalic,
+            color = Ink2,
+            modifier = Modifier.padding(top = 2.dp),
+          )
+        }
+      }
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 2 — Name the sigil
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepNameSigil(state: ForgeUiState, onChange: (String) -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(horizontal = 22.dp),
+  ) {
+    Text(
+      text = "NAME THE SIGIL",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Spacer(Modifier.height(8.dp))
+    Text(
+      text = "what shall the elders call this iNFT?",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+    Spacer(Modifier.height(14.dp))
+
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Text(
+        text = "NAME",
+        style = ClanWorldTheme.type.monoNano,
+        color = Ink3,
+      )
+      Spacer(Modifier.height(6.dp))
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(48.dp),
+      ) {
+        if (state.sigilName.isEmpty()) {
+          Text(
+            text = "the unnamed seal…",
+            style = ClanWorldTheme.type.scriptItalic.copy(color = Ink3),
+          )
+        }
+        BasicTextField(
+          value = state.sigilName,
+          onValueChange = onChange,
+          singleLine = true,
+          textStyle = LocalTextStyle.current.copy(
+            fontFamily = ClanWorldTheme.type.letterName.fontFamily,
+            fontSize = ClanWorldTheme.type.letterName.fontSize,
+            color = Ink,
+          ),
+          cursorBrush = SolidColor(Ink2),
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+      Spacer(Modifier.height(8.dp))
+      Text(
+        text = "${state.sigilName.length}/32",
+        style = ClanWorldTheme.type.monoNano,
+        color = Ink3,
+        textAlign = TextAlign.End,
+        modifier = Modifier.fillMaxWidth(),
+      )
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 3 — Pick harness
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepPickHarness(state: ForgeUiState, onSelect: (Harness) -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(horizontal = 22.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Text(
+      text = "PICK YOUR HARNESS",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Spacer(Modifier.height(2.dp))
+    Text(
+      text = "the bend the elder will favor",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+    Spacer(Modifier.height(8.dp))
+
+    Harness.values().forEach { h ->
+      HarnessCard(
+        harness = h,
+        selected = state.harness == h,
+        onClick = { onSelect(h) },
+      )
+    }
+  }
+}
+
+@Composable
+private fun HarnessCard(harness: Harness, selected: Boolean, onClick: () -> Unit) {
+  val accent = when (harness) {
+    Harness.Iron -> ClanWorldTheme.colors.rune
+    Harness.Tide -> ClanWorldTheme.colors.gold
+    Harness.Ember -> ClanWorldTheme.colors.ember
+  }
+  val border = if (selected) accent else ClanWorldTheme.colors.hairline
+  val stroke = if (selected) 2.dp else 1.dp
+
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { onClick() }
+      .drawBehind {
+        drawRoundRect(
+          color = border,
+          cornerRadius = CornerRadius(6.dp.toPx()),
+          style = Stroke(width = stroke.toPx()),
+        )
+      },
+  ) {
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        Box(
+          modifier = Modifier
+            .size(14.dp)
+            .clip(RoundedCornerShape(50))
+            .background(accent),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            text = harness.display.uppercase(),
+            style = ClanWorldTheme.type.letterName,
+            color = Ink,
+          )
+          Text(
+            text = harness.tagline,
+            style = ClanWorldTheme.type.scriptItalic,
+            color = Ink2,
+            modifier = Modifier.padding(top = 2.dp),
+          )
+        }
+      }
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 4 — Confirm + sign
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepConfirm(state: ForgeUiState, onForge: () -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(horizontal = 22.dp),
+    verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Text(
+      text = "CONFIRM THE FORGE",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Text(
+      text = "your seal is required before the iNFT goes to your wallet.",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+
+    Spacer(Modifier.height(2.dp))
+
+    val clanId = state.clanId
+    if (clanId == null) {
+      Text(
+        text = "no clan chosen — go back to step 1.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.danger,
+      )
+      return@Column
+    }
+
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Row(
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+      ) {
+        WaxSeal(
+          glyph = painterResource(clanGlyphRes(clanId)),
+          clanColor = clanColor(clanId),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            text = state.sigilName.ifBlank { "the unnamed seal" },
+            style = ClanWorldTheme.type.letterName,
+            color = Ink,
+          )
+          Text(
+            text = clanDisplayName(clanId),
+            style = ClanWorldTheme.type.scriptItalic,
+            color = Ink2,
+            modifier = Modifier.padding(top = 2.dp),
+          )
+        }
+      }
+      Spacer(Modifier.height(12.dp))
+      Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+        ConfirmStat(label = "Clan", value = clanDisplayName(clanId))
+        ConfirmStat(label = "Harness", value = state.harness.display)
+        ConfirmStat(label = "Cost", value = "free • demo")
+      }
+    }
+
+    Spacer(Modifier.height(2.dp))
+
+    when (state.mintPhase) {
+      SendPhase.Idle, SendPhase.Failed -> {
+        EmberCta(
+          text = if (state.mintPhase == SendPhase.Failed) "Try Again" else "Sign and Forge",
+          onClick = onForge,
+          enabled = state.sigilName.isNotBlank(),
+          modifier = Modifier.fillMaxWidth(),
+        )
+        if (state.mintPhase == SendPhase.Failed) {
+          Text(
+            text = state.errorMessage ?: "the seal could not be set.",
+            style = ClanWorldTheme.type.scriptItalic,
+            color = ClanWorldTheme.colors.danger,
+          )
+        }
+      }
+      SendPhase.Signing -> {
+        Text(
+          text = "the wallet is preparing the seal…",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.gold,
+        )
+      }
+      SendPhase.Queued -> {
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .background(ClanWorldTheme.colors.success.copy(alpha = 0.18f))
+            .padding(vertical = 16.dp),
+          contentAlignment = Alignment.Center,
+        ) {
+          Text(
+            text = "FORGED ✓",
+            style = ClanWorldTheme.type.ctaLabel,
+            color = ClanWorldTheme.colors.success,
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.ConfirmStat(label: String, value: String) {
+  Column(Modifier.weight(1f)) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Text(
+      text = value,
+      style = ClanWorldTheme.type.monoData,
+      color = Ink,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Bottom nav row (Back / Next)
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun NavRow(state: ForgeUiState, onNext: () -> Unit, onPrev: () -> Unit) {
+  val isFirst = state.step == ForgeStep.PickClan
+  val isLast = state.step == ForgeStep.Confirm
+  val canAdvance = when (state.step) {
+    ForgeStep.PickClan -> state.clanId != null
+    ForgeStep.NameSigil -> state.sigilName.isNotBlank()
+    ForgeStep.PickHarness -> true
+    ForgeStep.Confirm -> false
+  }
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 8.dp),
+    horizontalArrangement = Arrangement.SpaceBetween,
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    if (!isFirst) {
+      Text(
+        text = "← BACK",
+        style = ClanWorldTheme.type.monoMicro,
+        color = ClanWorldTheme.colors.warmDim,
+        modifier = Modifier
+          .clickable { onPrev() }
+          .padding(horizontal = 8.dp, vertical = 10.dp),
+      )
+    } else {
+      Spacer(Modifier.size(1.dp))
+    }
+    if (!isLast) {
+      val tint = if (canAdvance) ClanWorldTheme.colors.gold else ClanWorldTheme.colors.warmFaint
+      Text(
+        text = "NEXT →",
+        style = ClanWorldTheme.type.monoMicro,
+        color = tint,
+        modifier = Modifier
+          .clickable(enabled = canAdvance) { onNext() }
+          .padding(horizontal = 8.dp, vertical = 10.dp),
+      )
+    } else {
+      Spacer(Modifier.size(1.dp))
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -59,16 +59,18 @@ fun HallScreenRoute(
   app: App,
   factory: ClanWorldViewModelFactory,
   onOpenInft: (Int) -> Unit,
+  onForge: () -> Unit = {},
 ) {
   val vm: HallViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
-  HallScreen(state = state, onOpenInft = onOpenInft)
+  HallScreen(state = state, onOpenInft = onOpenInft, onForge = onForge)
 }
 
 @Composable
 private fun HallScreen(
   state: HallUiState,
   onOpenInft: (Int) -> Unit,
+  onForge: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
   Column(
@@ -86,7 +88,21 @@ private fun HallScreen(
       HallHead(count = state.items.size)
     }
 
-    Spacer(Modifier.height(18.dp))
+    // Forge entry — sits between the head divider and the list. Always
+    // available; an empty hall still wants the option to forge a new one.
+    Text(
+      text = "+ FORGE A NEW SIGIL",
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.gold,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(top = 18.dp, bottom = 8.dp)
+        .clickable { onForge() }
+        .padding(vertical = 8.dp),
+      textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+    )
+
+    Spacer(Modifier.height(10.dp))
 
     if (state.isLoading) {
       Text(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -15,6 +15,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
     BazaarViewModel::class.java -> BazaarViewModel()
+    ForgeViewModel::class.java -> ForgeViewModel()
     CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")
   } as T

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
@@ -1,0 +1,71 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+enum class ForgeStep { PickClan, NameSigil, PickHarness, Confirm }
+
+/**
+ * Themed harness choices for a freshly forged sigil.
+ *  - Iron   → defensive bias
+ *  - Tide   → balanced bias
+ *  - Ember  → aggressive bias
+ */
+enum class Harness(val display: String, val tagline: String) {
+  Iron("Iron", "hold the line; trade no ground without weight"),
+  Tide("Tide", "read the strait; move when both shores agree"),
+  Ember("Ember", "forge ahead; the season favors the bold"),
+}
+
+data class ForgeUiState(
+  val step: ForgeStep = ForgeStep.PickClan,
+  val clanId: Int? = null,
+  val sigilName: String = "",
+  val harness: Harness = Harness.Tide,
+  val mintPhase: SendPhase = SendPhase.Idle,
+  val errorMessage: String? = null,
+)
+
+/**
+ * Slice 6: Forge. Four-step mint wizard.
+ *
+ * No real on-chain mint exists. The MWA sign at the end is the seam —
+ * a future on-chain mint replaces only the screen-level send call.
+ */
+class ForgeViewModel : ViewModel() {
+
+  private val _state = MutableStateFlow(ForgeUiState())
+  val state: StateFlow<ForgeUiState> = _state.asStateFlow()
+
+  fun setClanId(clanId: Int) = _state.update { it.copy(clanId = clanId) }
+  fun setSigilName(name: String) = _state.update { it.copy(sigilName = name.take(32)) }
+  fun setHarness(h: Harness) = _state.update { it.copy(harness = h) }
+
+  fun goTo(step: ForgeStep) = _state.update { it.copy(step = step) }
+
+  fun next() = _state.update {
+    val nxt = when (it.step) {
+      ForgeStep.PickClan -> ForgeStep.NameSigil
+      ForgeStep.NameSigil -> ForgeStep.PickHarness
+      ForgeStep.PickHarness -> ForgeStep.Confirm
+      ForgeStep.Confirm -> ForgeStep.Confirm
+    }
+    it.copy(step = nxt)
+  }
+
+  fun back() = _state.update {
+    val prv = when (it.step) {
+      ForgeStep.PickClan -> ForgeStep.PickClan
+      ForgeStep.NameSigil -> ForgeStep.PickClan
+      ForgeStep.PickHarness -> ForgeStep.NameSigil
+      ForgeStep.Confirm -> ForgeStep.PickHarness
+    }
+    it.copy(step = prv)
+  }
+
+  fun setMintPhase(phase: SendPhase, error: String? = null) =
+    _state.update { it.copy(mintPhase = phase, errorMessage = error) }
+}


### PR DESCRIPTION
## Summary

Last RN-reference scope item from the original plan. Multi-step parchment-card wizard.

**Stacked on #75 (Phase 5 Treasury).**

### Steps
1. **Pick Clan** — 8 ParchmentCard rows with WaxSeal + name + tagline; selected card gets a clan-color 2dp border
2. **Name Sigil** — 32-char ParchmentCard text input with placeholder copy
3. **Pick Harness** — themed bias choice: Iron (defensive), Tide (balanced), Ember (aggressive). Accent dot + tagline per card
4. **Confirm** — summary parchment card (name + clan + harness + cost \"free • demo\") + Sign and Forge CTA. On sign: Forged ✓ for 1.5s → \`onForged()\` pop

### UX
- Progress dots + \"STEP N OF 4\" counter at top
- Animated step transitions via \`AnimatedContent\` (slide direction follows step ordinal)
- Bottom NavRow: ← BACK / NEXT → with disabled state until each step's required value is picked
- Default harness = Tide (so step 3 advance never blocks)

### Wiring
- New route: \`forge\` (no clanId — wizard picks one)
- \"+ FORGE A NEW SIGIL\" link at top of Hall (between header and list)
- Tabbar visible during Forge (Hall selected)
- \`ForgeViewModel\` in factory; sign uses existing \`MwaClient.signMessage(mwaSender, …)\`

No real on-chain mint yet — sign is the seam; backend mint is a one-line swap when ready.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 27s.

## Test plan

- [ ] Hall → tap \"+ FORGE A NEW SIGIL\" → wizard step 1 (Pick Clan)
- [ ] Tap a clan card → border highlights in clan color → Next becomes gold/active
- [ ] Step 2: Name input → 32-char limit → Next gates on non-blank name
- [ ] Step 3: Harness pills (Iron/Tide/Ember) → tagline updates per selection
- [ ] Step 4: Summary card shows correct name + clan + harness → Sign and Forge → MWA wallet sheet
- [ ] On sign: \"FORGED ✓\" success state → auto-pop after 1.5s back to Hall
- [ ] On user-decline: returns to Idle state, can retry
- [ ] Back button at any step returns to previous step (or pops to Hall on step 1)
- [ ] Step transitions slide forward/backward by ordinal direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)