### PR TITLE
feat(android): pull-to-refresh + tap-to-retry on data screens

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/RefreshableContent.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/RefreshableContent.kt
@@ -1,0 +1,105 @@
+package world.clan.app.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * Pull-to-refresh wrapper using Material3's [PullToRefreshBox].
+ *
+ * Drop-in replacement for `Box(Modifier.fillMaxSize())` around a vertically
+ * scrollable child. Pulls a refresh callback from the host viewmodel.
+ *
+ * Notes:
+ * - The Material3 indicator is themed by ColorScheme; we let it inherit
+ *   from the obsidian color scheme rather than pinning. If the default
+ *   indicator looks wrong, swap to a custom one via `indicator =`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RefreshableContent(
+  isRefreshing: Boolean,
+  onRefresh: () -> Unit,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  PullToRefreshBox(
+    isRefreshing = isRefreshing,
+    onRefresh = onRefresh,
+    modifier = modifier,
+  ) {
+    content()
+  }
+}
+
+/**
+ * Error notice for data-fetch failures. Renders the message + a tap-to-retry
+ * affordance. Same script-italic + danger-color palette as the other
+ * screens' error texts, with an extra CTA button beneath.
+ */
+@Composable
+fun RetryNotice(
+  message: String,
+  onRetry: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val danger = ClanWorldTheme.colors.danger
+  val iron2 = ClanWorldTheme.colors.iron2
+  val hairlineMid = ClanWorldTheme.colors.hairlineMid
+  val parchment = ClanWorldTheme.colors.parchment
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 16.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Text(
+      text = message,
+      style = ClanWorldTheme.type.scriptItalic,
+      color = danger,
+      textAlign = TextAlign.Center,
+    )
+    Box(
+      modifier = Modifier
+        .clip(RoundedCornerShape(4.dp))
+        .background(iron2)
+        .drawBehind {
+          drawRoundRect(
+            color = hairlineMid,
+            cornerRadius = CornerRadius(4.dp.toPx()),
+            style = Stroke(width = 1.dp.toPx()),
+          )
+        }
+        .clickable { onRetry() }
+        .padding(horizontal = 18.dp, vertical = 10.dp),
+    ) {
+      Text(
+        text = "TAP TO RETRY",
+        style = ClanWorldTheme.type.monoMicro,
+        color = parchment,
+      )
+    }
+    Spacer(Modifier.height(4.dp))
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -63,7 +63,12 @@ fun HallScreenRoute(
 ) {
   val vm: HallViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
-  HallScreen(state = state, onOpenInft = onOpenInft, onForge = onForge)
+  HallScreen(
+    state = state,
+    onOpenInft = onOpenInft,
+    onForge = onForge,
+    onRefresh = vm::refresh,
+  )
 }
 
 @Composable
@@ -71,6 +76,7 @@ private fun HallScreen(
   state: HallUiState,
   onOpenInft: (Int) -> Unit,
   onForge: () -> Unit = {},
+  onRefresh: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
   Column(
@@ -111,25 +117,42 @@ private fun HallScreen(
         color = ClanWorldTheme.colors.warmFaint,
         modifier = Modifier.padding(top = 24.dp),
       )
-    } else if (state.items.isEmpty()) {
-      Text(
-        text = state.errorMessage ?: "your hall is quiet — no sigils linked.",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.warmFaint,
-        modifier = Modifier.padding(top = 24.dp),
+    } else if (state.errorMessage != null && state.items.isEmpty()) {
+      world.clan.app.ui.components.RetryNotice(
+        message = state.errorMessage,
+        onRetry = onRefresh,
       )
     } else {
-      LazyColumn(
+      world.clan.app.ui.components.RefreshableContent(
+        isRefreshing = state.isRefreshing,
+        onRefresh = onRefresh,
         modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(14.dp),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 24.dp),
       ) {
-        items(state.items, key = { it.tokenId }) { card ->
-          StaggeredEntry(index = card.tokenId.coerceAtMost(8)) {
-            LetterCard(
-              card = card,
-              onClick = { onOpenInft(card.clanId) },
-            )
+        if (state.items.isEmpty()) {
+          LazyColumn(modifier = Modifier.fillMaxSize()) {
+            item {
+              Text(
+                text = "your hall is quiet — no sigils linked.",
+                style = ClanWorldTheme.type.scriptItalic,
+                color = ClanWorldTheme.colors.warmFaint,
+                modifier = Modifier.padding(top = 24.dp),
+              )
+            }
+          }
+        } else {
+          LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 24.dp),
+          ) {
+            items(state.items, key = { it.tokenId }) { card ->
+              StaggeredEntry(index = card.tokenId.coerceAtMost(8)) {
+                LetterCard(
+                  card = card,
+                  onClick = { onOpenInft(card.clanId) },
+                )
+              }
+            }
           }
         }
       }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
@@ -70,12 +70,13 @@ fun HearthScreenRoute(
 ) {
   val vm: HearthViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
-  HearthScreen(state = state)
+  HearthScreen(state = state, onRefresh = vm::refresh)
 }
 
 @Composable
 private fun HearthScreen(
   state: HearthUiState,
+  onRefresh: () -> Unit = {},
 ) {
   // Background and tab bar are hosted at the app level (ClanWorldApp.kt);
   // this screen is just the page content.
@@ -89,6 +90,19 @@ private fun HearthScreen(
       modifier = Modifier.fillMaxWidth(),
     )
 
+    if (state.errorMessage != null && state.leaderboard.isEmpty()) {
+      world.clan.app.ui.components.RetryNotice(
+        message = state.errorMessage,
+        onRetry = onRefresh,
+      )
+      return@Column
+    }
+
+    world.clan.app.ui.components.RefreshableContent(
+      isRefreshing = state.isRefreshing,
+      onRefresh = onRefresh,
+      modifier = Modifier.fillMaxSize(),
+    ) {
     Column(
       modifier = Modifier
         .fillMaxSize()
@@ -125,6 +139,7 @@ private fun HearthScreen(
         WhispersList(state.recentComms)
       }
     }
+    } // close RefreshableContent
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
@@ -61,6 +61,7 @@ fun TreasuryScreenRoute(
     clanId = clanId,
     onBack = onBack,
     onSetFilter = vm::setFilter,
+    onRefresh = vm::refresh,
   )
 }
 
@@ -70,6 +71,7 @@ private fun TreasuryScreen(
   clanId: Int,
   onBack: () -> Unit,
   onSetFilter: (TreasuryFilter) -> Unit,
+  onRefresh: () -> Unit = {},
 ) {
   Column(modifier = Modifier.fillMaxSize()) {
     BackBar(text = "back to ${clanDisplayName(clanId).lowercase()}", onBack = onBack)
@@ -86,11 +88,9 @@ private fun TreasuryScreen(
           modifier = Modifier.padding(top = 18.dp),
         )
       } else if (state.errorMessage != null) {
-        Text(
-          text = state.errorMessage,
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.danger,
-          modifier = Modifier.padding(top = 18.dp),
+        world.clan.app.ui.components.RetryNotice(
+          message = state.errorMessage,
+          onRetry = onRefresh,
         )
       } else {
         GoldHeroCard(gold = state.balance.gold, clanId = clanId)
@@ -110,23 +110,33 @@ private fun TreasuryScreen(
 
     if (!state.isLoading && state.errorMessage == null) {
       val items = state.filteredMovements()
-      if (items.isEmpty()) {
-        Text(
-          text = "the vault keeps its silence",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-          modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
-        )
-      } else {
-        LazyColumn(
-          modifier = Modifier.fillMaxSize(),
-          verticalArrangement = Arrangement.spacedBy(0.dp),
-          contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
-        ) {
-          items(items.withIndex().toList(), key = { (i, m) -> "${i}-${m.tick}-${m.resource}" }) { (_, mv) ->
-            MovementRow(mv)
+      world.clan.app.ui.components.RefreshableContent(
+        isRefreshing = state.isLoading,
+        onRefresh = onRefresh,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        if (items.isEmpty()) {
+          LazyColumn(modifier = Modifier.fillMaxSize()) {
+            item {
+              Text(
+                text = "the vault keeps its silence",
+                style = ClanWorldTheme.type.scriptItalic,
+                color = ClanWorldTheme.colors.warmFaint,
+                modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
+              )
+            }
           }
-          item { Spacer(Modifier.height(40.dp)) }
+        } else {
+          LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(0.dp),
+            contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+          ) {
+            items(items.withIndex().toList(), key = { (i, m) -> "${i}-${m.tick}-${m.resource}" }) { (_, mv) ->
+              MovementRow(mv)
+            }
+            item { Spacer(Modifier.height(40.dp)) }
+          }
         }
       }
     }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -58,6 +58,7 @@ fun WhispersScreenRoute(
     onBack = onBack,
     onSetFilter = vm::setFilter,
     onCompose = onCompose,
+    onRefresh = vm::refresh,
   )
 }
 
@@ -68,6 +69,7 @@ private fun WhispersScreen(
   onBack: () -> Unit,
   onSetFilter: (WhispersFilter) -> Unit,
   onCompose: () -> Unit = {},
+  onRefresh: () -> Unit = {},
 ) {
   Column(modifier = Modifier.fillMaxSize()) {
     InboxBackBar(clanId = clanId, onBack = onBack)
@@ -100,30 +102,39 @@ private fun WhispersScreen(
           modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
         )
       }
-      state.errorMessage != null -> {
-        Text(
-          text = state.errorMessage,
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.danger,
-          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
-        )
-      }
-      items.isEmpty() -> {
-        Text(
-          text = "no whispers carry this kind.",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+      state.errorMessage != null && items.isEmpty() -> {
+        world.clan.app.ui.components.RetryNotice(
+          message = state.errorMessage,
+          onRetry = onRefresh,
         )
       }
       else -> {
-        LazyColumn(
+        world.clan.app.ui.components.RefreshableContent(
+          isRefreshing = state.isLoading,
+          onRefresh = onRefresh,
           modifier = Modifier.fillMaxSize(),
-          verticalArrangement = Arrangement.spacedBy(10.dp),
-          contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
         ) {
-          items(items.withIndex().toList(), key = { (i, c) -> "${i}-${c.tick ?: c.timestamp ?: 0}" }) { (_, c) ->
-            InboxRow(comm = c)
+          if (items.isEmpty()) {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+              item {
+                Text(
+                  text = "no whispers carry this kind.",
+                  style = ClanWorldTheme.type.scriptItalic,
+                  color = ClanWorldTheme.colors.warmFaint,
+                  modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+                )
+              }
+            }
+          } else {
+            LazyColumn(
+              modifier = Modifier.fillMaxSize(),
+              verticalArrangement = Arrangement.spacedBy(10.dp),
+              contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+            ) {
+              items(items.withIndex().toList(), key = { (i, c) -> "${i}-${c.tick ?: c.timestamp ?: 0}" }) { (_, c) ->
+                InboxRow(comm = c)
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Polish pass on the four data-fetching screens. Currently if the user opens the app offline or a Convex query fails, they see a static error string with no way to recover without re-navigating.

**Stacked on #76 (Phase 6 Forge).**

### New: \`ui/components/RefreshableContent.kt\`
- \`RefreshableContent\` — Material3 \`PullToRefreshBox\` wrapper, drop-in around any vertically scrollable child
- \`RetryNotice\` — error message + \"TAP TO RETRY\" button (replaces the inline danger-color Text)

### Wired into:
- **Hearth** — pull-to-refresh wraps the leaderboard + whispers scroll; errorMessage now renders RetryNotice
- **Hall** — pull-to-refresh around the LazyColumn; both empty hall + error become refreshable
- **Whispers** — PullToRefreshBox over the inbox LazyColumn; error → retry
- **Treasury** — PullToRefreshBox over movements LazyColumn; error → retry

InftDetail intentionally not wrapped — its tabs use Crossfade and the Vault tab already has a \"FULL TREASURY →\" deep-link to the refreshable TreasuryScreen.

Each screen's existing \`vm.refresh()\` is wired to \`onRefresh\`.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 14s.

## Test plan

- [ ] Hearth/Hall/Whispers/Treasury: swipe down → refresh indicator appears, data refetches, indicator clears
- [ ] Toggle airplane mode → swipe to refresh → error state shows RetryNotice → tap-to-retry on reconnect succeeds
- [ ] Refresh during isRefreshing=true: indicator persists, no duplicate fires
- [ ] Empty hall (no LINKED_CLAN_IDS data): empty message still renders, swipe-to-refresh still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)