### PR TITLE
fix(contracts): close public demo blockers

### DIFF
--- a/.github/workflows/chainclient-abi.yml
+++ b/.github/workflows/chainclient-abi.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -82,52 +82,18 @@ contract DeployDiamond is Script {
 
         IDiamondCut(address(diamond))
             .diamondCut(
-                _coreFacetCuts(
+                _bootstrapFacetCuts(
                     address(loupeFacet),
                     address(adminOwnershipFacet),
-                    address(heartbeatFacet),
-                    address(heartbeatConfigFacet),
-                    address(worldPauseFacet),
-                    address(finalizeSeasonFacet),
-                    address(rawWorldViewsFacet),
-                    address(rawTreasuryViewsFacet),
-                    address(rawClanViewsFacet),
-                    address(rawBanditViewsFacet),
-                    address(lifecycleFacet)
-                ),
-                address(0),
-                ""
-            );
-        IDiamondCut(address(diamond))
-            .diamondCut(
-                _orderFacetCuts(
-                    address(submitOrdersFacet),
-                    address(clanOwnershipFacet),
                     address(treasuryFacet),
-                    address(settlementFacet),
-                    address(directTransfersFacet)
-                ),
-                address(0),
-                ""
-            );
-        IDiamondCut(address(diamond))
-            .diamondCut(
-                _viewFacetCuts(
-                    address(derivedViewsFacet),
-                    address(marketViewsFacet),
-                    address(banditViewsFacet),
-                    address(regionViewsFacet),
-                    address(snapshotViewsFacet),
-                    address(clanFullViewFacet),
-                    address(quoteViewsFacet),
-                    address(scoringViewsFacet)
+                    address(rawWorldViewsFacet),
+                    address(rawTreasuryViewsFacet)
                 ),
                 address(init),
                 abi.encodeCall(ClanWorldDiamondInit.init, ())
             );
 
         IClanWorld game = IClanWorld(address(diamond));
-        ClanWorldLens lens = new ClanWorldLens(game);
 
         MinimalERC20 wood = new MinimalERC20("Wood", "WOOD");
         MinimalERC20 iron = new MinimalERC20("Iron", "IRON");
@@ -173,6 +139,42 @@ contract DeployDiamond is Script {
             })
         );
 
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                _gameplayFacetCuts(
+                    address(heartbeatFacet),
+                    address(heartbeatConfigFacet),
+                    address(worldPauseFacet),
+                    address(finalizeSeasonFacet),
+                    address(rawClanViewsFacet),
+                    address(rawBanditViewsFacet),
+                    address(lifecycleFacet),
+                    address(submitOrdersFacet),
+                    address(clanOwnershipFacet),
+                    address(settlementFacet),
+                    address(directTransfersFacet)
+                ),
+                address(0),
+                ""
+            );
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                _viewFacetCuts(
+                    address(derivedViewsFacet),
+                    address(marketViewsFacet),
+                    address(banditViewsFacet),
+                    address(regionViewsFacet),
+                    address(snapshotViewsFacet),
+                    address(clanFullViewFacet),
+                    address(quoteViewsFacet),
+                    address(scoringViewsFacet)
+                ),
+                address(0),
+                ""
+            );
+
+        ClanWorldLens lens = new ClanWorldLens(game);
+
         console.log("CLAN_WORLD_DIAMOND_ADDRESS:       ", address(diamond));
         console.log("CLAN_WORLD_LENS_ADDRESS:          ", address(lens));
         console.log("WOOD_TOKEN_ADDRESS:               ", address(wood));
@@ -215,20 +217,14 @@ contract DeployDiamond is Script {
         vm.stopBroadcast();
     }
 
