### PR TITLE
feat(android): lineage log — owner action history surfaced in Codex

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/App.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/App.kt
@@ -2,6 +2,7 @@ package world.clan.app
 
 import android.app.Application
 import world.clan.app.data.ClanWorldConvexClient
+import world.clan.app.data.LineageStore
 import world.clan.app.data.SessionStore
 import world.clan.app.wallet.DeviceCapabilities
 import world.clan.app.wallet.DeviceClass
@@ -20,5 +21,6 @@ class App : Application() {
   }
   val mwaClient: MwaClient by lazy { MwaClient() }
   val sessionStore: SessionStore by lazy { SessionStore(this) }
+  val lineageStore: LineageStore by lazy { LineageStore(this) }
   val deviceClass: DeviceClass by lazy { DeviceCapabilities.inspect(this) }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/Lineage.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/Lineage.kt
@@ -1,0 +1,75 @@
+package world.clan.app.data
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * One row in the user's local lineage — the things they've signed in this
+ * install. Demo-only persistence (EncryptedSharedPreferences); no on-chain
+ * source-of-truth yet.
+ *
+ * `kind` discriminates which flow produced the row:
+ *   - "forged"      Forge wizard mint
+ *   - "hired"       Bazaar HireModal seal
+ *   - "whispered"   SteeringConsole compose
+ *   - "sealed"      StrategyEditor doctrine save
+ */
+@Serializable
+data class LineageEntry(
+  val kind: String,
+  val clanId: Int,
+  val title: String,
+  val subtitle: String? = null,
+  val tsEpochMs: Long = System.currentTimeMillis(),
+)
+
+/**
+ * Append-only local log of the user's owner actions. Backed by the same
+ * EncryptedSharedPreferences file as SessionStore — distinct file is
+ * unnecessary because the data is just-as-private and the lifetime
+ * matches.
+ *
+ * Capped at 64 entries; older entries roll off when full so the prefs
+ * blob stays small.
+ */
+class LineageStore(context: Context) {
+
+  private val prefs by lazy {
+    val masterKey = MasterKey.Builder(context)
+      .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+      .build()
+    EncryptedSharedPreferences.create(
+      context,
+      "clan-world-lineage.enc",
+      masterKey,
+      EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+      EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+  }
+
+  private val json = Json { encodeDefaults = true; ignoreUnknownKeys = true }
+
+  fun read(): List<LineageEntry> {
+    val raw = prefs.getString("entries", null) ?: return emptyList()
+    return runCatching { json.decodeFromString<List<LineageEntry>>(raw) }
+      .getOrElse { emptyList() }
+  }
+
+  fun append(entry: LineageEntry) {
+    val current = read()
+    val next = (listOf(entry) + current).take(MAX_ENTRIES)
+    prefs.edit().putString("entries", json.encodeToString<List<LineageEntry>>(next)).apply()
+  }
+
+  fun clear() {
+    prefs.edit().clear().apply()
+  }
+
+  companion object {
+    const val MAX_ENTRIES = 64
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -413,9 +413,16 @@ fun ClanWorldApp(
               isBazaar = true,
               mwaSender = mwaSender,
               onHireConfirmed = {
-                val name = world.clan.app.data.bazaarListingByClan(clanId)
-                  ?.let { l -> "tkn 0x${"%04x".format(l.tokenId)}" }
-                  .orEmpty()
+                val listing = world.clan.app.data.bazaarListingByClan(clanId)
+                val name = listing?.let { "tkn 0x${"%04x".format(it.tokenId)}" }.orEmpty()
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "hired",
+                    clanId = clanId,
+                    title = "Hired ${world.clan.app.viewmodel.clanDisplayName(clanId)}",
+                    subtitle = listing?.let { "${it.pricePerSeason}g · 1 season · $name" } ?: name,
+                  ),
+                )
                 nav.navigate(Routes.forged(clanId, name, "HIRED")) {
                   popUpTo(Routes.Bazaar) { saveState = true }
                 }
@@ -473,7 +480,17 @@ fun ClanWorldApp(
               mwaSender = mwaSender,
               initialClanId = clanId,
               onBack = { nav.popBackStack() },
-              onSent = { nav.popBackStack() },
+              onSent = {
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "whispered",
+                    clanId = clanId,
+                    title = "Whispered to ${world.clan.app.viewmodel.clanDisplayName(clanId)}",
+                    subtitle = "queued for next tick",
+                  ),
+                )
+                nav.popBackStack()
+              },
             )
           }
 
