### PR TITLE
feat(android): inft-detail TKN line surfaces real 0G dataHash

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -261,7 +261,14 @@ private fun HeroLetter(
     ) {
       Column(Modifier.weight(1f)) {
         Text(
-          text = "TKN 0x${"%04x".format(state.state?.token?.tokenId ?: clanId)}  ·  0G",
+          text = run {
+            val tknId = state.state?.token?.tokenId ?: clanId
+            val dataHashHint = state.state?.token?.dataHash
+              ?.takeIf { it.length > 6 }
+              ?.let { "·a${it.takeLast(6)}" }
+              ?: ""
+            "TKN 0x${"%04x".format(tknId)}  ·  0G$dataHashHint"
+          },
           style = ClanWorldTheme.type.monoMicro,
           color = Ink3,
         )


### PR DESCRIPTION
InftToken.dataHash was unused. TKN line now shows last 6 chars: `TKN 0x10A2  ·  0G·a3b4c5` (falls back to bare `· 0G` when no hash).

Stacked on #127.

`./gradlew :app:assembleDebug` → BUILD SUCCESSFUL in 24s.