### PR TITLE
feat(android): ForgedScreen — celebration landing for Forge + Hire

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -68,6 +68,7 @@ object Routes {
   const val StrategyEditor = "strategy/{clanId}"
   const val Treasury = "treasury/{clanId}"
   const val Forge = "forge"
+  const val Forged = "forged/{clanId}?name={name}&label={label}"
   const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
@@ -78,6 +79,11 @@ object Routes {
   fun steer(clanId: Int) = "steer/$clanId"
   fun strategy(clanId: Int) = "strategy/$clanId"
   fun treasury(clanId: Int) = "treasury/$clanId"
+  fun forged(clanId: Int, name: String = "", label: String = "FORGED"): String {
+    val n = java.net.URLEncoder.encode(name, "UTF-8")
+    val l = java.net.URLEncoder.encode(label, "UTF-8")
+    return "forged/$clanId?name=$n&label=$l"
+  }
   fun bridge(clanId: Int) = "bridge/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
@@ -407,9 +413,12 @@ fun ClanWorldApp(
               isBazaar = true,
               mwaSender = mwaSender,
               onHireConfirmed = {
-                // For now: simply pop back to Bazaar. A future "Hired"
-                // confirmation screen could replace this.
-                nav.popBackStack()
+                val name = world.clan.app.data.bazaarListingByClan(clanId)
+                  ?.let { l -> "tkn 0x${"%04x".format(l.tokenId)}" }
+                  .orEmpty()
+                nav.navigate(Routes.forged(clanId, name, "HIRED")) {
+                  popUpTo(Routes.Bazaar) { saveState = true }
+                }
               },
             )
           }
@@ -480,7 +489,53 @@ fun ClanWorldApp(
               factory = factory,
               mwaSender = mwaSender,
               onBack = { nav.popBackStack() },
-              onForged = { nav.popBackStack() },
+              onForged = { clanId, name ->
+                nav.navigate(Routes.forged(clanId, name, "FORGED")) {
+                  // Replace Forge wizard so back goes to Hall, not the
+                  // wizard's last step.
+                  popUpTo(Routes.Forge) { inclusive = true }
+                }
+              },
+            )
+          }
+
+          // ── Forged (celebration landing for Forge + Hire) ───────────────
+          composable(
+            route = Routes.Forged,
+            arguments = listOf(
+              androidx.navigation.navArgument("clanId") { type = NavType.IntType },
+              androidx.navigation.navArgument("name") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = ""
+              },
+              androidx.navigation.navArgument("label") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = "FORGED"
+              },
+            ),
+            enterTransition = { fadeIn(tween(360, easing = FastOutSlowInEasing)) },
+            popExitTransition = { fadeOut(tween(220, easing = FastOutSlowInEasing)) },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            val name = entry.arguments?.getString("name").orEmpty().let {
+              runCatching { java.net.URLDecoder.decode(it, "UTF-8") }.getOrDefault(it)
+            }
+            val label = (entry.arguments?.getString("label") ?: "FORGED").let {
+              runCatching { java.net.URLDecoder.decode(it, "UTF-8") }.getOrDefault(it)
+            }
+            world.clan.app.ui.screens.ForgedScreen(
+              clanId = clanId,
+              label = label,
+              sigilName = name,
+              onEnterHall = {
+                nav.navigate(Routes.Hall) {
+                  popUpTo(Routes.Hearth) { saveState = true }
+                  launchSingleTop = true
+                  restoreState = true
+                }
+              },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -75,7 +75,7 @@ fun ForgeScreenRoute(
   factory: ClanWorldViewModelFactory,
   mwaSender: ActivityResultSender,
   onBack: () -> Unit,
-  onForged: () -> Unit,
+  onForged: (clanId: Int, name: String) -> Unit,
 ) {
   val vm: ForgeViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
@@ -114,7 +114,8 @@ fun ForgeScreenRoute(
   if (state.mintPhase == SendPhase.Queued) {
     androidx.compose.runtime.LaunchedEffect(Unit) {
       delay(1500L)
-      onForged()
+      val cid = state.clanId ?: 1
+      onForged(cid, state.sigilName)
     }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgedScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgedScreen.kt
@@ -1,0 +1,155 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import world.clan.app.ui.components.EmberCta
+import world.clan.app.ui.components.Sigil
+import world.clan.app.ui.components.bigSigilSpec
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.clanTagline
+
+/**
+ * Celebration landing for both Forge mint + Bazaar hire flows.
+ *
+ * Replaces the previous "tiny Sealed ✓ then nav.popBackStack()" UX gap —
+ * after a successful sign, the user lands here for a beat to actually see
+ * the sigil they just bound to their wallet, then taps "Enter Your Hall"
+ * to land in Hall (popUpTo Hall, inclusive=false, so back doesn't bounce
+ * through the wizard).
+ *
+ * Visual hierarchy:
+ *   [LABEL]                       — small mono ("FORGED" or "HIRED")
+ *   <large rotating Sigil>        — clan-color, with breathing halo
+ *   <sigil name>                  — display script
+ *   <clan name>                   — italic
+ *   <tagline>                     — italic, dim
+ *   [Enter Your Hall]             — primary CTA
+ */
+@Composable
+fun ForgedScreen(
+  clanId: Int,
+  label: String,
+  sigilName: String,
+  onEnterHall: () -> Unit,
+) {
+  val accent = clanColor(clanId)
+  val transition = rememberInfiniteTransition(label = "forged-pulse")
+  val haloPulse by transition.animateFloat(
+    initialValue = 0.55f,
+    targetValue = 1f,
+    animationSpec = infiniteRepeatable(
+      animation = tween(durationMillis = 2400, easing = EaseInOut),
+      repeatMode = RepeatMode.Reverse,
+    ),
+    label = "halo",
+  )
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(horizontal = 22.dp),
+  ) {
+    Column(
+      modifier = Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      Text(
+        text = label.uppercase(),
+        style = ClanWorldTheme.type.monoNano,
+        color = accent,
+      )
+
+      Spacer(Modifier.height(20.dp))
+
+      // Sigil with a breathing accent halo behind it.
+      Box(
+        modifier = Modifier.size(200.dp),
+        contentAlignment = Alignment.Center,
+      ) {
+        // Halo
+        Box(
+          modifier = Modifier
+            .size(200.dp)
+            .alpha(haloPulse * 0.40f)
+            .drawBehind {
+              drawCircle(
+                color = accent,
+                radius = size.minDimension / 2f,
+                blendMode = BlendMode.Plus,
+              )
+            },
+        )
+        Sigil(
+          spec = bigSigilSpec(accent),
+          modifier = Modifier.size(160.dp),
+        )
+      }
+
+      Spacer(Modifier.height(28.dp))
+
+      Text(
+        text = sigilName.ifBlank { "the unnamed seal" },
+        style = ClanWorldTheme.type.displayHero,
+        color = ClanWorldTheme.colors.parchment,
+        textAlign = TextAlign.Center,
+      )
+
+      Spacer(Modifier.height(6.dp))
+
+      Text(
+        text = clanDisplayName(clanId),
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warm,
+        textAlign = TextAlign.Center,
+      )
+
+      Spacer(Modifier.height(2.dp))
+
+      Text(
+        text = clanTagline(clanId),
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warmDim,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(horizontal = 28.dp),
+      )
+
+      Spacer(Modifier.height(36.dp))
+
+      Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
+        EmberCta(
+          text = "Enter Your Hall",
+          onClick = onEnterHall,
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the \"tiny Sealed ✓ then \`nav.popBackStack()\`\" UX gap. After a successful sign in either the Forge wizard or the Bazaar HireModal, the user lands on a full-screen celebration of the sigil they just bound to their wallet, then taps \"Enter Your Hall\" to land in Hall.

**Stacked on #77 (polish: pull-to-refresh).**

### ForgedScreen visual hierarchy
- \`[LABEL]\` — small mono accent (\"FORGED\" or \"HIRED\")
- Large rotating \`Sigil\` with a breathing accent halo behind it (Plus blend mode against obsidian for the glow)
- Sigil name (or \"the unnamed seal\" if blank) — display script
- Clan name + tagline — italic
- \"Enter Your Hall\" EmberCta

### Routing
- New route: \`forged/{clanId}?name={name}&label={label}\` — query args so we can pass arbitrary sigil names without path-encoding pain
- **Forge wizard**: \`onForged\` signature is now \`(clanId, name) → Unit\` → navigate with \`popUpTo(Forge, inclusive=true)\` so back doesn't bounce through the wizard steps
- **Bazaar Hire flow**: HireModal seal → \`forged/{clanId}?label=HIRED\` with the listing's \`tkn 0x...\` as the name, \`popUpTo(Bazaar, saveState)\`

ForgedScreen is fade-in only (no slide); the moment should feel arrived-at, not slid-in-from-the-right like a normal detail.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 30s.

## Test plan

- [ ] Hall → \"+ FORGE A NEW SIGIL\" → wizard → Sign and Forge → Forged ✓ → ForgedScreen with rotating sigil + sigil name
- [ ] Tap \"Enter Your Hall\" → lands on Hall (not Forge wizard)
- [ ] System back from ForgedScreen: also lands on Hall, not the wizard
- [ ] Bazaar → tap listing → Hire This Sigil → MWA sign → Sealed → ForgedScreen with HIRED label + token id
- [ ] System back from HIRED ForgedScreen: lands on Bazaar (saveState=true)
- [ ] Forge with empty sigil name: ForgedScreen shows \"the unnamed seal\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)