### PR TITLE
feat(android): tap a lineage row to open InftDetail

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -372,6 +372,7 @@ fun ClanWorldApp(
             CodexScreenRoute(
               app = app,
               factory = factory,
+              onOpenInft = { clanId -> nav.navigate(Routes.inftDetail(clanId)) },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -55,19 +55,25 @@ import world.clan.app.viewmodel.shortenPubkey
 fun CodexScreenRoute(
   app: App,
   factory: ClanWorldViewModelFactory,
+  onOpenInft: (Int) -> Unit = {},
 ) {
   val vm: CodexViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
   // Re-read lineage on each Codex visit so newly-signed actions appear
   // without a kill/relaunch.
   androidx.compose.runtime.LaunchedEffect(Unit) { vm.refreshLineage() }
-  CodexScreen(state = state, onResetDemo = vm::resetDemoState)
+  CodexScreen(
+    state = state,
+    onResetDemo = vm::resetDemoState,
+    onOpenInft = onOpenInft,
+  )
 }
 
 @Composable
 private fun CodexScreen(
   state: CodexUiState,
   onResetDemo: () -> Unit = {},
+  onOpenInft: (Int) -> Unit = {},
 ) {
   // Background and tab bar are app-level. Disconnect now lives in the
   // wallet-pill dropdown in CrownHeader — no big "FORGET THIS SIGIL"
@@ -136,7 +142,9 @@ private fun CodexScreen(
       }
       StaggeredEntry(index = 10) {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-          state.lineage.take(12).forEach { entry -> LineageRow(entry) }
+          state.lineage.take(12).forEach { entry ->
+            LineageRow(entry, onClick = { onOpenInft(entry.clanId) })
+          }
         }
       }
       Spacer(Modifier.height(20.dp))
@@ -347,7 +355,10 @@ private fun RowCard(
 }
 
 @Composable
-private fun LineageRow(entry: world.clan.app.data.LineageEntry) {
+private fun LineageRow(
+  entry: world.clan.app.data.LineageEntry,
+  onClick: () -> Unit = {},
+) {
   val parchment = ClanWorldTheme.colors.parchment
   val warm = ClanWorldTheme.colors.warm
   val warmDim = ClanWorldTheme.colors.warmDim
@@ -366,6 +377,7 @@ private fun LineageRow(entry: world.clan.app.data.LineageEntry) {
       .clip(RoundedCornerShape(6.dp))
       .background(ClanWorldTheme.colors.iron)
       .border(1.dp, ClanWorldTheme.colors.hairline, RoundedCornerShape(6.dp))
+      .clickable { onClick() }
       .padding(horizontal = 14.dp, vertical = 10.dp),
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(12.dp),


### PR DESCRIPTION
## Summary

Codex Lineage entries are now clickable. Tap \"Forged Caldris\" → InftDetail for clan 2; tap \"Whispered to Tideborne\" → InftDetail for clan 2. Connects the activity log to the rest of the app — every row already carries clanId, this just turns that into navigation.

**Stacked on #89 (forge clan context).**

### Changes
- \`CodexScreen.LineageRow\`: takes \`onClick\`; clickable on the surrounding Row
- \`CodexScreenRoute\`: takes \`onOpenInft\` and threads it down to LineageRow
- \`ClanWorldApp.kt\`: wires the InftDetail nav target

No data changes. Pure navigation hook.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 25s.

## Test plan

- [ ] Codex with at least one lineage row → tap → opens InftDetail for that clan
- [ ] Tap a hired-row → InftDetail still in linked-mode (we don't pass isBazaar; the user owns this clan now)
- [ ] System back from InftDetail returns to Codex with scroll position preserved
- [ ] Lineage rows visually unchanged; press is just an additional affordance

🤖 Generated with [Claude Code](https://claude.com/claude-code)