### PR TITLE
feat(android): provenance badges on Hall + demo-reset in Codex

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/App.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/App.kt
@@ -2,6 +2,7 @@ package world.clan.app
 
 import android.app.Application
 import world.clan.app.data.ClanWorldConvexClient
+import world.clan.app.data.LineageStore
 import world.clan.app.data.SessionStore
 import world.clan.app.wallet.DeviceCapabilities
 import world.clan.app.wallet.DeviceClass
@@ -20,5 +21,6 @@ class App : Application() {
   }
   val mwaClient: MwaClient by lazy { MwaClient() }
   val sessionStore: SessionStore by lazy { SessionStore(this) }
+  val lineageStore: LineageStore by lazy { LineageStore(this) }
   val deviceClass: DeviceClass by lazy { DeviceCapabilities.inspect(this) }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/Lineage.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/Lineage.kt
@@ -1,0 +1,75 @@
+package world.clan.app.data
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * One row in the user's local lineage — the things they've signed in this
+ * install. Demo-only persistence (EncryptedSharedPreferences); no on-chain
+ * source-of-truth yet.
+ *
+ * `kind` discriminates which flow produced the row:
+ *   - "forged"      Forge wizard mint
+ *   - "hired"       Bazaar HireModal seal
+ *   - "whispered"   SteeringConsole compose
+ *   - "sealed"      StrategyEditor doctrine save
+ */
+@Serializable
+data class LineageEntry(
+  val kind: String,
+  val clanId: Int,
+  val title: String,
+  val subtitle: String? = null,
+  val tsEpochMs: Long = System.currentTimeMillis(),
+)
+
+/**
+ * Append-only local log of the user's owner actions. Backed by the same
+ * EncryptedSharedPreferences file as SessionStore — distinct file is
+ * unnecessary because the data is just-as-private and the lifetime
+ * matches.
+ *
+ * Capped at 64 entries; older entries roll off when full so the prefs
+ * blob stays small.
+ */
+class LineageStore(context: Context) {
+
+  private val prefs by lazy {
+    val masterKey = MasterKey.Builder(context)
+      .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+      .build()
+    EncryptedSharedPreferences.create(
+      context,
+      "clan-world-lineage.enc",
+      masterKey,
+      EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+      EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+  }
+
+  private val json = Json { encodeDefaults = true; ignoreUnknownKeys = true }
+
+  fun read(): List<LineageEntry> {
+    val raw = prefs.getString("entries", null) ?: return emptyList()
+    return runCatching { json.decodeFromString<List<LineageEntry>>(raw) }
+      .getOrElse { emptyList() }
+  }
+
+  fun append(entry: LineageEntry) {
+    val current = read()
+    val next = (listOf(entry) + current).take(MAX_ENTRIES)
+    prefs.edit().putString("entries", json.encodeToString<List<LineageEntry>>(next)).apply()
+  }
+
+  fun clear() {
+    prefs.edit().clear().apply()
+  }
+
+  companion object {
+    const val MAX_ENTRIES = 64
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -104,6 +104,24 @@ class SessionStore(context: Context) {
     ed.apply()
   }
 
+  // ── Hired clan IDs ────────────────────────────────────────────────────
+  // After a successful Bazaar hire, the clan is added to this set. Hall +
+  // Hearth + Codex union LINKED_CLAN_IDS with this set when displaying
+  // "your" sigils, so a freshly-hired card appears in the user's hall
+  // without a relaunch.
+
+  fun getHiredClanIds(): Set<Int> =
+    prefs.getStringSet("hired:clanIds", emptySet())
+      ?.mapNotNullTo(mutableSetOf()) { it.toIntOrNull() }
+      ?: emptySet()
+
+  fun addHiredClanId(clanId: Int) {
+    val current = getHiredClanIds()
+    if (clanId in current) return
+    val next = (current + clanId).map { it.toString() }.toSet()
+    prefs.edit().putStringSet("hired:clanIds", next).apply()
+  }
+
   // ── One-shot UI flags ─────────────────────────────────────────────────
   // Persisted booleans for onboarding hints / coachmarks. Once a flag is
   // marked seen, it stays seen across reinstalls (within EncryptedShared

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -82,4 +82,25 @@ class SessionStore(context: Context) {
   fun clear() {
     prefs.edit().clear().apply()
   }
+
+  // ── Form-draft persistence ────────────────────────────────────────────
+  //
+  // SteeringConsole / StrategyEditor / Forge text inputs survive process
+  // death + backgrounding. Keys are namespaced "draft:<scope>:<field>".
+  // On successful submit the relevant scope is cleared.
+
+  fun getDraft(scope: String, field: String): String? =
+    prefs.getString("draft:$scope:$field", null)
+
+  fun setDraft(scope: String, field: String, value: String) {
+    prefs.edit().putString("draft:$scope:$field", value).apply()
+  }
+
+  fun clearDrafts(scope: String) {
+    val toRemove = prefs.all.keys.filter { it.startsWith("draft:$scope:") }
+    if (toRemove.isEmpty()) return
+    val ed = prefs.edit()
+    toRemove.forEach { ed.remove(it) }
+    ed.apply()
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -83,6 +83,24 @@ class SessionStore(context: Context) {
     prefs.edit().clear().apply()
   }
 
+  /**
+   * Wipe demo-only state (hired clans, forged clans, drafts, hint flags)
+   * but KEEP the auth token + pubkey + walletLabel so the user doesn't
+   * need to re-pair MWA after a reset. Used by the "reset demo state"
+   * button in Codex.
+   */
+  fun resetDemoState() {
+    val ed = prefs.edit()
+    prefs.all.keys.forEach { key ->
+      val isDemoState = key.startsWith("hired:") ||
+        key.startsWith("forged:") ||
+        key.startsWith("draft:") ||
+        key.startsWith("flag:")
+      if (isDemoState) ed.remove(key)
+    }
+    ed.apply()
+  }
+
   // ── Form-draft persistence ────────────────────────────────────────────
   //
   // SteeringConsole / StrategyEditor / Forge text inputs survive process

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -103,4 +103,15 @@ class SessionStore(context: Context) {
     toRemove.forEach { ed.remove(it) }
     ed.apply()
   }
+
+  // ── One-shot UI flags ─────────────────────────────────────────────────
+  // Persisted booleans for onboarding hints / coachmarks. Once a flag is
+  // marked seen, it stays seen across reinstalls (within EncryptedShared
+  // Preferences' device-keystore lifetime).
+
+  fun hasSeenFlag(key: String): Boolean = prefs.getBoolean("flag:$key", false)
+
+  fun markFlagSeen(key: String) {
+    prefs.edit().putBoolean("flag:$key", true).apply()
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/SessionStore.kt
@@ -104,22 +104,36 @@ class SessionStore(context: Context) {
     ed.apply()
   }
 
-  // ── Hired clan IDs ────────────────────────────────────────────────────
-  // After a successful Bazaar hire, the clan is added to this set. Hall +
-  // Hearth + Codex union LINKED_CLAN_IDS with this set when displaying
-  // "your" sigils, so a freshly-hired card appears in the user's hall
-  // without a relaunch.
+  // ── Hired / Forged clan IDs ───────────────────────────────────────────
+  // After a successful Bazaar hire OR a Forge wizard mint, the clan is
+  // added to the matching set. Hall + Hearth + Codex union LINKED_CLAN_IDS
+  // with both sets when displaying "your" sigils — a freshly-hired or
+  // freshly-forged card appears in the user's hall without a relaunch.
+  //
+  // Sets are kept separate so Lineage / future analytics can tell forged
+  // from hired; ownership unions read both via getOwnedClanIdsExtra().
 
-  fun getHiredClanIds(): Set<Int> =
-    prefs.getStringSet("hired:clanIds", emptySet())
+  fun getHiredClanIds(): Set<Int> = readClanIdSet("hired:clanIds")
+
+  fun addHiredClanId(clanId: Int) = writeClanIdSet("hired:clanIds", clanId)
+
+  fun getForgedClanIds(): Set<Int> = readClanIdSet("forged:clanIds")
+
+  fun addForgedClanId(clanId: Int) = writeClanIdSet("forged:clanIds", clanId)
+
+  /** Union of hired + forged. LINKED_CLAN_IDS is added by ViewModels. */
+  fun getOwnedClanIdsExtra(): Set<Int> = getHiredClanIds() + getForgedClanIds()
+
+  private fun readClanIdSet(prefKey: String): Set<Int> =
+    prefs.getStringSet(prefKey, emptySet())
       ?.mapNotNullTo(mutableSetOf()) { it.toIntOrNull() }
       ?: emptySet()
 
-  fun addHiredClanId(clanId: Int) {
-    val current = getHiredClanIds()
+  private fun writeClanIdSet(prefKey: String, clanId: Int) {
+    val current = readClanIdSet(prefKey)
     if (clanId in current) return
     val next = (current + clanId).map { it.toString() }.toSet()
-    prefs.edit().putStringSet("hired:clanIds", next).apply()
+    prefs.edit().putStringSet(prefKey, next).apply()
   }
 
   // ── One-shot UI flags ─────────────────────────────────────────────────

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -413,9 +413,16 @@ fun ClanWorldApp(
               isBazaar = true,
               mwaSender = mwaSender,
               onHireConfirmed = {
-                val name = world.clan.app.data.bazaarListingByClan(clanId)
-                  ?.let { l -> "tkn 0x${"%04x".format(l.tokenId)}" }
-                  .orEmpty()
+                val listing = world.clan.app.data.bazaarListingByClan(clanId)
+                val name = listing?.let { "tkn 0x${"%04x".format(it.tokenId)}" }.orEmpty()
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "hired",
+                    clanId = clanId,
+                    title = "Hired ${world.clan.app.viewmodel.clanDisplayName(clanId)}",
+                    subtitle = listing?.let { "${it.pricePerSeason}g · 1 season · $name" } ?: name,
+                  ),
+                )
                 nav.navigate(Routes.forged(clanId, name, "HIRED")) {
                   popUpTo(Routes.Bazaar) { saveState = true }
                 }
@@ -473,7 +480,17 @@ fun ClanWorldApp(
               mwaSender = mwaSender,
               initialClanId = clanId,
               onBack = { nav.popBackStack() },
-              onSent = { nav.popBackStack() },
+              onSent = {
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "whispered",
+                    clanId = clanId,
+                    title = "Whispered to ${world.clan.app.viewmodel.clanDisplayName(clanId)}",
+                    subtitle = "queued for next tick",
+                  ),
+                )
+                nav.popBackStack()
+              },
             )
           }
 
@@ -490,9 +507,15 @@ fun ClanWorldApp(
               mwaSender = mwaSender,
               onBack = { nav.popBackStack() },
               onForged = { clanId, name ->
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "forged",
+                    clanId = clanId,
+                    title = "Forged ${name.ifBlank { "the unnamed seal" }}",
+                    subtitle = world.clan.app.viewmodel.clanDisplayName(clanId),
+                  ),
+                )
                 nav.navigate(Routes.forged(clanId, name, "FORGED")) {
-                  // Replace Forge wizard so back goes to Hall, not the
-                  // wizard's last step.
                   popUpTo(Routes.Forge) { inclusive = true }
                 }
               },
@@ -569,7 +592,17 @@ fun ClanWorldApp(
               mwaSender = mwaSender,
               clanId = clanId,
               onBack = { nav.popBackStack() },
-              onSaved = { nav.popBackStack() },
+              onSaved = {
+                app.lineageStore.append(
+                  world.clan.app.data.LineageEntry(
+                    kind = "sealed",
+                    clanId = clanId,
+                    title = "Sealed doctrine for ${world.clan.app.viewmodel.clanDisplayName(clanId)}",
+                    subtitle = "the elder will hold this counsel",
+                  ),
+                )
+                nav.popBackStack()
+              },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -66,6 +66,7 @@ object Routes {
   const val Whispers = "whispers/{clanId}"
   const val SteeringConsole = "steer/{clanId}"
   const val StrategyEditor = "strategy/{clanId}"
+  const val Treasury = "treasury/{clanId}"
   const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
@@ -75,6 +76,7 @@ object Routes {
   fun whispers(clanId: Int) = "whispers/$clanId"
   fun steer(clanId: Int) = "steer/$clanId"
   fun strategy(clanId: Int) = "strategy/$clanId"
+  fun treasury(clanId: Int) = "treasury/$clanId"
   fun bridge(clanId: Int) = "bridge/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
@@ -217,7 +219,8 @@ fun ClanWorldApp(
     currentRoute?.startsWith("inft/") == true ||
     currentRoute?.startsWith("bazaarInft/") == true ||
     currentRoute?.startsWith("whispers/") == true ||
-    currentRoute?.startsWith("strategy/") == true
+    currentRoute?.startsWith("strategy/") == true ||
+    currentRoute?.startsWith("treasury/") == true
   // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
@@ -228,6 +231,7 @@ fun ClanWorldApp(
     currentRoute?.startsWith("bazaarInft/") == true -> RootTab.Bazaar // detail derived from Bazaar
     currentRoute?.startsWith("whispers/") == true -> RootTab.Hall // inbox is a Hall drill-in
     currentRoute?.startsWith("strategy/") == true -> RootTab.Hall // editor is a Hall drill-in
+    currentRoute?.startsWith("treasury/") == true -> RootTab.Hall // treasury is a Hall drill-in
     currentRoute?.startsWith("steer/") == true ||
       currentRoute?.startsWith("bridge/") == true ||
       currentRoute == Routes.Cockpit ||
@@ -376,6 +380,7 @@ fun ClanWorldApp(
               onEnterCockpit = { nav.navigate(Routes.bridge(clanId)) },
               onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
               onEditStrategy = { nav.navigate(Routes.strategy(clanId)) },
+              onOpenTreasury = { nav.navigate(Routes.treasury(clanId)) },
             )
           }
 
@@ -394,6 +399,7 @@ fun ClanWorldApp(
               clanId = clanId,
               onBack = { nav.popBackStack() },
               onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
+              onOpenTreasury = { nav.navigate(Routes.treasury(clanId)) },
               isBazaar = true,
               mwaSender = mwaSender,
               onHireConfirmed = {
@@ -455,6 +461,22 @@ fun ClanWorldApp(
               initialClanId = clanId,
               onBack = { nav.popBackStack() },
               onSent = { nav.popBackStack() },
+            )
+          }
+
+          // ── Treasury (per-iNFT GOLD + resources + movements; from Vault tab) ─
+          composable(
+            route = Routes.Treasury,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            world.clan.app.ui.screens.TreasuryScreenRoute(
+              app = app,
+              clanId = clanId,
+              onBack = { nav.popBackStack() },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -423,6 +423,10 @@ fun ClanWorldApp(
                     subtitle = listing?.let { "${it.pricePerSeason}g · 1 season · $name" } ?: name,
                   ),
                 )
+                // Persist that this clan is now in the user's hall — so
+                // it shows up next time HallScreen refreshes (also affects
+                // Hearth leaderboard `isMine` and Codex linked-clans line).
+                app.sessionStore.addHiredClanId(clanId)
                 nav.navigate(Routes.forged(clanId, name, "HIRED")) {
                   popUpTo(Routes.Bazaar) { saveState = true }
                 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -68,6 +68,7 @@ object Routes {
   const val StrategyEditor = "strategy/{clanId}"
   const val Treasury = "treasury/{clanId}"
   const val Forge = "forge"
+  const val Forged = "forged/{clanId}?name={name}&label={label}"
   const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
@@ -78,6 +79,11 @@ object Routes {
   fun steer(clanId: Int) = "steer/$clanId"
   fun strategy(clanId: Int) = "strategy/$clanId"
   fun treasury(clanId: Int) = "treasury/$clanId"
+  fun forged(clanId: Int, name: String = "", label: String = "FORGED"): String {
+    val n = java.net.URLEncoder.encode(name, "UTF-8")
+    val l = java.net.URLEncoder.encode(label, "UTF-8")
+    return "forged/$clanId?name=$n&label=$l"
+  }
   fun bridge(clanId: Int) = "bridge/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
@@ -407,9 +413,12 @@ fun ClanWorldApp(
               isBazaar = true,
               mwaSender = mwaSender,
               onHireConfirmed = {
-                // For now: simply pop back to Bazaar. A future "Hired"
-                // confirmation screen could replace this.
-                nav.popBackStack()
+                val name = world.clan.app.data.bazaarListingByClan(clanId)
+                  ?.let { l -> "tkn 0x${"%04x".format(l.tokenId)}" }
+                  .orEmpty()
+                nav.navigate(Routes.forged(clanId, name, "HIRED")) {
+                  popUpTo(Routes.Bazaar) { saveState = true }
+                }
               },
             )
           }
@@ -480,7 +489,53 @@ fun ClanWorldApp(
               factory = factory,
               mwaSender = mwaSender,
               onBack = { nav.popBackStack() },
-              onForged = { nav.popBackStack() },
+              onForged = { clanId, name ->
+                nav.navigate(Routes.forged(clanId, name, "FORGED")) {
+                  // Replace Forge wizard so back goes to Hall, not the
+                  // wizard's last step.
+                  popUpTo(Routes.Forge) { inclusive = true }
+                }
+              },
+            )
+          }
+
+          // ── Forged (celebration landing for Forge + Hire) ───────────────
+          composable(
+            route = Routes.Forged,
+            arguments = listOf(
+              androidx.navigation.navArgument("clanId") { type = NavType.IntType },
+              androidx.navigation.navArgument("name") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = ""
+              },
+              androidx.navigation.navArgument("label") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = "FORGED"
+              },
+            ),
+            enterTransition = { fadeIn(tween(360, easing = FastOutSlowInEasing)) },
+            popExitTransition = { fadeOut(tween(220, easing = FastOutSlowInEasing)) },
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
+            val name = entry.arguments?.getString("name").orEmpty().let {
+              runCatching { java.net.URLDecoder.decode(it, "UTF-8") }.getOrDefault(it)
+            }
+            val label = (entry.arguments?.getString("label") ?: "FORGED").let {
+              runCatching { java.net.URLDecoder.decode(it, "UTF-8") }.getOrDefault(it)
+            }
+            world.clan.app.ui.screens.ForgedScreen(
+              clanId = clanId,
+              label = label,
+              sigilName = name,
+              onEnterHall = {
+                nav.navigate(Routes.Hall) {
+                  popUpTo(Routes.Hearth) { saveState = true }
+                  launchSingleTop = true
+                  restoreState = true
+                }
+              },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -67,6 +67,7 @@ object Routes {
   const val SteeringConsole = "steer/{clanId}"
   const val StrategyEditor = "strategy/{clanId}"
   const val Treasury = "treasury/{clanId}"
+  const val Forge = "forge"
   const val Bridge = "bridge/{clanId}"
   const val Cockpit = "cockpit"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
@@ -220,7 +221,8 @@ fun ClanWorldApp(
     currentRoute?.startsWith("bazaarInft/") == true ||
     currentRoute?.startsWith("whispers/") == true ||
     currentRoute?.startsWith("strategy/") == true ||
-    currentRoute?.startsWith("treasury/") == true
+    currentRoute?.startsWith("treasury/") == true ||
+    currentRoute == Routes.Forge
   // Cockpit + Owner sign-in / coming-soon are full-screen flows: tabbar hidden.
   val selectedTab = when {
     currentRoute == Routes.Hearth -> RootTab.Hearth
@@ -232,6 +234,7 @@ fun ClanWorldApp(
     currentRoute?.startsWith("whispers/") == true -> RootTab.Hall // inbox is a Hall drill-in
     currentRoute?.startsWith("strategy/") == true -> RootTab.Hall // editor is a Hall drill-in
     currentRoute?.startsWith("treasury/") == true -> RootTab.Hall // treasury is a Hall drill-in
+    currentRoute == Routes.Forge -> RootTab.Hall // forge wizard surfaces from Hall
     currentRoute?.startsWith("steer/") == true ||
       currentRoute?.startsWith("bridge/") == true ||
       currentRoute == Routes.Cockpit ||
@@ -324,6 +327,7 @@ fun ClanWorldApp(
               app = app,
               factory = factory,
               onOpenInft = { clanId -> nav.navigate(Routes.inftDetail(clanId)) },
+              onForge = { nav.navigate(Routes.Forge) },
             )
           }
 
@@ -461,6 +465,22 @@ fun ClanWorldApp(
               initialClanId = clanId,
               onBack = { nav.popBackStack() },
               onSent = { nav.popBackStack() },
+            )
+          }
+
+          // ── Forge (4-step mint wizard; surfaces from Hall) ──────────────
+          composable(
+            route = Routes.Forge,
+            enterTransition = { detailEnter() },
+            popExitTransition = { detailPopExit() },
+            exitTransition = { tabExit() },
+          ) {
+            world.clan.app.ui.screens.ForgeScreenRoute(
+              app = app,
+              factory = factory,
+              mwaSender = mwaSender,
+              onBack = { nav.popBackStack() },
+              onForged = { nav.popBackStack() },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -519,6 +519,10 @@ fun ClanWorldApp(
                     subtitle = world.clan.app.viewmodel.clanDisplayName(clanId),
                   ),
                 )
+                // Persist that this clan is now in the user's hall — same
+                // mechanism as Bazaar Hire. Hall + Hearth + Codex unions
+                // pick this up on next refresh.
+                app.sessionStore.addForgedClanId(clanId)
                 nav.navigate(Routes.forged(clanId, name, "FORGED")) {
                   popUpTo(Routes.Forge) { inclusive = true }
                 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/EmptyState.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/EmptyState.kt
@@ -1,0 +1,91 @@
+package world.clan.app.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * Inviting empty state. Renders centered title + body italics, plus an
+ * optional outlined-pill CTA at the bottom. Use when a list is genuinely
+ * empty (no error, just nothing yet) and there's a sensible next action.
+ *
+ * Distinguished from RetryNotice (which is for errors): this is for
+ * "all good, nothing here yet" rather than "something went wrong".
+ */
+@Composable
+fun EmptyState(
+  title: String,
+  body: String,
+  ctaLabel: String? = null,
+  onCta: (() -> Unit)? = null,
+  modifier: Modifier = Modifier,
+) {
+  val warm = ClanWorldTheme.colors.warm
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val parchment = ClanWorldTheme.colors.parchment
+  val gold = ClanWorldTheme.colors.gold
+  val hairlineMid = ClanWorldTheme.colors.hairlineMid
+  val iron2 = ClanWorldTheme.colors.iron2
+
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 32.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Text(
+      text = title,
+      style = ClanWorldTheme.type.scriptItalic,
+      color = warm,
+      textAlign = TextAlign.Center,
+    )
+    Text(
+      text = body,
+      style = ClanWorldTheme.type.scriptItalic,
+      color = warmDim,
+      textAlign = TextAlign.Center,
+    )
+    if (ctaLabel != null && onCta != null) {
+      Spacer(Modifier.height(6.dp))
+      Box(
+        modifier = Modifier
+          .clip(RoundedCornerShape(4.dp))
+          .background(iron2)
+          .drawBehind {
+            drawRoundRect(
+              color = hairlineMid,
+              cornerRadius = CornerRadius(4.dp.toPx()),
+              style = Stroke(width = 1.dp.toPx()),
+            )
+          }
+          .clickable { onCta() }
+          .padding(horizontal = 18.dp, vertical = 10.dp),
+      ) {
+        Text(
+          text = ctaLabel.uppercase(),
+          style = ClanWorldTheme.type.monoMicro,
+          color = gold,
+        )
+      }
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/OnboardingHint.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/OnboardingHint.kt
@@ -1,0 +1,134 @@
+package world.clan.app.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import world.clan.app.R
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * One-shot dismissible coachmark for first-time users. Renders a small
+ * parchment-tinted banner with title + body + close icon. Disappears
+ * permanently when dismissed (or on first prevent-show-again signal from
+ * the host).
+ *
+ * Hosts manage the "have they seen it?" flag via SessionStore.hasSeenFlag /
+ * markFlagSeen. The banner shrinks itself out cleanly on dismiss so the
+ * surrounding content reflows without a layout pop.
+ */
+@Composable
+fun OnboardingHint(
+  visible: Boolean,
+  title: String,
+  body: String,
+  onDismiss: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  // Local visibility tracks the parent's `visible` plus an in-flight
+  // dismissal. Without this the parent flag flips synchronously and the
+  // exit animation has nothing to animate.
+  var localVisible by remember(visible) { mutableStateOf(visible) }
+
+  AnimatedVisibility(
+    visible = localVisible,
+    enter = fadeIn(),
+    exit = fadeOut() + shrinkVertically(),
+    modifier = modifier,
+  ) {
+    val gold = ClanWorldTheme.colors.gold
+    val goldDim = ClanWorldTheme.colors.goldDim
+    val warm = ClanWorldTheme.colors.warm
+    val warmDim = ClanWorldTheme.colors.warmDim
+    val iron2 = ClanWorldTheme.colors.iron2
+
+    Row(
+      modifier = Modifier
+        .fillMaxWidth()
+        .clip(RoundedCornerShape(6.dp))
+        .background(
+          Brush.verticalGradient(
+            0f to gold.copy(alpha = 0.10f),
+            1f to gold.copy(alpha = 0.04f),
+          ),
+        )
+        .drawBehind {
+          drawRoundRect(
+            color = goldDim,
+            cornerRadius = CornerRadius(6.dp.toPx()),
+            style = Stroke(width = 1.dp.toPx()),
+          )
+        }
+        .padding(horizontal = 14.dp, vertical = 12.dp),
+      verticalAlignment = Alignment.Top,
+      horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+      // Small ember-pill marker on the left
+      Box(
+        modifier = Modifier
+          .size(8.dp)
+          .clip(RoundedCornerShape(50))
+          .background(gold),
+      )
+      Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+      ) {
+        Text(
+          text = title.uppercase(),
+          style = ClanWorldTheme.type.monoMicro,
+          color = gold,
+        )
+        Text(
+          text = body,
+          style = ClanWorldTheme.type.scriptItalic,
+          color = warm,
+        )
+      }
+      // Dismiss × button
+      Box(
+        modifier = Modifier
+          .clip(RoundedCornerShape(50))
+          .background(iron2)
+          .clickable {
+            localVisible = false
+            onDismiss()
+          }
+          .padding(6.dp),
+      ) {
+        Icon(
+          painter = painterResource(R.drawable.ui_check),
+          contentDescription = "dismiss",
+          tint = warmDim,
+          modifier = Modifier.size(12.dp),
+        )
+      }
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/RefreshableContent.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/RefreshableContent.kt
@@ -1,0 +1,105 @@
+package world.clan.app.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * Pull-to-refresh wrapper using Material3's [PullToRefreshBox].
+ *
+ * Drop-in replacement for `Box(Modifier.fillMaxSize())` around a vertically
+ * scrollable child. Pulls a refresh callback from the host viewmodel.
+ *
+ * Notes:
+ * - The Material3 indicator is themed by ColorScheme; we let it inherit
+ *   from the obsidian color scheme rather than pinning. If the default
+ *   indicator looks wrong, swap to a custom one via `indicator =`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RefreshableContent(
+  isRefreshing: Boolean,
+  onRefresh: () -> Unit,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  PullToRefreshBox(
+    isRefreshing = isRefreshing,
+    onRefresh = onRefresh,
+    modifier = modifier,
+  ) {
+    content()
+  }
+}
+
+/**
+ * Error notice for data-fetch failures. Renders the message + a tap-to-retry
+ * affordance. Same script-italic + danger-color palette as the other
+ * screens' error texts, with an extra CTA button beneath.
+ */
+@Composable
+fun RetryNotice(
+  message: String,
+  onRetry: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val danger = ClanWorldTheme.colors.danger
+  val iron2 = ClanWorldTheme.colors.iron2
+  val hairlineMid = ClanWorldTheme.colors.hairlineMid
+  val parchment = ClanWorldTheme.colors.parchment
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 16.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Text(
+      text = message,
+      style = ClanWorldTheme.type.scriptItalic,
+      color = danger,
+      textAlign = TextAlign.Center,
+    )
+    Box(
+      modifier = Modifier
+        .clip(RoundedCornerShape(4.dp))
+        .background(iron2)
+        .drawBehind {
+          drawRoundRect(
+            color = hairlineMid,
+            cornerRadius = CornerRadius(4.dp.toPx()),
+            style = Stroke(width = 1.dp.toPx()),
+          )
+        }
+        .clickable { onRetry() }
+        .padding(horizontal = 18.dp, vertical = 10.dp),
+    ) {
+      Text(
+        text = "TAP TO RETRY",
+        style = ClanWorldTheme.type.monoMicro,
+        color = parchment,
+      )
+    }
+    Spacer(Modifier.height(4.dp))
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Skeleton.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Skeleton.kt
@@ -1,0 +1,255 @@
+package world.clan.app.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import world.clan.app.ui.theme.ClanWorldTheme
+
+/**
+ * Sweep a translucent gold band diagonally across the modifier's bounds,
+ * looping every ~1500ms. Apply via .then(rememberShimmer()).
+ *
+ * The sweep is drawn ON TOP of existing content via drawWithContent, so the
+ * caller renders a solid base color first and the shimmer overlays it.
+ */
+@Composable
+fun Modifier.shimmer(): Modifier {
+  val gold = ClanWorldTheme.colors.goldDim
+  val transition = rememberInfiniteTransition(label = "skeleton-shimmer")
+  val sweepX by transition.animateFloat(
+    initialValue = -1f,
+    targetValue = 2f,
+    animationSpec = infiniteRepeatable(
+      animation = tween(durationMillis = 1500, easing = LinearEasing),
+      repeatMode = RepeatMode.Restart,
+    ),
+    label = "shimmer-x",
+  )
+  return this.drawWithContent {
+    drawContent()
+    val w = size.width
+    val band = w * 0.45f
+    val x0 = sweepX * w * 1.5f
+    drawRect(
+      brush = Brush.linearGradient(
+        colors = listOf(
+          Color.Transparent,
+          gold.copy(alpha = 0.18f),
+          Color.Transparent,
+        ),
+        start = Offset(x0, 0f),
+        end = Offset(x0 + band, size.height),
+      ),
+      topLeft = Offset(0f, 0f),
+      size = Size(w, size.height),
+    )
+  }
+}
+
+/**
+ * One rectangular skeleton "bone" — solid iron2 base + gold shimmer sweep.
+ * Building block for every higher-level skeleton card.
+ */
+@Composable
+fun SkeletonBone(
+  width: Dp? = null,
+  height: Dp = 12.dp,
+  cornerRadius: Dp = 4.dp,
+  modifier: Modifier = Modifier,
+) {
+  val base = ClanWorldTheme.colors.iron2
+  val mod = (if (width != null) modifier.width(width) else modifier.fillMaxWidth())
+    .height(height)
+    .clip(RoundedCornerShape(cornerRadius))
+    .background(base)
+    .shimmer()
+  Box(modifier = mod)
+}
+
+/**
+ * Hall list placeholder — mimics LetterCard shape: parchment-toned bg,
+ * round seal area on the right, two text lines on the left, divider, three
+ * stat columns. Renders four of these stacked when called from HallScreen.
+ */
+@Composable
+fun SkeletonLetterCard(modifier: Modifier = Modifier) {
+  val parchmentTint = ClanWorldTheme.colors.parchmentShade.copy(alpha = 0.10f)
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(6.dp))
+      .background(parchmentTint)
+      .padding(horizontal = 16.dp, vertical = 14.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Row(
+      verticalAlignment = androidx.compose.ui.Alignment.Top,
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        SkeletonBone(height = 18.dp)
+        SkeletonBone(height = 10.dp, width = 140.dp)
+      }
+      Box(
+        modifier = Modifier
+          .size(54.dp)
+          .clip(CircleShape)
+          .background(ClanWorldTheme.colors.iron2)
+          .shimmer(),
+      )
+    }
+    SkeletonBone(height = 12.dp)
+    SkeletonBone(height = 12.dp, width = 200.dp)
+    Spacer(Modifier.height(2.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+      repeat(3) {
+        Column(
+          modifier = Modifier.weight(1f),
+          verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+          SkeletonBone(height = 8.dp, width = 50.dp)
+          SkeletonBone(height = 12.dp)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * WhisperRow placeholder — left-edge accent line, meta + body bones.
+ */
+@Composable
+fun SkeletonWhisperRow(modifier: Modifier = Modifier) {
+  Row(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(start = 12.dp, end = 10.dp, top = 6.dp, bottom = 6.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Box(
+      modifier = Modifier
+        .width(2.dp)
+        .height(46.dp)
+        .background(ClanWorldTheme.colors.runeDim),
+    )
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+      SkeletonBone(height = 8.dp, width = 110.dp)
+      SkeletonBone(height = 14.dp)
+      SkeletonBone(height = 14.dp, width = 220.dp)
+    }
+  }
+}
+
+/**
+ * Treasury hero placeholder — gold value bone + clan dot.
+ */
+@Composable
+fun SkeletonTreasuryHero(modifier: Modifier = Modifier) {
+  val parchmentTint = ClanWorldTheme.colors.parchmentShade.copy(alpha = 0.10f)
+  Row(
+    modifier = modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(6.dp))
+      .background(parchmentTint)
+      .padding(horizontal = 16.dp, vertical = 18.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+  ) {
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      SkeletonBone(height = 8.dp, width = 50.dp)
+      SkeletonBone(height = 28.dp, width = 160.dp)
+      SkeletonBone(height = 10.dp, width = 200.dp)
+    }
+    Box(
+      modifier = Modifier
+        .size(28.dp)
+        .clip(CircleShape)
+        .background(ClanWorldTheme.colors.iron2)
+        .shimmer(),
+    )
+  }
+}
+
+/**
+ * Treasury movement row placeholder — tick label + resource + amount.
+ */
+@Composable
+fun SkeletonMovementRow(modifier: Modifier = Modifier) {
+  Row(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(vertical = 12.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+  ) {
+    SkeletonBone(height = 8.dp, width = 36.dp)
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+      SkeletonBone(height = 12.dp, width = 80.dp)
+      SkeletonBone(height = 8.dp, width = 50.dp)
+    }
+    SkeletonBone(height = 14.dp, width = 60.dp)
+  }
+}
+
+/**
+ * Leaderboard row placeholder — rank + name + tagline + value.
+ */
+@Composable
+fun SkeletonLeaderboardRow(modifier: Modifier = Modifier) {
+  Row(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(vertical = 8.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+  ) {
+    SkeletonBone(height = 14.dp, width = 24.dp)
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+      SkeletonBone(height = 14.dp, width = 140.dp)
+      SkeletonBone(height = 8.dp, width = 90.dp)
+    }
+    SkeletonBone(height = 14.dp, width = 64.dp)
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
@@ -51,6 +51,9 @@ fun BazaarScreenRoute(
 ) {
   val vm: BazaarViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
+  // Re-apply the hired-clan filter on (re-)entry so a freshly-hired
+  // sigil drops out of the listings without an app kill.
+  androidx.compose.runtime.LaunchedEffect(Unit) { vm.refresh() }
   BazaarScreen(state = state, onOpenListing = onOpenListing)
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
@@ -57,6 +58,9 @@ fun CodexScreenRoute(
 ) {
   val vm: CodexViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
+  // Re-read lineage on each Codex visit so newly-signed actions appear
+  // without a kill/relaunch.
+  androidx.compose.runtime.LaunchedEffect(Unit) { vm.refreshLineage() }
   CodexScreen(state = state)
 }
 
@@ -123,6 +127,19 @@ private fun CodexScreen(
     }
 
     Spacer(Modifier.height(20.dp))
+
+    // ── Lineage ──────────────────────────────────────────────────────
+    if (state.lineage.isNotEmpty()) {
+      StaggeredEntry(index = 9) {
+        SectionHeader(title = "Lineage", showLozenge = false)
+      }
+      StaggeredEntry(index = 10) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          state.lineage.take(12).forEach { entry -> LineageRow(entry) }
+        }
+      }
+      Spacer(Modifier.height(20.dp))
+    }
 
     // ── Share ────────────────────────────────────────────────────────
     StaggeredEntry(index = 5) {
@@ -270,6 +287,79 @@ private fun RowCard(
         )
       }
     }
+  }
+}
+
+@Composable
+private fun LineageRow(entry: world.clan.app.data.LineageEntry) {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warm = ClanWorldTheme.colors.warm
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val warmFaint = ClanWorldTheme.colors.warmFaint
+  val accent = world.clan.app.ui.theme.clanColor(entry.clanId)
+  val kindGlyph = when (entry.kind) {
+    "forged" -> "✦"
+    "hired" -> "◈"
+    "whispered" -> "≈"
+    "sealed" -> "✕"
+    else -> "·"
+  }
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(6.dp))
+      .background(ClanWorldTheme.colors.iron)
+      .border(1.dp, ClanWorldTheme.colors.hairline, RoundedCornerShape(6.dp))
+      .padding(horizontal = 14.dp, vertical = 10.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Box(
+      modifier = Modifier
+        .size(28.dp)
+        .clip(CircleShape)
+        .background(accent.copy(alpha = 0.18f))
+        .border(1.dp, accent.copy(alpha = 0.55f), CircleShape),
+      contentAlignment = Alignment.Center,
+    ) {
+      Text(
+        text = kindGlyph,
+        style = ClanWorldTheme.type.body,
+        color = accent,
+      )
+    }
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+      Text(
+        text = entry.title,
+        style = ClanWorldTheme.type.body,
+        color = parchment,
+      )
+      if (!entry.subtitle.isNullOrBlank()) {
+        Text(
+          text = entry.subtitle,
+          style = ClanWorldTheme.type.scriptItalicSmall,
+          color = warmDim,
+        )
+      }
+    }
+    Text(
+      text = formatRelativeTime(entry.tsEpochMs),
+      style = ClanWorldTheme.type.monoNano,
+      color = warmFaint,
+    )
+  }
+}
+
+private fun formatRelativeTime(tsMs: Long): String {
+  val deltaMs = System.currentTimeMillis() - tsMs
+  return when {
+    deltaMs < 60_000 -> "just now"
+    deltaMs < 60 * 60_000 -> "${deltaMs / 60_000}m"
+    deltaMs < 24 * 60 * 60_000 -> "${deltaMs / (60 * 60_000)}h"
+    else -> "${deltaMs / (24 * 60 * 60_000)}d"
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -98,9 +98,15 @@ private fun CodexScreen(
           copyable = state.solanaPubkey != null,
           copyText = state.solanaPubkey,
         )
+        if (state.walletLabel != null) {
+          RowCard(
+            label = "Wallet account",
+            value = state.walletLabel,
+          )
+        }
         RowCard(
-          label = "Linked clan",
-          value = "Caldris of the Strait — sealed at tick demo.",
+          label = "Linked clans · ${state.linkedClansCount} of viii",
+          value = linkedClansLine(state.linkedClanIds),
           isScript = true,
         )
       }
@@ -118,15 +124,58 @@ private fun CodexScreen(
 
     Spacer(Modifier.height(20.dp))
 
-    // ── About ────────────────────────────────────────────────────────
+    // ── Share ────────────────────────────────────────────────────────
     StaggeredEntry(index = 5) {
-      SectionHeader(title = "About", showLozenge = false)
+      SectionHeader(title = "Share", showLozenge = false)
     }
     StaggeredEntry(index = 6) {
-      RowCard(label = "Build", value = state.build)
+      RowCard(
+        label = "APK download · for friends",
+        value = state.apkShareUrl,
+        copyable = true,
+        copyText = state.apkShareUrl,
+      )
+    }
+
+    Spacer(Modifier.height(20.dp))
+
+    // ── About ────────────────────────────────────────────────────────
+    StaggeredEntry(index = 7) {
+      SectionHeader(title = "About", showLozenge = false)
+    }
+    StaggeredEntry(index = 8) {
+      Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        RowCard(label = "Build", value = state.build)
+        RowCard(
+          label = "Convex deployment",
+          value = state.convexUrl,
+          copyable = true,
+          copyText = state.convexUrl,
+        )
+      }
     }
 
     Spacer(Modifier.height(40.dp))
+  }
+}
+
+private fun linkedClansLine(ids: List<Int>): String {
+  if (ids.isEmpty()) return "no clans linked yet"
+  val names = ids.map { id ->
+    when (id) {
+      1 -> "Storm-Edge"; 2 -> "Tideborne"; 3 -> "Sunhold"; 4 -> "Vale-Ward"
+      5 -> "Twilight"; 6 -> "Ember"; 7 -> "Forge"; 8 -> "Star"
+      else -> "Clan $id"
+    }
+  }
+  return when (names.size) {
+    1 -> "${names[0]} stands under your hand."
+    2 -> "${names[0]} and ${names[1]} stand under your hand."
+    else -> {
+      val head = names.dropLast(1).joinToString(", ")
+      val tail = names.last()
+      "$head, and $tail stand under your hand."
+    }
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -61,12 +61,13 @@ fun CodexScreenRoute(
   // Re-read lineage on each Codex visit so newly-signed actions appear
   // without a kill/relaunch.
   androidx.compose.runtime.LaunchedEffect(Unit) { vm.refreshLineage() }
-  CodexScreen(state = state)
+  CodexScreen(state = state, onResetDemo = vm::resetDemoState)
 }
 
 @Composable
 private fun CodexScreen(
   state: CodexUiState,
+  onResetDemo: () -> Unit = {},
 ) {
   // Background and tab bar are app-level. Disconnect now lives in the
   // wallet-pill dropdown in CrownHeader — no big "FORGET THIS SIGIL"
@@ -172,7 +173,62 @@ private fun CodexScreen(
       }
     }
 
+    Spacer(Modifier.height(28.dp))
+
+    // ── Demo reset (bottom of Codex) ─────────────────────────────────
+    StaggeredEntry(index = 11) {
+      DemoResetRow(onConfirm = onResetDemo)
+    }
+
     Spacer(Modifier.height(40.dp))
+  }
+}
+
+@Composable
+private fun DemoResetRow(onConfirm: () -> Unit) {
+  val armedState = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+  val armed = armedState.value
+  Column(
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Text(
+      text = "Demo".uppercase(),
+      style = ClanWorldTheme.type.crownLabel,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .clip(RoundedCornerShape(6.dp))
+        .background(ClanWorldTheme.colors.iron)
+        .border(
+          1.dp,
+          if (armed) ClanWorldTheme.colors.danger else ClanWorldTheme.colors.hairline,
+          RoundedCornerShape(6.dp),
+        )
+        .clickable {
+          if (armed) {
+            onConfirm()
+            armedState.value = false
+          } else {
+            armedState.value = true
+          }
+        }
+        .padding(horizontal = 14.dp, vertical = 14.dp),
+    ) {
+      Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+          text = if (armed) "TAP AGAIN TO CONFIRM RESET" else "RESET DEMO STATE",
+          style = ClanWorldTheme.type.monoMicro,
+          color = if (armed) ClanWorldTheme.colors.danger else ClanWorldTheme.colors.warmDim,
+        )
+        Text(
+          text = "wipes hired + forged clans, drafts, and lineage. wallet stays connected.",
+          style = ClanWorldTheme.type.scriptItalicSmall,
+          color = ClanWorldTheme.colors.warmFaint,
+        )
+      }
+    }
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -75,7 +75,7 @@ fun ForgeScreenRoute(
   factory: ClanWorldViewModelFactory,
   mwaSender: ActivityResultSender,
   onBack: () -> Unit,
-  onForged: () -> Unit,
+  onForged: (clanId: Int, name: String) -> Unit,
 ) {
   val vm: ForgeViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
@@ -114,7 +114,8 @@ fun ForgeScreenRoute(
   if (state.mintPhase == SendPhase.Queued) {
     androidx.compose.runtime.LaunchedEffect(Unit) {
       delay(1500L)
-      onForged()
+      val cid = state.clanId ?: 1
+      onForged(cid, state.sigilName)
     }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
@@ -271,6 +272,15 @@ private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
       color = ClanWorldTheme.colors.warmFaint,
       modifier = Modifier.padding(horizontal = 22.dp),
     )
+    if (state.ownedClanIds.isNotEmpty()) {
+      Spacer(Modifier.height(4.dp))
+      Text(
+        text = "clans already under your hand can't be re-forged.",
+        style = ClanWorldTheme.type.scriptItalicSmall,
+        color = ClanWorldTheme.colors.warmFaint,
+        modifier = Modifier.padding(horizontal = 22.dp),
+      )
+    }
     Spacer(Modifier.height(10.dp))
     LazyColumn(
       modifier = Modifier.fillMaxSize(),
@@ -278,10 +288,12 @@ private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
       contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
     ) {
       items((1..8).toList()) { clanId ->
+        val owned = clanId in state.ownedClanIds
         ClanCard(
           clanId = clanId,
           selected = state.clanId == clanId,
-          onClick = { onSelect(clanId) },
+          owned = owned,
+          onClick = { if (!owned) onSelect(clanId) },
         )
       }
     }
@@ -289,15 +301,26 @@ private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
 }
 
 @Composable
-private fun ClanCard(clanId: Int, selected: Boolean, onClick: () -> Unit) {
+private fun ClanCard(
+  clanId: Int,
+  selected: Boolean,
+  owned: Boolean,
+  onClick: () -> Unit,
+) {
   val accent = clanColor(clanId)
-  val borderColor = if (selected) accent else ClanWorldTheme.colors.hairline
-  val borderStroke = if (selected) 2.dp else 1.dp
+  val borderColor = when {
+    owned -> ClanWorldTheme.colors.hairline
+    selected -> accent
+    else -> ClanWorldTheme.colors.hairline
+  }
+  val borderStroke = if (selected && !owned) 2.dp else 1.dp
+  val cardAlpha = if (owned) 0.45f else 1f
 
   Box(
     modifier = Modifier
       .fillMaxWidth()
-      .clickable { onClick() }
+      .alpha(cardAlpha)
+      .clickable(enabled = !owned) { onClick() }
       .drawBehind {
         drawRoundRect(
           color = borderColor,
@@ -323,7 +346,7 @@ private fun ClanCard(clanId: Int, selected: Boolean, onClick: () -> Unit) {
             color = Ink,
           )
           Text(
-            text = clanTagline(clanId),
+            text = if (owned) "already under your hand" else clanTagline(clanId),
             style = ClanWorldTheme.type.scriptItalic,
             color = Ink2,
             modifier = Modifier.padding(top = 2.dp),

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -1,0 +1,668 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentTransitionScope.SlideDirection
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import world.clan.app.App
+import world.clan.app.R
+import world.clan.app.ui.components.EmberCta
+import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.components.WaxSeal
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.ui.theme.clanGlyphRes
+import world.clan.app.viewmodel.ClanWorldViewModelFactory
+import world.clan.app.viewmodel.ForgeStep
+import world.clan.app.viewmodel.ForgeUiState
+import world.clan.app.viewmodel.ForgeViewModel
+import world.clan.app.viewmodel.Harness
+import world.clan.app.viewmodel.SendPhase
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.clanTagline
+import world.clan.app.wallet.MwaResult
+
+@Composable
+fun ForgeScreenRoute(
+  app: App,
+  factory: ClanWorldViewModelFactory,
+  mwaSender: ActivityResultSender,
+  onBack: () -> Unit,
+  onForged: () -> Unit,
+) {
+  val vm: ForgeViewModel = viewModel(factory = factory)
+  val state by vm.state.collectAsState()
+  val scope = rememberCoroutineScope()
+
+  ForgeScreen(
+    state = state,
+    onBack = onBack,
+    onSelectClan = vm::setClanId,
+    onSetName = vm::setSigilName,
+    onSetHarness = vm::setHarness,
+    onNext = vm::next,
+    onPrev = vm::back,
+    onForge = {
+      scope.launch {
+        vm.setMintPhase(SendPhase.Signing)
+        val token = app.sessionStore.read()?.mwaAuthToken
+        if (token == null) {
+          vm.setMintPhase(SendPhase.Queued)
+          return@launch
+        }
+        val msg = ("ClanWorld Forge — clan ${state.clanId} | ${state.sigilName} | " +
+          "${state.harness.name}").toByteArray()
+        when (val r = app.mwaClient.signMessage(mwaSender, token, msg)) {
+          is MwaResult.Ok -> vm.setMintPhase(SendPhase.Queued)
+          is MwaResult.UserDeclined -> vm.setMintPhase(SendPhase.Idle)
+          is MwaResult.WalletNotFound ->
+            vm.setMintPhase(SendPhase.Failed, "no wallet found on device.")
+          is MwaResult.Error ->
+            vm.setMintPhase(SendPhase.Failed, r.cause.message ?: "the wallet refused the seal.")
+        }
+      }
+    },
+  )
+
+  if (state.mintPhase == SendPhase.Queued) {
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+      delay(1500L)
+      onForged()
+    }
+  }
+}
+
+@Composable
+private fun ForgeScreen(
+  state: ForgeUiState,
+  onBack: () -> Unit,
+  onSelectClan: (Int) -> Unit,
+  onSetName: (String) -> Unit,
+  onSetHarness: (Harness) -> Unit,
+  onNext: () -> Unit,
+  onPrev: () -> Unit,
+  onForge: () -> Unit,
+) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    BackBar(text = "back to hall", onBack = onBack)
+
+    Column(modifier = Modifier.padding(horizontal = 22.dp)) {
+      ForgeHead()
+      Spacer(Modifier.height(10.dp))
+      ProgressDots(step = state.step)
+      Spacer(Modifier.height(18.dp))
+    }
+
+    AnimatedContent(
+      targetState = state.step,
+      transitionSpec = {
+        val direction = if (targetState.ordinal > initialState.ordinal) SlideDirection.Start else SlideDirection.End
+        (slideIntoContainer(direction, animationSpec = tween(280)) + fadeIn(tween(220))) togetherWith
+          (slideOutOfContainer(direction, animationSpec = tween(280)) + fadeOut(tween(180)))
+      },
+      label = "forge-step",
+      modifier = Modifier.weight(1f),
+    ) { step ->
+      when (step) {
+        ForgeStep.PickClan -> StepPickClan(
+          state = state,
+          onSelect = onSelectClan,
+        )
+        ForgeStep.NameSigil -> StepNameSigil(
+          state = state,
+          onChange = onSetName,
+        )
+        ForgeStep.PickHarness -> StepPickHarness(
+          state = state,
+          onSelect = onSetHarness,
+        )
+        ForgeStep.Confirm -> StepConfirm(
+          state = state,
+          onForge = onForge,
+        )
+      }
+    }
+
+    NavRow(state = state, onNext = onNext, onPrev = onPrev)
+    Spacer(Modifier.height(20.dp))
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Header + progress dots
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun BackBar(text: String, onBack: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 14.dp)
+      .clickable { onBack() },
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      painter = painterResource(R.drawable.ui_arrow),
+      contentDescription = "back",
+      tint = ClanWorldTheme.colors.warm,
+      modifier = Modifier.height(16.dp),
+    )
+    Text(
+      text = text,
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+  }
+}
+
+@Composable
+private fun ForgeHead() {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 14f),
+          end = Offset(size.width, size.height + 14f),
+          strokeWidth = 1f,
+        )
+      },
+  ) {
+    Text(text = "FORGE", style = ClanWorldTheme.type.displayHero, color = parchment)
+    Text(
+      text = "the unmade seal awaits its line",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = warmDim,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+@Composable
+private fun ProgressDots(step: ForgeStep) {
+  val ember = ClanWorldTheme.colors.ember
+  val warmFaint = ClanWorldTheme.colors.warmFaint
+  val total = ForgeStep.values().size
+  val activeIdx = step.ordinal
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    for (i in 0 until total) {
+      val color = if (i <= activeIdx) ember else warmFaint
+      Box(
+        modifier = Modifier
+          .size(8.dp)
+          .clip(RoundedCornerShape(50))
+          .background(color),
+      )
+    }
+    Spacer(Modifier.fillMaxWidth().weight(1f, fill = false))
+    Text(
+      text = "STEP ${activeIdx + 1} OF $total",
+      style = ClanWorldTheme.type.monoNano,
+      color = warmFaint,
+      modifier = Modifier.padding(start = 12.dp),
+    )
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 1 — Pick clan
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    Text(
+      text = "CHOOSE YOUR CLAN",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+      modifier = Modifier.padding(horizontal = 22.dp),
+    )
+    Spacer(Modifier.height(10.dp))
+    LazyColumn(
+      modifier = Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.spacedBy(10.dp),
+      contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+    ) {
+      items((1..8).toList()) { clanId ->
+        ClanCard(
+          clanId = clanId,
+          selected = state.clanId == clanId,
+          onClick = { onSelect(clanId) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun ClanCard(clanId: Int, selected: Boolean, onClick: () -> Unit) {
+  val accent = clanColor(clanId)
+  val borderColor = if (selected) accent else ClanWorldTheme.colors.hairline
+  val borderStroke = if (selected) 2.dp else 1.dp
+
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { onClick() }
+      .drawBehind {
+        drawRoundRect(
+          color = borderColor,
+          cornerRadius = CornerRadius(6.dp.toPx()),
+          style = Stroke(width = borderStroke.toPx()),
+        )
+      },
+  ) {
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+      ) {
+        WaxSeal(
+          glyph = painterResource(clanGlyphRes(clanId)),
+          clanColor = accent,
+          size = 44.dp,
+        )
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            text = clanDisplayName(clanId),
+            style = ClanWorldTheme.type.letterName,
+            color = Ink,
+          )
+          Text(
+            text = clanTagline(clanId),
+            style = ClanWorldTheme.type.scriptItalic,
+            color = Ink2,
+            modifier = Modifier.padding(top = 2.dp),
+          )
+        }
+      }
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 2 — Name the sigil
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepNameSigil(state: ForgeUiState, onChange: (String) -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(horizontal = 22.dp),
+  ) {
+    Text(
+      text = "NAME THE SIGIL",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Spacer(Modifier.height(8.dp))
+    Text(
+      text = "what shall the elders call this iNFT?",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+    Spacer(Modifier.height(14.dp))
+
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Text(
+        text = "NAME",
+        style = ClanWorldTheme.type.monoNano,
+        color = Ink3,
+      )
+      Spacer(Modifier.height(6.dp))
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(48.dp),
+      ) {
+        if (state.sigilName.isEmpty()) {
+          Text(
+            text = "the unnamed seal…",
+            style = ClanWorldTheme.type.scriptItalic.copy(color = Ink3),
+          )
+        }
+        BasicTextField(
+          value = state.sigilName,
+          onValueChange = onChange,
+          singleLine = true,
+          textStyle = LocalTextStyle.current.copy(
+            fontFamily = ClanWorldTheme.type.letterName.fontFamily,
+            fontSize = ClanWorldTheme.type.letterName.fontSize,
+            color = Ink,
+          ),
+          cursorBrush = SolidColor(Ink2),
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+      Spacer(Modifier.height(8.dp))
+      Text(
+        text = "${state.sigilName.length}/32",
+        style = ClanWorldTheme.type.monoNano,
+        color = Ink3,
+        textAlign = TextAlign.End,
+        modifier = Modifier.fillMaxWidth(),
+      )
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 3 — Pick harness
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepPickHarness(state: ForgeUiState, onSelect: (Harness) -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(horizontal = 22.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Text(
+      text = "PICK YOUR HARNESS",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Spacer(Modifier.height(2.dp))
+    Text(
+      text = "the bend the elder will favor",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+    Spacer(Modifier.height(8.dp))
+
+    Harness.values().forEach { h ->
+      HarnessCard(
+        harness = h,
+        selected = state.harness == h,
+        onClick = { onSelect(h) },
+      )
+    }
+  }
+}
+
+@Composable
+private fun HarnessCard(harness: Harness, selected: Boolean, onClick: () -> Unit) {
+  val accent = when (harness) {
+    Harness.Iron -> ClanWorldTheme.colors.rune
+    Harness.Tide -> ClanWorldTheme.colors.gold
+    Harness.Ember -> ClanWorldTheme.colors.ember
+  }
+  val border = if (selected) accent else ClanWorldTheme.colors.hairline
+  val stroke = if (selected) 2.dp else 1.dp
+
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { onClick() }
+      .drawBehind {
+        drawRoundRect(
+          color = border,
+          cornerRadius = CornerRadius(6.dp.toPx()),
+          style = Stroke(width = stroke.toPx()),
+        )
+      },
+  ) {
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        Box(
+          modifier = Modifier
+            .size(14.dp)
+            .clip(RoundedCornerShape(50))
+            .background(accent),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            text = harness.display.uppercase(),
+            style = ClanWorldTheme.type.letterName,
+            color = Ink,
+          )
+          Text(
+            text = harness.tagline,
+            style = ClanWorldTheme.type.scriptItalic,
+            color = Ink2,
+            modifier = Modifier.padding(top = 2.dp),
+          )
+        }
+      }
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 4 — Confirm + sign
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun StepConfirm(state: ForgeUiState, onForge: () -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(horizontal = 22.dp),
+    verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Text(
+      text = "CONFIRM THE FORGE",
+      style = ClanWorldTheme.type.monoNano,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Text(
+      text = "your seal is required before the iNFT goes to your wallet.",
+      style = ClanWorldTheme.type.scriptItalic,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+
+    Spacer(Modifier.height(2.dp))
+
+    val clanId = state.clanId
+    if (clanId == null) {
+      Text(
+        text = "no clan chosen — go back to step 1.",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.danger,
+      )
+      return@Column
+    }
+
+    ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+      Row(
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+      ) {
+        WaxSeal(
+          glyph = painterResource(clanGlyphRes(clanId)),
+          clanColor = clanColor(clanId),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            text = state.sigilName.ifBlank { "the unnamed seal" },
+            style = ClanWorldTheme.type.letterName,
+            color = Ink,
+          )
+          Text(
+            text = clanDisplayName(clanId),
+            style = ClanWorldTheme.type.scriptItalic,
+            color = Ink2,
+            modifier = Modifier.padding(top = 2.dp),
+          )
+        }
+      }
+      Spacer(Modifier.height(12.dp))
+      Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+        ConfirmStat(label = "Clan", value = clanDisplayName(clanId))
+        ConfirmStat(label = "Harness", value = state.harness.display)
+        ConfirmStat(label = "Cost", value = "free • demo")
+      }
+    }
+
+    Spacer(Modifier.height(2.dp))
+
+    when (state.mintPhase) {
+      SendPhase.Idle, SendPhase.Failed -> {
+        EmberCta(
+          text = if (state.mintPhase == SendPhase.Failed) "Try Again" else "Sign and Forge",
+          onClick = onForge,
+          enabled = state.sigilName.isNotBlank(),
+          modifier = Modifier.fillMaxWidth(),
+        )
+        if (state.mintPhase == SendPhase.Failed) {
+          Text(
+            text = state.errorMessage ?: "the seal could not be set.",
+            style = ClanWorldTheme.type.scriptItalic,
+            color = ClanWorldTheme.colors.danger,
+          )
+        }
+      }
+      SendPhase.Signing -> {
+        Text(
+          text = "the wallet is preparing the seal…",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.gold,
+        )
+      }
+      SendPhase.Queued -> {
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .background(ClanWorldTheme.colors.success.copy(alpha = 0.18f))
+            .padding(vertical = 16.dp),
+          contentAlignment = Alignment.Center,
+        ) {
+          Text(
+            text = "FORGED ✓",
+            style = ClanWorldTheme.type.ctaLabel,
+            color = ClanWorldTheme.colors.success,
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.ConfirmStat(label: String, value: String) {
+  Column(Modifier.weight(1f)) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Text(
+      text = value,
+      style = ClanWorldTheme.type.monoData,
+      color = Ink,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Bottom nav row (Back / Next)
+// ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun NavRow(state: ForgeUiState, onNext: () -> Unit, onPrev: () -> Unit) {
+  val isFirst = state.step == ForgeStep.PickClan
+  val isLast = state.step == ForgeStep.Confirm
+  val canAdvance = when (state.step) {
+    ForgeStep.PickClan -> state.clanId != null
+    ForgeStep.NameSigil -> state.sigilName.isNotBlank()
+    ForgeStep.PickHarness -> true
+    ForgeStep.Confirm -> false
+  }
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 8.dp),
+    horizontalArrangement = Arrangement.SpaceBetween,
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    if (!isFirst) {
+      Text(
+        text = "← BACK",
+        style = ClanWorldTheme.type.monoMicro,
+        color = ClanWorldTheme.colors.warmDim,
+        modifier = Modifier
+          .clickable { onPrev() }
+          .padding(horizontal = 8.dp, vertical = 10.dp),
+      )
+    } else {
+      Spacer(Modifier.size(1.dp))
+    }
+    if (!isLast) {
+      val tint = if (canAdvance) ClanWorldTheme.colors.gold else ClanWorldTheme.colors.warmFaint
+      Text(
+        text = "NEXT →",
+        style = ClanWorldTheme.type.monoMicro,
+        color = tint,
+        modifier = Modifier
+          .clickable(enabled = canAdvance) { onNext() }
+          .padding(horizontal = 8.dp, vertical = 10.dp),
+      )
+    } else {
+      Spacer(Modifier.size(1.dp))
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgedScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgedScreen.kt
@@ -1,0 +1,155 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import world.clan.app.ui.components.EmberCta
+import world.clan.app.ui.components.Sigil
+import world.clan.app.ui.components.bigSigilSpec
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.clanTagline
+
+/**
+ * Celebration landing for both Forge mint + Bazaar hire flows.
+ *
+ * Replaces the previous "tiny Sealed ✓ then nav.popBackStack()" UX gap —
+ * after a successful sign, the user lands here for a beat to actually see
+ * the sigil they just bound to their wallet, then taps "Enter Your Hall"
+ * to land in Hall (popUpTo Hall, inclusive=false, so back doesn't bounce
+ * through the wizard).
+ *
+ * Visual hierarchy:
+ *   [LABEL]                       — small mono ("FORGED" or "HIRED")
+ *   <large rotating Sigil>        — clan-color, with breathing halo
+ *   <sigil name>                  — display script
+ *   <clan name>                   — italic
+ *   <tagline>                     — italic, dim
+ *   [Enter Your Hall]             — primary CTA
+ */
+@Composable
+fun ForgedScreen(
+  clanId: Int,
+  label: String,
+  sigilName: String,
+  onEnterHall: () -> Unit,
+) {
+  val accent = clanColor(clanId)
+  val transition = rememberInfiniteTransition(label = "forged-pulse")
+  val haloPulse by transition.animateFloat(
+    initialValue = 0.55f,
+    targetValue = 1f,
+    animationSpec = infiniteRepeatable(
+      animation = tween(durationMillis = 2400, easing = EaseInOut),
+      repeatMode = RepeatMode.Reverse,
+    ),
+    label = "halo",
+  )
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(horizontal = 22.dp),
+  ) {
+    Column(
+      modifier = Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      Text(
+        text = label.uppercase(),
+        style = ClanWorldTheme.type.monoNano,
+        color = accent,
+      )
+
+      Spacer(Modifier.height(20.dp))
+
+      // Sigil with a breathing accent halo behind it.
+      Box(
+        modifier = Modifier.size(200.dp),
+        contentAlignment = Alignment.Center,
+      ) {
+        // Halo
+        Box(
+          modifier = Modifier
+            .size(200.dp)
+            .alpha(haloPulse * 0.40f)
+            .drawBehind {
+              drawCircle(
+                color = accent,
+                radius = size.minDimension / 2f,
+                blendMode = BlendMode.Plus,
+              )
+            },
+        )
+        Sigil(
+          spec = bigSigilSpec(accent),
+          modifier = Modifier.size(160.dp),
+        )
+      }
+
+      Spacer(Modifier.height(28.dp))
+
+      Text(
+        text = sigilName.ifBlank { "the unnamed seal" },
+        style = ClanWorldTheme.type.displayHero,
+        color = ClanWorldTheme.colors.parchment,
+        textAlign = TextAlign.Center,
+      )
+
+      Spacer(Modifier.height(6.dp))
+
+      Text(
+        text = clanDisplayName(clanId),
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warm,
+        textAlign = TextAlign.Center,
+      )
+
+      Spacer(Modifier.height(2.dp))
+
+      Text(
+        text = clanTagline(clanId),
+        style = ClanWorldTheme.type.scriptItalic,
+        color = ClanWorldTheme.colors.warmDim,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(horizontal = 28.dp),
+      )
+
+      Spacer(Modifier.height(36.dp))
+
+      Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
+        EmberCta(
+          text = "Enter Your Hall",
+          onClick = onEnterHall,
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+    }
+  }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -16,6 +16,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -63,11 +66,21 @@ fun HallScreenRoute(
 ) {
   val vm: HallViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
+  // First-launch coachmark: read once from SessionStore, dismiss-on-tap
+  // toggles the local state and writes the persistent flag.
+  val hintFlagKey = "hall.hintSeen"
+  val hintInitial = remember { !app.sessionStore.hasSeenFlag(hintFlagKey) }
+  var hintVisible by remember { mutableStateOf(hintInitial) }
   HallScreen(
     state = state,
     onOpenInft = onOpenInft,
     onForge = onForge,
     onRefresh = vm::refresh,
+    showHint = hintVisible,
+    onDismissHint = {
+      hintVisible = false
+      app.sessionStore.markFlagSeen(hintFlagKey)
+    },
   )
 }
 
@@ -77,6 +90,8 @@ private fun HallScreen(
   onOpenInft: (Int) -> Unit,
   onForge: () -> Unit = {},
   onRefresh: () -> Unit = {},
+  showHint: Boolean = false,
+  onDismissHint: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
   Column(
@@ -93,6 +108,15 @@ private fun HallScreen(
     StaggeredEntry(index = 0) {
       HallHead(count = state.items.size)
     }
+
+    // First-launch coachmark — points new users at the FORGE entry below.
+    Spacer(Modifier.height(14.dp))
+    world.clan.app.ui.components.OnboardingHint(
+      visible = showHint,
+      title = "Begin your line",
+      body = "Tap “+ Forge a new sigil” below to mint your first iNFT.",
+      onDismiss = onDismissHint,
+    )
 
     // Forge entry — sits between the head divider and the list. Always
     // available; an empty hall still wants the option to forge a new one.

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -133,11 +133,11 @@ private fun HallScreen(
         if (state.items.isEmpty()) {
           LazyColumn(modifier = Modifier.fillMaxSize()) {
             item {
-              Text(
-                text = "your hall is quiet — no sigils linked.",
-                style = ClanWorldTheme.type.scriptItalic,
-                color = ClanWorldTheme.colors.warmFaint,
-                modifier = Modifier.padding(top = 24.dp),
+              world.clan.app.ui.components.EmptyState(
+                title = "your hall is quiet",
+                body = "no sigils stand under your hand yet — forge one to begin.",
+                ctaLabel = "+ Forge a sigil",
+                onCta = onForge,
               )
             }
           }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -63,7 +63,12 @@ fun HallScreenRoute(
 ) {
   val vm: HallViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
-  HallScreen(state = state, onOpenInft = onOpenInft, onForge = onForge)
+  HallScreen(
+    state = state,
+    onOpenInft = onOpenInft,
+    onForge = onForge,
+    onRefresh = vm::refresh,
+  )
 }
 
 @Composable
@@ -71,6 +76,7 @@ private fun HallScreen(
   state: HallUiState,
   onOpenInft: (Int) -> Unit,
   onForge: () -> Unit = {},
+  onRefresh: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
   Column(
@@ -111,25 +117,42 @@ private fun HallScreen(
         color = ClanWorldTheme.colors.warmFaint,
         modifier = Modifier.padding(top = 24.dp),
       )
-    } else if (state.items.isEmpty()) {
-      Text(
-        text = state.errorMessage ?: "your hall is quiet — no sigils linked.",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.warmFaint,
-        modifier = Modifier.padding(top = 24.dp),
+    } else if (state.errorMessage != null && state.items.isEmpty()) {
+      world.clan.app.ui.components.RetryNotice(
+        message = state.errorMessage,
+        onRetry = onRefresh,
       )
     } else {
-      LazyColumn(
+      world.clan.app.ui.components.RefreshableContent(
+        isRefreshing = state.isRefreshing,
+        onRefresh = onRefresh,
         modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(14.dp),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 24.dp),
       ) {
-        items(state.items, key = { it.tokenId }) { card ->
-          StaggeredEntry(index = card.tokenId.coerceAtMost(8)) {
-            LetterCard(
-              card = card,
-              onClick = { onOpenInft(card.clanId) },
-            )
+        if (state.items.isEmpty()) {
+          LazyColumn(modifier = Modifier.fillMaxSize()) {
+            item {
+              Text(
+                text = "your hall is quiet — no sigils linked.",
+                style = ClanWorldTheme.type.scriptItalic,
+                color = ClanWorldTheme.colors.warmFaint,
+                modifier = Modifier.padding(top = 24.dp),
+              )
+            }
+          }
+        } else {
+          LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 24.dp),
+          ) {
+            items(state.items, key = { it.tokenId }) { card ->
+              StaggeredEntry(index = card.tokenId.coerceAtMost(8)) {
+                LetterCard(
+                  card = card,
+                  onClick = { onOpenInft(card.clanId) },
+                )
+              }
+            }
           }
         }
       }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -111,12 +111,14 @@ private fun HallScreen(
     Spacer(Modifier.height(10.dp))
 
     if (state.isLoading) {
-      Text(
-        text = "gathering the sigils…",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.warmFaint,
-        modifier = Modifier.padding(top = 24.dp),
-      )
+      Column(
+        modifier = Modifier
+          .fillMaxSize()
+          .padding(top = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+      ) {
+        repeat(3) { world.clan.app.ui.components.SkeletonLetterCard() }
+      }
     } else if (state.errorMessage != null && state.items.isEmpty()) {
       world.clan.app.ui.components.RetryNotice(
         message = state.errorMessage,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -1,6 +1,8 @@
 package world.clan.app.ui.screens
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -52,6 +55,7 @@ import world.clan.app.ui.theme.clanColor
 import world.clan.app.ui.theme.clanGlyphRes
 import world.clan.app.viewmodel.ClanWorldViewModelFactory
 import world.clan.app.viewmodel.HallCard
+import world.clan.app.viewmodel.HallProvenance
 import world.clan.app.viewmodel.HallUiState
 import world.clan.app.viewmodel.HallViewModel
 import world.clan.app.viewmodel.clanDisplayName
@@ -270,11 +274,18 @@ private fun LetterCard(
       horizontalArrangement = Arrangement.spacedBy(14.dp),
     ) {
       Column(Modifier.weight(1f)) {
-        Text(
-          text = letterTitle(card.clanId),
-          style = ClanWorldTheme.type.letterName,
-          color = Ink,
-        )
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          Text(
+            text = letterTitle(card.clanId),
+            style = ClanWorldTheme.type.letterName,
+            color = Ink,
+            modifier = Modifier.weight(1f, fill = false),
+          )
+          ProvenanceBadge(card.provenance)
+        }
         Text(
           text = "tkn 0x${"%04x".format(card.tokenId)} · clan ${roman(card.clanId).lowercase()}",
           style = ClanWorldTheme.type.monoMicro,
@@ -321,6 +332,28 @@ private fun LetterCard(
       LetterStat(label = "Memory", value = "${card.memoryCount} keys", color = Ink)
       LetterStat(label = "Vault", value = "—", color = Ink)
     }
+  }
+}
+
+@Composable
+private fun ProvenanceBadge(provenance: HallProvenance) {
+  if (provenance == HallProvenance.Linked) return
+  val (label, accent) = when (provenance) {
+    HallProvenance.Hired -> "HIRED" to ClanWorldTheme.colors.rune
+    HallProvenance.Forged -> "FORGED" to ClanWorldTheme.colors.ember
+    HallProvenance.Linked -> return
+  }
+  Box(
+    modifier = Modifier
+      .clip(RoundedCornerShape(2.dp))
+      .background(accent.copy(alpha = 0.16f))
+      .padding(horizontal = 6.dp, vertical = 3.dp),
+  ) {
+    Text(
+      text = label,
+      style = ClanWorldTheme.type.monoNano,
+      color = accent,
+    )
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -59,16 +59,18 @@ fun HallScreenRoute(
   app: App,
   factory: ClanWorldViewModelFactory,
   onOpenInft: (Int) -> Unit,
+  onForge: () -> Unit = {},
 ) {
   val vm: HallViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
-  HallScreen(state = state, onOpenInft = onOpenInft)
+  HallScreen(state = state, onOpenInft = onOpenInft, onForge = onForge)
 }
 
 @Composable
 private fun HallScreen(
   state: HallUiState,
   onOpenInft: (Int) -> Unit,
+  onForge: () -> Unit = {},
 ) {
   // Background and tab bar are app-level (ClanWorldApp.kt).
   Column(
@@ -86,7 +88,21 @@ private fun HallScreen(
       HallHead(count = state.items.size)
     }
 
-    Spacer(Modifier.height(18.dp))
+    // Forge entry — sits between the head divider and the list. Always
+    // available; an empty hall still wants the option to forge a new one.
+    Text(
+      text = "+ FORGE A NEW SIGIL",
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.gold,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(top = 18.dp, bottom = 8.dp)
+        .clickable { onForge() }
+        .padding(vertical = 8.dp),
+      textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+    )
+
+    Spacer(Modifier.height(10.dp))
 
     if (state.isLoading) {
       Text(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
@@ -70,12 +70,13 @@ fun HearthScreenRoute(
 ) {
   val vm: HearthViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
-  HearthScreen(state = state)
+  HearthScreen(state = state, onRefresh = vm::refresh)
 }
 
 @Composable
 private fun HearthScreen(
   state: HearthUiState,
+  onRefresh: () -> Unit = {},
 ) {
   // Background and tab bar are hosted at the app level (ClanWorldApp.kt);
   // this screen is just the page content.
@@ -89,6 +90,19 @@ private fun HearthScreen(
       modifier = Modifier.fillMaxWidth(),
     )
 
+    if (state.errorMessage != null && state.leaderboard.isEmpty()) {
+      world.clan.app.ui.components.RetryNotice(
+        message = state.errorMessage,
+        onRetry = onRefresh,
+      )
+      return@Column
+    }
+
+    world.clan.app.ui.components.RefreshableContent(
+      isRefreshing = state.isRefreshing,
+      onRefresh = onRefresh,
+      modifier = Modifier.fillMaxSize(),
+    ) {
     Column(
       modifier = Modifier
         .fillMaxSize()
@@ -125,6 +139,7 @@ private fun HearthScreen(
         WhispersList(state.recentComms)
       }
     }
+    } // close RefreshableContent
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
@@ -126,7 +126,7 @@ private fun HearthScreen(
             )
           }
           StaggeredEntry(index = 2) {
-            LeaderboardSurface(state.leaderboard)
+            LeaderboardSurface(state.leaderboard, isLoading = state.isLoading)
           }
 
           StaggeredEntry(index = 3) {
@@ -136,7 +136,7 @@ private fun HearthScreen(
             )
           }
       StaggeredEntry(index = 4) {
-        WhispersList(state.recentComms)
+        WhispersList(state.recentComms, isLoading = state.isLoading)
       }
     }
     } // close RefreshableContent
@@ -355,7 +355,10 @@ private fun Int.spelledOut(): String {
 // ─────────────────────────────────────────────────────────────────────────
 
 @Composable
-private fun LeaderboardSurface(rows: List<HearthUiState.LeaderboardRow>) {
+private fun LeaderboardSurface(
+  rows: List<HearthUiState.LeaderboardRow>,
+  isLoading: Boolean = false,
+) {
   val hairline = ClanWorldTheme.colors.hairline
   Column(
     modifier = Modifier
@@ -365,7 +368,17 @@ private fun LeaderboardSurface(rows: List<HearthUiState.LeaderboardRow>) {
       .border(1.dp, hairline, RoundedCornerShape(6.dp)),
     verticalArrangement = Arrangement.spacedBy(1.dp),
   ) {
-    if (rows.isEmpty()) {
+    if (rows.isEmpty() && isLoading) {
+      Column(
+        modifier = Modifier
+          .fillMaxWidth()
+          .background(ClanWorldTheme.colors.iron)
+          .padding(horizontal = 14.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+      ) {
+        repeat(4) { world.clan.app.ui.components.SkeletonLeaderboardRow() }
+      }
+    } else if (rows.isEmpty()) {
       Box(
         Modifier
           .fillMaxWidth()
@@ -401,7 +414,16 @@ private fun LeaderboardSurface(rows: List<HearthUiState.LeaderboardRow>) {
 // ─────────────────────────────────────────────────────────────────────────
 
 @Composable
-private fun WhispersList(comms: List<CombinedComm>) {
+private fun WhispersList(
+  comms: List<CombinedComm>,
+  isLoading: Boolean = false,
+) {
+  if (comms.isEmpty() && isLoading) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+      repeat(2) { world.clan.app.ui.components.SkeletonWhisperRow() }
+    }
+    return
+  }
   if (comms.isEmpty()) {
     Text(
       text = "no whispers in the wind…",

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -81,6 +81,7 @@ fun InftDetailScreenRoute(
   onEnterCockpit: () -> Unit = {},
   onOpenInbox: () -> Unit = {},
   onEditStrategy: () -> Unit = {},
+  onOpenTreasury: () -> Unit = {},
   isBazaar: Boolean = false,
   mwaSender: com.solana.mobilewalletadapter.clientlib.ActivityResultSender? = null,
   onHireConfirmed: (() -> Unit)? = null,
@@ -95,6 +96,7 @@ fun InftDetailScreenRoute(
     onEnterCockpit = onEnterCockpit,
     onOpenInbox = onOpenInbox,
     onEditStrategy = onEditStrategy,
+    onOpenTreasury = onOpenTreasury,
     isBazaar = isBazaar,
     app = app,
     mwaSender = mwaSender,
@@ -111,6 +113,7 @@ private fun InftDetailScreen(
   onEnterCockpit: () -> Unit,
   onOpenInbox: () -> Unit = {},
   onEditStrategy: () -> Unit = {},
+  onOpenTreasury: () -> Unit = {},
   isBazaar: Boolean = false,
   app: App? = null,
   mwaSender: com.solana.mobilewalletadapter.clientlib.ActivityResultSender? = null,
@@ -160,7 +163,7 @@ private fun InftDetailScreen(
           state.state?.memory.orEmpty(),
           onEditStrategy = if (!isBazaar) onEditStrategy else null,
         )
-        DetailTab.Vault -> VaultPanel(state.vault)
+        DetailTab.Vault -> VaultPanel(state.vault, onOpenTreasury = onOpenTreasury)
         DetailTab.Whispers -> WhispersPanel(state.comms, onOpenInbox = onOpenInbox)
         DetailTab.Bulletin -> BulletinPanel(state.state?.bulletins?.map { it.body } ?: emptyList())
       }
@@ -470,7 +473,11 @@ private fun MemoryPanel(
 }
 
 @Composable
-private fun VaultPanel(vault: List<VaultMovement>) {
+private fun VaultPanel(
+  vault: List<VaultMovement>,
+  onOpenTreasury: () -> Unit = {},
+) {
+  Column {
   PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
     if (vault.isEmpty()) {
       ComingNextSlice("the vault keeps its silence")
@@ -505,6 +512,17 @@ private fun VaultPanel(vault: List<VaultMovement>) {
       }
     }
   }
+  Text(
+    text = "FULL TREASURY →",
+    style = ClanWorldTheme.type.monoMicro,
+    color = ClanWorldTheme.colors.gold,
+    textAlign = TextAlign.Center,
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { onOpenTreasury() }
+      .padding(horizontal = 22.dp, vertical = 14.dp),
+  )
+  } // close outer Column
 }
 
 @Composable

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -432,29 +432,23 @@ private fun MemoryPanel(
   onEditStrategy: (() -> Unit)? = null,
 ) {
   Column {
+    if (memory.isEmpty()) {
+      world.clan.app.ui.components.EmptyState(
+        title = "no doctrine written yet",
+        body = "the elder waits for your first counsel.",
+        ctaLabel = if (onEditStrategy != null) "+ Write doctrine" else null,
+        onCta = onEditStrategy,
+      )
+      return@Column
+    }
     PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
-      if (memory.isEmpty()) {
-        Box(
-          Modifier
-            .fillMaxWidth()
-            .padding(20.dp),
-          contentAlignment = Alignment.Center,
-        ) {
-          Text(
-            "no memory written yet",
-            style = ClanWorldTheme.type.scriptItalic,
-            color = ClanWorldTheme.colors.warmFaint,
-          )
-        }
-      } else {
-        memory.take(10).forEach { entry ->
-          MemoryRow(
-            key = entry.key,
-            body = inlineCodeBody(entry.value),
-            stamp = "written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}",
-            modifier = Modifier.fillMaxWidth(),
-          )
-        }
+      memory.take(10).forEach { entry ->
+        MemoryRow(
+          key = entry.key,
+          body = inlineCodeBody(entry.value),
+          stamp = "written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}",
+          modifier = Modifier.fillMaxWidth(),
+        )
       }
     }
     if (onEditStrategy != null) {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -68,7 +68,7 @@ fun SteeringConsoleScreenRoute(
   onSent: () -> Unit,
 ) {
   val vm: SteeringConsoleViewModel =
-    viewModel(factory = SteeringConsoleViewModelFactory(initialClanId))
+    viewModel(factory = SteeringConsoleViewModelFactory(app, initialClanId))
   val state by vm.state.collectAsState()
   val scope = rememberCoroutineScope()
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
@@ -1,0 +1,375 @@
+package world.clan.app.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import world.clan.app.App
+import world.clan.app.R
+import world.clan.app.data.VaultMovement
+import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.theme.ClanWorldTheme
+import world.clan.app.ui.theme.Ink
+import world.clan.app.ui.theme.Ink2
+import world.clan.app.ui.theme.Ink3
+import world.clan.app.ui.theme.clanColor
+import world.clan.app.viewmodel.ResourceBalance
+import world.clan.app.viewmodel.TreasuryFilter
+import world.clan.app.viewmodel.TreasuryUiState
+import world.clan.app.viewmodel.TreasuryViewModel
+import world.clan.app.viewmodel.TreasuryViewModelFactory
+import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.viewmodel.filteredMovements
+
+@Composable
+fun TreasuryScreenRoute(
+  app: App,
+  clanId: Int,
+  onBack: () -> Unit,
+) {
+  val vm: TreasuryViewModel = viewModel(factory = TreasuryViewModelFactory(app, clanId))
+  val state by vm.state.collectAsState()
+  TreasuryScreen(
+    state = state,
+    clanId = clanId,
+    onBack = onBack,
+    onSetFilter = vm::setFilter,
+  )
+}
+
+@Composable
+private fun TreasuryScreen(
+  state: TreasuryUiState,
+  clanId: Int,
+  onBack: () -> Unit,
+  onSetFilter: (TreasuryFilter) -> Unit,
+) {
+  Column(modifier = Modifier.fillMaxSize()) {
+    BackBar(text = "back to ${clanDisplayName(clanId).lowercase()}", onBack = onBack)
+
+    Column(modifier = Modifier.padding(horizontal = 22.dp)) {
+      TreasuryHead(clanId = clanId, balance = state.balance)
+      Spacer(Modifier.height(14.dp))
+
+      if (state.isLoading) {
+        Text(
+          text = "the keep is being weighed…",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(top = 18.dp),
+        )
+      } else if (state.errorMessage != null) {
+        Text(
+          text = state.errorMessage,
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.danger,
+          modifier = Modifier.padding(top = 18.dp),
+        )
+      } else {
+        GoldHeroCard(gold = state.balance.gold, clanId = clanId)
+        Spacer(Modifier.height(12.dp))
+        ResourceStripCard(balance = state.balance)
+        Spacer(Modifier.height(18.dp))
+        Text(
+          text = "MOVEMENTS",
+          style = ClanWorldTheme.type.monoNano,
+          color = ClanWorldTheme.colors.warmFaint,
+        )
+        Spacer(Modifier.height(8.dp))
+        FilterRow(active = state.filter, onSelect = onSetFilter)
+        Spacer(Modifier.height(10.dp))
+      }
+    }
+
+    if (!state.isLoading && state.errorMessage == null) {
+      val items = state.filteredMovements()
+      if (items.isEmpty()) {
+        Text(
+          text = "the vault keeps its silence",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
+        )
+      } else {
+        LazyColumn(
+          modifier = Modifier.fillMaxSize(),
+          verticalArrangement = Arrangement.spacedBy(0.dp),
+          contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+        ) {
+          items(items.withIndex().toList(), key = { (i, m) -> "${i}-${m.tick}-${m.resource}" }) { (_, mv) ->
+            MovementRow(mv)
+          }
+          item { Spacer(Modifier.height(40.dp)) }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun BackBar(text: String, onBack: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 22.dp, vertical = 14.dp)
+      .clickable { onBack() },
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      painter = painterResource(R.drawable.ui_arrow),
+      contentDescription = "back",
+      tint = ClanWorldTheme.colors.warm,
+      modifier = Modifier.height(16.dp),
+    )
+    Text(
+      text = text,
+      style = ClanWorldTheme.type.monoMicro,
+      color = ClanWorldTheme.colors.warmDim,
+    )
+  }
+}
+
+@Composable
+private fun TreasuryHead(clanId: Int, balance: ResourceBalance) {
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val hairline = ClanWorldTheme.colors.hairline
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height + 14f),
+          end = Offset(size.width, size.height + 14f),
+          strokeWidth = 1f,
+        )
+      },
+    horizontalArrangement = Arrangement.SpaceBetween,
+    verticalAlignment = Alignment.Bottom,
+  ) {
+    Column {
+      Text(
+        text = "TREASURY",
+        style = ClanWorldTheme.type.displayHero,
+        color = parchment,
+      )
+      Text(
+        text = "the keeping of ${clanDisplayName(clanId).lowercase()}",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = warmDim,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+  }
+}
+
+@Composable
+private fun GoldHeroCard(gold: Long, clanId: Int) {
+  ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.SpaceBetween,
+      modifier = Modifier.fillMaxWidth(),
+    ) {
+      Column(modifier = Modifier.weight(1f)) {
+        Text(
+          text = "GOLD",
+          style = ClanWorldTheme.type.monoNano,
+          color = Ink3,
+        )
+        Text(
+          text = formatGold(gold),
+          style = ClanWorldTheme.type.displayHero,
+          color = Ink,
+          modifier = Modifier.padding(top = 4.dp),
+        )
+        Text(
+          text = "stored under ${clanDisplayName(clanId).lowercase()}",
+          style = ClanWorldTheme.type.scriptItalic,
+          color = Ink2,
+          modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+      // accent dot in clan color
+      Box(
+        modifier = Modifier
+          .padding(start = 8.dp)
+          .clip(RoundedCornerShape(50))
+          .background(clanColor(clanId))
+          .padding(8.dp),
+      ) {
+        Text(
+          text = " ",
+          style = ClanWorldTheme.type.monoNano,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun ResourceStripCard(balance: ResourceBalance) {
+  ParchmentCard(modifier = Modifier.fillMaxWidth()) {
+    Text(
+      text = "RESOURCES",
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Spacer(Modifier.height(10.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+      ResourceCell(label = "Wood", value = balance.wood)
+      ResourceCell(label = "Iron", value = balance.iron)
+      ResourceCell(label = "Wheat", value = balance.wheat)
+      ResourceCell(label = "Fish", value = balance.fish)
+    }
+  }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.ResourceCell(label: String, value: Long) {
+  Column(Modifier.weight(1f)) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoNano,
+      color = Ink3,
+    )
+    Text(
+      text = "%,d".format(value),
+      style = ClanWorldTheme.type.monoData,
+      color = Ink,
+      modifier = Modifier.padding(top = 2.dp),
+    )
+  }
+}
+
+@Composable
+private fun FilterRow(active: TreasuryFilter, onSelect: (TreasuryFilter) -> Unit) {
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    FilterChip(label = "All", selected = active == TreasuryFilter.All, onClick = { onSelect(TreasuryFilter.All) })
+    FilterChip(label = "Gold", selected = active == TreasuryFilter.Gold, onClick = { onSelect(TreasuryFilter.Gold) })
+    FilterChip(label = "Resources", selected = active == TreasuryFilter.Resources, onClick = { onSelect(TreasuryFilter.Resources) })
+  }
+}
+
+@Composable
+private fun FilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
+  val bg = if (selected) ClanWorldTheme.colors.iron2 else Color.Transparent
+  val border = if (selected) ClanWorldTheme.colors.hairlineStrong else ClanWorldTheme.colors.hairline
+  val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
+  Box(
+    modifier = Modifier
+      .clip(RoundedCornerShape(4.dp))
+      .background(bg)
+      .drawBehind {
+        drawRoundRect(
+          color = border,
+          cornerRadius = CornerRadius(4.dp.toPx()),
+          style = Stroke(width = 1.dp.toPx()),
+        )
+      }
+      .clickable { onClick() }
+      .padding(horizontal = 12.dp, vertical = 8.dp),
+  ) {
+    Text(
+      text = label.uppercase(),
+      style = ClanWorldTheme.type.monoMicro,
+      color = tint,
+    )
+  }
+}
+
+@Composable
+private fun MovementRow(mv: VaultMovement) {
+  val warm = ClanWorldTheme.colors.warm
+  val warmDim = ClanWorldTheme.colors.warmDim
+  val warmFaint = ClanWorldTheme.colors.warmFaint
+  val gold = ClanWorldTheme.colors.gold
+  val danger = ClanWorldTheme.colors.danger
+  val rune = ClanWorldTheme.colors.rune
+  val hairline = ClanWorldTheme.colors.hairline
+
+  val sign = if (mv.type == "spend") "−" else "+"
+  val amountColor = when (mv.type) {
+    "spend" -> danger
+    "transfer" -> rune
+    else -> gold
+  }
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .drawBehind {
+        drawLine(
+          color = hairline,
+          start = Offset(0f, size.height),
+          end = Offset(size.width, size.height),
+          strokeWidth = 1f,
+        )
+      }
+      .padding(vertical = 12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Text(
+      text = "T %04d".format(mv.tick),
+      style = ClanWorldTheme.type.monoNano,
+      color = warmFaint,
+      modifier = Modifier.padding(end = 4.dp),
+    )
+    Column(modifier = Modifier.weight(1f)) {
+      Text(
+        text = mv.resource.replaceFirstChar { it.uppercase() },
+        style = ClanWorldTheme.type.body,
+        color = warm,
+      )
+      mv.source?.takeIf { it.isNotBlank() }?.let { src ->
+        Text(
+          text = src,
+          style = ClanWorldTheme.type.monoNano,
+          color = warmDim,
+          modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+    }
+    Text(
+      text = "$sign%.2f".format(mv.amount),
+      style = ClanWorldTheme.type.monoData,
+      color = amountColor,
+    )
+  }
+}
+
+private fun formatGold(value: Long): String =
+  if (value >= 1_000_000) "%.1fM".format(value / 1_000_000.0)
+  else if (value >= 1_000) "%.1fk".format(value / 1_000.0)
+  else "%,d".format(value)

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
@@ -61,6 +61,7 @@ fun TreasuryScreenRoute(
     clanId = clanId,
     onBack = onBack,
     onSetFilter = vm::setFilter,
+    onRefresh = vm::refresh,
   )
 }
 
@@ -70,6 +71,7 @@ private fun TreasuryScreen(
   clanId: Int,
   onBack: () -> Unit,
   onSetFilter: (TreasuryFilter) -> Unit,
+  onRefresh: () -> Unit = {},
 ) {
   Column(modifier = Modifier.fillMaxSize()) {
     BackBar(text = "back to ${clanDisplayName(clanId).lowercase()}", onBack = onBack)
@@ -86,11 +88,9 @@ private fun TreasuryScreen(
           modifier = Modifier.padding(top = 18.dp),
         )
       } else if (state.errorMessage != null) {
-        Text(
-          text = state.errorMessage,
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.danger,
-          modifier = Modifier.padding(top = 18.dp),
+        world.clan.app.ui.components.RetryNotice(
+          message = state.errorMessage,
+          onRetry = onRefresh,
         )
       } else {
         GoldHeroCard(gold = state.balance.gold, clanId = clanId)
@@ -110,23 +110,33 @@ private fun TreasuryScreen(
 
     if (!state.isLoading && state.errorMessage == null) {
       val items = state.filteredMovements()
-      if (items.isEmpty()) {
-        Text(
-          text = "the vault keeps its silence",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-          modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
-        )
-      } else {
-        LazyColumn(
-          modifier = Modifier.fillMaxSize(),
-          verticalArrangement = Arrangement.spacedBy(0.dp),
-          contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
-        ) {
-          items(items.withIndex().toList(), key = { (i, m) -> "${i}-${m.tick}-${m.resource}" }) { (_, mv) ->
-            MovementRow(mv)
+      world.clan.app.ui.components.RefreshableContent(
+        isRefreshing = state.isLoading,
+        onRefresh = onRefresh,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        if (items.isEmpty()) {
+          LazyColumn(modifier = Modifier.fillMaxSize()) {
+            item {
+              Text(
+                text = "the vault keeps its silence",
+                style = ClanWorldTheme.type.scriptItalic,
+                color = ClanWorldTheme.colors.warmFaint,
+                modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
+              )
+            }
           }
-          item { Spacer(Modifier.height(40.dp)) }
+        } else {
+          LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(0.dp),
+            contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+          ) {
+            items(items.withIndex().toList(), key = { (i, m) -> "${i}-${m.tick}-${m.resource}" }) { (_, mv) ->
+              MovementRow(mv)
+            }
+            item { Spacer(Modifier.height(40.dp)) }
+          }
         }
       }
     }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
@@ -81,12 +81,11 @@ private fun TreasuryScreen(
       Spacer(Modifier.height(14.dp))
 
       if (state.isLoading) {
-        Text(
-          text = "the keep is being weighed…",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-          modifier = Modifier.padding(top = 18.dp),
-        )
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+          world.clan.app.ui.components.SkeletonTreasuryHero()
+          Spacer(Modifier.height(2.dp))
+          repeat(5) { world.clan.app.ui.components.SkeletonMovementRow() }
+        }
       } else if (state.errorMessage != null) {
         world.clan.app.ui.components.RetryNotice(
           message = state.errorMessage,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -95,12 +95,12 @@ private fun WhispersScreen(
     val items = state.filtered()
     when {
       state.isLoading -> {
-        Text(
-          text = "the whispers gather…",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
-        )
+        Column(
+          modifier = Modifier.padding(horizontal = 22.dp, vertical = 8.dp),
+          verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+          repeat(5) { world.clan.app.ui.components.SkeletonWhisperRow() }
+        }
       }
       state.errorMessage != null && items.isEmpty() -> {
         world.clan.app.ui.components.RetryNotice(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -117,11 +117,13 @@ private fun WhispersScreen(
           if (items.isEmpty()) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
               item {
-                Text(
-                  text = "no whispers carry this kind.",
-                  style = ClanWorldTheme.type.scriptItalic,
-                  color = ClanWorldTheme.colors.warmFaint,
-                  modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+                val isFiltered = state.filter != WhispersFilter.All
+                world.clan.app.ui.components.EmptyState(
+                  title = if (isFiltered) "no whispers carry this kind" else "the inbox is silent",
+                  body = if (isFiltered) "try another filter, or compose one yourself."
+                  else "no whispers heard yet — be the first to speak.",
+                  ctaLabel = if (isFiltered) null else "+ New whisper",
+                  onCta = if (isFiltered) null else onCompose,
                 )
               }
             }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -58,6 +58,7 @@ fun WhispersScreenRoute(
     onBack = onBack,
     onSetFilter = vm::setFilter,
     onCompose = onCompose,
+    onRefresh = vm::refresh,
   )
 }
 
@@ -68,6 +69,7 @@ private fun WhispersScreen(
   onBack: () -> Unit,
   onSetFilter: (WhispersFilter) -> Unit,
   onCompose: () -> Unit = {},
+  onRefresh: () -> Unit = {},
 ) {
   Column(modifier = Modifier.fillMaxSize()) {
     InboxBackBar(clanId = clanId, onBack = onBack)
@@ -100,30 +102,39 @@ private fun WhispersScreen(
           modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
         )
       }
-      state.errorMessage != null -> {
-        Text(
-          text = state.errorMessage,
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.danger,
-          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
-        )
-      }
-      items.isEmpty() -> {
-        Text(
-          text = "no whispers carry this kind.",
-          style = ClanWorldTheme.type.scriptItalic,
-          color = ClanWorldTheme.colors.warmFaint,
-          modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+      state.errorMessage != null && items.isEmpty() -> {
+        world.clan.app.ui.components.RetryNotice(
+          message = state.errorMessage,
+          onRetry = onRefresh,
         )
       }
       else -> {
-        LazyColumn(
+        world.clan.app.ui.components.RefreshableContent(
+          isRefreshing = state.isLoading,
+          onRefresh = onRefresh,
           modifier = Modifier.fillMaxSize(),
-          verticalArrangement = Arrangement.spacedBy(10.dp),
-          contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
         ) {
-          items(items.withIndex().toList(), key = { (i, c) -> "${i}-${c.tick ?: c.timestamp ?: 0}" }) { (_, c) ->
-            InboxRow(comm = c)
+          if (items.isEmpty()) {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+              item {
+                Text(
+                  text = "no whispers carry this kind.",
+                  style = ClanWorldTheme.type.scriptItalic,
+                  color = ClanWorldTheme.colors.warmFaint,
+                  modifier = Modifier.padding(horizontal = 22.dp, vertical = 24.dp),
+                )
+              }
+            }
+          } else {
+            LazyColumn(
+              modifier = Modifier.fillMaxSize(),
+              verticalArrangement = Arrangement.spacedBy(10.dp),
+              contentPadding = PaddingValues(horizontal = 22.dp, vertical = 4.dp),
+            ) {
+              items(items.withIndex().toList(), key = { (i, c) -> "${i}-${c.tick ?: c.timestamp ?: 0}" }) { (_, c) ->
+                InboxRow(comm = c)
+              }
+            }
           }
         }
       }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/BazaarViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/BazaarViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import world.clan.app.data.BAZAAR_LISTINGS
 import world.clan.app.data.BazaarListing
+import world.clan.app.data.SessionStore
 
 data class BazaarUiState(
   val isLoading: Boolean = false,
@@ -14,15 +16,24 @@ data class BazaarUiState(
 )
 
 /**
- * Slice 4: Bazaar viewmodel. The listings are a static demo list; no Convex
- * marketplace query exists yet. ViewModel still exists so that the screen
- * can subscribe through StateFlow like every other screen — when a real
- * listings query lands, only this file changes.
+ * Bazaar viewmodel. Listings are a static demo set; no Convex marketplace
+ * query exists yet. Filters out clans already hired (so a hired sigil
+ * can't be hired again in the same install).
  */
-class BazaarViewModel : ViewModel() {
+class BazaarViewModel(
+  private val sessionStore: SessionStore? = null,
+) : ViewModel() {
 
-  private val _state = MutableStateFlow(
-    BazaarUiState(listings = BAZAAR_LISTINGS),
-  )
+  private val _state = MutableStateFlow(BazaarUiState(listings = currentListings()))
   val state: StateFlow<BazaarUiState> = _state.asStateFlow()
+
+  /** Re-read hired set + reapply filter — call when re-entering the screen. */
+  fun refresh() {
+    _state.update { it.copy(listings = currentListings()) }
+  }
+
+  private fun currentListings(): List<BazaarListing> {
+    val hired = sessionStore?.getHiredClanIds().orEmpty()
+    return BAZAAR_LISTINGS.filter { it.clanId !in hired }
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -15,7 +15,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
     BazaarViewModel::class.java -> BazaarViewModel()
-    ForgeViewModel::class.java -> ForgeViewModel()
+    ForgeViewModel::class.java -> ForgeViewModel(app.sessionStore)
     CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")
   } as T
@@ -43,11 +43,12 @@ class WhispersViewModelFactory(
 
 /** Per-route factory for SteeringConsole, parameterized by the initial target clan. */
 class SteeringConsoleViewModelFactory(
+  private val app: App,
   private val initialClanId: Int,
 ) : ViewModelProvider.Factory {
   @Suppress("UNCHECKED_CAST")
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
-    SteeringConsoleViewModel(initialClanId) as T
+    SteeringConsoleViewModel(initialClanId, app.sessionStore) as T
 }
 
 /** Per-route factory for StrategyEditor, parameterized by clanId. */
@@ -57,7 +58,7 @@ class StrategyEditorViewModelFactory(
 ) : ViewModelProvider.Factory {
   @Suppress("UNCHECKED_CAST")
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
-    StrategyEditorViewModel(app.convexClient, clanId) as T
+    StrategyEditorViewModel(app.convexClient, clanId, app.sessionStore) as T
 }
 
 /** Per-route factory for Treasury, parameterized by clanId. */

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -58,3 +58,13 @@ class StrategyEditorViewModelFactory(
   override fun <T : ViewModel> create(modelClass: Class<T>): T =
     StrategyEditorViewModel(app.convexClient, clanId) as T
 }
+
+/** Per-route factory for Treasury, parameterized by clanId. */
+class TreasuryViewModelFactory(
+  private val app: App,
+  private val clanId: Int,
+) : ViewModelProvider.Factory {
+  @Suppress("UNCHECKED_CAST")
+  override fun <T : ViewModel> create(modelClass: Class<T>): T =
+    TreasuryViewModel(app.convexClient, clanId) as T
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -14,7 +14,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     ConnectViewModel::class.java -> ConnectViewModel(app.mwaClient, app.sessionStore)
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
-    BazaarViewModel::class.java -> BazaarViewModel()
+    BazaarViewModel::class.java -> BazaarViewModel(app.sessionStore)
     ForgeViewModel::class.java -> ForgeViewModel(app.sessionStore)
     CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.lineageStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -16,7 +16,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
     BazaarViewModel::class.java -> BazaarViewModel()
     ForgeViewModel::class.java -> ForgeViewModel(app.sessionStore)
-    CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.deviceClass)
+    CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.lineageStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")
   } as T
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -15,6 +15,7 @@ class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factor
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
     BazaarViewModel::class.java -> BazaarViewModel()
+    ForgeViewModel::class.java -> ForgeViewModel()
     CodexViewModel::class.java -> CodexViewModel(app.sessionStore, app.deviceClass)
     else -> error("Unknown ViewModel: ${modelClass.simpleName}")
   } as T

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -68,4 +68,21 @@ class CodexViewModel(
     sessionStore.clear()
     _state.value = _state.value.copy(solanaPubkey = null, walletLabel = null)
   }
+
+  /**
+   * Wipe demo-only state and reload the screen. Useful for repeat demos
+   * on the same device — restores Hall to LINKED_CLAN_IDS, empties
+   * Lineage, re-enables disabled Forge clans, re-shows the onboarding
+   * coachmark.
+   */
+  fun resetDemoState() {
+    sessionStore.resetDemoState()
+    lineageStore.clear()
+    val owned = HearthViewModel.LINKED_CLAN_IDS.distinct()
+    _state.value = _state.value.copy(
+      lineage = emptyList(),
+      linkedClansCount = owned.size,
+      linkedClanIds = owned,
+    )
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import world.clan.app.BuildConfig
+import world.clan.app.data.LineageEntry
+import world.clan.app.data.LineageStore
 import world.clan.app.data.SessionStore
 import world.clan.app.wallet.DeviceClass
 
@@ -17,14 +19,16 @@ data class CodexUiState(
   val linkedClansCount: Int,
   val linkedClanIds: List<Int>,
   val apkShareUrl: String,
+  val lineage: List<LineageEntry> = emptyList(),
 )
 
 /**
- * Codex — read-only identity / device / about summary. Powered by
- * BuildConfig + SessionStore.
+ * Codex — read-only identity / device / about / lineage summary. Powered
+ * by BuildConfig + SessionStore + LineageStore.
  */
 class CodexViewModel(
   private val sessionStore: SessionStore,
+  private val lineageStore: LineageStore,
   deviceClass: DeviceClass,
 ) : ViewModel() {
 
@@ -40,10 +44,16 @@ class CodexViewModel(
         linkedClansCount = HearthViewModel.LINKED_CLAN_IDS.size,
         linkedClanIds = HearthViewModel.LINKED_CLAN_IDS,
         apkShareUrl = "https://shared.claude.do/public/clanworld-mobile-slice-1.apk",
+        lineage = lineageStore.read(),
       )
     },
   )
   val state: StateFlow<CodexUiState> = _state.asStateFlow()
+
+  /** Re-read lineage when the screen is re-entered after a successful sign. */
+  fun refreshLineage() {
+    _state.value = _state.value.copy(lineage = lineageStore.read())
+  }
 
   fun disconnect() {
     sessionStore.clear()

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -35,7 +35,7 @@ class CodexViewModel(
   private val _state = MutableStateFlow(
     run {
       val s = sessionStore.read()
-      val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+      val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).distinct()
       CodexUiState(
         deviceClass = deviceClass,
         solanaPubkey = s?.solanaPubkeyBase58,
@@ -56,7 +56,7 @@ class CodexViewModel(
    * and freshly-hired sigils appear in Codex without an app kill.
    */
   fun refreshLineage() {
-    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).distinct()
     _state.value = _state.value.copy(
       lineage = lineageStore.read(),
       linkedClansCount = owned.size,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -35,14 +35,15 @@ class CodexViewModel(
   private val _state = MutableStateFlow(
     run {
       val s = sessionStore.read()
+      val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
       CodexUiState(
         deviceClass = deviceClass,
         solanaPubkey = s?.solanaPubkeyBase58,
         walletLabel = s?.walletLabel,
         build = "v ${BuildConfig.VERSION_NAME} · build ${BuildConfig.VERSION_CODE}",
         convexUrl = BuildConfig.CONVEX_URL,
-        linkedClansCount = HearthViewModel.LINKED_CLAN_IDS.size,
-        linkedClanIds = HearthViewModel.LINKED_CLAN_IDS,
+        linkedClansCount = owned.size,
+        linkedClanIds = owned,
         apkShareUrl = "https://shared.claude.do/public/clanworld-mobile-slice-1.apk",
         lineage = lineageStore.read(),
       )
@@ -50,9 +51,17 @@ class CodexViewModel(
   )
   val state: StateFlow<CodexUiState> = _state.asStateFlow()
 
-  /** Re-read lineage when the screen is re-entered after a successful sign. */
+  /**
+   * Re-read lineage + hired clans on (re-)entry so newly-signed actions
+   * and freshly-hired sigils appear in Codex without an app kill.
+   */
   fun refreshLineage() {
-    _state.value = _state.value.copy(lineage = lineageStore.read())
+    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+    _state.value = _state.value.copy(
+      lineage = lineageStore.read(),
+      linkedClansCount = owned.size,
+      linkedClanIds = owned,
+    )
   }
 
   fun disconnect() {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -4,19 +4,24 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import world.clan.app.BuildConfig
 import world.clan.app.data.SessionStore
 import world.clan.app.wallet.DeviceClass
 
 data class CodexUiState(
   val deviceClass: DeviceClass,
   val solanaPubkey: String?,
+  val walletLabel: String?,
   val build: String,
+  val convexUrl: String,
+  val linkedClansCount: Int,
+  val linkedClanIds: List<Int>,
+  val apkShareUrl: String,
 )
 
 /**
- * Slice 1 Codex screen — read-only summary of identity + device + about.
- * No EVM paste, no profile selector, no validation. The Solana pubkey is
- * the only identifier this app cares about.
+ * Codex — read-only identity / device / about summary. Powered by
+ * BuildConfig + SessionStore.
  */
 class CodexViewModel(
   private val sessionStore: SessionStore,
@@ -24,16 +29,24 @@ class CodexViewModel(
 ) : ViewModel() {
 
   private val _state = MutableStateFlow(
-    CodexUiState(
-      deviceClass = deviceClass,
-      solanaPubkey = sessionStore.read()?.solanaPubkeyBase58,
-      build = "v 0.1.0 · slice I",
-    ),
+    run {
+      val s = sessionStore.read()
+      CodexUiState(
+        deviceClass = deviceClass,
+        solanaPubkey = s?.solanaPubkeyBase58,
+        walletLabel = s?.walletLabel,
+        build = "v ${BuildConfig.VERSION_NAME} · build ${BuildConfig.VERSION_CODE}",
+        convexUrl = BuildConfig.CONVEX_URL,
+        linkedClansCount = HearthViewModel.LINKED_CLAN_IDS.size,
+        linkedClanIds = HearthViewModel.LINKED_CLAN_IDS,
+        apkShareUrl = "https://shared.claude.do/public/clanworld-mobile-slice-1.apk",
+      )
+    },
   )
   val state: StateFlow<CodexUiState> = _state.asStateFlow()
 
   fun disconnect() {
     sessionStore.clear()
-    _state.value = _state.value.copy(solanaPubkey = null)
+    _state.value = _state.value.copy(solanaPubkey = null, walletLabel = null)
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import world.clan.app.data.SessionStore
 
 enum class ForgeStep { PickClan, NameSigil, PickHarness, Confirm }
 
@@ -35,14 +36,41 @@ data class ForgeUiState(
  * No real on-chain mint exists. The MWA sign at the end is the seam —
  * a future on-chain mint replaces only the screen-level send call.
  */
-class ForgeViewModel : ViewModel() {
+class ForgeViewModel(
+  private val sessionStore: SessionStore? = null,
+) : ViewModel() {
 
-  private val _state = MutableStateFlow(ForgeUiState())
+  private val draftScope = "forge"
+
+  private val _state = MutableStateFlow(initial())
   val state: StateFlow<ForgeUiState> = _state.asStateFlow()
 
-  fun setClanId(clanId: Int) = _state.update { it.copy(clanId = clanId) }
-  fun setSigilName(name: String) = _state.update { it.copy(sigilName = name.take(32)) }
-  fun setHarness(h: Harness) = _state.update { it.copy(harness = h) }
+  private fun initial(): ForgeUiState {
+    val draftClan = sessionStore?.getDraft(draftScope, "clanId")?.toIntOrNull()
+    val draftName = sessionStore?.getDraft(draftScope, "sigilName").orEmpty()
+    val draftHarness = sessionStore?.getDraft(draftScope, "harness")
+      ?.let { runCatching { Harness.valueOf(it) }.getOrNull() }
+      ?: Harness.Tide
+    return ForgeUiState(
+      clanId = draftClan,
+      sigilName = draftName,
+      harness = draftHarness,
+    )
+  }
+
+  fun setClanId(clanId: Int) {
+    _state.update { it.copy(clanId = clanId) }
+    sessionStore?.setDraft(draftScope, "clanId", clanId.toString())
+  }
+  fun setSigilName(name: String) {
+    val capped = name.take(32)
+    _state.update { it.copy(sigilName = capped) }
+    sessionStore?.setDraft(draftScope, "sigilName", capped)
+  }
+  fun setHarness(h: Harness) {
+    _state.update { it.copy(harness = h) }
+    sessionStore?.setDraft(draftScope, "harness", h.name)
+  }
 
   fun goTo(step: ForgeStep) = _state.update { it.copy(step = step) }
 
@@ -66,6 +94,8 @@ class ForgeViewModel : ViewModel() {
     it.copy(step = prv)
   }
 
-  fun setMintPhase(phase: SendPhase, error: String? = null) =
+  fun setMintPhase(phase: SendPhase, error: String? = null) {
     _state.update { it.copy(mintPhase = phase, errorMessage = error) }
+    if (phase == SendPhase.Queued) sessionStore?.clearDrafts(draftScope)
+  }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
@@ -1,0 +1,71 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+enum class ForgeStep { PickClan, NameSigil, PickHarness, Confirm }
+
+/**
+ * Themed harness choices for a freshly forged sigil.
+ *  - Iron   → defensive bias
+ *  - Tide   → balanced bias
+ *  - Ember  → aggressive bias
+ */
+enum class Harness(val display: String, val tagline: String) {
+  Iron("Iron", "hold the line; trade no ground without weight"),
+  Tide("Tide", "read the strait; move when both shores agree"),
+  Ember("Ember", "forge ahead; the season favors the bold"),
+}
+
+data class ForgeUiState(
+  val step: ForgeStep = ForgeStep.PickClan,
+  val clanId: Int? = null,
+  val sigilName: String = "",
+  val harness: Harness = Harness.Tide,
+  val mintPhase: SendPhase = SendPhase.Idle,
+  val errorMessage: String? = null,
+)
+
+/**
+ * Slice 6: Forge. Four-step mint wizard.
+ *
+ * No real on-chain mint exists. The MWA sign at the end is the seam —
+ * a future on-chain mint replaces only the screen-level send call.
+ */
+class ForgeViewModel : ViewModel() {
+
+  private val _state = MutableStateFlow(ForgeUiState())
+  val state: StateFlow<ForgeUiState> = _state.asStateFlow()
+
+  fun setClanId(clanId: Int) = _state.update { it.copy(clanId = clanId) }
+  fun setSigilName(name: String) = _state.update { it.copy(sigilName = name.take(32)) }
+  fun setHarness(h: Harness) = _state.update { it.copy(harness = h) }
+
+  fun goTo(step: ForgeStep) = _state.update { it.copy(step = step) }
+
+  fun next() = _state.update {
+    val nxt = when (it.step) {
+      ForgeStep.PickClan -> ForgeStep.NameSigil
+      ForgeStep.NameSigil -> ForgeStep.PickHarness
+      ForgeStep.PickHarness -> ForgeStep.Confirm
+      ForgeStep.Confirm -> ForgeStep.Confirm
+    }
+    it.copy(step = nxt)
+  }
+
+  fun back() = _state.update {
+    val prv = when (it.step) {
+      ForgeStep.PickClan -> ForgeStep.PickClan
+      ForgeStep.NameSigil -> ForgeStep.PickClan
+      ForgeStep.PickHarness -> ForgeStep.NameSigil
+      ForgeStep.Confirm -> ForgeStep.PickHarness
+    }
+    it.copy(step = prv)
+  }
+
+  fun setMintPhase(phase: SendPhase, error: String? = null) =
+    _state.update { it.copy(mintPhase = phase, errorMessage = error) }
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ForgeViewModel.kt
@@ -28,6 +28,8 @@ data class ForgeUiState(
   val harness: Harness = Harness.Tide,
   val mintPhase: SendPhase = SendPhase.Idle,
   val errorMessage: String? = null,
+  /** Clans the user already owns — disabled in step 1 (PickClan). */
+  val ownedClanIds: Set<Int> = emptySet(),
 )
 
 /**
@@ -51,14 +53,22 @@ class ForgeViewModel(
     val draftHarness = sessionStore?.getDraft(draftScope, "harness")
       ?.let { runCatching { Harness.valueOf(it) }.getOrNull() }
       ?: Harness.Tide
+    val owned = (HearthViewModel.LINKED_CLAN_IDS + sessionStore?.getOwnedClanIdsExtra().orEmpty()).toSet()
+    // If the persisted draftClan was a clan you've since acquired, drop
+    // it so step 1 doesn't preselect a now-disabled card.
+    val safeClanId = draftClan?.takeIf { it !in owned }
     return ForgeUiState(
-      clanId = draftClan,
+      clanId = safeClanId,
       sigilName = draftName,
       harness = draftHarness,
+      ownedClanIds = owned,
     )
   }
 
   fun setClanId(clanId: Int) {
+    // Defensive: ignore taps on already-owned clans (step 1 should already
+    // tap-disable them, but the VM is the source of truth).
+    if (clanId in _state.value.ownedClanIds) return
     _state.update { it.copy(clanId = clanId) }
     sessionStore?.setDraft(draftScope, "clanId", clanId.toString())
   }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
@@ -62,7 +62,7 @@ class HallViewModel(
   fun refresh() {
     viewModelScope.launch {
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
-      val ownedClanIds = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
+      val ownedClanIds = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).distinct()
       runCatching {
         coroutineScope {
           ownedClanIds

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
@@ -28,6 +28,8 @@ data class HallUiState(
 /**
  * Aggregated card data for one iNFT in the Hall list.
  */
+enum class HallProvenance { Linked, Hired, Forged }
+
 data class HallCard(
   val tokenId: Int,
   val clanId: Int,
@@ -35,6 +37,7 @@ data class HallCard(
   val memoryCount: Int,
   val sealedAtTick: Long?,
   val mostRecentTransferTick: Long?,
+  val provenance: HallProvenance = HallProvenance.Linked,
 )
 
 /**
@@ -62,7 +65,9 @@ class HallViewModel(
   fun refresh() {
     viewModelScope.launch {
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
-      val ownedClanIds = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).distinct()
+      val hired = sessionStore.getHiredClanIds()
+      val forged = sessionStore.getForgedClanIds()
+      val ownedClanIds = (HearthViewModel.LINKED_CLAN_IDS + hired + forged).distinct()
       runCatching {
         coroutineScope {
           ownedClanIds
@@ -70,7 +75,16 @@ class HallViewModel(
             .awaitAll()
         }
       }.onSuccess { results ->
-        val cards = results.mapNotNull { (demo, clanId) -> demo?.let { toCard(clanId, it) } }
+        val cards = results.mapNotNull { (demo, clanId) ->
+          demo?.let {
+            val provenance = when {
+              clanId in forged -> HallProvenance.Forged
+              clanId in hired -> HallProvenance.Hired
+              else -> HallProvenance.Linked
+            }
+            toCard(clanId, it, provenance)
+          }
+        }
         _state.update {
           it.copy(
             isLoading = false,
@@ -91,7 +105,11 @@ class HallViewModel(
     }
   }
 
-  private fun toCard(clanId: Int, demo: InftDemoState): HallCard {
+  private fun toCard(
+    clanId: Int,
+    demo: InftDemoState,
+    provenance: HallProvenance = HallProvenance.Linked,
+  ): HallCard {
     return HallCard(
       tokenId = demo.token?.tokenId ?: clanId,
       clanId = clanId,
@@ -99,6 +117,7 @@ class HallViewModel(
       memoryCount = demo.memory.size,
       sealedAtTick = demo.transfers.minOfOrNull { it.transferredAt ?: 0L }?.takeIf { it > 0 },
       mostRecentTransferTick = demo.transfers.maxOfOrNull { it.transferredAt ?: 0L }?.takeIf { it > 0 },
+      provenance = provenance,
     )
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
@@ -46,15 +46,15 @@ data class HallCard(
  */
 class HallViewModel(
   private val convex: ClanWorldConvexClient,
-  sessionStore: SessionStore,
+  private val sessionStore: SessionStore,
 ) : ViewModel() {
 
-  private val _state = MutableStateFlow(initial(sessionStore))
+  private val _state = MutableStateFlow(initial())
   val state: StateFlow<HallUiState> = _state.asStateFlow()
 
   init { refresh() }
 
-  private fun initial(sessionStore: SessionStore): HallUiState {
+  private fun initial(): HallUiState {
     val s = sessionStore.read()
     return HallUiState(walletShort = s?.solanaPubkeyBase58?.shortenPubkey().orEmpty())
   }
@@ -62,9 +62,10 @@ class HallViewModel(
   fun refresh() {
     viewModelScope.launch {
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
+      val ownedClanIds = (HearthViewModel.LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).distinct()
       runCatching {
         coroutineScope {
-          HearthViewModel.LINKED_CLAN_IDS
+          ownedClanIds
             .map { clanId -> async { runCatching { convex.getInftDemoState(clanId) }.getOrNull() to clanId } }
             .awaitAll()
         }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -58,7 +58,7 @@ class HearthViewModel(
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
       val session = sessionStore.read()
       val selectedClan = session?.selectedClanId ?: DEFAULT_LINKED_CLAN
-      val ownedClanIds = (LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).toSet()
+      val ownedClanIds = (LINKED_CLAN_IDS + sessionStore.getOwnedClanIdsExtra()).toSet()
       runCatching {
         val snap = convex.getSnapshot()
         val comms = runCatching { convex.getCombinedComms(selectedClan, limit = 3) }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -58,6 +58,7 @@ class HearthViewModel(
       _state.update { it.copy(isRefreshing = true, errorMessage = null) }
       val session = sessionStore.read()
       val selectedClan = session?.selectedClanId ?: DEFAULT_LINKED_CLAN
+      val ownedClanIds = (LINKED_CLAN_IDS + sessionStore.getHiredClanIds()).toSet()
       runCatching {
         val snap = convex.getSnapshot()
         val comms = runCatching { convex.getCombinedComms(selectedClan, limit = 3) }
@@ -65,7 +66,7 @@ class HearthViewModel(
         snap to comms
       }.onSuccess { (snap, comms) ->
         _state.update { _ ->
-          project(snap, selectedClan, comms, session?.solanaPubkeyBase58.orEmpty())
+          project(snap, selectedClan, comms, session?.solanaPubkeyBase58.orEmpty(), ownedClanIds)
         }
       }.onFailure { e ->
         _state.update {
@@ -84,6 +85,7 @@ class HearthViewModel(
     selectedClanId: Int,
     comms: List<CombinedComm>,
     solanaPubkey: String,
+    ownedClanIds: Set<Int>,
   ): HearthUiState {
     // Sort clans by goldBalance (wei → whole), descending. Empty / null
     // gold goes last.
@@ -103,7 +105,7 @@ class HearthViewModel(
         tagline = clanTagline(p.clanId),
         gold = p.gold,
         delta = 0L, // no delta data in snapshot — keep at 0 for v0; UI shows "—"
-        isMine = LINKED_CLAN_IDS.contains(p.clanId),
+        isMine = ownedClanIds.contains(p.clanId),
       )
     }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/SteeringConsoleViewModel.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import world.clan.app.data.SessionStore
 
 enum class SendPhase { Idle, Signing, Queued, Failed }
 
@@ -19,21 +20,31 @@ data class SteeringConsoleUiState(
  * Slice 4c: SteeringConsole. The owner's whisper composer — drafts a
  * single-line steering message addressed to one of their elders.
  *
+ * Drafts are persisted through process death via SessionStore (key
+ * "draft:steer:<clanId>"); cleared on successful submit (Queued phase).
+ *
  * No real Convex mutation exists yet (per BUILD_PLAN — whisper send
  * needs a backend mutation that doesn't exist). This view-model holds
  * draft state; the screen handles the MWA sign + the (stubbed) send.
  */
 class SteeringConsoleViewModel(
   initialClanId: Int,
+  private val sessionStore: SessionStore? = null,
 ) : ViewModel() {
 
+  private val draftScope = "steer:$initialClanId"
+
   private val _state = MutableStateFlow(
-    SteeringConsoleUiState(targetClanId = initialClanId),
+    SteeringConsoleUiState(
+      targetClanId = initialClanId,
+      draft = sessionStore?.getDraft(draftScope, "body").orEmpty(),
+    ),
   )
   val state: StateFlow<SteeringConsoleUiState> = _state.asStateFlow()
 
   fun setDraft(text: String) {
     _state.update { it.copy(draft = text) }
+    sessionStore?.setDraft(draftScope, "body", text)
   }
 
   fun setTarget(clanId: Int) {
@@ -42,5 +53,6 @@ class SteeringConsoleViewModel(
 
   fun setPhase(p: SendPhase, error: String? = null) {
     _state.update { it.copy(phase = p, errorMessage = error) }
+    if (p == SendPhase.Queued) sessionStore?.clearDrafts(draftScope)
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/StrategyEditorViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/StrategyEditorViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import world.clan.app.data.ClanWorldConvexClient
+import world.clan.app.data.SessionStore
 
 enum class Posture { Defensive, Balanced, Aggressive }
 
@@ -33,7 +34,10 @@ data class StrategyEditorUiState(
 class StrategyEditorViewModel(
   private val convex: ClanWorldConvexClient,
   clanId: Int,
+  private val sessionStore: SessionStore? = null,
 ) : ViewModel() {
+
+  private val draftScope = "strategy:$clanId"
 
   private val _state = MutableStateFlow(StrategyEditorUiState(clanId = clanId))
   val state: StateFlow<StrategyEditorUiState> = _state.asStateFlow()
@@ -42,14 +46,20 @@ class StrategyEditorViewModel(
 
   private fun hydrate(clanId: Int) {
     viewModelScope.launch {
+      val draftDoctrine = sessionStore?.getDraft(draftScope, "doctrine")
+      val draftPinned = sessionStore?.getDraft(draftScope, "pinnedKey")
+      val draftPosture = sessionStore?.getDraft(draftScope, "posture")
+        ?.let { runCatching { Posture.valueOf(it) }.getOrNull() }
+
       runCatching { convex.getInftDemoState(clanId) }
         .onSuccess { demo ->
           val firstMem = demo.memory.firstOrNull()
           _state.update {
             it.copy(
               isLoading = false,
-              doctrine = firstMem?.value?.take(180) ?: defaultDoctrine(clanId),
-              pinnedKey = firstMem?.key ?: "policy:default",
+              doctrine = draftDoctrine ?: firstMem?.value?.take(180) ?: defaultDoctrine(clanId),
+              pinnedKey = draftPinned ?: firstMem?.key ?: "policy:default",
+              posture = draftPosture ?: it.posture,
             )
           }
         }
@@ -57,19 +67,33 @@ class StrategyEditorViewModel(
           _state.update {
             it.copy(
               isLoading = false,
-              doctrine = defaultDoctrine(clanId),
-              pinnedKey = "policy:default",
+              doctrine = draftDoctrine ?: defaultDoctrine(clanId),
+              pinnedKey = draftPinned ?: "policy:default",
+              posture = draftPosture ?: it.posture,
             )
           }
         }
     }
   }
 
-  fun setPosture(p: Posture) = _state.update { it.copy(posture = p) }
-  fun setDoctrine(text: String) = _state.update { it.copy(doctrine = text.take(280)) }
-  fun setPinnedKey(text: String) = _state.update { it.copy(pinnedKey = text.take(64)) }
-  fun setSavePhase(phase: SendPhase, error: String? = null) =
+  fun setPosture(p: Posture) {
+    _state.update { it.copy(posture = p) }
+    sessionStore?.setDraft(draftScope, "posture", p.name)
+  }
+  fun setDoctrine(text: String) {
+    val capped = text.take(280)
+    _state.update { it.copy(doctrine = capped) }
+    sessionStore?.setDraft(draftScope, "doctrine", capped)
+  }
+  fun setPinnedKey(text: String) {
+    val capped = text.take(64)
+    _state.update { it.copy(pinnedKey = capped) }
+    sessionStore?.setDraft(draftScope, "pinnedKey", capped)
+  }
+  fun setSavePhase(phase: SendPhase, error: String? = null) {
     _state.update { it.copy(savePhase = phase, errorMessage = error) }
+    if (phase == SendPhase.Queued) sessionStore?.clearDrafts(draftScope)
+  }
 
   private fun defaultDoctrine(clanId: Int): String = when (clanId) {
     1 -> "Hold the high pass. Trade no ground without iron."

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
@@ -1,0 +1,107 @@
+package world.clan.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import world.clan.app.data.ClanWorldConvexClient
+import world.clan.app.data.VaultMovement
+import world.clan.app.data.weiToWhole
+
+enum class TreasuryFilter { All, Gold, Resources }
+
+data class ResourceBalance(
+  val gold: Long,
+  val wood: Long,
+  val iron: Long,
+  val wheat: Long,
+  val fish: Long,
+)
+
+data class TreasuryUiState(
+  val isLoading: Boolean = true,
+  val clanId: Int,
+  val balance: ResourceBalance = ResourceBalance(0, 0, 0, 0, 0),
+  val movements: List<VaultMovement> = emptyList(),
+  val filter: TreasuryFilter = TreasuryFilter.All,
+  val errorMessage: String? = null,
+)
+
+/**
+ * Slice 5: per-clan Treasury.
+ *
+ * Aggregates two existing queries in parallel:
+ *   - getSnapshot — to read goldBalance / vaultWood / vaultIron / etc for THIS clan
+ *   - getVaultMovements — recent gains/spends/transfers
+ *
+ * Wei-precision balances (`String?` → `Long`) parsed via existing weiToWhole().
+ * Filtering is client-side over `movements`.
+ */
+class TreasuryViewModel(
+  private val convex: ClanWorldConvexClient,
+  private val clanId: Int,
+) : ViewModel() {
+
+  private val _state = MutableStateFlow(TreasuryUiState(clanId = clanId))
+  val state: StateFlow<TreasuryUiState> = _state.asStateFlow()
+
+  init { refresh() }
+
+  fun refresh() {
+    viewModelScope.launch {
+      _state.update { it.copy(isLoading = true, errorMessage = null) }
+      runCatching {
+        coroutineScope {
+          val snap = async { convex.getSnapshot() }
+          val moves = async {
+            runCatching { convex.getVaultMovements(clanId, limit = 24) }
+              .getOrDefault(emptyList())
+          }
+          snap.await() to moves.await()
+        }
+      }
+        .onSuccess { (snapshot, moves) ->
+          val mine = snapshot.clans.firstOrNull { it.id.toIntOrNull() == clanId }
+          val bal = if (mine == null) ResourceBalance(0, 0, 0, 0, 0)
+          else ResourceBalance(
+            gold = mine.goldBalance.weiToWhole(),
+            wood = mine.vaultWood.weiToWhole(),
+            iron = mine.vaultIron.weiToWhole(),
+            wheat = mine.vaultWheat.weiToWhole(),
+            fish = mine.vaultFish.weiToWhole(),
+          )
+          _state.update {
+            it.copy(
+              isLoading = false,
+              balance = bal,
+              movements = moves,
+              errorMessage = null,
+            )
+          }
+        }
+        .onFailure { e ->
+          _state.update {
+            it.copy(
+              isLoading = false,
+              errorMessage = e.message ?: "Failed to load treasury.",
+            )
+          }
+        }
+    }
+  }
+
+  fun setFilter(f: TreasuryFilter) {
+    _state.update { it.copy(filter = f) }
+  }
+}
+
+fun TreasuryUiState.filteredMovements(): List<VaultMovement> = when (filter) {
+  TreasuryFilter.All -> movements
+  TreasuryFilter.Gold -> movements.filter { it.resource == "gold" }
+  TreasuryFilter.Resources -> movements.filter { it.resource != "gold" }
+}


### PR DESCRIPTION
## Summary

Two complementary demo-polish bits that make repeat-demoing on the same device much smoother.

**Stacked on #87 (forged-appears).**

### Hall provenance badges
- New \`HallProvenance\` enum (Linked / Hired / Forged) on \`HallCard\`
- \`HallViewModel\` computes per-card provenance by checking the clan id against \`sessionStore.getHiredClanIds / getForgedClanIds\`; LINKED is the default fallback
- \`LetterCard\` renders a small clip(2dp) + colored-tint badge next to the title for non-Linked cards: rune-color \"HIRED\" or ember-color \"FORGED\"
- Linked cards show no badge — the absence is the signal for \"this is yours from session 0\"

### Codex \"Reset demo state\"
- New \`SessionStore.resetDemoState()\`: wipes keys prefixed with \`hired:\`, \`forged:\`, \`draft:\`, \`flag:\`; KEEPS the auth token + pubkey so MWA stays paired after reset
- New \`CodexViewModel.resetDemoState()\` chains \`sessionStore.resetDemoState + lineageStore.clear + reload\`
- New \`DemoResetRow\` at the bottom of Codex: two-tap-confirm pattern (first tap arms in danger color, second tap fires)
- Subtitle: \"wipes hired + forged clans, drafts, and lineage. wallet stays connected.\"

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 24s.

## Test plan

- [ ] Hall: linked cards (clans 2/5/6) show no badge
- [ ] Hire a clan from Bazaar → Hall: that card now shows rune-color \"HIRED\" badge next to its title
- [ ] Forge a clan → Hall: ember-color \"FORGED\" badge
- [ ] Codex bottom: \"RESET DEMO STATE\" row visible
- [ ] First tap: row arms in danger-red border + label
- [ ] Second tap: state cleared — Hall back to 3 linked, Bazaar listings restored, Lineage section gone, onboarding hint reappears, Forge wizard re-enables previously-owned clans
- [ ] Wallet still connected after reset (no Connect screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)