### PR TITLE
feat(android): bulletin meta — 0g dataHash hint between tick and tx

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -677,6 +677,10 @@ private fun BulletinPanel(bulletins: List<world.clan.app.data.Bulletin>) {
             // Right-side meta: written-tick + truncated tx-hash if present.
             val meta = buildString {
               b.updatedAt?.let { append("T %04d".format(it)) }
+              b.dataHash?.takeIf { it.length > 6 }?.let {
+                if (isNotEmpty()) append(" · ")
+                append("0g·${it.takeLast(6)}")
+              }
               b.txHash?.takeIf { it.length > 6 }?.let {
                 if (isNotEmpty()) append(" · ")
                 append("tx ${it.takeLast(6)}")


### PR DESCRIPTION
Bulletin.dataHash was unused. Adds "0g·<hash6>" segment to the meta line:

`T 0042 · 0g·a3b4c5 · tx 9f8e7d`

Completes the dataHash-surface pattern from #128 (token), #133 (memory), now #134 (bulletin).

Stacked on #133.

`./gradlew :app:assembleDebug` → BUILD SUCCESSFUL in 26s.