### PR TITLE
feat(android): EmberCta tap fires haptic feedback

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/EmberCta.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/EmberCta.kt
@@ -53,6 +53,7 @@ fun EmberCta(
   val ember = ClanWorldTheme.colors.ember
   val emberGlow = ClanWorldTheme.colors.emberGlow
   val shape = RoundedCornerShape(6.dp)
+  val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
 
   val infinite = rememberInfiniteTransition(label = "ember-cta")
   val glow by infinite.animateFloat(
@@ -123,7 +124,10 @@ fun EmberCta(
           size = Size(w, size.height),
         )
       }
-      .clickable(enabled = enabled, role = Role.Button) { onClick() },
+      .clickable(enabled = enabled, role = Role.Button) {
+        haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+        onClick()
+      },
     contentAlignment = Alignment.Center,
   ) {
     Text(


### PR DESCRIPTION
## Summary

Every primary action in the app routes through EmberCta — Connect, Hire, Sign and Send, Sign and Seal, Sign and Forge, Try Again, Enter Your Hall (forged screen). Adding a single tap-haptic at the component level grounds them all.

**Stacked on #102 (wallet pill long-press).**

### Change
- \`LocalHapticFeedback.current\` read at compose time
- Inside the existing onClick: \`performHapticFeedback(LongPress)\` runs first, then \`onClick()\`
- LongPress = Compose's \"confirm / commit\" semantic — heavier than a normal tap, lighter than a system notification. Matches \"you're about to ask the wallet to sign something\"

No surface change. Disabled state still skips the haptic (\`clickable(enabled = false)\` short-circuits before the lambda).

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 17s.

## Test plan

- [ ] Tap Connect on Connect screen: short haptic bump
- [ ] Tap Sign and Forge on Forge step 4: same haptic
- [ ] Tap Sign with Wallet on HireModal: same haptic
- [ ] Tap Sign and Seal on StrategyEditor: same haptic
- [ ] Tap Sign and Send on SteeringConsole: same haptic
- [ ] Tap Enter Your Hall on ForgedScreen: same haptic
- [ ] Disabled CTA (e.g. Sign and Forge before name entered) — tap does nothing, no haptic

🤖 Generated with [Claude Code](https://claude.com/claude-code)