### PR TITLE
feat(android): demo reset row auto-disarms after 4s

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -263,6 +263,18 @@ private fun DemoResetRow(onConfirm: () -> Unit) {
   val armedState = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
   val armed = armedState.value
   val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
+
+  // Auto-disarm after 4s of inactivity. If the user taps once by accident
+  // and walks away, the row should not stay armed indefinitely — a stray
+  // second tap on return would wipe their hired/forged state without
+  // confirmation. Resetting `armedState.value` to false also undoes the
+  // danger-color border so they can see at a glance that they're safe.
+  androidx.compose.runtime.LaunchedEffect(armed) {
+    if (armed) {
+      kotlinx.coroutines.delay(4000L)
+      armedState.value = false
+    }
+  }
   Column(
     verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {


### PR DESCRIPTION
## Summary

Real safety bug surfaced by #107's test plan: if the user accidentally tapped the Reset Demo State row and walked away, the row stayed armed indefinitely. A stray second tap on return — by them, by a friend borrowing the phone, by lap-pocket — would wipe their hired + forged state with no second prompt.

**Stacked on #107 (demo reset haptics).**

### Fix
\`LaunchedEffect(armed)\` in DemoResetRow. When \`armed\` flips to true, delay 4000ms then flip it back to false. The danger-color border clears at the same moment so the user sees they're safe again.

If the user does tap-confirm inside the 4s window, the LaunchedEffect cancels cleanly (\`armed\` flips to false on confirm too, re-keying the effect).

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 21s.

## Test plan

- [ ] Tap Reset Demo State once → row arms in danger color
- [ ] Wait 4s without second tap → row disarms cleanly, danger color clears
- [ ] Tap once → tap again within 4s → confirms (state wiped)
- [ ] Tap once → wait 4s → tap again → arms (NOT confirms — clean disarm reset cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)