@@ -490,9 +507,15 @@ fun ClanWorldApp(
               mwaSender = mwaSender,
               onBack = { nav.popBackStack() },
               onForged = { clanId, name ->
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "forged",
+                    clanId = clanId,
+                    title = "Forged ${name.ifBlank { "the unnamed seal" }}",
+                    subtitle = world.clan.app.viewmodel.clanDisplayName(clanId),
+                  ),
+                )
                 nav.navigate(Routes.forged(clanId, name, "FORGED")) {
-                  // Replace Forge wizard so back goes to Hall, not the
-                  // wizard's last step.
                   popUpTo(Routes.Forge) { inclusive = true }
                 }
               },
@@ -569,7 +592,17 @@ fun ClanWorldApp(
               mwaSender = mwaSender,
               clanId = clanId,
               onBack = { nav.popBackStack() },
-              onSaved = { nav.popBackStack() },
+              onSaved = {
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "sealed",
+                    clanId = clanId,
+                    title = "Sealed doctrine for ${world.clan.app.viewmodel.clanDisplayName(clanId)}",
+                    subtitle = "the elder will hold this counsel",
+                  ),
+                )
+                nav.popBackStack()
+              },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
@@ -57,6 +58,9 @@ fun CodexScreenRoute(
 ) {
   val vm: CodexViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
+  // Re-read lineage on each Codex visit so newly-signed actions appear
+  // without a kill/relaunch.
+  androidx.compose.runtime.LaunchedEffect(Unit) { vm.refreshLineage() }
   CodexScreen(state = state)
 }
 
@@ -123,6 +127,19 @@ private fun CodexScreen(
     }
 
     Spacer(Modifier.height(20.dp))
+
+    // ── Lineage ──────────────────────────────────────────────────────
+    if (state.lineage.isNotEmpty()) {
+      StaggeredEntry(index = 9) {
+        SectionHeader(title = "Lineage", showLozenge = false)
+      }
+      StaggeredEntry(index = 10) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          state.lineage.take(12).forEach { entry -> LineageRow(entry) }
+        }
+      }
+      Spacer(Modifier.height(20.dp))
+    }
 
     // ── Share ────────────────────────────────────────────────────────
     StaggeredEntry(index = 5) {
@@ -270,6 +287,79 @@ private fun RowCard(
         )
       }
     }
+  }
+}
+
+@Composable
+private fun LineageRow(entry: world.clan.app.data.LineageEntry) {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warm = ClanWorldTheme.colors.warm
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val warmFaint = ClanWorldTheme.colors.warmFaint
+  val accent = world.clan.app.ui.theme.clanColor(entry.clanId)
+  val kindGlyph = when (entry.kind) {
+    "forged" -> "✦"
+    "hired" -> "◈"
+    "whispered" -> "≈"
+    "sealed" -> "✕"
+    else -> "·"
+  }
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(6.dp))
+      .background(ClanWorldTheme.colors.iron)
+      .border(1.dp, ClanWorldTheme.colors.hairline, RoundedCornerShape(6.dp))
+      .padding(horizontal = 14.dp, vertical = 10.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Box(
+      modifier = Modifier
+        .size(28.dp)
+        .clip(CircleShape)
+        .background(accent.copy(alpha = 0.18f))
+        .border(1.dp, accent.copy(alpha = 0.55f), CircleShape),
+      contentAlignment = Alignment.Center,
+    ) {
+      Text(
+        text = kindGlyph,
+        style = ClanWorldTheme.type.body,
+        color = accent,
+      )
+    }
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+      Text(
+        text = entry.title,
+        style = ClanWorldTheme.type.body,
+        color = parchment,
+      )
+      if (!entry.subtitle.isNullOrBlank()) {
+        Text(
+          text = entry.subtitle,
+          style = ClanWorldTheme.type.scriptItalicSmall,
+          color = warmDim,
+        )
+      }
+    }
+    Text(
+      text = formatRelativeTime(entry.tsEpochMs),
+      style = ClanWorldTheme.type.monoNano,
+      color = warmFaint,
+    )
+  }
+}
+
+private fun formatRelativeTime(tsMs: Long): String {
+  val deltaMs = System.currentTimeMillis() - tsMs
+  return when {
+    deltaMs < 60_000 -> "just now"
+    deltaMs < 60 * 60_000 -> "${deltaMs / 60_000}m"
+    deltaMs < 24 * 60 * 60_000 -> "${deltaMs / (60 * 60_000)}h"
+    else -> "${deltaMs / (24 * 60 * 60_000)}d"
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -16,7 +16,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
     BazaarViewModel::class.java -> BazaarViewModel()
     ForgeViewModel::class.java -> ForgeViewModel(app.sessionStore)
-    CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.deviceClass)
+    CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.lineageStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")
   } as T
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import world.clan.app.BuildConfig
+import world.clan.app.data.LineageEntry
+import world.clan.app.data.LineageStore
 import world.clan.app.data.SessionStore
 import world.clan.app.wallet.DeviceClass
 
