### PR TITLE
feat(android): hearth banner — live tick countdown

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
@@ -119,6 +119,7 @@ private fun HearthScreen(
               seasonEndTick = state.seasonEndTick,
               winterActive = state.winterActive,
               winterApproachingInTicks = state.winterApproachingInTicks,
+              nextTickAtEpochMs = state.nextTickAtEpochMs,
             )
           }
 
@@ -200,6 +201,7 @@ private fun HearthBanner(
   seasonEndTick: Long,
   winterActive: Boolean = false,
   winterApproachingInTicks: Long? = null,
+  nextTickAtEpochMs: Long? = null,
 ) {
   val iron = ClanWorldTheme.colors.iron
   val gold = ClanWorldTheme.colors.gold
@@ -283,7 +285,26 @@ private fun HearthBanner(
       ) {
         // Tick block
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-          Text("TICK", style = ClanWorldTheme.type.monoMicro, color = gold)
+          Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("TICK", style = ClanWorldTheme.type.monoMicro, color = gold)
+            if (nextTickAtEpochMs != null) {
+              val countdownMs by androidx.compose.runtime.produceState(
+                initialValue = (nextTickAtEpochMs - System.currentTimeMillis()).coerceAtLeast(0L),
+                key1 = nextTickAtEpochMs,
+              ) {
+                while (true) {
+                  value = (nextTickAtEpochMs - System.currentTimeMillis()).coerceAtLeast(0L)
+                  kotlinx.coroutines.delay(1000L)
+                }
+              }
+              val seconds = (countdownMs / 1000L).toInt()
+              Text(
+                text = if (seconds > 0) "next in ${seconds}s" else "next imminent…",
+                style = ClanWorldTheme.type.monoMicro,
+                color = warmFaint,
+              )
+            }
+          }
           Row(verticalAlignment = Alignment.Bottom) {
             Text(
               text = "%04d".format(tick),

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -23,6 +23,8 @@ data class HearthUiState(
   val winterActive: Boolean = false,
   /** Ticks remaining until winter, when winter is forecast but not yet active. */
   val winterApproachingInTicks: Long? = null,
+  /** Wall-clock millis when the next tick is expected, derived from snap.tickEpoch. */
+  val nextTickAtEpochMs: Long? = null,
   val leaderboard: List<LeaderboardRow> = emptyList(),
   val recentComms: List<CombinedComm> = emptyList(),
   val banditAlert: BanditAlert? = null,
@@ -157,6 +159,16 @@ class HearthViewModel(
       }
     } else null
 
+    // Project the wall-clock time when the next tick should fire. Convex
+    // returns startedAt (epoch ms of tick 0) + durationMs (cadence). The
+    // banner subtracts System.currentTimeMillis() in a 1Hz LaunchedEffect
+    // so the countdown ticks live, even between snapshot refreshes.
+    val nextTickAtMs = snap.tickEpoch?.let { ep ->
+      val started = ep.startedAt ?: return@let null
+      val dur = ep.durationMs ?: return@let null
+      if (dur <= 0L) null else started + (snap.tick + 1L) * dur
+    }
+
     return HearthUiState(
       isLoading = false,
       isRefreshing = false,
@@ -166,6 +178,7 @@ class HearthViewModel(
       seasonEndTick = seasonEnd,
       winterActive = snap.winterActive,
       winterApproachingInTicks = winterApproaching,
+      nextTickAtEpochMs = nextTickAtMs,
       leaderboard = leaderboard,
       recentComms = comms,
       banditAlert = banditAlert,


### PR DESCRIPTION
## Summary

\`WorldSnapshot.tickEpoch\` (startedAt + durationMs) was unused. Adds a live countdown next to the TICK label that ticks down 1Hz between heartbeat refreshes — closes the gap between \"I just refreshed\" and \"the world advanced\", makes Hearth feel alive in real time.

**Stacked on #123 (winter approaching).**

### \`HearthViewModel.project()\`
Computes \`nextTickAtEpochMs = startedAt + (currentTick + 1) × durationMs\`. Stored on \`HearthUiState\` so the banner can subtract \`System.currentTimeMillis()\` in a 1Hz \`produceState\` loop.

### \`HearthBanner\`
- \`produceState\` keyed off \`nextTickAtEpochMs\` so it re-launches on each snapshot refresh (which advances the projected next-tick timestamp)
- Shows \"next in Ns\" while seconds > 0, \"next imminent…\" at 0
- Sits next to the existing \"TICK\" label in monoMicro / warmFaint — doesn't compete with the big tick number

Cadence: snapshot refreshes every 30s (from #119), countdown updates every 1s. Displayed seconds accurate within ±1s of the real next-tick time projected at last refresh.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 26s.

## Test plan

- [ ] Land on Hearth → \"next in Ns\" appears next to TICK label, decrements every second
- [ ] When countdown reaches 0 → \"next imminent…\" copy, then auto-refresh fires (within 30s window)
- [ ] On snapshot refresh: counter resets to the new next-tick projection
- [ ] No tickEpoch in snapshot → counter not rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)