### PR TITLE
feat(android): forge step 1 — empty state when all 8 clans owned

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -288,6 +288,16 @@ private fun ProgressDots(step: ForgeStep) {
 
 @Composable
 private fun StepPickClan(state: ForgeUiState, onSelect: (Int) -> Unit) {
+  // If every clan is already owned, the wizard has nothing to offer —
+  // render an EmptyState pointing to Codex's reset rather than 8
+  // greyed cards.
+  if (state.ownedClanIds.size >= 8) {
+    world.clan.app.ui.components.EmptyState(
+      title = "every clan is yours",
+      body = "all eight sigils stand under your hand. to forge again, reset demo state in Codex.",
+    )
+    return
+  }
   Column(modifier = Modifier.fillMaxSize()) {
     Text(
       text = "CHOOSE YOUR CLAN",


### PR DESCRIPTION
## Summary

Symmetric to #99 (Bazaar empty state). After hiring + forging across all 8 clans, the Forge wizard step 1 was rendering 8 fully-greyed cards each saying \"already under your hand\" — confusing and reads as broken.

Now: when \`state.ownedClanIds.size >= 8\`, render EmptyState with:
- Title: \"every clan is yours\"
- Body: \"all eight sigils stand under your hand. to forge again, reset demo state in Codex.\"
- No CTA — user has to self-navigate to Codex's demo-reset (intentional: the reset is a deliberate destructive action, not a one-tap escape)

**Stacked on #99 (bazaar empty state).**

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 21s.

## Test plan

- [ ] Forge or hire all 8 clans (3 LINKED + 5 BAZAAR_LISTINGS or 3 + various forges) → tap \"+ FORGE A NEW SIGIL\" from Hall → step 1 renders the empty state, not the 8 greyed cards
- [ ] NEXT button is disabled (canAdvance is still false because clanId is null)
- [ ] BACK from step 1 pops the wizard
- [ ] Reset demo state in Codex → re-enter Forge: full clan list restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)