@@ -17,14 +19,16 @@ data class CodexUiState(
   val linkedClansCount: Int,
   val linkedClanIds: List<Int>,
   val apkShareUrl: String,
+  val lineage: List<LineageEntry> = emptyList(),
 )
 
 /**
- * Codex — read-only identity / device / about summary. Powered by
- * BuildConfig + SessionStore.
+ * Codex — read-only identity / device / about / lineage summary. Powered
+ * by BuildConfig + SessionStore + LineageStore.
  */
 class CodexViewModel(
   private val sessionStore: SessionStore,
+  private val lineageStore: LineageStore,
   deviceClass: DeviceClass,
 ) : ViewModel() {
 
@@ -40,10 +44,16 @@ class CodexViewModel(
         linkedClansCount = HearthViewModel.LINKED_CLAN_IDS.size,
         linkedClanIds = HearthViewModel.LINKED_CLAN_IDS,
         apkShareUrl = "https://shared.claude.do/public/clanworld-mobile-slice-1.apk",
+        lineage = lineageStore.read(),
       )
     },
   )
   val state: StateFlow<CodexUiState> = _state.asStateFlow()
+
+  /** Re-read lineage when the screen is re-entered after a successful sign. */
+  fun refreshLineage() {
+    _state.value = _state.value.copy(lineage = lineageStore.read())
+  }
 
   fun disconnect() {
     sessionStore.clear()


### PR DESCRIPTION
## Summary

Local persisted log of the user's owner actions in this install. Helps the demo land: a tester forges + whispers + seals + hires, then opens Codex and sees a tidy parchment record of what they just signed.

**Stacked on #83 (onboarding hint).**

### \`data/Lineage.kt\` — new
- \`LineageEntry\`: kind / clanId / title / subtitle / tsEpochMs. kind discriminator: \`forged\` / \`hired\` / \`whispered\` / \`sealed\`
- \`LineageStore\`: separate EncryptedSharedPreferences file (\`clan-world-lineage.enc\`) — keeps wallet pubkey + auth token cleanly separated from action history. Capped at MAX_ENTRIES = 64; new entries prepend, older roll off
- kotlinx.serialization for the JSON encoding (already in deps)

### \`App.kt\`
- New \`LineageStore\` singleton alongside \`SessionStore\`

### \`ClanWorldApp.kt\` — append on each successful sign
- Forge \`onForged\`: \`forged\` / \"Forged <name>\" / <clan name>
- Bazaar \`onHireConfirmed\`: \`hired\` / \"Hired <clan>\" / \"<price>g · 1 season · <tkn>\"
- SteeringConsole \`onSent\`: \`whispered\` / \"Whispered to <clan>\" / \"queued for next tick\"
- StrategyEditor \`onSaved\`: \`sealed\` / \"Sealed doctrine for <clan>\" / \"the elder will hold this counsel\"

### \`CodexViewModel\`
- Adds \`lineage\` field; reads from LineageStore on init
- \`refreshLineage()\` callable from screen on (re-)entry so newly-signed rows appear without app kill

### \`CodexScreen\`
- New \"Lineage\" section between Device and Share (suppressed when empty)
- \`LineageRow\`: clan-color-accent glyph circle (✦/◈/≈/✕) + title + subtitle + relative time (just now / Nm / Nh / Nd)
- \`LaunchedEffect(Unit)\` on route entry triggers refresh

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 15s.

## Test plan

- [ ] Forge a sigil → after FORGED ✓ → open Codex → \"Lineage\" section shows \"Forged <name>\" row at top with relative time \"just now\"
- [ ] Send a whisper → Codex shows \"Whispered to <clan>\"
- [ ] Save strategy → Codex shows \"Sealed doctrine for <clan>\"
- [ ] Hire from Bazaar → Codex shows \"Hired <clan>\" with price+season+tkn subtitle
- [ ] Multiple actions accumulate in newest-first order
- [ ] Lineage section hidden when no entries (fresh install)
- [ ] Disconnect + reconnect: lineage persists (it's a per-install log, not per-session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)