### PR TITLE
feat(android): forged sigils appear in Hall + Forge guards owned clans

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -104,22 +104,36 @@ class SessionStore(context: Context) {
     ed.apply()
   }
 
-  // ── Hired clan IDs ────────────────────────────────────────────────────
-  // After a successful Bazaar hire, the clan is added to this set. Hall +
-  // Hearth + Codex union LINKED_CLAN_IDS with this set when displaying
-  // "your" sigils, so a freshly-hired card appears in the user's hall
-  // without a relaunch.
+  // ── Hired / Forged clan IDs ───────────────────────────────────────────
+  // After a successful Bazaar hire OR a Forge wizard mint, the clan is
+  // added to the matching set. Hall + Hearth + Codex union LINKED_CLAN_IDS
+  // with both sets when displaying "your" sigils — a freshly-hired or
+  // freshly-forged card appears in the user's hall without a relaunch.
+  //
+  // Sets are kept separate so Lineage / future analytics can tell forged
+  // from hired; ownership unions read both via getOwnedClanIdsExtra().
 
-  fun getHiredClanIds(): Set<Int> =
-    prefs.getStringSet("hired:clanIds", emptySet())
+  fun getHiredClanIds(): Set<Int> = readClanIdSet("hired:clanIds")
+
+  fun addHiredClanId(clanId: Int) = writeClanIdSet("hired:clanIds", clanId)
+
+  fun getForgedClanIds(): Set<Int> = readClanIdSet("forged:clanIds")
+
+  fun addForgedClanId(clanId: Int) = writeClanIdSet("forged:clanIds", clanId)
+
+  /** Union of hired + forged. LINKED_CLAN_IDS is added by ViewModels. */
+  fun getOwnedClanIdsExtra(): Set<Int> = getHiredClanIds() + getForgedClanIds()
+
+  private fun readClanIdSet(prefKey: String): Set<Int> =
+    prefs.getStringSet(prefKey, emptySet())
       ?.mapNotNullTo(mutableSetOf()) { it.toIntOrNull() }
       ?: emptySet()
 
-  fun addHiredClanId(clanId: Int) {
-    val current = getHiredClanIds()
+  private fun writeClanIdSet(prefKey: String, clanId: Int) {
+    val current = readClanIdSet(prefKey)
     if (clanId in current) return
     val next = (current + clanId).map { it.toString() }.toSet()
-    prefs.edit().putStringSet("hired:clanIds", next).apply()
+    prefs.edit().putStringSet(prefKey, next).apply()
   }
 
   // ── One-shot UI flags ─────────────────────────────────────────────────

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -519,6 +519,10 @@ fun ClanWorldApp(
                     subtitle = world.clan.app.viewmodel.clanDisplayName(clanId),
                   ),
                 )
+                // Persist that this clan is now in the user's hall — same
+                // mechanism as Bazaar Hire. Hall + Hearth + Codex unions
+                // pick this up on next refresh.
+                app.sessionStore.addForgedClanId(clanId)
                 nav.navigate(Routes.forged(clanId, name, "FORGED")) {
                   popUpTo(Routes.Forge) { inclusive = true }
                 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
@@ -271,6 +272,15 @@ private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
       color = ClanWorldTheme.colors.warmFaint,
       modifier = Modifier.padding(horizontal = 22.dp),
     )
+    if (state.ownedClanIds.isNotEmpty()) {
+      Spacer(Modifier.height(4.dp))
+      Text(
+        text = "clans already under your hand can't be re-forged.",
+        style = ClanWorldTheme.type.scriptItalicSmall,
+        color = ClanWorldTheme.colors.warmFaint,
+        modifier = Modifier.padding(horizontal = 22.dp),
+      )
+    }
     Spacer(Modifier.height(10.dp))
     LazyColumn(
       modifier = Modifier.fillMaxSize(),
@@ -278,10 +288,12 @@ private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
       contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
     ) {
       items((1..8).toList()) { clanId ->
+        val owned = clanId in state.ownedClanIds
         ClanCard(
           clanId = clanId,
           selected = state.clanId == clanId,
-          onClick = { onSelect(clanId) },
+          owned = owned,
+          onClick = { if (!owned) onSelect(clanId) },
         )
       }
     }
@@ -289,15 +301,26 @@ private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
 }
 
 @Composable
