### PR TITLE
fix(android): disconnect clears lineage as well as session

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -11,7 +11,7 @@ import world.clan.app.App
 class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factory {
   @Suppress("UNCHECKED_CAST")
   override fun <T : ViewModel> create(modelClass: Class<T>): T = when (modelClass) {
-    ConnectViewModel::class.java -> ConnectViewModel(app.mwaClient, app.sessionStore)
+    ConnectViewModel::class.java -> ConnectViewModel(app.mwaClient, app.sessionStore, app.lineageStore)
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
     BazaarViewModel::class.java -> BazaarViewModel(app.sessionStore)

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import world.clan.app.data.LineageStore
 import world.clan.app.data.Session
 import world.clan.app.data.SessionStore
 import world.clan.app.wallet.MwaClient
@@ -48,6 +49,7 @@ data class ConnectUiState(
 class ConnectViewModel(
   private val mwa: MwaClient,
   private val sessionStore: SessionStore,
+  private val lineageStore: LineageStore? = null,
 ) : ViewModel() {
 
   private val _state = MutableStateFlow(initialState())
@@ -81,6 +83,10 @@ class ConnectViewModel(
 
   fun disconnect() {
     sessionStore.clear()
+    // Lineage lives in a separate prefs file from sessionStore; clear
+    // it on disconnect so the next-connected wallet doesn't see the
+    // previous wallet's owner-action history.
+    lineageStore?.clear()
     _state.value = ConnectUiState()
   }
 


### PR DESCRIPTION
## Summary

Real bug. Disconnect from the wallet pill dropdown calls \`sessionStore.clear()\` which wipes hired / forged / drafts / flag:* keys (they all live in \`clan-world-session.enc\`). But \`LineageStore\` is a separate prefs file (\`clan-world-lineage.enc\`) and was NOT being cleared on disconnect.

A flow like \"user A connects, forges + hires, disconnects; user B connects\" would show user A's \"Forged Caldris / Hired Tideborne\" entries in user B's Codex Lineage section. Privacy leak between wallets on the same device.

**Stacked on #116 (HireModal back-handler).**

### Fix
- \`ConnectViewModel\` takes an optional \`lineageStore: LineageStore? = null\` (factory now passes \`app.lineageStore\`)
- \`disconnect()\` calls \`lineageStore?.clear()\` alongside \`sessionStore.clear()\`
- Optional ctor param so tests can construct ConnectViewModel without a real LineageStore — null-safe \`?.clear()\`

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 25s.

## Test plan

- [ ] Connect wallet A → forge a sigil → check Codex Lineage shows \"Forged X\"
- [ ] Tap wallet pill → Disconnect
- [ ] Connect wallet B (different MWA account)
- [ ] Codex Lineage section: empty (was: still showed wallet A's entries)
- [ ] Demo Reset still works (orthogonal — different code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)