### PR TITLE
feat(android): codex identity surfaces resolved .skr / .sol name

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -103,6 +103,18 @@ private fun CodexScreen(
     }
     StaggeredEntry(index = 2) {
       Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        // Resolved on-chain name — .skr / .sol — when available. Otherwise
+        // skip the row; wallet label below carries the same role.
+        val identity = world.clan.app.ui.components.LocalWalletIdentity.current
+        val resolved = identity?.skrName ?: identity?.solName
+        if (resolved != null) {
+          RowCard(
+            label = if (identity?.skrName != null) "Seeker · .skr" else "SNS · .sol",
+            value = resolved,
+            copyable = true,
+            copyText = resolved,
+          )
+        }
         RowCard(
           label = "Solana pubkey · MWA",
           value = state.solanaPubkey?.shortenPubkey() ?: "not connected",


### PR DESCRIPTION
WalletIdentity's resolved name (.skr → .sol) was only used by the wallet pill. Codex Identity now shows it as a top row when present.

Stacked on #128.

`./gradlew :app:assembleDebug` → BUILD SUCCESSFUL in 24s.