### PR TITLE
feat(android): memory row stamp adds tx hash suffix

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -501,10 +501,16 @@ private fun MemoryPanel(
     }
     PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
       memory.take(10).forEach { entry ->
+        val stamp = buildString {
+          append("written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}")
+          entry.txHash?.takeIf { it.length > 6 }?.let {
+            append(" · tx ${it.takeLast(6)}")
+          }
+        }
         MemoryRow(
           key = entry.key,
           body = inlineCodeBody(entry.value),
-          stamp = "written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}",
+          stamp = stamp,
           modifier = Modifier.fillMaxWidth(),
         )
       }


### PR DESCRIPTION
MemoryEntry.txHash was unused. Stamp line now appends "· tx XXXXXX" (last 6 chars of the hash) when present, mirroring the bulletin meta pattern from #126.

Stacked on #126.

`./gradlew :app:assembleDebug` → BUILD SUCCESSFUL in 22s.