### PR TITLE
feat(android): tab switches fire light haptic feedback

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Tabbar.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Tabbar.kt
@@ -144,6 +144,7 @@ private fun TabItem(
 ) {
   val ember = ClanWorldTheme.colors.ember
   val warmFaint = ClanWorldTheme.colors.warmFaint
+  val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
 
   // Smooth tint crossfade on selection. The actual halo is drawn ONCE
   // by the parent at an animated offset — this composable never moves.
@@ -154,7 +155,14 @@ private fun TabItem(
   )
 
   Column(
-    modifier = modifier.clickable(role = Role.Tab) { onClick() },
+    modifier = modifier.clickable(role = Role.Tab) {
+      // Lighter tick than the EmberCta LongPress — tabs are navigation,
+      // not commit-style actions.
+      if (!selected) {
+        haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.TextHandleMove)
+      }
+      onClick()
+    },
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.spacedBy(5.dp),
   ) {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -411,6 +411,7 @@ private fun DetailTabs(active: DetailTab, onSelect: (DetailTab) -> Unit) {
   val ember = ClanWorldTheme.colors.ember
   val warmFaint = ClanWorldTheme.colors.warmFaint
   val hairline = ClanWorldTheme.colors.hairline
+  val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
   val activeIdx = DetailTab.values().indexOf(active)
   val tabCount = DetailTab.values().size
 
@@ -439,7 +440,12 @@ private fun DetailTabs(active: DetailTab, onSelect: (DetailTab) -> Unit) {
         Box(
           modifier = Modifier
             .weight(1f)
-            .clickable { onSelect(tab) }
+            .clickable {
+              if (tab != active) {
+                haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.TextHandleMove)
+              }
+              onSelect(tab)
+            }
             .padding(vertical = 10.dp),
           contentAlignment = Alignment.Center,
         ) {


### PR DESCRIPTION
## Summary

Bottom tab bar (\`ClanWorldTabBar\`) + InftDetail tabs (\`DetailTabs\`) now fire \`HapticFeedbackType.TextHandleMove\` on switch.

Lighter than the EmberCta LongPress haptic from #103 — tabs are navigation, not commit-style actions, so they should \"tick\" not \"thump\".

Re-tap on the currently-selected tab is silent; only transitions to a different tab fire the haptic. Avoids spamming the user when they double-tap by accident.

**Stacked on #103 (EmberCta haptic).**

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 23s.

## Test plan

- [ ] Bottom tab bar: Hearth → Hall → Bazaar → Codex each fire a soft tick
- [ ] Re-tap on the active tab: silent
- [ ] InftDetail: Memory → Vault → Whispers → Bulletin same soft tick
- [ ] Re-tap on the active detail tab: silent
- [ ] Connect screen, Forge wizard, etc — non-tab clicks unchanged (still LongPress on EmberCta, no extra haptic on plain Box clicks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)