### PR TITLE
feat(android): forge wizard system back-press walks back through steps

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -84,6 +84,13 @@ fun ForgeScreenRoute(
   val state by vm.state.collectAsState()
   val scope = rememberCoroutineScope()
 
+  // System back inside the wizard walks back through steps rather than
+  // popping the whole route. Only on step 1 (PickClan) does back actually
+  // exit the wizard back to Hall.
+  androidx.activity.compose.BackHandler(enabled = state.step != ForgeStep.PickClan) {
+    vm.back()
+  }
+
   ForgeScreen(
     state = state,
     onBack = onBack,


### PR DESCRIPTION
## Summary

Real UX bug. Pressing system back from inside the Forge wizard popped the entire route to Hall — losing the user's progress through the 4-step flow. On step 4, that meant a single accidental swipe-back wiped name + clan + harness picks. Drafts persist via #79 so the values come back, but the user still landed on Hall and had to re-open the wizard.

**Stacked on #114 (steering target tagline).**

### Fix
Adds \`androidx.activity.compose.BackHandler\` scoped to \`ForgeScreenRoute\`:
- \`enabled = state.step != ForgeStep.PickClan\` → only intercepts when there's a step to walk back to
- onBack fires \`vm.back()\` to walk one step backward
- On step 1 (PickClan), BackHandler is disabled and Compose Navigation pops the route to Hall as before

Same pattern web wizards use: in-wizard navigation gets first refusal on the back press, only the first step exits to the host.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 27s.

## Test plan

- [ ] Forge wizard step 1 → swipe back → exits to Hall (unchanged)
- [ ] Step 2 → swipe back → returns to step 1 (NEW; previously popped to Hall)
- [ ] Step 3 → swipe back → step 2
- [ ] Step 4 → swipe back → step 3
- [ ] Confirm-and-forge from step 4 → ForgedScreen → swipe back: returns to Hall (Forge popped via popUpTo inclusive=true on success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)