### PR TITLE
feat(android): codex device chip — model + Android version subline

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/CodexScreen.kt
@@ -642,6 +642,15 @@ private fun DeviceChip(state: CodexUiState) {
         style = ClanWorldTheme.type.scriptItalicSmall,
         color = warmDim,
       )
+      val buildLine = state.deviceClass.buildLine
+      if (buildLine.isNotEmpty()) {
+        Text(
+          text = buildLine,
+          style = ClanWorldTheme.type.monoNano,
+          color = ClanWorldTheme.colors.warmFaint,
+          modifier = Modifier.padding(top = 2.dp),
+        )
+      }
     }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/DeviceCapabilities.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/DeviceCapabilities.kt
@@ -14,7 +14,17 @@ data class DeviceClass(
   val seedVaultAvailable: Boolean,
   val manufacturer: String,
   val model: String,
+  val androidRelease: String = "",
 ) {
+
+  /** Compact "Model · Android NN" line for debug surfaces (Codex). */
+  val buildLine: String
+    get() {
+      val device = model.ifBlank { manufacturer }.takeIf { it.isNotBlank() }
+      val android = androidRelease.takeIf { it.isNotBlank() }?.let { "Android $it" }
+      return listOfNotNull(device, android).joinToString(" · ")
+    }
+
   /** Display label for the Codex device chip. */
   val displayLabel: String
     get() = when {
@@ -53,6 +63,7 @@ object DeviceCapabilities {
       seedVaultAvailable = seedVaultAvailable,
       manufacturer = manufacturer,
       model = model,
+      androidRelease = Build.VERSION.RELEASE ?: "",
     )
   }
 }


### PR DESCRIPTION
Adds `androidRelease` to DeviceClass + a `buildLine` helper ("Pixel 8 · Android 14") rendered below the description on the Codex device chip. Bug-report-friendly device fingerprint.

Stacked on #129.

`./gradlew :app:assembleDebug` → BUILD SUCCESSFUL in 25s.