### PR TITLE
feat(android): hall letter card surfaces 'Last Move' from transfer history

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HallScreen.kt
@@ -330,7 +330,11 @@ private fun LetterCard(
     Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
       LetterStat(label = "Hunger", value = "tended", color = ClanWorldTheme.colors.success)
       LetterStat(label = "Memory", value = "${card.memoryCount} keys", color = Ink)
-      LetterStat(label = "Vault", value = "—", color = Ink)
+      LetterStat(
+        label = "Last Move",
+        value = card.mostRecentTransferTick?.let { "T %04d".format(it) } ?: "—",
+        color = Ink,
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary

\`HallCard.mostRecentTransferTick\` was computed in HallViewModel.toCard (via \`demo.transfers.maxOfOrNull\`) but never displayed — the third stat column on each LetterCard was a static \"Vault → —\" placeholder.

**Stacked on #124 (tick countdown).**

### Change
Third stat: \"Last Move → T 0042\" (using the existing \`T %04d\` format from TreasuryScreen movement rows for visual consistency). Falls back to \"—\" when there are no transfers, matching the original placeholder behavior.

Real activity signal — at a glance the user can see which sigils have moved recently vs which have been quiet.

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 26s.

## Test plan

- [ ] Hall card with transfer history → third stat shows \"Last Move T NNNN\"
- [ ] Hall card with no transfers → \"Last Move —\" (was \"Vault —\")
- [ ] Format matches Treasury MovementRow's \`T %04d\` style

🤖 Generated with [Claude Code](https://claude.com/claude-code)