### PR TITLE
feat(android): codex disconnect wallet row

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -178,8 +178,16 @@ private fun CodexScreen(
 
     Spacer(Modifier.height(28.dp))
 
-    // ── Demo reset (bottom of Codex) ─────────────────────────────────
+    // ── Disconnect (above Demo Reset) ────────────────────────────────
+    val onDisconnect = world.clan.app.ui.components.LocalOnDisconnect.current
     StaggeredEntry(index = 11) {
+      DisconnectRow(onClick = onDisconnect)
+    }
+
+    Spacer(Modifier.height(12.dp))
+
+    // ── Demo reset (bottom of Codex) ─────────────────────────────────
+    StaggeredEntry(index = 12) {
       DemoResetRow(onConfirm = onResetDemo)
     }
 
@@ -252,6 +260,43 @@ private fun ShareApkRow(url: String) {
           text = "SHARE",
           style = ClanWorldTheme.type.monoNano,
           color = ClanWorldTheme.colors.gold,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun DisconnectRow(onClick: () -> Unit) {
+  val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
+  Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Text(
+      text = "Wallet".uppercase(),
+      style = ClanWorldTheme.type.crownLabel,
+      color = ClanWorldTheme.colors.warmFaint,
+    )
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .clip(RoundedCornerShape(6.dp))
+        .background(ClanWorldTheme.colors.iron)
+        .border(1.dp, ClanWorldTheme.colors.hairline, RoundedCornerShape(6.dp))
+        .clickable {
+          haptics.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+          onClick()
+        }
+        .padding(horizontal = 14.dp, vertical = 14.dp),
+    ) {
+      Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+          text = "DISCONNECT WALLET",
+          style = ClanWorldTheme.type.monoMicro,
+          color = ClanWorldTheme.colors.warm,
+        )
+        Text(
+          text = "clears auth + lineage. you'll re-authorize on next launch.",
+          style = ClanWorldTheme.type.scriptItalicSmall,
+          color = ClanWorldTheme.colors.warmFaint,
         )
       }
     }


### PR DESCRIPTION
## Summary

Adds a \"DISCONNECT WALLET\" row in Codex (new \"Wallet\" section, above Demo Reset). Same effect as the wallet pill dropdown's Disconnect — routes through \`LocalOnDisconnect\` → \`ConnectViewModel.disconnect()\` which clears session + lineage + drafts + hired/forged, and navigates to Connect with \`popUpTo(0)\`.

**Stacked on #119 (auto-refresh sweep).**

### Why a secondary surface
Some users never tap the wallet pill (it visually reads as a status indicator) and end up looking for disconnect in settings-like surfaces. Codex is where they look.

Subtitle copy mirrors the demo-reset row's pattern: \"clears auth + lineage. you'll re-authorize on next launch.\" — sets expectations without surprise.

LongPress haptic on tap (same as EmberCta — disconnect is a commit-style action).

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 25s.

## Test plan

- [ ] Codex → scroll to bottom → \"Wallet\" section visible above \"Demo\"
- [ ] Tap DISCONNECT WALLET: heavy haptic, navigates to Connect, no session
- [ ] Reconnect: lineage is empty (cleared by disconnect, same as #117 fix)
- [ ] Codex disconnect ≡ wallet pill disconnect (same code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)