### PR TITLE
feat(android): selection-pill haptics — clan / posture / harness

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -348,12 +348,18 @@ private fun ClanCard(
   }
   val borderStroke = if (selected && !owned) 2.dp else 1.dp
   val cardAlpha = if (owned) 0.45f else 1f
+  val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
 
   Box(
     modifier = Modifier
       .fillMaxWidth()
       .alpha(cardAlpha)
-      .clickable(enabled = !owned) { onClick() }
+      .clickable(enabled = !owned) {
+        if (!selected) {
+          haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.TextHandleMove)
+        }
+        onClick()
+      }
       .drawBehind {
         drawRoundRect(
           color = borderColor,
@@ -536,11 +542,17 @@ private fun HarnessCard(harness: Harness, selected: Boolean, onClick: () -> Unit
   }
   val border = if (selected) accent else ClanWorldTheme.colors.hairline
   val stroke = if (selected) 2.dp else 1.dp
+  val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
 
   Box(
     modifier = Modifier
       .fillMaxWidth()
-      .clickable { onClick() }
+      .clickable {
+        if (!selected) {
+          haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.TextHandleMove)
+        }
+        onClick()
+      }
       .drawBehind {
         drawRoundRect(
           color = border,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -239,6 +239,7 @@ private fun ClanPill(clanId: Int, selected: Boolean, onClick: () -> Unit) {
   val bg = if (selected) accent.copy(alpha = 0.18f) else Color.Transparent
   val border = if (selected) accent else ClanWorldTheme.colors.hairline
   val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
+  val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
   Row(
     modifier = Modifier
       .clip(RoundedCornerShape(4.dp))
@@ -250,7 +251,12 @@ private fun ClanPill(clanId: Int, selected: Boolean, onClick: () -> Unit) {
           style = Stroke(width = 1.dp.toPx()),
         )
       }
-      .clickable { onClick() }
+      .clickable {
+        if (!selected) {
+          haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.TextHandleMove)
+        }
+        onClick()
+      }
       .padding(horizontal = 12.dp, vertical = 8.dp),
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
@@ -308,6 +308,7 @@ private fun PosturePill(posture: Posture, selected: Boolean, onClick: () -> Unit
   val bg = if (selected) accent.copy(alpha = 0.18f) else Color.Transparent
   val border = if (selected) accent else ClanWorldTheme.colors.hairline
   val tint = if (selected) ClanWorldTheme.colors.parchment else ClanWorldTheme.colors.warmDim
+  val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
   Row(
     modifier = Modifier
       .clip(RoundedCornerShape(4.dp))
@@ -319,7 +320,12 @@ private fun PosturePill(posture: Posture, selected: Boolean, onClick: () -> Unit
           style = Stroke(width = 1.dp.toPx()),
         )
       }
-      .clickable { onClick() }
+      .clickable {
+        if (!selected) {
+          haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.TextHandleMove)
+        }
+        onClick()
+      }
       .padding(horizontal = 14.dp, vertical = 10.dp),
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(8.dp),


### PR DESCRIPTION
## Summary

Continues the haptic-coverage pass. Four selection-list components now fire \`TextHandleMove\` haptic on selection change (silent on re-tap of the active item):

- **Forge ClanCard** (step 1: pick which clan to forge into)
- **Forge HarnessCard** (step 3: Iron / Tide / Ember)
- **SteeringConsole ClanPill** (target clan for the whisper)
- **StrategyEditor PosturePill** (Defensive / Balanced / Aggressive)

**Stacked on #105 (filter chip haptics).**

Combined with EmberCta (#103), tab haptics (#104), filter chips (#105), every interactive surface in the app now ticks:
- Primary actions → LongPress (commit-style, heavier)
- Navigation/selection → TextHandleMove (lighter)

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 21s.

## Test plan

- [ ] Forge step 1: tap each clan card → tick haptic; re-tap active → silent
- [ ] Forge step 3: tap Iron / Tide / Ember → tick
- [ ] SteeringConsole: tap each clan in target row → tick
- [ ] StrategyEditor: tap Defensive / Balanced / Aggressive → tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)