-    function _coreFacetCuts(
+    function _bootstrapFacetCuts(
         address loupeFacet,
         address adminOwnershipFacet,
-        address heartbeatFacet,
-        address heartbeatConfigFacet,
-        address worldPauseFacet,
-        address finalizeSeasonFacet,
+        address treasuryFacet,
         address rawWorldViewsFacet,
-        address rawTreasuryViewsFacet,
-        address rawClanViewsFacet,
-        address rawBanditViewsFacet,
-        address lifecycleFacet
+        address rawTreasuryViewsFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](11);
+        cut = new IDiamondCut.FacetCut[](5);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -240,81 +236,87 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.ownershipFacetSelectors()
         });
         cut[2] = IDiamondCut.FacetCut({
-            facetAddress: heartbeatFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.heartbeatSelectors()
-        });
-        cut[3] = IDiamondCut.FacetCut({
-            facetAddress: heartbeatConfigFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.heartbeatConfigSelectors()
-        });
-        cut[4] = IDiamondCut.FacetCut({
-            facetAddress: worldPauseFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.worldPauseSelectors()
-        });
-        cut[5] = IDiamondCut.FacetCut({
-            facetAddress: finalizeSeasonFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.seasonSelectors()
-        });
-        cut[6] = IDiamondCut.FacetCut({
-            facetAddress: rawWorldViewsFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.rawWorldViewsSelectors()
-        });
-        cut[7] = IDiamondCut.FacetCut({
-            facetAddress: rawTreasuryViewsFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.rawTreasuryViewsSelectors()
-        });
-        cut[8] = IDiamondCut.FacetCut({
-            facetAddress: rawClanViewsFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.rawClanViewsSelectors()
-        });
-        cut[9] = IDiamondCut.FacetCut({
-            facetAddress: rawBanditViewsFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.rawBanditViewsSelectors()
-        });
-        cut[10] = IDiamondCut.FacetCut({
-            facetAddress: lifecycleFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.lifecycleSelectors()
-        });
-    }
-
-    function _orderFacetCuts(
-        address submitOrdersFacet,
-        address clanOwnershipFacet,
-        address treasuryFacet,
-        address settlementFacet,
-        address directTransfersFacet
-    ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](5);
-        cut[0] = IDiamondCut.FacetCut({
-            facetAddress: submitOrdersFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.submitOrdersSelectors()
-        });
-        cut[1] = IDiamondCut.FacetCut({
-            facetAddress: clanOwnershipFacet,
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: DiamondSelectors.ownershipSelectors()
-        });
-        cut[2] = IDiamondCut.FacetCut({
             facetAddress: treasuryFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.treasurySelectors()
         });
         cut[3] = IDiamondCut.FacetCut({
+            facetAddress: rawWorldViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.rawWorldViewsSelectors()
+        });
+        cut[4] = IDiamondCut.FacetCut({
+            facetAddress: rawTreasuryViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.rawTreasuryViewsSelectors()
+        });
+    }
+
+    function _gameplayFacetCuts(
+        address heartbeatFacet,
+        address heartbeatConfigFacet,
+        address worldPauseFacet,
+        address finalizeSeasonFacet,
+        address rawClanViewsFacet,
+        address rawBanditViewsFacet,
+        address lifecycleFacet,
+        address submitOrdersFacet,
+        address clanOwnershipFacet,
+        address settlementFacet,
+        address directTransfersFacet
+    ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](11);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: heartbeatFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.heartbeatSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: heartbeatConfigFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.heartbeatConfigSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: worldPauseFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.worldPauseSelectors()
+        });
+        cut[3] = IDiamondCut.FacetCut({
+            facetAddress: finalizeSeasonFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.seasonSelectors()
+        });
+        cut[4] = IDiamondCut.FacetCut({
+            facetAddress: rawClanViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.rawClanViewsSelectors()
+        });
+        cut[5] = IDiamondCut.FacetCut({
+            facetAddress: rawBanditViewsFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.rawBanditViewsSelectors()
+        });
+        cut[6] = IDiamondCut.FacetCut({
+            facetAddress: lifecycleFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.lifecycleSelectors()
+        });
+        cut[7] = IDiamondCut.FacetCut({
+            facetAddress: submitOrdersFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.submitOrdersSelectors()
+        });
+        cut[8] = IDiamondCut.FacetCut({
+            facetAddress: clanOwnershipFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.ownershipSelectors()
+        });
+        cut[9] = IDiamondCut.FacetCut({
             facetAddress: settlementFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.settlementSelectors()
         });
-        cut[4] = IDiamondCut.FacetCut({
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: directTransfersFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.directTransferSelectors()

--- a/packages/contracts/src/diamond/lib/LibSettlement.sol
+++ b/packages/contracts/src/diamond/lib/LibSettlement.sol
@@ -59,6 +59,12 @@ library LibSettlement {
         uint256 fishDelta,
         uint64 atTick
     );
+    event ClanEliminated(uint32 indexed clanId, uint64 indexed tick);
+    event ClanDied(uint32 indexed clanId, uint64 tick, string reason);
+    event ClanStarvationChanged(uint32 indexed clanId, bool isStarving, uint64 atTick);
+    event ClanColdShortage(uint32 indexed clanId, uint64 tick, uint256 woodShort);
+    event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint64 tick);
+    event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint64 tick);
     // BanditEscaped + BanditTargetDied moved to LibBanditCombat (canonical
     // emitter post-dedup). Same event signatures; ABI consumers unaffected.
 
