### PR TITLE
feat(android): empty-state CTAs — turn dead-ends into next-actions

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/EmptyState.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/EmptyState.kt
@@ -1,0 +1,91 @@
+package world.clan.app.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * Inviting empty state. Renders centered title + body italics, plus an
+ * optional outlined-pill CTA at the bottom. Use when a list is genuinely
+ * empty (no error, just nothing yet) and there's a sensible next action.
+ *
+ * Distinguished from RetryNotice (which is for errors): this is for
+ * "all good, nothing here yet" rather than "something went wrong".
+ */
+@Composable
+fun EmptyState(
+  title: String,
+  body: String,
+  ctaLabel: String? = null,
+  onCta: (() -> Unit)? = null,
+  modifier: Modifier = Modifier,
+) {
+  val warm = ClanWorldTheme.colors.warm
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val parchment = ClanWorldTheme.colors.parchment
+  val gold = ClanWorldTheme.colors.gold
+  val hairlineMid = ClanWorldTheme.colors.hairlineMid
+  val iron2 = ClanWorldTheme.colors.iron2
+
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 32.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Text(
+      text = title,
+      style = ClanWorldTheme.type.scriptItalic,
+      color = warm,
+      textAlign = TextAlign.Center,
+    )
+    Text(
+      text = body,
+      style = ClanWorldTheme.type.scriptItalic,
+      color = warmDim,
+      textAlign = TextAlign.Center,
+    )
+    if (ctaLabel != null && onCta != null) {
+      Spacer(Modifier.height(6.dp))
+      Box(
+        modifier = Modifier
+          .clip(RoundedCornerShape(4.dp))
+          .background(iron2)
+          .drawBehind {
+            drawRoundRect(
+              color = hairlineMid,
+              cornerRadius = CornerRadius(4.dp.toPx()),
+              style = Stroke(width = 1.dp.toPx()),
+            )
+          }
+          .clickable { onCta() }
+          .padding(horizontal = 18.dp, vertical = 10.dp),
+      ) {
+        Text(
+          text = ctaLabel.uppercase(),
+          style = ClanWorldTheme.type.monoMicro,
+          color = gold,
+        )
+      }
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -133,11 +133,11 @@ private fun HallScreen(
         if (state.items.isEmpty()) {
           LazyColumn(modifier = Modifier.fillMaxSize()) {
             item {
-              Text(
-                text = "your hall is quiet — no sigils linked.",
-                style = ClanWorldTheme.type.scriptItalic,
-                color = ClanWorldTheme.colors.warmFaint,
-                modifier = Modifier.padding(top = 24.dp),
+              world.clan.app.ui.components.EmptyState(
+                title = "your hall is quiet",
+                body = "no sigils stand under your hand yet — forge one to begin.",
+                ctaLabel = "+ Forge a sigil",
+                onCta = onForge,
               )
             }
           }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -432,29 +432,23 @@ private fun MemoryPanel(
   onEditStrategy: (() -> Unit)? = null,
 ) {
   Column {
+    if (memory.isEmpty()) {
+      world.clan.app.ui.components.EmptyState(
+        title = "no doctrine written yet",
+        body = "the elder waits for your first counsel.",
+        ctaLabel = if (onEditStrategy != null) "+ Write doctrine" else null,
+        onCta = onEditStrategy,
+      )
+      return@Column
+    }
     PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
-      if (memory.isEmpty()) {
-        Box(
-          Modifier
-            .fillMaxWidth()
-            .padding(20.dp),
-          contentAlignment = Alignment.Center,
-        ) {
-          Text(
-            "no memory written yet",
-            style = ClanWorldTheme.type.scriptItalic,
-            color = ClanWorldTheme.colors.warmFaint,
-          )
-        }
-      } else {
-        memory.take(10).forEach { entry ->
-          MemoryRow(
-            key = entry.key,
-            body = inlineCodeBody(entry.value),
-            stamp = "written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}",
-            modifier = Modifier.fillMaxWidth(),
-          )
-        }
+      memory.take(10).forEach { entry ->
+        MemoryRow(
+          key = entry.key,
+          body = inlineCodeBody(entry.value),
+          stamp = "written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}",
+          modifier = Modifier.fillMaxWidth(),
+        )
       }
     }
     if (onEditStrategy != null) {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -117,11 +117,13 @@ private fun WhispersScreen(
           if (items.isEmpty()) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
               item {
-                Text(
-                  text = "no whispers carry this kind.",
-                  style = ClanWorldTheme.type.scriptItalic,
-                  color = ClanWorldTheme.colors.warmFaint,
-                  modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+                val isFiltered = state.filter != WhispersFilter.All
+                world.clan.app.ui.components.EmptyState(
+                  title = if (isFiltered) "no whispers carry this kind" else "the inbox is silent",
+                  body = if (isFiltered) "try another filter, or compose one yourself."
+                  else "no whispers heard yet — be the first to speak.",
+                  ctaLabel = if (isFiltered) null else "+ New whisper",
+                  onCta = if (isFiltered) null else onCompose,
                 )
               }
             }


### PR DESCRIPTION
## Summary

Empty states across the app were terminal text (\"your hall is quiet — no sigils linked.\") with no clear next step. Replaces with inviting copy + outlined-pill CTAs where there's a sensible action.

**Stacked on #81 (skeleton loaders).**

### New \`ui/components/EmptyState.kt\`
- Reusable empty-state composable: title + body italics, optional outlined CTA pill at bottom
- Distinguished from RetryNotice (errors) — this is for \"all good, nothing here yet\"

### Wiring
- **HallScreen empty** → \"+ Forge a sigil\" (same target as the always-visible top link, but front-and-center for first-run users)
- **WhispersScreen empty, filter=All** → \"+ New whisper\" (→ SteeringConsole)
- **WhispersScreen empty, filter active** → no CTA, hint to try another filter (avoids encouraging compose when user is just narrowing)
- **InftDetail Memory empty** → \"+ Write doctrine\" (→ StrategyEditor). Replaces the \"no memory written yet\" inline text; existing \"EDIT STRATEGY →\" link still appears below for populated case

Treasury empty and InftDetail Bulletin empty intentionally not converted — neither has a user-facing action that makes sense to call out.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 28s.

## Test plan

- [ ] First-launch user with empty Hall → empty-state with \"+ Forge a sigil\" CTA → tap → opens Forge wizard
- [ ] Whispers inbox with no comms (clan with empty backend) → \"the inbox is silent\" + \"+ New whisper\" CTA
- [ ] Whispers with filter=Peers and no peer whispers → \"no whispers carry this kind\" without CTA
- [ ] InftDetail → Memory tab with no memory entries → \"+ Write doctrine\" CTA → opens StrategyEditor

🤖 Generated with [Claude Code](https://claude.com/claude-code)