-private fun ClanCard(clanId: Int, selected: Boolean, onClick: () -> Unit) {
+private fun ClanCard(
+  clanId: Int,
+  selected: Boolean,
+  owned: Boolean,
+  onClick: () -> Unit,
+) {
   val accent = clanColor(clanId)
-  val borderColor = if (selected) accent else ClanWorldTheme.colors.hairline
-  val borderStroke = if (selected) 2.dp else 1.dp
+  val borderColor = when {
+    owned -> ClanWorldTheme.colors.hairline
+    selected -> accent
+    else -> ClanWorldTheme.colors.hairline
+  }
+  val borderStroke = if (selected && !owned) 2.dp else 1.dp
+  val cardAlpha = if (owned) 0.45f else 1f
 
   Box(
     modifier = Modifier
       .fillMaxWidth()
-      .clickable { onClick() }
+      .alpha(cardAlpha)
+      .clickable(enabled = !owned) { onClick() }
       .drawBehind {
         drawRoundRect(
           color = borderColor,
@@ -323,7 +346,7 @@ private fun ClanCard(clanId: Int, selected: Boolean, onClick: () -> Unit) {
             color = Ink,
           )
           Text(
-            text = clanTagline(clanId),
+            text = if (owned) "already under your hand" else clanTagline(clanId),
             style = ClanWorldTheme.type.scriptItalic,
             color = Ink2,
             modifier = Modifier.padding(top = 2.dp),

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -35,7 +35,7 @@ class CodexViewModel(
   private val _state = MutableStateFlow(
     run {
       val s = sessionStore.read()
-      val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+      val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).distinct()
       CodexUiState(
         deviceClass = deviceClass,
         solanaPubkey = s?.solanaPubkeyBase58,
@@ -56,7 +56,7 @@ class CodexViewModel(
    * and freshly-hired sigils appear in Codex without an app kill.
    */
   fun refreshLineage() {
-    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).distinct()
     _state.value = _state.value.copy(
       lineage = lineageStore.read(),
       linkedClansCount = owned.size,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
@@ -28,6 +28,8 @@ data class ForgeUiState(
   val harness: Harness = Harness.Tide,
   val mintPhase: SendPhase = SendPhase.Idle,
   val errorMessage: String? = null,
+  /** Clans the user already owns — disabled in step 1 (PickClan). */
+  val ownedClanIds: Set<Int> = emptySet(),
 )
 
 /**
@@ -51,14 +53,22 @@ class ForgeViewModel(
     val draftHarness = sessionStore?.getDraft(draftScope, "harness")
       ?.let { runCatching { Harness.valueOf(it) }.getOrNull() }
       ?: Harness.Tide
+    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore?.getOwnedClanIdsExtra().orEmpty()).toSet()
+    // If the persisted draftClan was a clan you've since acquired, drop
+    // it so step 1 doesn't preselect a now-disabled card.
+    val safeClanId = draftClan?.takeIf { it !in owned }
     return ForgeUiState(
-      clanId = draftClan,
+      clanId = safeClanId,
       sigilName = draftName,
       harness = draftHarness,
+      ownedClanIds = owned,
     )
   }
 
   fun setClanId(clanId: Int) {
+    // Defensive: ignore taps on already-owned clans (step 1 should already
+    // tap-disable them, but the VM is the source of truth).
+    if (clanId in _state.value.ownedClanIds) return
     _state.update { it.copy(clanId = clanId) }
     sessionStore?.setDraft(draftScope, "clanId", clanId.toString())
   }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
@@ -62,7 +62,7 @@ class HallViewModel(
   fun refresh() {
     viewModelScope.launch {
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
-      val ownedClanIds = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+      val ownedClanIds = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).distinct()
       runCatching {
         coroutineScope {
           ownedClanIds

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -58,7 +58,7 @@ class HearthViewModel(
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
       val session = sessionStore.read()
       val selectedClan = session?.selectedClanId ?: DEFAULT_LINKED_CLAN
-      val ownedClanIds = (LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).toSet()
+      val ownedClanIds = (LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).toSet()
       runCatching {
         val snap = convex.getSnapshot()
         val comms = runCatching { convex.getCombinedComms(selectedClan, limit = 3) }


### PR DESCRIPTION
## Summary

Symmetric to #86 (hired-appears). Forging a clan in the wizard now adds it to your Hall + the Hearth leaderboard \`isMine\` highlight + the Codex linked-clans line. Forge step 1 greys-out and tap-disables clans you already own so the user can't try to re-forge into one already linked / hired / forged.

**Stacked on #86 (hired-appears-in-Hall).**

### \`SessionStore\` (data/)
- Refactor: factored \`readClanIdSet\` / \`writeClanIdSet\` helpers
- Added \`getForgedClanIds\` / \`addForgedClanId\` mirroring the hired pair
- New \`getOwnedClanIdsExtra()\` returns hired ∪ forged — used by every viewmodel that wants \"extra ownership beyond LINKED_CLAN_IDS\"

### \`HallViewModel\` / \`HearthViewModel\` / \`CodexViewModel\`
- Replaced \`getHiredClanIds()\` reads with \`getOwnedClanIdsExtra()\`

### \`ForgeViewModel\`
- New \`ForgeUiState.ownedClanIds: Set<Int>\` (LINKED + hired + forged) hydrated on init
- \`setClanId\` is defensive: ignores taps on owned clans
- If a persisted draft clanId becomes owned later, drop it on hydrate so step 1 doesn't preselect a now-disabled card

### \`ForgeScreen\` step 1
- ClanCard takes an \`owned: Boolean\` prop. When true:
  - alpha = 0.45f (visually greyed)
  - clickable disabled (tap is no-op)
  - tagline replaced with \"already under your hand\"
- Header gets a one-line italic note when ownedClanIds is non-empty: \"clans already under your hand can't be re-forged\"

### \`ClanWorldApp.kt\`
- Forge \`onForged\`: append \`addForgedClanId(clanId)\` alongside the existing lineage append. Symmetric to Hire's \`addHiredClanId\`

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 25s.

## Test plan

- [ ] Forge wizard: clans 2/5/6 (LINKED) render greyed with \"already under your hand\" subtitle, taps are ignored
- [ ] After hiring clan 1: re-enter Forge wizard, clan 1 also greyed
- [ ] Pick clan 7 → name → harness → confirm → FORGED ✓ → Hall now includes clan 7
- [ ] Hearth leaderboard: clan 7 row now shows the \"mine\" highlight
- [ ] Codex: \"Linked clans · 4 of viii\" + line includes Forge
- [ ] Re-enter Forge wizard: clan 7 is now greyed too (forged set persists)
- [ ] Cold-launch: forged clans persist (StringSet survives kill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)