### PR TITLE
fix(android): PR #69 SuperSwarm HIGHs — Hall refresh + Cockpit clanId threading

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/CockpitScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/CockpitScreen.kt
@@ -47,9 +47,13 @@ import world.clan.app.ui.theme.CockpitTokens
 @Composable
 fun CockpitScreen(
   onOwnerControl: (Int) -> Unit,
+  initialClanId: Int = 1,
 ) {
   var collapsed by rememberSaveable { mutableStateOf(false) }
-  var activeClanId by rememberSaveable { mutableStateOf(1) }
+  // Key the saver on initialClanId so navigating into Cockpit for a
+  // different clan resets the active selection instead of stickying the
+  // previous clan's id from process restoration.
+  var activeClanId by rememberSaveable(initialClanId) { mutableStateOf(initialClanId) }
   var bulletinOpen by rememberSaveable { mutableStateOf(false) }
 
   // Singleton-per-screen data source. Survives recompositions, dies with

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -70,7 +70,7 @@ object Routes {
   const val Forge = "forge"
   const val Forged = "forged/{clanId}?name={name}&label={label}"
   const val Bridge = "bridge/{clanId}"
-  const val Cockpit = "cockpit"
+  const val Cockpit = "cockpit/{clanId}"
   const val OwnerSignIn = "ownerSignIn/{clanId}"
   const val OwnerComingSoon = "ownerComingSoon/{clanId}"
   fun inftDetail(clanId: Int) = "inft/$clanId"
@@ -85,6 +85,7 @@ object Routes {
     return "forged/$clanId?name=$n&label=$l"
   }
   fun bridge(clanId: Int) = "bridge/$clanId"
+  fun cockpit(clanId: Int) = "cockpit/$clanId"
   fun ownerSignIn(clanId: Int) = "ownerSignIn/$clanId"
   fun ownerComingSoon(clanId: Int) = "ownerComingSoon/$clanId"
 }
@@ -243,7 +244,7 @@ fun ClanWorldApp(
     currentRoute == Routes.Forge -> RootTab.Hall // forge wizard surfaces from Hall
     currentRoute?.startsWith("steer/") == true ||
       currentRoute?.startsWith("bridge/") == true ||
-      currentRoute == Routes.Cockpit ||
+      currentRoute?.startsWith("cockpit/") == true ||
       currentRoute?.startsWith("ownerSignIn/") == true ||
       currentRoute?.startsWith("ownerComingSoon/") == true -> RootTab.Hall
     else -> RootTab.Hearth
@@ -446,7 +447,7 @@ fun ClanWorldApp(
             world.clan.app.ui.screens.BridgeScreen(
               clanId = clanId,
               onReady = {
-                nav.navigate(Routes.Cockpit) {
+                nav.navigate(Routes.cockpit(clanId)) {
                   popUpTo(Routes.Bridge) { inclusive = true }
                 }
               },
@@ -617,13 +618,16 @@ fun ClanWorldApp(
           // ── Cockpit (deep route from Bridge after the loader resolves) ──
           composable(
             route = Routes.Cockpit,
+            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
             enterTransition = { detailEnter() },
             popExitTransition = { detailPopExit() },
             exitTransition = { tabExit() },
-          ) {
+          ) { entry ->
+            val clanId = entry.arguments?.getInt("clanId") ?: 1
             CockpitScreen(
-              onOwnerControl = { clanId ->
-                nav.navigate(Routes.ownerSignIn(clanId))
+              initialClanId = clanId,
+              onOwnerControl = { c ->
+                nav.navigate(Routes.ownerSignIn(c))
               },
             )
           }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -66,6 +67,15 @@ fun HallScreenRoute(
 ) {
   val vm: HallViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
+  // Refresh on every (re)entry into the Hall route. The HallViewModel is
+  // held by the NavHost across navigations (Hall → Forge/Hire → celebration
+  // → back), so without this LaunchedEffect the user sees a stale list
+  // until pull-to-refresh. SessionStore.add{Forged,Hired}ClanId() are
+  // called before the celebration screen lands, so by the time we pop
+  // back to Hall the extras are already present.
+  LaunchedEffect(Unit) {
+    vm.refresh()
+  }
   // First-launch coachmark: read once from SessionStore, dismiss-on-tap
   // toggles the local state and writes the persistent flag.
   val hintFlagKey = "hall.hintSeen"


### PR DESCRIPTION
## Summary

Fixes 2 HIGH demo-flow blockers found by codex 5.5 in PR #69 SuperSwarm review (`docs/reviews/pr69-synthesis.md`).

### HIGH #1 — Hall didn't refresh on re-entry after Forge/Hire

**File:** `apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt`

`HallViewModel` is held by the NavHost, so navigating `Hall → Forge/Hire → celebration → back` showed the OLD list until pull-to-refresh. `sessionStore.addForgedClanId()` / `addHiredClanId()` already fire before the celebration screen lands, so by the time we pop back to Hall the new clan is already in the extras — we just weren't reading them.

Fix: added a `LaunchedEffect(Unit)` in `HallScreenRoute` that calls `vm.refresh()` on every (re)composition of the route.

### HIGH #2 — `Enter Cockpit` dropped the selected clanId

**Files:** `ClanWorldApp.kt`, `cockpit/CockpitScreen.kt`

Bridge route received the selected clanId, navigated to plain `Routes.Cockpit` (no clan param), and `CockpitScreen` defaulted `activeClanId` to `1`. Tapping Enter Cockpit from any non-clan-1 iNFT landed the demo in clan 1's cockpit.

Fix:
- `Routes.Cockpit` is now `"cockpit/{clanId}"`; added `Routes.cockpit(clanId)` builder.
- `Bridge → Cockpit` navigate now passes the clanId.
- Cockpit composable in NavHost extracts the arg and threads it as `CockpitScreen(initialClanId = clanId)`.
- `CockpitScreen` accepts `initialClanId: Int = 1` and seeds `activeClanId` from it via `rememberSaveable(initialClanId)` (keyed so a fresh clan resets selection rather than stickying the previous clan's id from process restoration).
- Tabbar visibility/selection logic switched from `currentRoute == Routes.Cockpit` literal-equality to `startsWith("cockpit/")` since the route now carries an arg suffix.

## Files changed

- `apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt` — `LaunchedEffect` refresh on re-entry.
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt` — parameterized cockpit route + tabbar match update.
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/CockpitScreen.kt` — `initialClanId` param + saver key.

## Test plan

- [x] `./gradlew :app:assembleDebug` → BUILD SUCCESSFUL (44s).
- [ ] Smoke: open app → Hall has clan A → Forge a new sigil → celebration → tap back → new sigil now visible in Hall without pull-to-refresh.
- [ ] Smoke: open app → Hall → Bazaar → Hire a clan → celebration → tap back → hired clan now visible in Hall without pull-to-refresh.
- [ ] Smoke: Hall → tap clan 5 (or any non-clan-1) iNFT → Enter Cockpit → cockpit shows clan 5's data, NOT clan 1.