### PR TITLE
feat(android): hired sigils appear in Hall + drop from Bazaar

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -104,6 +104,24 @@ class SessionStore(context: Context) {
     ed.apply()
   }
 
+  // ── Hired clan IDs ────────────────────────────────────────────────────
+  // After a successful Bazaar hire, the clan is added to this set. Hall +
+  // Hearth + Codex union LINKED_CLAN_IDS with this set when displaying
+  // "your" sigils, so a freshly-hired card appears in the user's hall
+  // without a relaunch.
+
+  fun getHiredClanIds(): Set<Int> =
+    prefs.getStringSet("hired:clanIds", emptySet())
+      ?.mapNotNullTo(mutableSetOf()) { it.toIntOrNull() }
+      ?: emptySet()
+
+  fun addHiredClanId(clanId: Int) {
+    val current = getHiredClanIds()
+    if (clanId in current) return
+    val next = (current + clanId).map { it.toString() }.toSet()
+    prefs.edit().putStringSet("hired:clanIds", next).apply()
+  }
+
   // ── One-shot UI flags ─────────────────────────────────────────────────
   // Persisted booleans for onboarding hints / coachmarks. Once a flag is
   // marked seen, it stays seen across reinstalls (within EncryptedShared

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -423,6 +423,10 @@ fun ClanWorldApp(
                     subtitle = listing?.let { "${it.pricePerSeason}g · 1 season · $name" } ?: name,
                   ),
                 )