@@ -67,6 +73,22 @@ library LibSettlement {
         ResourcesGathered,
         ResourcesDeposited,
         ResourcesWithdrawn
+    }
+
+    enum UpkeepLogKind {
+        None,
+        ClanStarvationChanged,
+        ClanColdShortage,
+        WallDegradedByCold,
+        ClansmanColdDeath,
+        ClanEliminated,
+        ClanDied
+    }
+
+    enum ClanDeathReason {
+        None,
+        Starvation,
+        Cold
     }
 
     struct SettlementLog {
@@ -81,13 +103,25 @@ library LibSettlement {
         uint64 tick;
     }
 
+    struct UpkeepLog {
+        UpkeepLogKind kind;
+        uint32 clansmanId;
+        uint64 tick;
+        uint256 amount;
+        uint8 level;
+        bool flag;
+        ClanDeathReason reason;
+    }
+
     struct SettlementSimulation {
         Clan clan;
         Clansman[] clansmen;
         Mission[] missions;
         WheatPlot[2] wheatPlots;
         SettlementLog[] logs;
+        UpkeepLog[] upkeepLogs;
         uint256 logCount;
+        uint256 upkeepLogCount;
         uint64[11] simMonumentReachedAt;
         bool[] simWallReservationCleared;
         bool[] simBaseReservationCleared;
@@ -147,7 +181,9 @@ library LibSettlement {
         if (toTick > fromTick + LibGameRules.MAX_LAZY_SETTLE_BACKLOG) {
             toTick = fromTick + LibGameRules.MAX_LAZY_SETTLE_BACKLOG;
         }
-        sim.logs = new SettlementLog[](sim.clansmen.length * (toTick - fromTick));
+        uint256 tickCount = toTick - fromTick;
+        sim.logs = new SettlementLog[](sim.clansmen.length * tickCount);
+        sim.upkeepLogs = new UpkeepLog[]((sim.clansmen.length + 6) * tickCount);
 
         for (uint64 tick = fromTick; tick < toTick; tick++) {
             applyUpkeep(s, sim, tick);
@@ -172,6 +208,8 @@ library LibSettlement {
         s.clans[clanId] = sim.clan;
         s.wheatPlots[clanId][0] = sim.wheatPlots[0];
         s.wheatPlots[clanId][1] = sim.wheatPlots[1];
+
+        emitUpkeepLogs(sim);
 
         for (uint256 i = 0; i < sim.clansmen.length; i++) {
             uint32 clansmanId = sim.clansmen[i].clansmanId;
@@ -215,6 +253,25 @@ library LibSettlement {
         for (uint8 level = 1; level < sim.simMonumentReachedAt.length; level++) {
             if (sim.simMonumentReachedAt[level] != 0 && s.monumentLevelReachedAt[clanId][level] == 0) {
                 s.monumentLevelReachedAt[clanId][level] = sim.simMonumentReachedAt[level];
+            }
+        }
+    }
+
+    function emitUpkeepLogs(SettlementSimulation memory sim) internal {
+        for (uint256 i = 0; i < sim.upkeepLogCount; i++) {
+            UpkeepLog memory entry = sim.upkeepLogs[i];
+            if (entry.kind == UpkeepLogKind.ClanStarvationChanged) {
+                emit ClanStarvationChanged(sim.clan.clanId, entry.flag, entry.tick);
+            } else if (entry.kind == UpkeepLogKind.ClanColdShortage) {
+                emit ClanColdShortage(sim.clan.clanId, entry.tick, entry.amount);
+            } else if (entry.kind == UpkeepLogKind.WallDegradedByCold) {
+                emit WallDegradedByCold(sim.clan.clanId, entry.level, entry.tick);
+            } else if (entry.kind == UpkeepLogKind.ClansmanColdDeath) {
+                emit ClansmanColdDeath(sim.clan.clanId, entry.clansmanId, entry.tick);
+            } else if (entry.kind == UpkeepLogKind.ClanEliminated) {
+                emit ClanEliminated(sim.clan.clanId, entry.tick);
+            } else if (entry.kind == UpkeepLogKind.ClanDied) {
+                emit ClanDied(sim.clan.clanId, entry.tick, deathReasonString(entry.reason));
             }
         }
     }
@@ -273,6 +330,34 @@ library LibSettlement {
         });
     }
 
+    function recordUpkeepLog(
+        SettlementSimulation memory sim,
+        UpkeepLogKind kind,
+        uint32 clansmanId,
+        uint64 tick,
+        uint256 amount,
+        uint8 level,
+        bool flag,
+        ClanDeathReason reason
+    ) internal pure {
+        if (sim.upkeepLogCount >= sim.upkeepLogs.length) return;
+        sim.upkeepLogs[sim.upkeepLogCount++] = UpkeepLog({
+            kind: kind,
+            clansmanId: clansmanId,
+            tick: tick,
+            amount: amount,
+            level: level,
+            flag: flag,
+            reason: reason
+        });
+    }
+
+    function deathReasonString(ClanDeathReason reason) internal pure returns (string memory) {
+        if (reason == ClanDeathReason.Starvation) return "starvation";
+        if (reason == ClanDeathReason.Cold) return "cold";
+        return "unknown";
+    }
+
     function applyUpkeep(LibStorage.AppStorage storage s, SettlementSimulation memory sim, uint64 tick) internal view {
         bool winter = LibSeason.isWinterActiveAt(tick);
         if (!winter && tick > 0 && LibSeason.isWinterActiveAt(tick - 1)) {
@@ -302,8 +387,28 @@ library LibSettlement {
         bool starving = !hadEnoughWheat || !hadEnoughFish;
         if (starving && sim.clan.starvationStartsAtTick == 0) {
             sim.clan.starvationStartsAtTick = tick + 1;
+            recordUpkeepLog(
+                sim,
+                UpkeepLogKind.ClanStarvationChanged,
+                0,
+                tick + 1,
+                0,
+                0,
+                true,
+                ClanDeathReason.None
+            );
         } else if (!starving && sim.clan.starvationStartsAtTick != 0) {
             sim.clan.starvationStartsAtTick = 0;
+            recordUpkeepLog(
+                sim,
+                UpkeepLogKind.ClanStarvationChanged,
+                0,
+                tick,
+                0,
+                0,
+                false,
+                ClanDeathReason.None
+            );
         }
 
         uint8 livingBeforeStarvation = sim.clan.livingClansmen;
@@ -313,7 +418,7 @@ library LibSettlement {
                 ? sim.clan.starvationStartsAtTick
                 : winterStartsAtTick;
             if (effectiveStarvationStartsAtTick < tick) {
-                killNextClansmanFromStarvation(s, sim);
+                killNextClansmanFromStarvation(s, sim, tick);
             }
         }
         if (sim.clan.clanState == ClanState.DEAD) return;
@@ -326,11 +431,22 @@ library LibSettlement {
             if (spendableWood >= woodNeeded) {
                 sim.clan.vaultWood -= woodNeeded;
             } else {
+                uint256 woodShort = woodNeeded - spendableWood;
                 sim.clan.vaultWood -= spendableWood;
                 uint16 oldColdDamage = sim.clan.coldDamage;
                 if (sim.clan.coldDamage < type(uint16).max) {
                     sim.clan.coldDamage += 1;
                 }
+                recordUpkeepLog(
+                    sim,
+                    UpkeepLogKind.ClanColdShortage,
+                    0,
+                    tick,
+                    woodShort,
+                    0,
+                    false,
+                    ClanDeathReason.None
+                );
                 applyColdDamageConsequence(s, sim, tick, oldColdDamage);
             }
         }
@@ -352,6 +468,16 @@ library LibSettlement {
             ) return;
 
             sim.clan.wallLevel--;
+            recordUpkeepLog(
+                sim,
+                UpkeepLogKind.WallDegradedByCold,
+                0,
+                tick,
+                0,
+                sim.clan.wallLevel,
+                false,
+                ClanDeathReason.None
+            );
             return;
         }
 
@@ -395,14 +521,24 @@ library LibSettlement {
             }
 
             markClansmanDead(s, sim, i);
+            recordUpkeepLog(
+                sim,
+                UpkeepLogKind.ClansmanColdDeath,
+                sim.clansmen[i].clansmanId,
+                tick,
+                0,
+                0,
+                false,
+                ClanDeathReason.None
+            );
             if (sim.clan.livingClansmen == 0) {
-                markClanDead(s, sim);
+                markClanDead(s, sim, ClanDeathReason.Cold, tick);
             }
             return;
         }
     }
 
-    function killNextClansmanFromStarvation(LibStorage.AppStorage storage s, SettlementSimulation memory sim)
+    function killNextClansmanFromStarvation(LibStorage.AppStorage storage s, SettlementSimulation memory sim, uint64 tick)
         internal
         view
     {
@@ -413,7 +549,7 @@ library LibSettlement {
 
             markClansmanDead(s, sim, i);
             if (sim.clan.livingClansmen == 0) {
-                markClanDead(s, sim);
+                markClanDead(s, sim, ClanDeathReason.Starvation, tick);
             }
             return;
         }
@@ -439,7 +575,12 @@ library LibSettlement {
         }
     }
 
-    function markClanDead(LibStorage.AppStorage storage s, SettlementSimulation memory sim) internal view {
+    function markClanDead(
+        LibStorage.AppStorage storage s,
+        SettlementSimulation memory sim,
+        ClanDeathReason reason,
+        uint64 tick
+    ) internal view {
         if (sim.clan.clanId == ClanWorldConstants.CLAN_ID_NULL || sim.clan.clanState == ClanState.DEAD) return;
 
         sim.clan.clanState = ClanState.DEAD;
@@ -462,6 +603,26 @@ library LibSettlement {
             }
         }
         sim.simClanDied = true;
+        recordUpkeepLog(
+            sim,
+            UpkeepLogKind.ClanEliminated,
+            0,
+            tick,
+            0,
+            0,
+            false,
+            ClanDeathReason.None
+        );
+        recordUpkeepLog(
+            sim,
+            UpkeepLogKind.ClanDied,
+            0,
+            tick,
+            0,
+            0,
+            false,
+            reason
+        );
     }
 
     function regrowWheatPlots(SettlementSimulation memory sim, uint64 tick) internal pure {
@@ -825,12 +986,10 @@ library LibSettlement {
             return true;
         }
         if (held.fromLevel != sim.clan.wallLevel) {
-            if (held.fromLevel < sim.clan.wallLevel) {
-                clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeWall);
-                sim.reservedWood = LibSettlementMath.subtractHeld(sim.reservedWood, held.woodCost);
-                sim.reservedIron = LibSettlementMath.subtractHeld(sim.reservedIron, held.ironCost);
-            }
-            return false;
+            clearUpgradeReservation(sim, clansmanId, ActionType.UpgradeWall);
+            sim.reservedWood = LibSettlementMath.subtractHeld(sim.reservedWood, held.woodCost);
+            sim.reservedIron = LibSettlementMath.subtractHeld(sim.reservedIron, held.ironCost);
+            return true;
         }
 
         (uint256 woodCost, uint256 ironCost) = LibGameRules.wallUpgradeCost(sim.clan.wallLevel);

--- a/packages/contracts/test/diamond/PublicDemoBlockers.t.sol
+++ b/packages/contracts/test/diamond/PublicDemoBlockers.t.sol
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {DiamondSelectors} from "../../script/DiamondSelectors.sol";
+import {Diamond} from "../../src/diamond/Diamond.sol";
+import {ClanWorldDiamondInit} from "../../src/diamond/ClanWorldDiamondInit.sol";
+import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
+import {IDiamondLoupe} from "../../src/diamond/IDiamondLoupe.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {OwnershipFacet} from "../../src/diamond/facets/OwnershipFacet.sol";
+import {RawWorldViewsFacet} from "../../src/diamond/facets/RawWorldViewsFacet.sol";
+import {RawTreasuryViewsFacet} from "../../src/diamond/facets/RawTreasuryViewsFacet.sol";
+import {RawClanViewsFacet} from "../../src/diamond/facets/RawClanViewsFacet.sol";
+import {TreasuryFacet} from "../../src/diamond/facets/TreasuryFacet.sol";
+import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.sol";
+import {HeartbeatFacet} from "../../src/diamond/facets/HeartbeatFacet.sol";
+import {SettlementFacet} from "../../src/diamond/facets/SettlementFacet.sol";
+import {SubmitOrdersFacet} from "../../src/diamond/facets/SubmitOrdersFacet.sol";
+import {LibStorage} from "../../src/diamond/lib/LibStorage.sol";
+import {MinimalERC20} from "../../src/MinimalERC20.sol";
+import {StubPool} from "../../src/StubPool.sol";
+import {
+    ActionType,
+    Clan,
+    ClanOrder,
+    ClanWorldConstants,
+    IClanWorld,
+    PoolSeedConfig,
+    StatusCode,
+    WithdrawResourcesData
+} from "../../src/IClanWorld.sol";
+
+interface IPublicDemoHarness {
+    function setCurrentTick(uint64 tick) external;
+    function setClanUpkeepState(
+        uint32 clanId,
+        uint64 lastSettledTick,
+        uint256 vaultWood,
+        uint256 vaultWheat,
+        uint256 vaultFish,
+        uint16 coldDamage
+    ) external;
+    function setClanWallLevel(uint32 clanId, uint8 wallLevel) external;
+    function setVault(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external;
+    function wallReservation(uint32 clansmanId)
+        external
+        view
+        returns (bool active, uint8 fromLevel, uint256 woodCost, uint256 ironCost);
+    function pendingWallUpgrades(uint32 clanId) external view returns (uint8);
+    function reservedWood(uint32 clanId) external view returns (uint256);
+    function reservedIron(uint32 clanId) external view returns (uint256);
+}
+
+contract PublicDemoHarnessFacet {
+    function setCurrentTick(uint64 tick) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        bytes32 tickSeed = bytes32(uint256(tick));
+        s.world.currentTick = tick;
+        s.world.nextHeartbeatAtTick = tick + 1;
+        s.world.nextHeartbeatAtTs = 0;
+        s.world.currentTickSeed = tickSeed;
+        s.tickSeeds[tick] = tickSeed;
+    }
+
+    function setClanUpkeepState(
+        uint32 clanId,
+        uint64 lastSettledTick,
+        uint256 vaultWood,
+        uint256 vaultWheat,
+        uint256 vaultFish,
+        uint16 coldDamage
+    ) external {
+        Clan storage clan = LibStorage.appStorage().clans[clanId];
+        clan.lastSettledTick = lastSettledTick;
+        clan.vaultWood = vaultWood;
+        clan.vaultWheat = vaultWheat;
+        clan.vaultFish = vaultFish;
+        clan.starvationStartsAtTick = 0;
+        clan.coldDamage = coldDamage;
+    }
+
+    function setClanWallLevel(uint32 clanId, uint8 wallLevel) external {
+        LibStorage.appStorage().clans[clanId].wallLevel = wallLevel;
+    }
+
+    function setVault(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        Clan storage clan = LibStorage.appStorage().clans[clanId];
+        clan.vaultWood = wood;
+        clan.vaultIron = iron;
+        clan.vaultWheat = wheat;
+        clan.vaultFish = fish;
+    }
+
+    function wallReservation(uint32 clansmanId)
+        external
+        view
+        returns (bool active, uint8 fromLevel, uint256 woodCost, uint256 ironCost)
+    {
+        LibStorage.WallUpgradeReservation storage r = LibStorage.appStorage().wallUpgradeReservations[clansmanId];
+        return (r.active, r.fromLevel, r.woodCost, r.ironCost);
+    }
+
+    function pendingWallUpgrades(uint32 clanId) external view returns (uint8) {
+        return LibStorage.appStorage().pendingWallUpgradesByClan[clanId];
+    }
+
+    function reservedWood(uint32 clanId) external view returns (uint256) {
+        return LibStorage.appStorage().reservedWoodByClan[clanId];
+    }
+
+    function reservedIron(uint32 clanId) external view returns (uint256) {
+        return LibStorage.appStorage().reservedIronByClan[clanId];
+    }
+}
+
+contract PublicDemoBlockersTest is Test {
+    event ClanColdShortage(uint32 indexed clanId, uint64 tick, uint256 woodShort);
+    event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint64 tick);
+    event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint64 tick);
+    event ClanEliminated(uint32 indexed clanId, uint64 indexed tick);
+    event ClanDied(uint32 indexed clanId, uint64 tick, string reason);
+
+    address private elder = address(0xA11CE);
+
+    function test_bootstrapSelectorsHideGameplayUntilTreasurySeeded() public {
+        Diamond diamond = _newDiamond();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond)).diamondCut(_bootstrapCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        assertEq(loupe.facetAddress(IClanWorld.initTreasury.selector) != address(0), true, "treasury selector");
+        assertEq(loupe.facetAddress(IClanWorld.seedPools.selector) != address(0), true, "seed selector");
+        assertEq(loupe.facetAddress(IClanWorld.mintClan.selector), address(0), "mint hidden");
+        assertEq(loupe.facetAddress(IClanWorld.heartbeat.selector), address(0), "heartbeat hidden");
+        assertEq(loupe.facetAddress(IClanWorld.submitClanOrders.selector), address(0), "orders hidden");
+        assertEq(loupe.facetAddress(IClanWorld.settleClan.selector), address(0), "settlement hidden");
+
+        _initAndSeedTreasury(IClanWorld(address(diamond)));
+
+        IDiamondCut(address(diamond)).diamondCut(_gameplayCut(), address(0), "");
+        assertEq(loupe.facetAddress(IClanWorld.mintClan.selector) != address(0), true, "mint live");
+        assertEq(loupe.facetAddress(IClanWorld.heartbeat.selector) != address(0), true, "heartbeat live");
+        assertEq(loupe.facetAddress(IClanWorld.submitClanOrders.selector) != address(0), true, "orders live");
+        assertEq(loupe.facetAddress(IClanWorld.settleClan.selector) != address(0), true, "settlement live");
+    }
+
+    function test_settlementUpkeepEmitsWinterColdAndDeathEvents() public {
+        IClanWorld world = _deploySettlementDiamond();
+        IPublicDemoHarness harness = IPublicDemoHarness(address(world));
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+
+        uint32 coldShortClan = _mint(world);
+        harness.setCurrentTick(winterStart + 1);
+        harness.setClanUpkeepState(coldShortClan, winterStart, 1e18, 100e18, 100e18, 0);
+        vm.expectEmit(true, false, false, true, address(world));
+        emit ClanColdShortage(coldShortClan, winterStart, 2e18);
+        world.settleClan(coldShortClan);
+
+        uint32 wallClan = _mint(world);
+        harness.setCurrentTick(winterStart + 1);
+        harness.setClanWallLevel(wallClan, 2);
+        harness.setClanUpkeepState(wallClan, winterStart, 0, 100e18, 100e18, 1);
+        vm.expectEmit(true, false, false, true, address(world));
+        emit WallDegradedByCold(wallClan, 1, winterStart);
+        world.settleClan(wallClan);
+
+        uint32 coldDeathClan = _mint(world);
+        harness.setCurrentTick(winterStart + 1);
+        harness.setClanUpkeepState(coldDeathClan, winterStart, 0, 100e18, 100e18, 1);
+        vm.recordLogs();
+        world.settleClan(coldDeathClan);
+        assertEq(_countLogs(vm.getRecordedLogs(), keccak256("ClansmanColdDeath(uint32,uint32,uint64)")), 1);
+
+        uint32 starvedClan = _mint(world);
+        harness.setCurrentTick(winterStart + 6);
+        harness.setClanUpkeepState(starvedClan, winterStart, 100e18, 0, 0, 0);
+        vm.expectEmit(true, true, false, true, address(world));
+        emit ClanEliminated(starvedClan, winterStart + 5);
+        vm.expectEmit(true, false, false, true, address(world));
+        emit ClanDied(starvedClan, winterStart + 5, "starvation");
+        world.settleClan(starvedClan);
+    }
+
+    function test_wallUpgradeReservationClearsWhenColdDegradesWallBeforeCompletion() public {
+        IClanWorld world = _deploySettlementDiamond();
+        IPublicDemoHarness harness = IPublicDemoHarness(address(world));
+        uint32 clanId = _mint(world);
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        harness.setClanWallLevel(clanId, 1);
+        harness.setVault(clanId, 100e18, 100e18, 100e18, 100e18);
+
+        ClanOrder[] memory orders = new ClanOrder[](1);
+        orders[0] = ClanOrder({
+            clansmanId: clansmanId,
+            gotoRegion: world.getClan(clanId).baseRegion,
+            action: ActionType.UpgradeWall,
+            targetClanId: 0,
+            marketToken: address(0),
+            marketAmount: 0,
+            maxGoldIn: 0,
+            withdrawResources: WithdrawResourcesData({wood: 0, iron: 0, wheat: 0, fish: 0})
+        });
+        vm.prank(elder);
+        assertEq(uint8(world.submitClanOrders(clanId, orders)[0].status), uint8(StatusCode.OK), "upgrade queued");
+        (bool active, uint8 fromLevel, uint256 woodCost, uint256 ironCost) = harness.wallReservation(clansmanId);
+        assertTrue(active, "reservation active");
+        assertEq(fromLevel, 1, "from level");
+        assertEq(harness.pendingWallUpgrades(clanId), 1, "pending wall");
+        assertEq(harness.reservedWood(clanId), woodCost, "reserved wood");
+        assertEq(harness.reservedIron(clanId), ironCost, "reserved iron");
+
+        uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
+        harness.setCurrentTick(winterStart + 1);
+        harness.setClanUpkeepState(clanId, winterStart, 0, 100e18, 100e18, 1);
+        world.settleClan(clanId);
+
+        (active,,,) = harness.wallReservation(clansmanId);
+        assertFalse(active, "reservation cleared");
+        assertEq(harness.pendingWallUpgrades(clanId), 0, "pending cleared");
+        assertEq(harness.reservedWood(clanId), 0, "wood released");
+        assertEq(harness.reservedIron(clanId), 0, "iron released");
+        assertEq(uint8(world.getActiveMission(clansmanId).action), uint8(ActionType.UpgradeWall), "mission action retained");
+        assertFalse(world.getActiveMission(clansmanId).active, "mission completed");
+    }
+
+    function _deploySettlementDiamond() private returns (IClanWorld world) {
+        Diamond diamond = _newDiamond();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+        IDiamondCut(address(diamond)).diamondCut(_settlementCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        return IClanWorld(address(diamond));
+    }
+
+    function _newDiamond() private returns (Diamond) {
+        DiamondCutFacet cutFacet = new DiamondCutFacet();
+        return new Diamond(address(this), address(cutFacet));
+    }
+
+    function _mint(IClanWorld world) private returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
+    }
+
+    function _initAndSeedTreasury(IClanWorld world) private {
+        address[6] memory tokens = [
+            address(new MinimalERC20("Wood", "WOOD")),
+            address(new MinimalERC20("Iron", "IRON")),
+            address(new MinimalERC20("Wheat", "WHEAT")),
+            address(new MinimalERC20("Fish", "FISH")),
+            address(new MinimalERC20("Gold", "GOLD")),
+            address(new MinimalERC20("Blueprint", "BPRT"))
+        ];
+        address[4] memory pools = [
+            address(new StubPool(tokens[0], tokens[4], address(world))),
+            address(new StubPool(tokens[2], tokens[4], address(world))),
+            address(new StubPool(tokens[3], tokens[4], address(world))),
+            address(new StubPool(tokens[1], tokens[4], address(world)))
+        ];
+        PoolSeedConfig memory cfg = PoolSeedConfig({
+            woodSeed: 100e18,
+            wheatSeed: 100e18,
+            fishSeed: 100e18,
+            ironSeed: 100e18,
+            goldSeedForWood: 100e18,
+            goldSeedForWheat: 100e18,
+            goldSeedForFish: 100e18,
+            goldSeedForIron: 100e18
+        });
+
+        world.initTreasury(tokens, pools);
+        MinimalERC20(tokens[0]).seedTreasury(address(this), cfg.woodSeed);
+        MinimalERC20(tokens[1]).seedTreasury(address(this), cfg.ironSeed);
+        MinimalERC20(tokens[2]).seedTreasury(address(this), cfg.wheatSeed);
+        MinimalERC20(tokens[3]).seedTreasury(address(this), cfg.fishSeed);
+        MinimalERC20(tokens[4]).seedTreasury(
+            address(this), cfg.goldSeedForWood + cfg.goldSeedForWheat + cfg.goldSeedForFish + cfg.goldSeedForIron
+        );
+        for (uint256 i = 0; i < 5; i++) {
+            MinimalERC20(tokens[i]).approve(address(world), type(uint256).max);
+        }
+        world.seedPools(cfg);
+    }
+
+    function _bootstrapCut() private returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](5);
+        cut[0] = _facetCut(address(new DiamondLoupeFacet()), DiamondSelectors.loupeSelectors());
+        cut[1] = _facetCut(address(new OwnershipFacet()), DiamondSelectors.ownershipFacetSelectors());
+        cut[2] = _facetCut(address(new TreasuryFacet()), DiamondSelectors.treasurySelectors());
+        cut[3] = _facetCut(address(new RawWorldViewsFacet()), DiamondSelectors.rawWorldViewsSelectors());
+        cut[4] = _facetCut(address(new RawTreasuryViewsFacet()), DiamondSelectors.rawTreasuryViewsSelectors());
+    }
+
+    function _gameplayCut() private returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](5);
+        cut[0] = _facetCut(address(new ClanLifecycleFacet()), DiamondSelectors.lifecycleSelectors());
+        cut[1] = _facetCut(address(new SubmitOrdersFacet()), DiamondSelectors.submitOrdersSelectors());
+        cut[2] = _facetCut(address(new SettlementFacet()), DiamondSelectors.settlementSelectors());
+        cut[3] = _facetCut(address(new RawClanViewsFacet()), DiamondSelectors.rawClanViewsSelectors());
+        cut[4] = _facetCut(address(new HeartbeatFacet()), DiamondSelectors.heartbeatSelectors());
+    }
+
+    function _settlementCut() private returns (IDiamondCut.FacetCut[] memory cut) {
+        bytes4[] memory harnessSelectors = new bytes4[](8);
+        harnessSelectors[0] = PublicDemoHarnessFacet.setCurrentTick.selector;
+        harnessSelectors[1] = PublicDemoHarnessFacet.setClanUpkeepState.selector;
+        harnessSelectors[2] = PublicDemoHarnessFacet.setClanWallLevel.selector;
+        harnessSelectors[3] = PublicDemoHarnessFacet.setVault.selector;
+        harnessSelectors[4] = PublicDemoHarnessFacet.wallReservation.selector;
+        harnessSelectors[5] = PublicDemoHarnessFacet.pendingWallUpgrades.selector;
+        harnessSelectors[6] = PublicDemoHarnessFacet.reservedWood.selector;
+        harnessSelectors[7] = PublicDemoHarnessFacet.reservedIron.selector;
+
+        cut = new IDiamondCut.FacetCut[](6);
+        cut[0] = _facetCut(address(new RawWorldViewsFacet()), DiamondSelectors.rawWorldViewsSelectors());
+        cut[1] = _facetCut(address(new RawClanViewsFacet()), DiamondSelectors.rawClanViewsSelectors());
+        cut[2] = _facetCut(address(new ClanLifecycleFacet()), DiamondSelectors.lifecycleSelectors());
+        cut[3] = _facetCut(address(new SubmitOrdersFacet()), DiamondSelectors.submitOrdersSelectors());
+        cut[4] = _facetCut(address(new SettlementFacet()), DiamondSelectors.settlementSelectors());
+        cut[5] = _facetCut(address(new PublicDemoHarnessFacet()), harnessSelectors);
+    }
+
+    function _facetCut(address facet, bytes4[] memory selectors) private pure returns (IDiamondCut.FacetCut memory) {
+        return IDiamondCut.FacetCut({
+            facetAddress: facet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: selectors
+        });
+    }
+
+    function _countLogs(Vm.Log[] memory logs, bytes32 topic0) private pure returns (uint256 count) {
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics.length > 0 && logs[i].topics[0] == topic0) count++;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Reorder diamond deployment so gameplay selectors are unavailable until initTreasury + seedPools complete
- Emit settlement/upkeep events for starvation, cold shortage, wall degradation, cold deaths, and settlement-caused clan death
- Clear/refund pending wall upgrade reservations on any wall-level mismatch
- Checkout git submodules in contracts and ABI workflows

## Validation
- bash scripts/forge.sh test --match-path test/diamond/PublicDemoBlockers.t.sol
- bash scripts/forge.sh test --match-path test/diamond/DiamondSkeleton.t.sol
- bash scripts/forge.sh test --match-path test/diamond/DiamondEventParity.t.sol
- bash scripts/forge.sh test --match-path test/ReservationConsistency.t.sol
- DEPLOYER_PRIVATE_KEY=... bash scripts/forge.sh script script/DeployDiamond.s.sol:DeployDiamond
- bash scripts/forge.sh build

## Notes
- pnpm run check:sizes still fails on pre-existing oversized artifacts: LibBundleTransfer, LibDirectTransfers, HeartbeatFacet, FinalizeSeasonFacet, LibSubmitOrders, and ClanOwnershipFacet. SettlementFacet remains below the deploy cap at 24290 bytes.