### PR TITLE
feat(android): bulletin panel surfaces slot + tick + tx hash

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -180,7 +180,7 @@ private fun InftDetailScreen(
         )
         DetailTab.Vault -> VaultPanel(state.vault, onOpenTreasury = onOpenTreasury)
         DetailTab.Whispers -> WhispersPanel(state.comms, onOpenInbox = onOpenInbox)
-        DetailTab.Bulletin -> BulletinPanel(state.state?.bulletins?.map { it.body } ?: emptyList())
+        DetailTab.Bulletin -> BulletinPanel(state.state?.bulletins.orEmpty())
       }
     }
 
@@ -626,12 +626,12 @@ private fun WhispersPanel(
 }
 
 @Composable
-private fun BulletinPanel(bulletins: List<String>) {
+private fun BulletinPanel(bulletins: List<world.clan.app.data.Bulletin>) {
   PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
     if (bulletins.isEmpty()) {
       ComingNextSlice("no bulletins posted")
     } else {
-      bulletins.forEachIndexed { i, body ->
+      bulletins.forEach { b ->
         Column(
           modifier = Modifier
             .fillMaxWidth()
@@ -639,13 +639,34 @@ private fun BulletinPanel(bulletins: List<String>) {
             .padding(horizontal = 14.dp, vertical = 12.dp),
           verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
+          Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text(
+              text = "SLOT %02d".format(b.slot),
+              style = ClanWorldTheme.type.monoNano,
+              color = ClanWorldTheme.colors.gold,
+            )
+            // Right-side meta: written-tick + truncated tx-hash if present.
+            val meta = buildString {
+              b.updatedAt?.let { append("T %04d".format(it)) }
+              b.txHash?.takeIf { it.length > 6 }?.let {
+                if (isNotEmpty()) append(" · ")
+                append("tx ${it.takeLast(6)}")
+              }
+            }
+            if (meta.isNotEmpty()) {
+              Text(
+                text = meta,
+                style = ClanWorldTheme.type.monoNano,
+                color = ClanWorldTheme.colors.warmFaint,
+              )
+            }
+          }
           Text(
-            text = "SLOT %02d".format(i + 1),
-            style = ClanWorldTheme.type.monoNano,
-            color = ClanWorldTheme.colors.gold,
-          )
-          Text(
-            text = body,
+            text = b.body,
             style = ClanWorldTheme.type.scriptItalic,
             color = ClanWorldTheme.colors.warm,
           )


### PR DESCRIPTION
## Summary

\`BulletinPanel\` previously took \`List<String>\` (just bodies), losing three real Bulletin fields:
- \`slot\` — was index-based, every bulletin showed \"SLOT 01\"
- \`updatedAt\` — tick when the bulletin was written
- \`txHash\` — which on-chain transaction posted it

**Stacked on #125 (last-move stat).**

### Change
Takes \`List<Bulletin>\` directly. Each bulletin shows:
- \"SLOT NN\" using \`b.slot\` (real slot number)
- Right-aligned \"T NNNN · tx XXXXXX\" meta when \`updatedAt\`/\`txHash\` exist (\"tx XXXXXX\" = last 6 chars — terse but uniquely identifying enough for a debug glance)

\`./gradlew :app:assembleDebug\` → BUILD SUCCESSFUL in 26s.

## Test plan

- [ ] Bulletins with mixed slot numbers: SLOT 01, SLOT 03, etc — not all SLOT 01
- [ ] Bulletin with updatedAt + txHash → right-side shows \"T NNNN · tx XXXXXX\"
- [ ] Bulletin with only updatedAt → \"T NNNN\" alone
- [ ] Bulletin with only txHash → \"tx XXXXXX\" alone
- [ ] Bulletin with neither → no meta line

🤖 Generated with [Claude Code](https://claude.com/claude-code)