### PR TITLE
feat(android): bazaar empty state — forge CTA when all sigils claimed

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -361,6 +361,7 @@ fun ClanWorldApp(
               app = app,
               factory = factory,
               onOpenListing = { clanId -> nav.navigate(Routes.bazaarInftDetail(clanId)) },
+              onForge = { nav.navigate(Routes.Forge) },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/BazaarScreen.kt
@@ -48,19 +48,21 @@ fun BazaarScreenRoute(
   app: App,
   factory: ClanWorldViewModelFactory,
   onOpenListing: (Int) -> Unit,
+  onForge: () -> Unit = {},
 ) {
   val vm: BazaarViewModel = viewModel(factory = factory)
   val state by vm.state.collectAsState()
   // Re-apply the hired-clan filter on (re-)entry so a freshly-hired
   // sigil drops out of the listings without an app kill.
   androidx.compose.runtime.LaunchedEffect(Unit) { vm.refresh() }
-  BazaarScreen(state = state, onOpenListing = onOpenListing)
+  BazaarScreen(state = state, onOpenListing = onOpenListing, onForge = onForge)
 }
 
 @Composable
 private fun BazaarScreen(
   state: BazaarUiState,
   onOpenListing: (Int) -> Unit,
+  onForge: () -> Unit = {},
 ) {
   Column(
     modifier = Modifier
@@ -86,11 +88,11 @@ private fun BazaarScreen(
         modifier = Modifier.padding(top = 24.dp),
       )
     } else if (state.listings.isEmpty()) {
-      Text(
-        text = state.errorMessage ?: "the bazaar is quiet — no listings posted.",
-        style = ClanWorldTheme.type.scriptItalic,
-        color = ClanWorldTheme.colors.warmFaint,
-        modifier = Modifier.padding(top = 24.dp),
+      world.clan.app.ui.components.EmptyState(
+        title = "the bazaar is quiet",
+        body = "every sigil has been claimed. forge a new line of your own.",
+        ctaLabel = "+ Forge a sigil",
+        onCta = onForge,
       )
     } else {
       LazyColumn(


### PR DESCRIPTION
## Summary

After hiring all 5 listings (now possible since Bazaar drops hired clans in #86), the bazaar empties out. Previously the empty state was just \"the bazaar is quiet — no listings posted.\" with no next-action.

Now uses the EmptyState component:
- Title: \"the bazaar is quiet\"
- Body: \"every sigil has been claimed. forge a new line of your own.\"
- CTA: \"+ Forge a sigil\" → Forge wizard

Same pattern as empty Hall + empty Whispers. The CTA target is also where the \"FORGE A NEW SIGIL\" link in Hall points, so it feels consistent.

**Stacked on #98 (bridge polish).**

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 24s.

## Test plan

- [ ] Hire all 5 bazaar listings → re-enter Bazaar tab → empty state with the CTA
- [ ] Tap \"+ Forge a sigil\" → opens Forge wizard at step 1
- [ ] Reset demo state in Codex → re-enter Bazaar: full 5-listing roster restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)