### PR TITLE
feat(android): forge wizard shows picked clan on steps 2-4

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -136,7 +136,7 @@ private fun ForgeScreen(
     BackBar(text = "back to hall", onBack = onBack)
 
     Column(modifier = Modifier.padding(horizontal = 22.dp)) {
-      ForgeHead()
+      ForgeHead(state.clanId, showClanContext = state.step != ForgeStep.PickClan)
       Spacer(Modifier.height(10.dp))
       ProgressDots(step = state.step)
       Spacer(Modifier.height(18.dp))
@@ -206,7 +206,7 @@ private fun BackBar(text: String, onBack: () -> Unit) {
 }
 
 @Composable
-private fun ForgeHead() {
+private fun ForgeHead(clanId: Int?, showClanContext: Boolean) {
   val parchment = ClanWorldTheme.colors.parchment
   val warmDim = ClanWorldTheme.colors.warmDim
   val hairline = ClanWorldTheme.colors.hairline
@@ -224,12 +224,33 @@ private fun ForgeHead() {
       },
   ) {
     Text(text = "FORGE", style = ClanWorldTheme.type.displayHero, color = parchment)
-    Text(
-      text = "the unmade seal awaits its line",
-      style = ClanWorldTheme.type.scriptItalic,
-      color = warmDim,
-      modifier = Modifier.padding(top = 2.dp),
-    )
+    if (showClanContext && clanId != null) {
+      val accent = clanColor(clanId)
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.padding(top = 4.dp),
+      ) {
+        Box(
+          modifier = Modifier
+            .size(8.dp)
+            .clip(androidx.compose.foundation.shape.RoundedCornerShape(50))
+            .background(accent),
+        )
+        Text(
+          text = "FORGING IN ${clanDisplayName(clanId).uppercase()}",
+          style = ClanWorldTheme.type.monoMicro,
+          color = accent,
+        )
+      }
+    } else {
+      Text(
+        text = "the unmade seal awaits its line",
+        style = ClanWorldTheme.type.scriptItalic,
+        color = warmDim,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Once the user picks a clan in step 1, the head's tagline \"the unmade seal awaits its line\" is replaced on steps 2-4 with \"FORGING IN <CLAN>\" in the clan's accent color (small mono caption + a 8dp clan-color dot).

Step 4 already showed the clan in its summary card, but steps 2 (name) and 3 (harness) had no on-screen reminder of which clan they were forging into — the picked clanId existed only in the view-model.

**Stacked on #88 (provenance badges + demo reset).**

Affects only \`ForgeScreen.kt\`; no behavior change beyond the head copy.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 22s.

## Test plan

- [ ] Forge wizard step 1: head shows \"the unmade seal awaits its line\"
- [ ] Pick a clan → tap NEXT → step 2: head replaces tagline with \"FORGING IN <CLAN>\" in clan accent color + dot
- [ ] Step 3 + step 4: same context line still visible
- [ ] Back to step 1 (BACK button): tagline returns since clanId is still set but step is PickClan
- [ ] Reset demo state → re-enter Forge: starts with tagline, no context line until step 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)