### PR TITLE
feat(android): winter active banner pill on hearth

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
@@ -116,6 +116,7 @@ private fun HearthScreen(
               seasonNumber = state.seasonNumber,
               seasonStartTick = state.seasonStartTick,
               seasonEndTick = state.seasonEndTick,
+              winterActive = state.winterActive,
             )
           }
 
@@ -153,6 +154,7 @@ private fun HearthBanner(
   seasonNumber: Int,
   seasonStartTick: Long,
   seasonEndTick: Long,
+  winterActive: Boolean = false,
 ) {
   val iron = ClanWorldTheme.colors.iron
   val gold = ClanWorldTheme.colors.gold
@@ -257,6 +259,20 @@ private fun HearthBanner(
           verticalArrangement = Arrangement.spacedBy(6.dp),
           modifier = Modifier.widthIn(min = 120.dp),
         ) {
+          if (winterActive) {
+            Box(
+              modifier = Modifier
+                .clip(RoundedCornerShape(2.dp))
+                .background(rune.copy(alpha = 0.18f))
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+            ) {
+              Text(
+                text = "WINTER",
+                style = ClanWorldTheme.type.monoNano,
+                color = rune,
+              )
+            }
+          }
           Text(
             text = seasonName.uppercase(),
             style = ClanWorldTheme.type.crownLabel,


### PR DESCRIPTION
## Summary

\`state.winterActive\` was being read from the Convex snapshot and stored in HearthUiState since slice 1, but never displayed. Dead state field.

**Stacked on #120 (codex disconnect button).**

### Change
When \`winterActive == true\`, the Hearth banner's season block shows a small rune-colored \"WINTER\" pill above the season name. Subtle (rune.copy alpha=0.18 bg, monoNano text). Visible game-state signal so the user can tell at a glance the world has shifted into winter without hunting through the cockpit.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 36s.

## Test plan

- [ ] Snapshot with winterActive=false: banner shows season block as before, no pill
- [ ] Snapshot with winterActive=true: small rune-color WINTER pill appears above the SEASON label
- [ ] Pill aligns to the right edge of the season block (column horizontalAlignment=End)

🤖 Generated with [Claude Code](https://claude.com/claude-code)