### PR TITLE
feat(android): auto-refresh Hall + Whispers + Treasury every 30s

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HallViewModel.kt
@@ -55,7 +55,19 @@ class HallViewModel(
   private val _state = MutableStateFlow(initial())
   val state: StateFlow<HallUiState> = _state.asStateFlow()
 
-  init { refresh() }
+  init {
+    refresh()
+    // Auto-refresh every 30s while VM is alive — new memory writes,
+    // transfers, etc should land in Hall without pull-to-refresh.
+    // Cleaned up by viewModelScope cancellation on disconnect.
+    viewModelScope.launch {
+      while (true) {
+        kotlinx.coroutines.delay(HearthViewModel.REFRESH_INTERVAL_MS)
+        if (_state.value.isLoading || _state.value.isRefreshing) continue
+        refresh()
+      }
+    }
+  }
 
   private fun initial(): HallUiState {
     val s = sessionStore.read()

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
@@ -50,7 +50,18 @@ class TreasuryViewModel(
   private val _state = MutableStateFlow(TreasuryUiState(clanId = clanId))
   val state: StateFlow<TreasuryUiState> = _state.asStateFlow()
 
-  init { refresh() }
+  init {
+    refresh()
+    // Gold movements / balance should refresh while screen is open.
+    // 30s cadence matches Hearth/Hall/Whispers.
+    viewModelScope.launch {
+      while (true) {
+        kotlinx.coroutines.delay(HearthViewModel.REFRESH_INTERVAL_MS)
+        if (_state.value.isLoading) continue
+        refresh()
+      }
+    }
+  }
 
   fun refresh() {
     viewModelScope.launch {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/WhispersViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/WhispersViewModel.kt
@@ -34,7 +34,18 @@ class WhispersViewModel(
   private val _state = MutableStateFlow(WhispersUiState())
   val state: StateFlow<WhispersUiState> = _state.asStateFlow()
 
-  init { refresh() }
+  init {
+    refresh()
+    // Inbox-style surface — new whispers should appear without manual
+    // pull. 30s cadence matches Hearth/Hall (see HearthViewModel).
+    viewModelScope.launch {
+      while (true) {
+        kotlinx.coroutines.delay(HearthViewModel.REFRESH_INTERVAL_MS)
+        if (_state.value.isLoading) continue
+        refresh()
+      }
+    }
+  }
 
   fun refresh() {
     viewModelScope.launch {


### PR DESCRIPTION
## Summary

Apply the Hearth auto-refresh pattern from #118 to the other three data-fetching ViewModels. Same in-flight guard, same VM-scope teardown on disconnect, same 30s cadence (\`HearthViewModel.REFRESH_INTERVAL_MS\` is the shared source of truth).

**Stacked on #118 (hearth auto-refresh).**

### Coverage
- **Hall** — new memory writes / transfers land without pull-to-refresh
- **Whispers** — chat-like surface, new whispers appear automatically
- **Treasury** — gold balance + movements update while screen is open

Cadence: 30s. Fast enough to feel alive within one tick window (20–60s ticks), slow enough not to burn data on a phone in the user's pocket.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 3s.

## Test plan

- [ ] Hall → wait 30s → list refreshes (verify in logs / by changing data)
- [ ] Whispers → leave open → new whisper appears within ~30s
- [ ] Treasury → leave open → movements list updates
- [ ] Pull-to-refresh during the 30s window → updates immediately, doesn't double-fire on auto cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)