### PR TITLE
feat(android): persist Forge / Steering / Strategy drafts across kills

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -82,4 +82,25 @@ class SessionStore(context: Context) {
   fun clear() {
     prefs.edit().clear().apply()
   }
+
+  // ── Form-draft persistence ────────────────────────────────────────────
+  //
+  // SteeringConsole / StrategyEditor / Forge text inputs survive process
+  // death + backgrounding. Keys are namespaced "draft:<scope>:<field>".
+  // On successful submit the relevant scope is cleared.
+
+  fun getDraft(scope: String, field: String): String? =
+    prefs.getString("draft:$scope:$field", null)
+
+  fun setDraft(scope: String, field: String, value: String) {
+    prefs.edit().putString("draft:$scope:$field", value).apply()
+  }
+
+  fun clearDrafts(scope: String) {
+    val toRemove = prefs.all.keys.filter { it.startsWith("draft:$scope:") }
+    if (toRemove.isEmpty()) return
+    val ed = prefs.edit()
+    toRemove.forEach { ed.remove(it) }
+    ed.apply()
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -68,7 +68,7 @@ fun SteeringConsoleScreenRoute(
   onSent: () -> Unit,
 ) {
   val vm: SteeringConsoleViewModel =
-    viewModel(factory = SteeringConsoleViewModelFactory(initialClanId))
+    viewModel(factory = SteeringConsoleViewModelFactory(app, initialClanId))
   val state by vm.state.collectAsState()
   val scope = rememberCoroutineScope()
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -15,7 +15,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
     BazaarViewModel::class.java -> BazaarViewModel()
-    ForgeViewModel::class.java -> ForgeViewModel()
+    ForgeViewModel::class.java -> ForgeViewModel(app.sessionStore)
     CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")
   } as T
@@ -43,11 +43,12 @@ class WhispersViewModelFactory(
 
 /** Per-route factory for SteeringConsole, parameterized by the initial target clan. */
 class SteeringConsoleViewModelFactory(
+  private val app: App,
   private val initialClanId: Int,
 ) : ViewModelProvider.Factory {
   @Suppress("UNCHECKED_CAST")
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
-    SteeringConsoleViewModel(initialClanId) as T
+    SteeringConsoleViewModel(initialClanId, app.sessionStore) as T
 }
 
 /** Per-route factory for StrategyEditor, parameterized by clanId. */
@@ -57,7 +58,7 @@ class StrategyEditorViewModelFactory(
 ) : ViewModelProvider.Factory {
   @Suppress("UNCHECKED_CAST")
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
-    StrategyEditorViewModel(app.convexClient, clanId) as T
+    StrategyEditorViewModel(app.convexClient, clanId, app.sessionStore) as T
 }
 
 /** Per-route factory for Treasury, parameterized by clanId. */

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import world.clan.app.data.SessionStore
 
 enum class ForgeStep { PickClan, NameSigil, PickHarness, Confirm }
 
@@ -35,14 +36,41 @@ data class ForgeUiState(
  * No real on-chain mint exists. The MWA sign at the end is the seam —
  * a future on-chain mint replaces only the screen-level send call.
  */
-class ForgeViewModel : ViewModel() {
+class ForgeViewModel(
+  private val sessionStore: SessionStore? = null,
+) : ViewModel() {
 
-  private val _state = MutableStateFlow(ForgeUiState())
+  private val draftScope = "forge"
+
+  private val _state = MutableStateFlow(initial())
   val state: StateFlow<ForgeUiState> = _state.asStateFlow()
 
-  fun setClanId(clanId: Int) = _state.update { it.copy(clanId = clanId) }
-  fun setSigilName(name: String) = _state.update { it.copy(sigilName = name.take(32)) }
-  fun setHarness(h: Harness) = _state.update { it.copy(harness = h) }
+  private fun initial(): ForgeUiState {
+    val draftClan = sessionStore?.getDraft(draftScope, "clanId")?.toIntOrNull()
+    val draftName = sessionStore?.getDraft(draftScope, "sigilName").orEmpty()
+    val draftHarness = sessionStore?.getDraft(draftScope, "harness")
+      ?.let { runCatching { Harness.valueOf(it) }.getOrNull() }
+      ?: Harness.Tide
+    return ForgeUiState(
+      clanId = draftClan,
+      sigilName = draftName,
+      harness = draftHarness,
+    )
+  }
+
+  fun setClanId(clanId: Int) {
+    _state.update { it.copy(clanId = clanId) }
+    sessionStore?.setDraft(draftScope, "clanId", clanId.toString())
+  }
+  fun setSigilName(name: String) {
+    val capped = name.take(32)
+    _state.update { it.copy(sigilName = capped) }
+    sessionStore?.setDraft(draftScope, "sigilName", capped)
+  }
+  fun setHarness(h: Harness) {
+    _state.update { it.copy(harness = h) }
+    sessionStore?.setDraft(draftScope, "harness", h.name)
+  }
 
   fun goTo(step: ForgeStep) = _state.update { it.copy(step = step) }
 
@@ -66,6 +94,8 @@ class ForgeViewModel : ViewModel() {
     it.copy(step = prv)
   }
 
-  fun setMintPhase(phase: SendPhase, error: String? = null) =
+  fun setMintPhase(phase: SendPhase, error: String? = null) {
     _state.update { it.copy(mintPhase = phase, errorMessage = error) }
+    if (phase == SendPhase.Queued) sessionStore?.clearDrafts(draftScope)
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import world.clan.app.data.SessionStore
 
 enum class SendPhase { Idle, Signing, Queued, Failed }
 
@@ -19,21 +20,31 @@ data class SteeringConsoleUiState(
  * Slice 4c: SteeringConsole. The owner's whisper composer — drafts a
  * single-line steering message addressed to one of their elders.
  *
+ * Drafts are persisted through process death via SessionStore (key
+ * "draft:steer:<clanId>"); cleared on successful submit (Queued phase).
+ *
  * No real Convex mutation exists yet (per BUILD_PLAN — whisper send
  * needs a backend mutation that doesn't exist). This view-model holds
  * draft state; the screen handles the MWA sign + the (stubbed) send.
  */
 class SteeringConsoleViewModel(
   initialClanId: Int,
+  private val sessionStore: SessionStore? = null,
 ) : ViewModel() {
 
+  private val draftScope = "steer:$initialClanId"
+
   private val _state = MutableStateFlow(
-    SteeringConsoleUiState(targetClanId = initialClanId),
+    SteeringConsoleUiState(
+      targetClanId = initialClanId,
+      draft = sessionStore?.getDraft(draftScope, "body").orEmpty(),
+    ),
   )
   val state: StateFlow<SteeringConsoleUiState> = _state.asStateFlow()
 
   fun setDraft(text: String) {
     _state.update { it.copy(draft = text) }
+    sessionStore?.setDraft(draftScope, "body", text)
   }
 
   fun setTarget(clanId: Int) {
@@ -42,5 +53,6 @@ class SteeringConsoleViewModel(
 
   fun setPhase(p: SendPhase, error: String? = null) {
     _state.update { it.copy(phase = p, errorMessage = error) }
+    if (p == SendPhase.Queued) sessionStore?.clearDrafts(draftScope)
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/StrategyEditorViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/StrategyEditorViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import world.clan.app.data.ClanWorldConvexClient
+import world.clan.app.data.SessionStore
 
 enum class Posture { Defensive, Balanced, Aggressive }
 
@@ -33,7 +34,10 @@ data class StrategyEditorUiState(
 class StrategyEditorViewModel(
   private val convex: ClanWorldConvexClient,
   clanId: Int,
+  private val sessionStore: SessionStore? = null,
 ) : ViewModel() {
+
+  private val draftScope = "strategy:$clanId"
 
   private val _state = MutableStateFlow(StrategyEditorUiState(clanId = clanId))
   val state: StateFlow<StrategyEditorUiState> = _state.asStateFlow()
@@ -42,14 +46,20 @@ class StrategyEditorViewModel(
 
   private fun hydrate(clanId: Int) {
     viewModelScope.launch {
+      val draftDoctrine = sessionStore?.getDraft(draftScope, "doctrine")
+      val draftPinned = sessionStore?.getDraft(draftScope, "pinnedKey")
+      val draftPosture = sessionStore?.getDraft(draftScope, "posture")
+        ?.let { runCatching { Posture.valueOf(it) }.getOrNull() }
+
       runCatching { convex.getInftDemoState(clanId) }
         .onSuccess { demo ->
           val firstMem = demo.memory.firstOrNull()
           _state.update {
             it.copy(
               isLoading = false,
-              doctrine = firstMem?.value?.take(180) ?: defaultDoctrine(clanId),
-              pinnedKey = firstMem?.key ?: "policy:default",
+              doctrine = draftDoctrine ?: firstMem?.value?.take(180) ?: defaultDoctrine(clanId),
+              pinnedKey = draftPinned ?: firstMem?.key ?: "policy:default",
+              posture = draftPosture ?: it.posture,
             )
           }
         }
@@ -57,19 +67,33 @@ class StrategyEditorViewModel(
           _state.update {
             it.copy(
               isLoading = false,
-              doctrine = defaultDoctrine(clanId),
-              pinnedKey = "policy:default",
+              doctrine = draftDoctrine ?: defaultDoctrine(clanId),
+              pinnedKey = draftPinned ?: "policy:default",
+              posture = draftPosture ?: it.posture,
             )
           }
         }
     }
   }
 
-  fun setPosture(p: Posture) = _state.update { it.copy(posture = p) }
-  fun setDoctrine(text: String) = _state.update { it.copy(doctrine = text.take(280)) }
-  fun setPinnedKey(text: String) = _state.update { it.copy(pinnedKey = text.take(64)) }
-  fun setSavePhase(phase: SendPhase, error: String? = null) =
+  fun setPosture(p: Posture) {
+    _state.update { it.copy(posture = p) }
+    sessionStore?.setDraft(draftScope, "posture", p.name)
+  }
+  fun setDoctrine(text: String) {
+    val capped = text.take(280)
+    _state.update { it.copy(doctrine = capped) }
+    sessionStore?.setDraft(draftScope, "doctrine", capped)
+  }
+  fun setPinnedKey(text: String) {
+    val capped = text.take(64)
+    _state.update { it.copy(pinnedKey = capped) }
+    sessionStore?.setDraft(draftScope, "pinnedKey", capped)
+  }
+  fun setSavePhase(phase: SendPhase, error: String? = null) {
     _state.update { it.copy(savePhase = phase, errorMessage = error) }
+    if (phase == SendPhase.Queued) sessionStore?.clearDrafts(draftScope)
+  }
 
   private fun defaultDoctrine(clanId: Int): String = when (clanId) {
     1 -> "Hold the high pass. Trade no ground without iron."


### PR DESCRIPTION
## Summary

Form drafts now survive process death + backgrounding via the existing EncryptedSharedPreferences-backed SessionStore. Real demo killer if you mid-type a doctrine and a notification yanks you out — typed text was gone on return.

**Stacked on #78 (ForgedScreen).**

### SessionStore
- New methods: \`getDraft\` / \`setDraft\` / \`clearDrafts\`. Keys namespaced \`draft:<scope>:<field>\` so each form has an isolated bucket and we wipe per-form on submit.

### SteeringConsoleViewModel
- Hydrates draft body from \`draft:steer:<clanId>:body\` on init
- Writes through on every \`setDraft\`
- Clears the scope when phase becomes Queued

### StrategyEditorViewModel
- Hydrates doctrine / pinnedKey / posture from \`draft:strategy:<clanId>:*\`
- Drafts override the Convex-seeded defaults (correctness: if user typed changes and got pulled away, their changes survive over the seed)
- Writes through on every setter; clears on Queued

### ForgeViewModel
- Hydrates clanId / sigilName / harness from \`draft:forge:*\` on init — user can resume the wizard exactly where they left off
- \`step\` is intentionally NOT persisted: want to re-enter at PickClan whichever step they were on (form values restored, but the flow is fresh)
- Writes through on every setter; clears on Queued

### Wiring
- Factory passes \`app.sessionStore\` to all three VM constructors
- \`SteeringConsoleScreenRoute\` factory call updated to take \`app\`

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 37s.

## Test plan

- [ ] SteeringConsole: type a draft → background app via system back → reopen → draft restored
- [ ] StrategyEditor: edit doctrine → kill app from recents → reopen → doctrine restored (overrides Convex seed)
- [ ] Forge: pick clan + name + harness → kill app → reopen forge wizard → form values restored, step resets to PickClan
- [ ] Successful sign on any of the three: draft cleared on Queued (re-open shows blank/seeded again)
- [ ] Multiple clans: SteeringConsole drafts for clan 2 don't leak into clan 5's draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)