### PR TITLE
feat(android): forge step 2 shows the picked clan's sigil above name input

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -53,7 +53,9 @@ import world.clan.app.App
 import world.clan.app.R
 import world.clan.app.ui.components.EmberCta
 import world.clan.app.ui.components.ParchmentCard
+import world.clan.app.ui.components.Sigil
 import world.clan.app.ui.components.WaxSeal
+import world.clan.app.ui.components.bigSigilSpec
 import world.clan.app.ui.theme.ClanWorldTheme
 import world.clan.app.ui.theme.Ink
 import world.clan.app.ui.theme.Ink2
@@ -401,7 +403,23 @@ private fun StepNameSigil(state: ForgeUiState, onChange: (String) -> Unit) {
       style = ClanWorldTheme.type.scriptItalic,
       color = ClanWorldTheme.colors.warmDim,
     )
-    Spacer(Modifier.height(14.dp))
+    Spacer(Modifier.height(20.dp))
+
+    // Picked-clan sigil preview — gives the user something to look at
+    // while they decide on a name. Animates so it doesn't feel static.
+    val pickedClan = state.clanId
+    if (pickedClan != null) {
+      Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+      ) {
+        Sigil(
+          spec = bigSigilSpec(clanColor(pickedClan)),
+          modifier = Modifier.size(110.dp),
+        )
+      }
+      Spacer(Modifier.height(20.dp))
+    }
 
     ParchmentCard(modifier = Modifier.fillMaxWidth()) {
       Text(


### PR DESCRIPTION
## Summary

Step 2 (Name Sigil) of the Forge wizard was previously just a text field with the clan name in the head. Now renders the picked clan's animated \`Sigil\` at 110dp above the name input — gives the user something to look at while deciding on a name.

The visual reinforcement matches the \"FORGING IN <CLAN>\" line in the head from #89.

**Stacked on #92 (codex share intent).**

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 8s.

## Test plan

- [ ] Forge wizard step 1 → pick clan 7 → NEXT → step 2 shows the Forge clan glyph + concentric runic rings (animated) at 110dp above the NAME card
- [ ] Each clan id shows its own accent color in the rings
- [ ] BACK → step 1: sigil hidden (no clan picked here in this view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)