### PR TITLE
feat(android): vault movements — sort newest-first

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -580,10 +580,16 @@ private fun VaultPanel(
             color = ClanWorldTheme.colors.parchment,
             modifier = Modifier.weight(1f),
           )
+          val sign = if (mv.type == "spend") "−" else "+"
+          val amountColor = when (mv.type) {
+            "spend" -> ClanWorldTheme.colors.danger
+            "transfer" -> ClanWorldTheme.colors.rune
+            else -> ClanWorldTheme.colors.gold
+          }
           Text(
-            text = "${if (mv.type == "spend") "−" else "+"}%.2f".format(mv.amount),
+            text = "$sign%.2f".format(mv.amount),
             style = ClanWorldTheme.type.monoData,
-            color = if (mv.type == "spend") ClanWorldTheme.colors.danger else ClanWorldTheme.colors.gold,
+            color = amountColor,
           )
         }
       }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -677,6 +677,10 @@ private fun BulletinPanel(bulletins: List<world.clan.app.data.Bulletin>) {
             // Right-side meta: written-tick + truncated tx-hash if present.
             val meta = buildString {
               b.updatedAt?.let { append("T %04d".format(it)) }
+              b.dataHash?.takeIf { it.length > 6 }?.let {
+                if (isNotEmpty()) append(" · ")
+                append("0g·${it.takeLast(6)}")
+              }
               b.txHash?.takeIf { it.length > 6 }?.let {
                 if (isNotEmpty()) append(" · ")
                 append("tx ${it.takeLast(6)}")

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -89,6 +89,7 @@ class HearthViewModel(
         val snap = convex.getSnapshot()
         val comms = runCatching { convex.getCombinedComms(selectedClan, limit = 3) }
           .getOrDefault(emptyList())
+          .sortedByDescending { it.tick ?: it.timestamp ?: 0L }
         snap to comms
       }.onSuccess { (snap, comms) ->
         _state.update { _ ->

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/InftDetailViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/InftDetailViewModel.kt
@@ -47,7 +47,9 @@ class InftDetailViewModel(
     viewModelScope.launch {
       _state.update { it.copy(isLoading = true, errorMessage = null) }
       val demo = runCatching { convex.getInftDemoState(clanId) }.getOrNull()
-      val comms = runCatching { convex.getCombinedComms(clanId, limit = 20) }.getOrDefault(emptyList())
+      val comms = runCatching { convex.getCombinedComms(clanId, limit = 20) }
+        .getOrDefault(emptyList())
+        .sortedByDescending { it.tick ?: it.timestamp ?: 0L }
       val vault = runCatching { convex.getVaultMovements(clanId, limit = 20) }.getOrDefault(emptyList())
       _state.update {
         it.copy(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/InftDetailViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/InftDetailViewModel.kt
@@ -50,7 +50,9 @@ class InftDetailViewModel(
       val comms = runCatching { convex.getCombinedComms(clanId, limit = 20) }
         .getOrDefault(emptyList())
         .sortedByDescending { it.tick ?: it.timestamp ?: 0L }
-      val vault = runCatching { convex.getVaultMovements(clanId, limit = 20) }.getOrDefault(emptyList())
+      val vault = runCatching { convex.getVaultMovements(clanId, limit = 20) }
+        .getOrDefault(emptyList())
+        .sortedByDescending { it.tick }
       _state.update {
         it.copy(
           isLoading = false,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
@@ -72,6 +72,7 @@ class TreasuryViewModel(
           val moves = async {
             runCatching { convex.getVaultMovements(clanId, limit = 24) }
               .getOrDefault(emptyList())
+              .sortedByDescending { it.tick }
           }
           snap.await() to moves.await()
         }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/WhispersViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/WhispersViewModel.kt
@@ -52,8 +52,11 @@ class WhispersViewModel(
       _state.update { it.copy(isLoading = true, errorMessage = null) }
       runCatching { convex.getCombinedComms(clanId, limit = 80) }
         .onSuccess { comms ->
+          // Newest-first by tick. Server order isn't guaranteed; this
+          // makes the inbox chat-like regardless.
+          val sorted = comms.sortedByDescending { it.tick ?: it.timestamp ?: 0L }
           _state.update {
-            it.copy(isLoading = false, items = comms, errorMessage = null)
+            it.copy(isLoading = false, items = sorted, errorMessage = null)
           }
         }
         .onFailure { e ->


### PR DESCRIPTION
Symmetric to #136 (comms). Treasury + InftDetail Vault tab both render VaultMovement; neither was sorting. Adds `sortedByDescending { it.tick }` at both call sites for consistent newest-first ledger order.

Stacked on #136.