### PR TITLE
feat(android): bandit alert pill on hearth

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
@@ -120,6 +121,11 @@ private fun HearthScreen(
             )
           }
 
+          if (state.banditAlert != null) {
+            StaggeredEntry(index = 1) {
+              BanditAlertPill(alert = state.banditAlert)
+            }
+          }
           StaggeredEntry(index = 1) {
             SectionHeader(
               title = "Leaderboard",
@@ -147,6 +153,43 @@ private fun HearthScreen(
 // ─────────────────────────────────────────────────────────────────────────
 // Banner
 // ─────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun BanditAlertPill(alert: HearthUiState.BanditAlert) {
+  val danger = ClanWorldTheme.colors.danger
+  val warm = ClanWorldTheme.colors.warm
+  val warmDim = ClanWorldTheme.colors.warmDim
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(6.dp))
+      .background(danger.copy(alpha = 0.10f))
+      .border(1.dp, danger.copy(alpha = 0.45f), RoundedCornerShape(6.dp))
+      .padding(horizontal = 14.dp, vertical = 10.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Box(
+      modifier = Modifier
+        .size(8.dp)
+        .clip(RoundedCornerShape(50))
+        .background(danger),
+    )
+    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+      Text(
+        text = "BANDIT · ID ${alert.banditId}" + (alert.tier?.let { " · TIER $it" } ?: ""),
+        style = ClanWorldTheme.type.monoMicro,
+        color = danger,
+      )
+      Text(
+        text = alert.regionName?.let { "rumored at $it." }
+          ?: "moves through the realms.",
+        style = ClanWorldTheme.type.scriptItalicSmall,
+        color = warmDim,
+      )
+    }
+  }
+}
 
 @Composable
 private fun HearthBanner(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -23,6 +23,7 @@ data class HearthUiState(
   val winterActive: Boolean = false,
   val leaderboard: List<LeaderboardRow> = emptyList(),
   val recentComms: List<CombinedComm> = emptyList(),
+  val banditAlert: BanditAlert? = null,
   val walletShort: String = "",
   val errorMessage: String? = null,
 ) {
@@ -34,6 +35,13 @@ data class HearthUiState(
     val gold: Long,
     val delta: Long,
     val isMine: Boolean,
+  )
+
+  /** A bandit visible in the snapshot — surfaced as an alert pill on Hearth. */
+  data class BanditAlert(
+    val banditId: Int,
+    val regionName: String?,
+    val tier: Int?,
   )
 }
 
@@ -130,6 +138,17 @@ class HearthViewModel(
     val seasonEnd = snap.seasonEndTick ?: (seasonStart + 60L)
     val seasonNumber = maxOf(1, (seasonStart / 60L).toInt() + 1)
 
+    val banditAlert = snap.bandit?.let { b ->
+      val regionName = snap.regions.firstOrNull { it.id.toIntOrNull() == b.region }?.name
+      HearthUiState.BanditAlert(
+        banditId = b.id,
+        regionName = regionName,
+        tier = b.tier,
+      )
+    } ?: snap.activeBanditId?.let { id ->
+      HearthUiState.BanditAlert(banditId = id, regionName = null, tier = null)
+    }
+
     return HearthUiState(
       isLoading = false,
       isRefreshing = false,
@@ -140,6 +159,7 @@ class HearthViewModel(
       winterActive = snap.winterActive,
       leaderboard = leaderboard,
       recentComms = comms,
+      banditAlert = banditAlert,
       walletShort = solanaPubkey.shortenPubkey(),
     )
   }


### PR DESCRIPTION
## Summary

\`WorldSnapshot.activeBanditId\` and \`bandit\` were parsed from Convex but dropped on the floor — Hearth never showed the user that a bandit was active in the realm. Companion to the winterActive surface from #121.

**Stacked on #121 (winter banner flag).**

### Implementation
- New \`HearthUiState.BanditAlert\` data class: \`banditId\`, \`regionName\`, \`tier\`
- \`HearthViewModel.project()\` builds it from \`snap.bandit\` (preferred) or \`snap.activeBanditId\` (fallback). Region name resolved by joining \`bandit.region\` against \`snap.regions[].id\` (parsed as int)
- New \`BanditAlertPill\` composable in HearthScreen renders danger-tinted pill above the Leaderboard SectionHeader: \"BANDIT · ID N · TIER N / rumored at <region>\"

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 10s.

## Test plan

- [ ] Snapshot with active bandit: pill appears above leaderboard with danger styling
- [ ] Region name resolves to a string when \`bandit.region\` matches a \`regions[]\` id
- [ ] Region missing → \"moves through the realms.\" fallback copy
- [ ] Tier missing → drop the \"· TIER N\" segment
- [ ] No bandit → pill not rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)