### PR TITLE
chore(android): remove dead CodexViewModel.disconnect()

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/CodexViewModel.kt
@@ -64,11 +64,6 @@ class CodexViewModel(
     )
   }
 
-  fun disconnect() {
-    sessionStore.clear()
-    _state.value = _state.value.copy(solanaPubkey = null, walletLabel = null)
-  }
-
   /**
    * Wipe demo-only state and reload the screen. Useful for repeat demos
    * on the same device — restores Hall to LINKED_CLAN_IDS, empties


### PR DESCRIPTION
Dead method that would have re-introduced the lineage privacy leak from #117 if anyone called it. The real disconnect path is LocalOnDisconnect → ConnectViewModel.disconnect() (which also clears lineage).

Stacked on #130.

`./gradlew :app:assembleDebug` → BUILD SUCCESSFUL in 24s.