### PR TITLE
feat(android): hearth banner shows approaching winter

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
@@ -118,6 +118,7 @@ private fun HearthScreen(
               seasonStartTick = state.seasonStartTick,
               seasonEndTick = state.seasonEndTick,
               winterActive = state.winterActive,
+              winterApproachingInTicks = state.winterApproachingInTicks,
             )
           }
 
@@ -198,6 +199,7 @@ private fun HearthBanner(
   seasonStartTick: Long,
   seasonEndTick: Long,
   winterActive: Boolean = false,
+  winterApproachingInTicks: Long? = null,
 ) {
   val iron = ClanWorldTheme.colors.iron
   val gold = ClanWorldTheme.colors.gold
@@ -302,18 +304,34 @@ private fun HearthBanner(
           verticalArrangement = Arrangement.spacedBy(6.dp),
           modifier = Modifier.widthIn(min = 120.dp),
         ) {
-          if (winterActive) {
-            Box(
-              modifier = Modifier
-                .clip(RoundedCornerShape(2.dp))
-                .background(rune.copy(alpha = 0.18f))
-                .padding(horizontal = 6.dp, vertical = 2.dp),
-            ) {
-              Text(
-                text = "WINTER",
-                style = ClanWorldTheme.type.monoNano,
-                color = rune,
-              )
+          when {
+            winterActive -> {
+              Box(
+                modifier = Modifier
+                  .clip(RoundedCornerShape(2.dp))
+                  .background(rune.copy(alpha = 0.18f))
+                  .padding(horizontal = 6.dp, vertical = 2.dp),
+              ) {
+                Text(
+                  text = "WINTER",
+                  style = ClanWorldTheme.type.monoNano,
+                  color = rune,
+                )
+              }
+            }
+            winterApproachingInTicks != null -> {
+              Box(
+                modifier = Modifier
+                  .clip(RoundedCornerShape(2.dp))
+                  .background(rune.copy(alpha = 0.10f))
+                  .padding(horizontal = 6.dp, vertical = 2.dp),
+              ) {
+                Text(
+                  text = "WINTER · ${winterApproachingInTicks}T",
+                  style = ClanWorldTheme.type.monoNano,
+                  color = rune.copy(alpha = 0.85f),
+                )
+              }
             }
           }
           Text(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -21,6 +21,8 @@ data class HearthUiState(
   val seasonStartTick: Long = 0,
   val seasonEndTick: Long = 60,
   val winterActive: Boolean = false,
+  /** Ticks remaining until winter, when winter is forecast but not yet active. */
+  val winterApproachingInTicks: Long? = null,
   val leaderboard: List<LeaderboardRow> = emptyList(),
   val recentComms: List<CombinedComm> = emptyList(),
   val banditAlert: BanditAlert? = null,
@@ -149,6 +151,12 @@ class HearthViewModel(
       HearthUiState.BanditAlert(banditId = id, regionName = null, tier = null)
     }
 
+    val winterApproaching = if (!snap.winterActive) {
+      snap.winterStartsAtTick?.let { startsAt ->
+        (startsAt - snap.tick).takeIf { it in 1..10 }
+      }
+    } else null
+
     return HearthUiState(
       isLoading = false,
       isRefreshing = false,
@@ -157,6 +165,7 @@ class HearthViewModel(
       seasonStartTick = seasonStart,
       seasonEndTick = seasonEnd,
       winterActive = snap.winterActive,
+      winterApproachingInTicks = winterApproaching,
       leaderboard = leaderboard,
       recentComms = comms,
       banditAlert = banditAlert,


### PR DESCRIPTION
## Summary

\`WorldSnapshot.winterStartsAtTick\` was unused. Adds a forecast pill in the same slot as the active \"WINTER\" pill from #121, but rendered at half-brightness when winter is approaching within 10 ticks but not yet here.

**Stacked on #122 (bandit alert).**

### State derivation
\`HearthUiState.winterApproachingInTicks: Long?\` — non-null only when:
\`winterActive == false && winterStartsAtTick != null && (winterStartsAtTick - tick) in 1..10\`

### UI
Banner picks one of three states:
- winter active → \"WINTER\" rune @ 0.18α (existing from #121)
- winter approaching → \"WINTER · NT\" rune @ 0.10α (dimmer; new)
- otherwise → no pill

10-tick threshold is a heuristic: long enough to give the user time to react, short enough that a winter five seasons out doesn't sit permanently in the banner.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 27s.

## Test plan

- [ ] Snapshot with winterActive=true → \"WINTER\" pill (full brightness)
- [ ] Snapshot with winterStartsAtTick = tick + 5 → \"WINTER · 5T\" (dim)
- [ ] Snapshot with winterStartsAtTick = tick + 30 → no pill
- [ ] Snapshot with no winter info → no pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)