### PR TITLE
feat(android): inft-detail surfaces encryptedKeyHash hint on TKN line

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -263,11 +263,16 @@ private fun HeroLetter(
         Text(
           text = run {
             val tknId = state.state?.token?.tokenId ?: clanId
-            val dataHashHint = state.state?.token?.dataHash
+            val token = state.state?.token
+            val dataHashHint = token?.dataHash
               ?.takeIf { it.length > 6 }
               ?.let { "·a${it.takeLast(6)}" }
               ?: ""
-            "TKN 0x${"%04x".format(tknId)}  ·  0G$dataHashHint"
+            val keyHint = token?.encryptedKeyHash
+              ?.takeIf { it.length > 6 }
+              ?.let { "  ·  KEY·${it.takeLast(6)}" }
+              ?: ""
+            "TKN 0x${"%04x".format(tknId)}  ·  0G$dataHashHint$keyHint"
           },
           style = ClanWorldTheme.type.monoMicro,
           color = Ink3,


### PR DESCRIPTION
InftToken.encryptedKeyHash was unused — yet it's the iNFT transfer demo punchline per CLAUDE.md §10 (key authorization handover).

TKN line now reads: `TKN 0x10A2  ·  0G·a3b4c5  ·  KEY·9f8e7d`

So when the user transfers the iNFT in slice 2, the key hash visibly changes — visual evidence of the handover. Hash is the public fingerprint, not the blob itself.

Stacked on #131.

`./gradlew :app:assembleDebug` → BUILD SUCCESSFUL in 23s.