### PR TITLE
feat(android): filter chip switches fire light haptic feedback

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/TreasuryScreen.kt
@@ -295,6 +295,7 @@ private fun FilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
   val bg = if (selected) ClanWorldTheme.colors.iron2 else Color.Transparent
   val border = if (selected) ClanWorldTheme.colors.hairlineStrong else ClanWorldTheme.colors.hairline
   val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
+  val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
   Box(
     modifier = Modifier
       .clip(RoundedCornerShape(4.dp))
@@ -306,7 +307,12 @@ private fun FilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
           style = Stroke(width = 1.dp.toPx()),
         )
       }
-      .clickable { onClick() }
+      .clickable {
+        if (!selected) {
+          haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.TextHandleMove)
+        }
+        onClick()
+      }
       .padding(horizontal = 12.dp, vertical = 8.dp),
   ) {
     Text(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -233,6 +233,7 @@ private fun FilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
   val bg = if (selected) ClanWorldTheme.colors.iron2 else Color.Transparent
   val border = if (selected) ClanWorldTheme.colors.hairlineStrong else ClanWorldTheme.colors.hairline
   val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
+  val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
   Box(
     modifier = Modifier
       .clip(RoundedCornerShape(4.dp))
@@ -251,7 +252,12 @@ private fun FilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
           strokeWidth = 1f,
         )
       }
-      .clickable { onClick() }
+      .clickable {
+        if (!selected) {
+          haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.TextHandleMove)
+        }
+        onClick()
+      }
       .padding(horizontal = 12.dp, vertical = 8.dp),
   ) {
     Text(


### PR DESCRIPTION
## Summary

Whispers chips (All / Peers / Orch / Owner) + Treasury chips (All / Gold / Resources) now fire \`HapticFeedbackType.TextHandleMove\` on selection change — same gating as tab haptics from #104: silent when re-tapping the active filter, ticks on transition.

Pairs with #104 — every navigation/filter surface in the app now has consistent tactile feedback.

**Stacked on #104 (tab haptics).**

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 20s.

## Test plan

- [ ] Whispers: tap Peers → soft tick; tap Peers again → silent
- [ ] Treasury: tap Gold → soft tick; tap Gold again → silent
- [ ] Same haptic strength as tab switches (TextHandleMove)

🤖 Generated with [Claude Code](https://claude.com/claude-code)