### PR TITLE
feat(android): codex APK row gets a system-share intent

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -155,12 +155,7 @@ private fun CodexScreen(
       SectionHeader(title = "Share", showLozenge = false)
     }
     StaggeredEntry(index = 6) {
-      RowCard(
-        label = "APK download · for friends",
-        value = state.apkShareUrl,
-        copyable = true,
-        copyText = state.apkShareUrl,
-      )
+      ShareApkRow(url = state.apkShareUrl)
     }
 
     Spacer(Modifier.height(20.dp))
@@ -189,6 +184,77 @@ private fun CodexScreen(
     }
 
     Spacer(Modifier.height(40.dp))
+  }
+}
+
+@Composable
+private fun ShareApkRow(url: String) {
+  val context = androidx.compose.ui.platform.LocalContext.current
+  val clipboard = LocalClipboardManager.current
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(6.dp))
+      .background(ClanWorldTheme.colors.iron)
+      .border(1.dp, ClanWorldTheme.colors.hairline, RoundedCornerShape(6.dp))
+      .padding(horizontal = 14.dp, vertical = 12.dp),
+  ) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+      Text(
+        text = "APK DOWNLOAD · FOR FRIENDS",
+        style = ClanWorldTheme.type.monoMicro,
+        color = ClanWorldTheme.colors.warmFaint,
+      )
+      Text(
+        text = url,
+        style = ClanWorldTheme.type.monoData,
+        color = ClanWorldTheme.colors.parchment,
+      )
+    }
+    Row(
+      modifier = Modifier.align(Alignment.TopEnd),
+      horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+      // Copy
+      Box(
+        modifier = Modifier
+          .clip(RoundedCornerShape(4.dp))
+          .border(1.dp, ClanWorldTheme.colors.hairline, RoundedCornerShape(4.dp))
+          .clickable { clipboard.setText(AnnotatedString(url)) }
+          .padding(horizontal = 8.dp, vertical = 4.dp),
+      ) {
+        Icon(
+          painter = painterResource(R.drawable.ui_copy),
+          contentDescription = "Copy",
+          tint = ClanWorldTheme.colors.warmDim,
+          modifier = Modifier.size(10.dp),
+        )
+      }
+      // Share via Android intent
+      Box(
+        modifier = Modifier
+          .clip(RoundedCornerShape(4.dp))
+          .border(1.dp, ClanWorldTheme.colors.hairlineMid, RoundedCornerShape(4.dp))
+          .clickable {
+            val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+              type = "text/plain"
+              putExtra(android.content.Intent.EXTRA_TEXT, url)
+              putExtra(android.content.Intent.EXTRA_SUBJECT, "Try the ClanWorld Android demo")
+            }
+            val chooser = android.content.Intent.createChooser(intent, "Share APK link").apply {
+              addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(chooser)
+          }
+          .padding(horizontal = 8.dp, vertical = 4.dp),
+      ) {
+        Text(
+          text = "SHARE",
+          style = ClanWorldTheme.type.monoNano,
+          color = ClanWorldTheme.colors.gold,
+        )
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

The APK download row in Codex previously had a copy-link affordance only. Adds a **SHARE** button alongside that fires Android \`Intent.ACTION_SEND\` with the URL and a subject \"Try the ClanWorld Android demo\" — opens the system share sheet so the user can pick Messages / Gmail / Slack / whatever for sending the APK to a friend.

**Stacked on #91 (inft-detail provenance).**

### Implementation
- Replaces \`RowCard\` with a custom \`ShareApkRow\` composable for that one row
- Two top-right affordances:
  - **COPY** icon — same clipboard behavior as before
  - **SHARE** text button — fires \`Intent.createChooser(Intent.ACTION_SEND, …)\`
- Both small + at the top-right so the URL itself stays primary content

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 26s.

## Test plan

- [ ] Codex → Share section: APK row shows both COPY and SHARE affordances
- [ ] Tap COPY: link is on clipboard
- [ ] Tap SHARE: Android share sheet opens with the APK URL prefilled
- [ ] Pick Messages: new SMS draft has the URL + subject
- [ ] No crash if no share targets installed (rare; chooser handles it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)