### PR TITLE
fix(android): v0.2.0 Connect bounce-back — disable cold-launch auto-reauthorize + clear stale session on any auth failure

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ConnectScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ConnectScreen.kt
@@ -62,15 +62,13 @@ fun ConnectScreenRoute(
     }
   }
 
-  // Cold-launch verification: if the ViewModel has flagged the stored
-  // session as stale (older than the freshness threshold), auto-trigger
-  // reauthorize on mount so we discover wallet-side revocation before the
-  // user notices broken auth on a signing operation. Fires once.
-  LaunchedEffect(Unit) {
-    if (state.pendingVerification && state.phase != ConnectUiState.Phase.Connecting) {
-      vm.connect(mwaSender)
-    }
-  }
+  // v0.2.0 demo regression fix — the cold-launch auto-reauthorize was
+  // racing with manual taps + producing a "tap → toast → bounce back to
+  // Connect" loop on devices with a stale stored session. Demo expects
+  // that "Open Seed Vault" is the SOLE trigger for any wallet activity.
+  // Stale sessions are recovered manually: tap → reauthorize → if it
+  // fails the VM clears the session and the next tap is a clean connect.
+  // Re-enable for v0.2.x once the silent-flash UX is reproducible.
 
   ConnectScreen(
     state = state,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
@@ -108,17 +108,21 @@ class ConnectViewModel(
         }
       }
       MwaResult.UserDeclined -> {
-        // If the user declined a cold-launch reauthorize the stored
-        // session is no longer trustworthy — clear it so the next
-        // launch is a clean Connect.
-        if (_state.value.pendingVerification) sessionStore.clear()
+        // Any failed authorize/reauthorize invalidates the stored session.
+        // Clearing here means the next "Open Seed Vault" tap is a fresh
+        // mwa.connect() — not another doomed reauthorize against a stale
+        // auth token. v0.2.0 demo regression: previously this only cleared
+        // on cold-launch pendingVerification, so a manual tap that hit a
+        // wallet-side-revoked token would loop ("tap → bounce → tap →
+        // bounce") forever.
+        val wasVerifying = _state.value.pendingVerification
+        sessionStore.clear()
         _state.update {
           it.copy(
             phase = ConnectUiState.Phase.Idle,
-            solanaPubkeyBase58 = null.takeIf { _state.value.pendingVerification }
-              ?: it.solanaPubkeyBase58,
+            solanaPubkeyBase58 = null,
             pendingVerification = false,
-            errorMessage = if (it.pendingVerification)
+            errorMessage = if (wasVerifying)
               "Your sigil could not be verified — please reconnect."
             else
               "Authorization declined.",
@@ -134,10 +138,14 @@ class ConnectViewModel(
           )
         }
       is MwaResult.Error -> {
-        if (_state.value.pendingVerification) sessionStore.clear()
+        // Same rationale as UserDeclined: clear so we never retry a token
+        // the wallet has rejected. A real network/IPC error will simply
+        // result in a fresh authorize on the user's next tap.
+        sessionStore.clear()
         _state.update {
           it.copy(
             phase = ConnectUiState.Phase.Error,
+            solanaPubkeyBase58 = null,
             pendingVerification = false,
             errorMessage = result.cause.message ?: "MWA error.",
           )


### PR DESCRIPTION
## Summary

User reports: tap "Open Seed Vault" → toast briefly appears at top of screen (looks like "reload" or similar word) → kicks back to sign-in screen. MWA connect non-functional in v0.2.0 demo APK; v0.1.16 was working.

## Root cause (best diagnosis under demo time-pressure)

`git diff v0.1.16..v0.2.0` for the Connect-flow source files (`ConnectScreen.kt`, `ConnectViewModel.kt`, `MwaClient.kt`, `MainActivity.kt`) is **byte-identical** — so this isn't a direct edit to those paths. The two plausible runtime paths to "tap → bounce":

1. **Cold-launch auto-reauthorize racing manual tap.** `ConnectScreenRoute` had a `LaunchedEffect(Unit)` that auto-triggered `vm.connect()` whenever a stored session was stale (>24h). That call fires concurrently with composition; if the user taps "Open Seed Vault" in the same beat, two invocations queue. The first hits a wallet-side-revoked `auth_token`, Phantom flashes a brief "Reload session" toast, and the SDK returns `UserDeclined` / `Error` → state flips back to `Idle` → user sees what looks exactly like "tap → bounce back."
2. **Stale auth_token loop.** `ConnectViewModel.handle()` only cleared the `SessionStore` on a failed authorize when `pendingVerification` was true (i.e. cold-launch auto-verify). A *user-initiated* reauthorize that failed left the stale token in storage, so the *next* tap also reauthorized against the same broken token → "tap → bounce → tap → bounce" forever.

## Fix (minimal, defensive)

- **`ConnectScreen.kt`**: remove the cold-launch auto-reauthorize `LaunchedEffect`. Demo flow now requires every wallet activity to be a direct response to a user tap. Re-enable post-hackathon once flash-back UX is reproducible.
- **`ConnectViewModel.kt`**: `handle()` now clears `SessionStore` on **any** failed authorize/reauthorize (`UserDeclined`, `Error`), not just when `pendingVerification == true`. Guarantees the next tap is a clean `mwa.connect()` instead of another doomed reauthorize.

No changes to `MainActivity.kt` (ActivityResultSender stays hoisted to `onCreate` per #64). No changes to `MwaClient`. No changes to NavHost. PR #96's `HallScreenRoute` `LaunchedEffect(Unit) { vm.refresh() }` is untouched.

## Build

- `./gradlew :app:assembleDebug` GREEN locally.

## Test plan

- [ ] Fresh install on Pixel: tap "Open Seed Vault" once → Phantom opens → approve → lands on Hearth.
- [ ] After successful connect: kill app, relaunch → cold-routes to Hearth (fresh session ≤ 24h).
- [ ] After 24h+ session: relaunch → lands on Connect (no auto-Phantom flash) → tap → reauthorize → Hearth.
- [ ] Failed reauthorize (wallet revokes token externally): tap → "Authorization declined." → tap again → fresh `mwa.connect()` runs (no doomed-reauthorize loop).

## Tag

Orchestrator will tag `v0.2.1` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)