### PR TITLE
feat(android): strategy posture pills get a tagline subline

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
@@ -149,7 +149,13 @@ private fun StrategyEditor(
             )
           }
         }
-        Spacer(Modifier.height(18.dp))
+        Spacer(Modifier.height(8.dp))
+        Text(
+          text = postureTagline(state.posture),
+          style = ClanWorldTheme.type.scriptItalicSmall,
+          color = ClanWorldTheme.colors.warmDim,
+        )
+        Spacer(Modifier.height(14.dp))
 
         // ── Pinned memory key ─────────────────────────────────────────────
         ParchmentCard(modifier = Modifier.fillMaxWidth()) {
@@ -301,6 +307,12 @@ private fun EditorHead(clanId: Int) {
       modifier = Modifier.padding(top = 2.dp),
     )
   }
+}
+
+private fun postureTagline(p: Posture): String = when (p) {
+  Posture.Defensive -> "hold the line; trade no ground without weight."
+  Posture.Balanced -> "read the season; move when both shores agree."
+  Posture.Aggressive -> "forge ahead; the season favors the bold."
 }
 
 @Composable


### PR DESCRIPTION
## Summary

The three-pill posture row in StrategyEditor (Defensive / Balanced / Aggressive) had no description of what each posture meant — the user could pick one but not learn from the picker itself. Compare to Forge step 3 where each HarnessCard already shows its tagline below the label.

**Stacked on #112 (counter warnings).**

### Change
Add a small italic line under the pills that updates when the active posture changes:
- **Defensive** → \"hold the line; trade no ground without weight.\"
- **Balanced** → \"read the season; move when both shores agree.\"
- **Aggressive** → \"forge ahead; the season favors the bold.\"

Same copy as Forge's Iron / Tide / Ember (since they map to the same three postures under thematic names) — keeps the lore consistent.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 19s.

## Test plan

- [ ] StrategyEditor → tap each posture pill → italic line updates with the matching tagline
- [ ] Defensive / Balanced / Aggressive copy matches the Forge harness copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)