### PR TITLE
feat(android): demo reset row — visible countdown bar drains over 4s

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -264,15 +264,27 @@ private fun DemoResetRow(onConfirm: () -> Unit) {
   val armed = armedState.value
   val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
 
-  // Auto-disarm after 4s of inactivity. If the user taps once by accident
-  // and walks away, the row should not stay armed indefinitely — a stray
-  // second tap on return would wipe their hired/forged state without
-  // confirmation. Resetting `armedState.value` to false also undoes the
-  // danger-color border so they can see at a glance that they're safe.
+  // Drives both the auto-disarm and the visible countdown bar. Animates
+  // 1f → 0f over 4s while armed; snaps back to 1f on disarm. Disarm
+  // fires either by user-confirm-tap (sets armed=false) or when the
+  // animation lands (we observe progress hitting 0f below).
+  val progress = androidx.compose.runtime.remember {
+    androidx.compose.animation.core.Animatable(1f)
+  }
   androidx.compose.runtime.LaunchedEffect(armed) {
     if (armed) {
-      kotlinx.coroutines.delay(4000L)
+      progress.snapTo(1f)
+      progress.animateTo(
+        targetValue = 0f,
+        animationSpec = androidx.compose.animation.core.tween(
+          durationMillis = 4000,
+          easing = androidx.compose.animation.core.LinearEasing,
+        ),
+      )
+      // animateTo finished → 4s elapsed without confirm → disarm.
       armedState.value = false
+    } else {
+      progress.snapTo(1f)
     }
   }
   Column(
@@ -318,6 +330,17 @@ private fun DemoResetRow(onConfirm: () -> Unit) {
           text = "wipes hired + forged clans, drafts, and lineage. wallet stays connected.",
           style = ClanWorldTheme.type.scriptItalicSmall,
           color = ClanWorldTheme.colors.warmFaint,
+        )
+      }
+      // Draining progress bar at the bottom — visible countdown so the
+      // user can see how much of the 4s arming window remains.
+      if (armed) {
+        Box(
+          modifier = Modifier
+            .align(Alignment.BottomStart)
+            .fillMaxWidth(fraction = progress.value)
+            .height(1.5.dp)
+            .background(ClanWorldTheme.colors.danger),
         )
       }
     }


### PR DESCRIPTION
## Summary

Refactor the auto-disarm from #108 (raw delay + flip) into a 4s LinearEasing \`Animatable\`, then render the progress as a thin danger-color line at the bottom of the armed row.

The bar starts full-width when the user arms the row, drains linearly to zero over 4 seconds, and the disarm fires when the animation lands. Visual + state stay in sync — previously the 4s timer was an opaque \`delay()\`, now it's a visible bar.

**Stacked on #108 (auto-disarm).**

### Behavior
- Tap once → bar fills full-width in danger color, drains over 4s
- Tap-confirm inside the window → \`armed = false\` → LaunchedEffect re-keys → animation cancels → progress snaps to 1f → bar disappears with the rest of armed-state UI
- 4s elapses without confirm → animation lands at 0f → \`armedState.value = false\`

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 19s.

## Test plan

- [ ] Tap Reset Demo State → red bar fills bottom of row, drains linearly to zero over 4s
- [ ] Tap-confirm at any point during drain: state wipes immediately, bar disappears
- [ ] Drain to zero without confirm: row disarms, bar disappears
- [ ] Re-arm after disarm: bar fills again from full

🤖 Generated with [Claude Code](https://claude.com/claude-code)