### PR TITLE
feat(android): forge step 3 also shows the picked clan's sigil

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -488,7 +488,24 @@ private fun StepPickHarness(state: ForgeUiState, onSelect: (Harness) -> Unit) {
       style = ClanWorldTheme.type.scriptItalic,
       color = ClanWorldTheme.colors.warmDim,
     )
-    Spacer(Modifier.height(8.dp))
+    Spacer(Modifier.height(12.dp))
+
+    // Picked-clan sigil preview (smaller than step 2; the harness cards
+    // are the focus here). Mirrors step 2's "see what you're naming"
+    // pattern.
+    val pickedClan = state.clanId
+    if (pickedClan != null) {
+      Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+      ) {
+        Sigil(
+          spec = bigSigilSpec(clanColor(pickedClan)),
+          modifier = Modifier.size(80.dp),
+        )
+      }
+      Spacer(Modifier.height(4.dp))
+    }
 
     Harness.values().forEach { h ->
       HarnessCard(


### PR DESCRIPTION
## Summary

Mirror of the step 2 sigil preview from #94. Step 3 (Pick Harness) now shows the picked clan's sigil at 80dp above the harness cards — smaller than step 2's 110dp because the harness cards are the visual focus here.

Reinforces the \"FORGING IN <CLAN>\" head context (#89) throughout the wizard so the user never loses track of which clan they're shaping.

**Stacked on #94 (forge step 2 sigil preview).**

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 19s.

## Test plan

- [ ] Forge step 3: clan-color sigil renders at 80dp above the harness cards
- [ ] Animation continues across step 2 → step 3 transition (sigils don't visibly stutter)
- [ ] No layout overlap with the three harness cards below

🤖 Generated with [Claude Code](https://claude.com/claude-code)