### PR TITLE
fix(android): connect screen footer pulls real version from BuildConfig

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ConnectScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ConnectScreen.kt
@@ -222,7 +222,7 @@ private fun ConnectScreen(
         }
         Spacer(Modifier.height(2.dp))
         Text(
-          text = "v 0.1.0   ·   Slice I   ·   Seeker · Pixel",
+          text = "v ${world.clan.app.BuildConfig.VERSION_NAME}   ·   build ${world.clan.app.BuildConfig.VERSION_CODE}",
           style = ClanWorldTheme.type.monoNano,
           color = warmFaint,
         )


### PR DESCRIPTION
## Summary

Real bug, not just polish. The Connect screen footer was hardcoded \"v 0.1.0   ·   Slice I   ·   Seeker · Pixel\" — last updated when the app was v0.1.0. We now ship v0.1.13 + build 6, so the footer was visibly stale on Connect — the first screen new users see.

**Stacked on #109 (demo reset countdown).**

### Change
Replaces with \`\"v \${VERSION_NAME}   ·   build \${VERSION_CODE}\"\` pulled from BuildConfig — same approach the Codex About row uses. Drops the \"Slice I\" / \"Seeker · Pixel\" labels since we're past slice 1 and the device class is already surfaced in Codex.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 19s.

## Test plan

- [ ] Connect screen footer reads \`v 0.1.13   ·   build 6\` (or whatever the gradle file says)
- [ ] Future version bumps in build.gradle.kts auto-update the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)