### PR TITLE
feat(android): inft-detail vault tab matches treasury's 3-color amounts

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -580,10 +580,16 @@ private fun VaultPanel(
             color = ClanWorldTheme.colors.parchment,
             modifier = Modifier.weight(1f),
           )
+          val sign = if (mv.type == "spend") "−" else "+"
+          val amountColor = when (mv.type) {
+            "spend" -> ClanWorldTheme.colors.danger
+            "transfer" -> ClanWorldTheme.colors.rune
+            else -> ClanWorldTheme.colors.gold
+          }
           Text(
-            text = "${if (mv.type == "spend") "−" else "+"}%.2f".format(mv.amount),
+            text = "$sign%.2f".format(mv.amount),
             style = ClanWorldTheme.type.monoData,
-            color = if (mv.type == "spend") ClanWorldTheme.colors.danger else ClanWorldTheme.colors.gold,
+            color = amountColor,
           )
         }
       }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -514,7 +514,14 @@ private fun MemoryPanel(
     PanelSurface(modifier = Modifier.padding(horizontal = 22.dp)) {
       memory.take(10).forEach { entry ->
         val stamp = buildString {
-          append("written tick ${entry.updatedAt ?: 0L} · ${entry.source ?: "local"}")
+          append("written tick ${entry.updatedAt ?: 0L} · ")
+          // source · dataHash hint when present, plain source otherwise
+          val source = entry.source ?: "local"
+          val dataHashHint = entry.dataHash
+            ?.takeIf { it.length > 6 }
+            ?.let { "·a${it.takeLast(6)}" }
+            ?: ""
+          append("$source$dataHashHint")
           entry.txHash?.takeIf { it.length > 6 }?.let {
             append(" · tx ${it.takeLast(6)}")
           }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -677,6 +677,10 @@ private fun BulletinPanel(bulletins: List<world.clan.app.data.Bulletin>) {
             // Right-side meta: written-tick + truncated tx-hash if present.
             val meta = buildString {
               b.updatedAt?.let { append("T %04d".format(it)) }
+              b.dataHash?.takeIf { it.length > 6 }?.let {
+                if (isNotEmpty()) append(" · ")
+                append("0g·${it.takeLast(6)}")
+              }
               b.txHash?.takeIf { it.length > 6 }?.let {
                 if (isNotEmpty()) append(" · ")
                 append("tx ${it.takeLast(6)}")


### PR DESCRIPTION
InftDetail Vault tab and TreasuryScreen render the same VaultMovement data with different color schemes. Aligning to Treasury's 3-color (spend=danger / transfer=rune / gain=gold) so the same data reads consistently across the two surfaces.

Stacked on #134.

`./gradlew :app:assembleDebug` → BUILD SUCCESSFUL in 22s.