### PR TITLE
feat(android): hire modal — system back-press dismisses the modal

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
@@ -78,6 +78,17 @@ fun HireModal(
     }
   }
 
+  // System back press dismisses the modal first, before it pops the
+  // BazaarInftDetail route. Disabled while the wallet is mid-sign so the
+  // user can't back out into a half-signed state — Phantom is in front
+  // anyway during Signing, so this only matters for the brief moments
+  // before / after.
+  androidx.activity.compose.BackHandler(
+    enabled = state.value == HireState.Idle || state.value == HireState.Failed,
+  ) {
+    onDismiss()
+  }
+
   Box(
     modifier = Modifier
       .fillMaxSize()


### PR DESCRIPTION
## Summary

Companion to the Forge wizard back-handler from #115. While HireModal is open, system back was popping the entire BazaarInftDetail route — the modal disappeared but so did the underlying iNFT detail. The user expected back to dismiss the modal first, like every other Android modal pattern.

**Stacked on #115 (forge back handler).**

### Fix
Adds \`androidx.activity.compose.BackHandler\` scoped inside HireModal:
- Enabled when state is \`Idle\` or \`Failed\` → fires \`onDismiss()\`
- Disabled when state is \`Signing\` (Phantom is in front anyway) or \`Sealed\` (auto-pops in 1.4s; back during the success linger feels inappropriate)

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 21s.

## Test plan

- [ ] Bazaar → tap listing → Hire This Sigil → modal opens → swipe back: modal dismisses, BazaarInftDetail stays visible
- [ ] Hire flow during MWA wallet sheet (Signing): swipe back not consumed (Phantom is the focused activity anyway)
- [ ] Sealed state: 1.4s linger — back-press inert, auto-pop fires as expected
- [ ] After dismiss → tap Hire again: modal re-opens fresh in Idle state

🤖 Generated with [Claude Code](https://claude.com/claude-code)