### PR TITLE
feat(android): hearth auto-refreshes every 30s while alive

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -45,7 +45,21 @@ class HearthViewModel(
   private val _state = MutableStateFlow(initial())
   val state: StateFlow<HearthUiState> = _state.asStateFlow()
 
-  init { refresh() }
+  init {
+    refresh()
+    // Auto-refresh every 30s while the VM is alive (i.e. while Hearth is
+    // on the back stack). Tick number + leaderboard are how the user reads
+    // the world's heartbeat — they should advance without a manual pull.
+    // Cancelled cleanly on viewModelScope teardown when the user
+    // disconnects (popUpTo(0) clears the back stack).
+    viewModelScope.launch {
+      while (true) {
+        kotlinx.coroutines.delay(REFRESH_INTERVAL_MS)
+        if (_state.value.isLoading || _state.value.isRefreshing) continue
+        refresh()
+      }
+    }
+  }
 
   private fun initial(): HearthUiState {
     val s = sessionStore.read()
@@ -142,6 +156,14 @@ class HearthViewModel(
     /** Hardcoded "yours" clan set — slice 1 UI demo. Edit one constant to shift. */
     val LINKED_CLAN_IDS = listOf(2, 6, 5)
     const val DEFAULT_LINKED_CLAN = 2
+
+    /**
+     * Auto-refresh cadence for the Hearth snapshot. 30s is a balance
+     * between "feels live" and "burns the user's data" — Convex tick
+     * cadence is 20s in dev, 60s in S2 KeeperHub, so 30s catches at
+     * least one new tick most of the time.
+     */
+    const val REFRESH_INTERVAL_MS = 30_000L
   }
 }
 


### PR DESCRIPTION
## Summary

Real feature gap, not just polish. Hearth's tick + leaderboard came from \`convex.getSnapshot()\` called once on \`HearthViewModel.refresh()\`. Without manual pull-to-refresh the user saw a frozen tick number — the world's \"live heartbeat\" UX that the banner copy implies wasn't there.

**Stacked on #117 (disconnect-clears-lineage).**

### Implementation
- \`viewModelScope.launch\` loop that fires \`refresh()\` every 30s
- Skips when \`isLoading\` / \`isRefreshing\` is already in flight (no overlapping queries on slow networks)
- Cleans up automatically on VM teardown — fires when the user disconnects (\`popUpTo(0)\` on Connect) so no leaked Convex calls into Connect

### Cadence
\`REFRESH_INTERVAL_MS = 30_000L\` — balance between \"feels live\" and \"burns data\". Convex tick cadence is 20s in dev / 60s in S2 KeeperHub, so 30s catches at least one new tick most of the time.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 6s.

## Test plan

- [ ] Land on Hearth → wait 30s → tick number advances without manual pull
- [ ] Pull-to-refresh during the 30s window → updates immediately, doesn't double-fire when 30s lands
- [ ] Disconnect from wallet pill → no orphan Convex requests after navigating away

🤖 Generated with [Claude Code](https://claude.com/claude-code)