### PR TITLE
feat(android): steering target tagline below the clan-pill row

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -230,6 +230,12 @@ private fun TargetClanRow(active: Int, onSelect: (Int) -> Unit) {
         )
       }
     }
+    Spacer(Modifier.height(8.dp))
+    Text(
+      text = world.clan.app.viewmodel.clanTagline(active),
+      style = ClanWorldTheme.type.scriptItalicSmall,
+      color = ClanWorldTheme.colors.warmDim,
+    )
   }
 }
 


### PR DESCRIPTION
## Summary

The \"TO ELDER\" row in SteeringConsole only showed clan-color dot + clan name. The user could pick a target but the picker gave no reminder of WHY they might whisper to that clan — what kind of elder they were addressing.

**Stacked on #113 (posture tagline).**

### Change
Adds a small italic line below the pill row that updates with the active clan's tagline from \`clanTagline()\` — same lookup Hearth's leaderboard subtext uses, so language is consistent:

- Storm-Edge → \"blades of the high pass\"
- Tideborne → \"guardians of the strait\"
- Twilight → \"they read the signs\"
- Ember → \"forge before all\"

Symmetric to the StrategyEditor posture tagline from #113.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 29s.

## Test plan

- [ ] SteeringConsole → tap each clan pill in TO ELDER row → tagline below updates
- [ ] Tagline matches the leaderboard subtext on Hearth (same source helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)