### PR TITLE
feat(android): bridge screen — staggered loading dots below the sigil

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BridgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BridgeScreen.kt
@@ -2,18 +2,22 @@ package world.clan.app.ui.screens
 
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.StartOffset
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,6 +25,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
@@ -96,6 +102,37 @@ fun BridgeScreen(
         style = ClanWorldTheme.type.monoNano,
         color = ClanWorldTheme.colors.gold,
         textAlign = TextAlign.Center,
+      )
+
+      Spacer(Modifier.height(20.dp))
+
+      // Three-dot loading pulse — staggered breathing alpha so the
+      // page reads as "still working" rather than just frozen at 1.4s.
+      LoadingDots(accent = clanColor(clanId))
+    }
+  }
+}
+
+@Composable
+private fun LoadingDots(accent: Color) {
+  val transition = rememberInfiniteTransition(label = "bridge-dots")
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    repeat(3) { i ->
+      val alpha by transition.animateFloat(
+        initialValue = 0.20f,
+        targetValue = 1.0f,
+        animationSpec = infiniteRepeatable(
+          animation = tween(durationMillis = 900, easing = EaseInOut),
+          repeatMode = RepeatMode.Reverse,
+          initialStartOffset = StartOffset(i * 200),
+        ),
+        label = "dot-$i",
+      )
+      Box(
+        modifier = Modifier
+          .size(6.dp)
+          .clip(CircleShape)
+          .background(accent.copy(alpha = alpha)),
       )
     }
   }


### PR DESCRIPTION
## Summary

Bridge previously was just a rotating sigil + \"preparing the strait…\" + clan-name ALL-CAPS for ~1.4s. Static screens that long can read as \"frozen\" rather than \"loading.\"

Adds a small 3-dot pulse below the clan name. Each dot breathes alpha 0.20 → 1.0 over 900ms with a 200ms phase offset between dots — so they wave rather than blinking together. Color is the picked clan's accent so the screen reads as still belonging to that clan.

**Stacked on #97 (sealed notice).**

No timing change — Bridge still pops to Cockpit at 1.4s. The dots just give the eye something to track during the linger.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 21s.

## Test plan

- [ ] InftDetail → Enter Cockpit → BridgeScreen shows: rotating sigil → \"preparing the strait…\" → CLAN NAME → 3 dots below pulsing in clan accent color
- [ ] Dots wave (200ms phase between each), don't all blink in unison
- [ ] Auto-advances to Cockpit at 1.4s — no extension of duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)