### PR TITLE
feat(android): first-launch onboarding hint on Hall

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -103,4 +103,15 @@ class SessionStore(context: Context) {
     toRemove.forEach { ed.remove(it) }
     ed.apply()
   }
+
+  // ── One-shot UI flags ─────────────────────────────────────────────────
+  // Persisted booleans for onboarding hints / coachmarks. Once a flag is
+  // marked seen, it stays seen across reinstalls (within EncryptedShared
+  // Preferences' device-keystore lifetime).
+
+  fun hasSeenFlag(key: String): Boolean = prefs.getBoolean("flag:$key", false)
+
+  fun markFlagSeen(key: String) {
+    prefs.edit().putBoolean("flag:$key", true).apply()
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/OnboardingHint.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/OnboardingHint.kt
@@ -1,0 +1,134 @@
+package world.clan.app.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import world.clan.app.R
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * One-shot dismissible coachmark for first-time users. Renders a small
+ * parchment-tinted banner with title + body + close icon. Disappears
+ * permanently when dismissed (or on first prevent-show-again signal from
+ * the host).
+ *
+ * Hosts manage the "have they seen it?" flag via SessionStore.hasSeenFlag /
+ * markFlagSeen. The banner shrinks itself out cleanly on dismiss so the
+ * surrounding content reflows without a layout pop.
+ */
+@Composable
+fun OnboardingHint(
+  visible: Boolean,
+  title: String,
+  body: String,
+  onDismiss: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  // Local visibility tracks the parent's `visible` plus an in-flight
+  // dismissal. Without this the parent flag flips synchronously and the
+  // exit animation has nothing to animate.
+  var localVisible by remember(visible) { mutableStateOf(visible) }
+
+  AnimatedVisibility(
+    visible = localVisible,
+    enter = fadeIn(),
+    exit = fadeOut() + shrinkVertically(),
+    modifier = modifier,
+  ) {
+    val gold = ClanWorldTheme.colors.gold
+    val goldDim = ClanWorldTheme.colors.goldDim
+    val warm = ClanWorldTheme.colors.warm
+    val warmDim = ClanWorldTheme.colors.warmDim
+    val iron2 = ClanWorldTheme.colors.iron2
+
+    Row(
+      modifier = Modifier
+        .fillMaxWidth()
+        .clip(RoundedCornerShape(6.dp))
+        .background(
+          Brush.verticalGradient(
+            0f to gold.copy(alpha = 0.10f),
+            1f to gold.copy(alpha = 0.04f),
+          ),
+        )
+        .drawBehind {
+          drawRoundRect(
+            color = goldDim,
+            cornerRadius = CornerRadius(6.dp.toPx()),
+            style = Stroke(width = 1.dp.toPx()),
+          )
+        }
+        .padding(horizontal = 14.dp, vertical = 12.dp),
+      verticalAlignment = Alignment.Top,
+      horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+      // Small ember-pill marker on the left
+      Box(
+        modifier = Modifier
+          .size(8.dp)
+          .clip(RoundedCornerShape(50))
+          .background(gold),
+      )
+      Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+      ) {
+        Text(
+          text = title.uppercase(),
+          style = ClanWorldTheme.type.monoMicro,
+          color = gold,
+        )
+        Text(
+          text = body,
+          style = ClanWorldTheme.type.scriptItalic,
+          color = warm,
+        )
+      }
+      // Dismiss × button
+      Box(
+        modifier = Modifier
+          .clip(RoundedCornerShape(50))
+          .background(iron2)
+          .clickable {
+            localVisible = false
+            onDismiss()
+          }
+          .padding(6.dp),
+      ) {
+        Icon(
+          painter = painterResource(R.drawable.ui_check),
+          contentDescription = "dismiss",
+          tint = warmDim,
+          modifier = Modifier.size(12.dp),
+        )
+      }
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -16,6 +16,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -63,11 +66,21 @@ fun HallScreenRoute(
 ) {
   val vm: HallViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
+  // First-launch coachmark: read once from SessionStore, dismiss-on-tap
+  // toggles the local state and writes the persistent flag.
+  val hintFlagKey = "hall.hintSeen"
+  val hintInitial = remember { !app.sessionStore.hasSeenFlag(hintFlagKey) }
+  var hintVisible by remember { mutableStateOf(hintInitial) }
   HallScreen(
     state = state,
     onOpenInft = onOpenInft,
     onForge = onForge,
     onRefresh = vm::refresh,
+    showHint = hintVisible,
+    onDismissHint = {
+      hintVisible = false
+      app.sessionStore.markFlagSeen(hintFlagKey)
+    },
   )
 }
 
@@ -77,6 +90,8 @@ private fun HallScreen(
   onOpenInft: (Int) -> Unit,
   onForge: () -> Unit = {},
   onRefresh: () -> Unit = {},
+  showHint: Boolean = false,
+  onDismissHint: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
   Column(
@@ -93,6 +108,15 @@ private fun HallScreen(
     StaggeredEntry(index = 0) {
       HallHead(count = state.items.size)
     }
+
+    // First-launch coachmark — points new users at the FORGE entry below.
+    Spacer(Modifier.height(14.dp))
+    world.clan.app.ui.components.OnboardingHint(
+      visible = showHint,
+      title = "Begin your line",
+      body = "Tap “+ Forge a new sigil” below to mint your first iNFT.",
+      onDismiss = onDismissHint,
+    )
 
     // Forge entry — sits between the head divider and the list. Always
     // available; an empty hall still wants the option to forge a new one.


### PR DESCRIPTION
## Summary

Drop a small dismissible parchment-tinted coachmark above the FORGE link the first time a user lands on Hall. Persisted so it doesn't return on subsequent launches.

**Stacked on #82 (empty-state CTAs).**

### \`ui/components/OnboardingHint.kt\`
- Reusable dismissible banner: title (mono, gold) + body (script italic, warm) + close × pill
- Gold-gradient background + gold dim hairline border — sits visually between obsidian dark surfaces and parchment cards
- \`AnimatedVisibility\` with \`fadeIn\` / \`fadeOut\` + \`shrinkVertically\` on dismiss so surrounding content reflows cleanly
- Caller manages persistence; component just animates

### SessionStore additions
- \`hasSeenFlag(key)\` / \`markFlagSeen(key)\` — namespaced one-shot booleans (\`flag:<key>\`) for onboarding hints / coachmarks
- Reusable for any future first-launch coachmarks

### HallScreen wiring
- New \`hall.hintSeen\` flag drives a coachmark: \"BEGIN YOUR LINE — Tap '+ Forge a new sigil' below to mint your first iNFT\"
- Hint visibility is local state hydrated from SessionStore on mount; dismiss writes the flag and animates the banner away
- Reflows above the FORGE link so the header divider doesn't move when the hint collapses

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 13s.

## Test plan

- [ ] Fresh install → land on Hall → coachmark visible above FORGE link
- [ ] Tap × on coachmark → banner shrinks + fades out, doesn't return
- [ ] Close + reopen app → coachmark stays gone (persisted)
- [ ] Wallet pill disconnect → reconnect: coachmark stays gone (no re-trigger on session changes — that's intentional, it's a per-install flag, not per-session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)