### PR TITLE
feat(android): demo reset row — armed + confirm haptics

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -262,6 +262,7 @@ private fun ShareApkRow(url: String) {
 private fun DemoResetRow(onConfirm: () -> Unit) {
   val armedState = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
   val armed = armedState.value
+  val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
   Column(
     verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
@@ -282,9 +283,14 @@ private fun DemoResetRow(onConfirm: () -> Unit) {
         )
         .clickable {
           if (armed) {
+            // Heavy bump to mark the destructive confirm.
+            haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
             onConfirm()
             armedState.value = false
           } else {
+            // Light tick to acknowledge the arm — the user is now one
+            // tap away from a destructive action.
+            haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.TextHandleMove)
             armedState.value = true
           }
         }


### PR DESCRIPTION
## Summary

The two-tap-confirm Reset Demo State row in Codex now fires distinct haptics for each tap:

- **First tap (armed)** → \`TextHandleMove\` — light tick acknowledging the arm. Same haptic as filter chips, signals \"you've made a small change\"
- **Second tap (confirmed)** → \`LongPress\` — heavier bump marking the destructive commit. Same haptic as primary EmberCta actions

The two sensations let the user tell by feel whether they've crossed the destructive threshold, not just by sight — useful when they're not directly looking at the row.

**Stacked on #106 (pill haptics).**

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 19s.

## Test plan

- [ ] Codex → tap Reset Demo State once: row arms (red border), light tick haptic
- [ ] Tap again: heavy bump haptic, state cleared
- [ ] Tap once then 3-second timeout (no auto-disarm yet — out of scope) — second tap fires confirm haptic still

🤖 Generated with [Claude Code](https://claude.com/claude-code)