+                // Persist that this clan is now in the user's hall — so
+                // it shows up next time HallScreen refreshes (also affects
+                // Hearth leaderboard `isMine` and Codex linked-clans line).
+                app.sessionStore.addHiredClanId(clanId)
                 nav.navigate(Routes.forged(clanId, name, "HIRED")) {
                   popUpTo(Routes.Bazaar) { saveState = true }
                 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
@@ -51,6 +51,9 @@ fun BazaarScreenRoute(
 ) {
   val vm: BazaarViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
+  // Re-apply the hired-clan filter on (re-)entry so a freshly-hired
+  // sigil drops out of the listings without an app kill.
+  androidx.compose.runtime.LaunchedEffect(Unit) { vm.refresh() }
   BazaarScreen(state = state, onOpenListing = onOpenListing)
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/BazaarViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/BazaarViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import world.clan.app.data.BAZAAR_LISTINGS
 import world.clan.app.data.BazaarListing
+import world.clan.app.data.SessionStore
 
 data class BazaarUiState(
   val isLoading: Boolean = false,
@@ -14,15 +16,24 @@ data class BazaarUiState(
 )
 
 /**
- * Slice 4: Bazaar viewmodel. The listings are a static demo list; no Convex
- * marketplace query exists yet. ViewModel still exists so that the screen
- * can subscribe through StateFlow like every other screen — when a real
- * listings query lands, only this file changes.
+ * Bazaar viewmodel. Listings are a static demo set; no Convex marketplace
+ * query exists yet. Filters out clans already hired (so a hired sigil
+ * can't be hired again in the same install).
  */
-class BazaarViewModel : ViewModel() {
+class BazaarViewModel(
+  private val sessionStore: SessionStore? = null,
+) : ViewModel() {
 
-  private val _state = MutableStateFlow(
-    BazaarUiState(listings = BAZAAR_LISTINGS),
-  )
+  private val _state = MutableStateFlow(BazaarUiState(listings = currentListings()))
   val state: StateFlow<BazaarUiState> = _state.asStateFlow()
+
+  /** Re-read hired set + reapply filter — call when re-entering the screen. */
+  fun refresh() {
+    _state.update { it.copy(listings = currentListings()) }
+  }
+
+  private fun currentListings(): List<BazaarListing> {
+    val hired = sessionStore?.getHiredClanIds().orEmpty()
+    return BAZAAR_LISTINGS.filter { it.clanId !in hired }
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -14,7 +14,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     ConnectViewModel::class.java -> ConnectViewModel(app.mwaClient, app.sessionStore)
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
-    BazaarViewModel::class.java -> BazaarViewModel()
+    BazaarViewModel::class.java -> BazaarViewModel(app.sessionStore)
     ForgeViewModel::class.java -> ForgeViewModel(app.sessionStore)
     CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.lineageStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -35,14 +35,15 @@ class CodexViewModel(
   private val _state = MutableStateFlow(
     run {
       val s = sessionStore.read()
+      val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
       CodexUiState(
         deviceClass = deviceClass,
         solanaPubkey = s?.solanaPubkeyBase58,
         walletLabel = s?.walletLabel,
         build = "v ${BuildConfig.VERSION_NAME} · build ${BuildConfig.VERSION_CODE}",
         convexUrl = BuildConfig.CONVEX_URL,
-        linkedClansCount = HearthViewModel.LINKED_CLAN_IDS.size,
-        linkedClanIds = HearthViewModel.LINKED_CLAN_IDS,
+        linkedClansCount = owned.size,
+        linkedClanIds = owned,
         apkShareUrl = "https://shared.claude.do/public/clanworld-mobile-slice-1.apk",
         lineage = lineageStore.read(),
       )
@@ -50,9 +51,17 @@ class CodexViewModel(
   )
   val state: StateFlow<CodexUiState> = _state.asStateFlow()
 
-  /** Re-read lineage when the screen is re-entered after a successful sign. */
+  /**
+   * Re-read lineage + hired clans on (re-)entry so newly-signed actions
+   * and freshly-hired sigils appear in Codex without an app kill.
+   */
   fun refreshLineage() {
-    _state.value = _state.value.copy(lineage = lineageStore.read())
+    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+    _state.value = _state.value.copy(
+      lineage = lineageStore.read(),
+      linkedClansCount = owned.size,
+      linkedClanIds = owned,
+    )
   }
 
   fun disconnect() {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
@@ -46,15 +46,15 @@ data class HallCard(
  */
 class HallViewModel(
   private val convex: ClanWorldConvexClient,
-  sessionStore: SessionStore,
+  private val sessionStore: SessionStore,
 ) : ViewModel() {
 
-  private val _state = MutableStateFlow(initial(sessionStore))
+  private val _state = MutableStateFlow(initial())
   val state: StateFlow<HallUiState> = _state.asStateFlow()
 
   init { refresh() }
 
-  private fun initial(sessionStore: SessionStore): HallUiState {
+  private fun initial(): HallUiState {
     val s = sessionStore.read()
     return HallUiState(walletShort = s?.solanaPubkeyBase58?.shortenPubkey().orEmpty())
   }
@@ -62,9 +62,10 @@ class HallViewModel(
   fun refresh() {
     viewModelScope.launch {
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
+      val ownedClanIds = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
       runCatching {
         coroutineScope {
-          HearthViewModel.LINKED_CLAN_IDS
+          ownedClanIds
             .map { clanId -> async { runCatching { convex.getInftDemoState(clanId) }.getOrNull() to clanId } }
             .awaitAll()
         }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -58,6 +58,7 @@ class HearthViewModel(
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
       val session = sessionStore.read()
       val selectedClan = session?.selectedClanId ?: DEFAULT_LINKED_CLAN
+      val ownedClanIds = (LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).toSet()
       runCatching {
         val snap = convex.getSnapshot()
         val comms = runCatching { convex.getCombinedComms(selectedClan, limit = 3) }
@@ -65,7 +66,7 @@ class HearthViewModel(
         snap to comms
       }.onSuccess { (snap, comms) ->
         _state.update { _ ->
-          project(snap, selectedClan, comms, session?.solanaPubkeyBase58.orEmpty())
+          project(snap, selectedClan, comms, session?.solanaPubkeyBase58.orEmpty(), ownedClanIds)
         }
       }.onFailure { e ->
         _state.update {
@@ -84,6 +85,7 @@ class HearthViewModel(
     selectedClanId: Int,
     comms: List<CombinedComm>,
     solanaPubkey: String,
+    ownedClanIds: Set<Int>,
   ): HearthUiState {
     // Sort clans by goldBalance (wei → whole), descending. Empty / null
     // gold goes last.
@@ -103,7 +105,7 @@ class HearthViewModel(
         tagline = clanTagline(p.clanId),
         gold = p.gold,
         delta = 0L, // no delta data in snapshot — keep at 0 for v0; UI shows "—"
-        isMine = LINKED_CLAN_IDS.contains(p.clanId),
+        isMine = ownedClanIds.contains(p.clanId),
       )
     }
 


### PR DESCRIPTION
## Summary

Closes the Bazaar → Hall demo loop. Before: hire a sigil, see \"HIRED ✓\" on the celebration screen, … then nothing — your Hall still showed the original three LINKED_CLAN_IDS and the same sigil was still browsable in the Bazaar listing. Now: it lands in your Hall, Hearth marks it yours on the leaderboard, the Codex linked-clans line includes it, and the Bazaar listing disappears.

**Stacked on #85 (lineage log).**

### \`SessionStore\` (data/)
- New methods: \`getHiredClanIds()\` / \`addHiredClanId(clanId)\`
- Backed by \`SharedPreferences.putStringSet\` under \"hired:clanIds\"; durable across kills + reboots like the other persisted state

### \`HallViewModel\`
- Promote \`sessionStore\` from plain ctor param → \`private val\` property so \`refresh()\` can read \`getHiredClanIds()\` inside the coroutine
- Owned set is the union of \`LINKED_CLAN_IDS + hiredClanIds\`

### \`HearthViewModel\`
- \`ownedClanIds = LINKED_CLAN_IDS + getHiredClanIds()\` threaded through \`project()\` to mark \`isMine\` on the leaderboard rows

### \`CodexViewModel\`
- \`linkedClansCount\` + \`linkedClanIds\` now come from the same union
- \`refreshLineage()\` also re-reads hired set so a newly-hired clan appears in the Codex \"Lineage\" + \"Linked clans\" lines without app kill (LaunchedEffect already calls this)

### \`BazaarViewModel\`
- Now takes SessionStore (factory updated). \`currentListings()\` filters \`BAZAAR_LISTINGS\` to drop already-hired clans
- New \`refresh()\` method called via \`LaunchedEffect\` on BazaarScreen entry so the filter re-applies on (re-)entry

### \`ClanWorldApp.kt\`
- Bazaar \`onHireConfirmed\`: append hired clan id to SessionStore alongside the existing lineage append

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 12s.

## Test plan

- [ ] Bazaar → tap a listing → Hire This Sigil → MWA sign → \"HIRED ✓\" → back to Bazaar
- [ ] Hall: hired sigil now appears alongside the original 3 (e.g. clan 1, 3, 4, 7, or 8 added)
- [ ] Hearth leaderboard: hired clan now shows the \"isMine\" highlight
- [ ] Bazaar: the hired listing is gone (re-entry refreshes filter)
- [ ] Codex: \"Linked clans · 4 of viii\" + the natural-language line includes the new clan
- [ ] Cold-launch app: hired clan persists (StringSet survives kill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)