### PR TITLE
feat(android): codex polish — real version, wallet label, share APK link

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -98,9 +98,15 @@ private fun CodexScreen(
           copyable = state.solanaPubkey != null,
           copyText = state.solanaPubkey,
         )
+        if (state.walletLabel != null) {
+          RowCard(
+            label = "Wallet account",
+            value = state.walletLabel,
+          )
+        }
         RowCard(
-          label = "Linked clan",
-          value = "Caldris of the Strait — sealed at tick demo.",
+          label = "Linked clans · ${state.linkedClansCount} of viii",
+          value = linkedClansLine(state.linkedClanIds),
           isScript = true,
         )
       }
@@ -118,15 +124,58 @@ private fun CodexScreen(
 
     Spacer(Modifier.height(20.dp))
 
-    // ── About ────────────────────────────────────────────────────────
+    // ── Share ────────────────────────────────────────────────────────
     StaggeredEntry(index = 5) {
-      SectionHeader(title = "About", showLozenge = false)
+      SectionHeader(title = "Share", showLozenge = false)
     }
     StaggeredEntry(index = 6) {
-      RowCard(label = "Build", value = state.build)
+      RowCard(
+        label = "APK download · for friends",
+        value = state.apkShareUrl,
+        copyable = true,
+        copyText = state.apkShareUrl,
+      )
+    }
+
+    Spacer(Modifier.height(20.dp))
+
+    // ── About ────────────────────────────────────────────────────────
+    StaggeredEntry(index = 7) {
+      SectionHeader(title = "About", showLozenge = false)
+    }
+    StaggeredEntry(index = 8) {
+      Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        RowCard(label = "Build", value = state.build)
+        RowCard(
+          label = "Convex deployment",
+          value = state.convexUrl,
+          copyable = true,
+          copyText = state.convexUrl,
+        )
+      }
     }
 
     Spacer(Modifier.height(40.dp))
+  }
+}
+
+private fun linkedClansLine(ids: List<Int>): String {
+  if (ids.isEmpty()) return "no clans linked yet"
+  val names = ids.map { id ->
+    when (id) {
+      1 -> "Storm-Edge"; 2 -> "Tideborne"; 3 -> "Sunhold"; 4 -> "Vale-Ward"
+      5 -> "Twilight"; 6 -> "Ember"; 7 -> "Forge"; 8 -> "Star"
+      else -> "Clan $id"
+    }
+  }
+  return when (names.size) {
+    1 -> "${names[0]} stands under your hand."
+    2 -> "${names[0]} and ${names[1]} stand under your hand."
+    else -> {
+      val head = names.dropLast(1).joinToString(", ")
+      val tail = names.last()
+      "$head, and $tail stand under your hand."
+    }
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -4,19 +4,24 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import world.clan.app.BuildConfig
 import world.clan.app.data.SessionStore
 import world.clan.app.wallet.DeviceClass
 
 data class CodexUiState(
   val deviceClass: DeviceClass,
   val solanaPubkey: String?,
+  val walletLabel: String?,
   val build: String,
+  val convexUrl: String,
+  val linkedClansCount: Int,
+  val linkedClanIds: List<Int>,
+  val apkShareUrl: String,
 )
 
 /**
- * Slice 1 Codex screen — read-only summary of identity + device + about.
- * No EVM paste, no profile selector, no validation. The Solana pubkey is
- * the only identifier this app cares about.
+ * Codex — read-only identity / device / about summary. Powered by
+ * BuildConfig + SessionStore.
  */
 class CodexViewModel(
   private val sessionStore: SessionStore,
@@ -24,16 +29,24 @@ class CodexViewModel(
 ) : ViewModel() {
 
   private val _state = MutableStateFlow(
-    CodexUiState(
-      deviceClass = deviceClass,
-      solanaPubkey = sessionStore.read()?.solanaPubkeyBase58,
-      build = "v 0.1.0 · slice I",
-    ),
+    run {
+      val s = sessionStore.read()
+      CodexUiState(
+        deviceClass = deviceClass,
+        solanaPubkey = s?.solanaPubkeyBase58,
+        walletLabel = s?.walletLabel,
+        build = "v ${BuildConfig.VERSION_NAME} · build ${BuildConfig.VERSION_CODE}",
+        convexUrl = BuildConfig.CONVEX_URL,
+        linkedClansCount = HearthViewModel.LINKED_CLAN_IDS.size,
+        linkedClanIds = HearthViewModel.LINKED_CLAN_IDS,
+        apkShareUrl = "https://shared.claude.do/public/clanworld-mobile-slice-1.apk",
+      )
+    },
   )
   val state: StateFlow<CodexUiState> = _state.asStateFlow()
 
   fun disconnect() {
     sessionStore.clear()
-    _state.value = _state.value.copy(solanaPubkey = null)
+    _state.value = _state.value.copy(solanaPubkey = null, walletLabel = null)
   }
 }


### PR DESCRIPTION
## Summary

CodexScreen was the only original screen left untouched. Now pulls real data from BuildConfig + SessionStore + LINKED_CLAN_IDS instead of hardcoded strings.

**Stacked on #79 (draft persistence).**

### CodexUiState updates
- **build**: was \"v 0.1.0 · slice I\" → \"v \${VERSION_NAME} · build \${VERSION_CODE}\" via BuildConfig (currently \"v 0.1.13 · build 6\")
- **convexUrl**: BuildConfig.CONVEX_URL — surfaced in About so QA can verify which deployment is being hit
- **walletLabel**: from sessionStore.read().walletLabel — the human nickname Phantom returns. Row hidden if null
- **linkedClansCount + linkedClanIds**: from HearthViewModel.LINKED_CLAN_IDS — replaces hardcoded \"Caldris of the Strait\"
- **apkShareUrl**: stable share link for sending the APK to friends/devices

### CodexScreen updates
- Identity section: keeps pubkey, conditionally adds Wallet account row, replaces hardcoded clan with natural-language line (\"Tideborne, Twilight, and Ember stand under your hand.\")
- New \"Share\" section: APK download row with copy-link affordance pointing at the publish-shared URL
- About now also shows the Convex deployment URL with copy support

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 26s.

## Test plan

- [ ] Codex shows correct version (matches build.gradle.kts versionName/versionCode)
- [ ] Connected: Solana pubkey + wallet label rows render; both copy
- [ ] Linked clans line lists Tideborne / Twilight / Ember (LINKED_CLAN_IDS = 2, 5, 6) in natural language
- [ ] Share section: tapping copy puts the APK URL on the clipboard
- [ ] About: Convex deployment row shows \`https://valuable-kudu-985.convex.cloud\`; copies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)