### PR TITLE
feat(android): character counters warn at 85%, danger at max

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -469,10 +469,15 @@ private fun StepNameSigil(state: ForgeUiState, onChange: (String) -> Unit) {
         )
       }
       Spacer(Modifier.height(8.dp))
+      val nameCounterColor = when {
+        state.sigilName.length >= 32 -> ClanWorldTheme.colors.danger
+        state.sigilName.length >= 27 -> ClanWorldTheme.colors.warn  // 85% of 32
+        else -> Ink3
+      }
       Text(
         text = "${state.sigilName.length}/32",
         style = ClanWorldTheme.type.monoNano,
-        color = Ink3,
+        color = nameCounterColor,
         textAlign = TextAlign.End,
         modifier = Modifier.fillMaxWidth(),
       )

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -309,10 +309,15 @@ private fun DraftCard(draft: String, onChange: (String) -> Unit, enabled: Boolea
       )
     }
     Spacer(Modifier.height(8.dp))
+    val counterColor = when {
+      draft.length >= 280 -> ClanWorldTheme.colors.danger
+      draft.length >= 238 -> ClanWorldTheme.colors.warn  // 85% of 280
+      else -> Ink3
+    }
     Text(
       text = "${draft.length}/280",
       style = ClanWorldTheme.type.monoNano,
-      color = Ink3,
+      color = counterColor,
       textAlign = TextAlign.End,
       modifier = Modifier.fillMaxWidth(),
     )

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
@@ -208,10 +208,15 @@ private fun StrategyEditor(
             )
           }
           Spacer(Modifier.height(8.dp))
+          val docCounterColor = when {
+            state.doctrine.length >= 280 -> ClanWorldTheme.colors.danger
+            state.doctrine.length >= 238 -> ClanWorldTheme.colors.warn
+            else -> Ink3
+          }
           Text(
             text = "${state.doctrine.length}/280",
             style = ClanWorldTheme.type.monoNano,
-            color = Ink3,
+            color = docCounterColor,
             textAlign = TextAlign.End,
             modifier = Modifier.fillMaxWidth(),
           )


### PR DESCRIPTION
## Summary

Three text-input character counters (SteeringConsole 280, StrategyEditor doctrine 280, Forge sigilName 32) were always rendered \`Ink3\` — gave the user no feedback that they were running out of room until the input silently stopped accepting keystrokes at the cap.

**Stacked on #110 (connect version footer).**

### Behavior
Each counter colorizes:
- \`Ink3\` (default) when length is comfortable
- \`warn\` (orange) when length ≥ 85% of max (238/280, 27/32)
- \`danger\` (red) when length == max

Same threshold logic in all three counters. Doesn't change the cap behavior — text still gets truncated at the input level by the existing \`take(N)\` calls in the ViewModels.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 30s.

## Test plan

- [ ] SteeringConsole: type 0–237 chars → counter Ink3; 238–279 → orange warn; 280 → red danger
- [ ] StrategyEditor doctrine: same thresholds
- [ ] Forge sigil name: 0–26 → Ink3; 27–31 → orange; 32 → red
- [ ] Backspace below threshold returns to lower color

🤖 Generated with [Claude Code](https://claude.com/claude-code)