### PR TITLE
feat(android): memory row source label gains dataHash hint

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -514,7 +514,14 @@ private fun MemoryPanel(
     PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
       memory.take(10).forEach { entry ->
         val stamp = buildString {
-          append("written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}")
+          append("written tick ${entry.updatedAt ?: 0L} · ")
+          // source · dataHash hint when present, plain source otherwise
+          val source = entry.source ?: "local"
+          val dataHashHint = entry.dataHash
+            ?.takeIf { it.length > 6 }
+            ?.let { "·a${it.takeLast(6)}" }
+            ?: ""
+          append("$source$dataHashHint")
           entry.txHash?.takeIf { it.length > 6 }?.let {
             append(" · tx ${it.takeLast(6)}")
           }


### PR DESCRIPTION
MemoryEntry.dataHash was unused. The source label was bare ("local" or "0g"); now appends "·a<hash6>" when dataHash is present:

`written tick 42 · 0g·a3b4c5 · tx XXXXXX`

Three signals on one stamp line. Stacked on #132.

`./gradlew :app:assembleDebug` → BUILD SUCCESSFUL in 23s.