### PR TITLE
chore(android): remove dead boldedMeta imports

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/WhisperMeta.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/WhisperMeta.kt
@@ -1,0 +1,40 @@
+package world.clan.app.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.AnnotatedString
+import world.clan.app.data.CombinedComm
+import world.clan.app.viewmodel.clanDisplayName
+
+/**
+ * Build the meta line for a whisper / orch / human comm row. Used by
+ * Hearth, WhispersScreen, and InftDetail's Whispers panel so the
+ * formatting stays consistent across the three surfaces.
+ *
+ * Output is an `AnnotatedString` produced by [boldedMeta] so the
+ * starred segments render bold against the rest.
+ *
+ * Examples:
+ *   "*Tideborne* · whispered to · *Twilight* · 0042"
+ *   "*Orchestrator* · 0042"
+ *   "*Owner* · steered · 0042"
+ */
+@Composable
+fun whisperMetaText(c: CombinedComm): AnnotatedString {
+  val from = c.fromClan?.let { clanDisplayName(it) }
+    ?: c.speaker
+    ?: when (c.kind) {
+      "orch" -> "Orchestrator"
+      "human" -> "Owner"
+      else -> "—"
+    }
+  val to = c.targetClan?.let { clanDisplayName(it) }
+  val tickStr = c.tick?.let { "%04d".format(it) } ?: "—"
+  val raw = when (c.kind) {
+    "whisper" -> if (to != null) "*$from* · whispered to · *$to* · $tickStr"
+                 else "*$from* · whispered · $tickStr"
+    "orch" -> "*Orchestrator* · $tickStr"
+    "human" -> "*$from* · steered · $tickStr"
+    else -> "*$from* · $tickStr"
+  }
+  return boldedMeta(raw.uppercase())
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
@@ -540,7 +540,7 @@ private fun WhispersList(
         else -> WhisperAccent.Default
       }
       WhisperRow(
-        meta = whisperMetaText(c),
+        meta = world.clan.app.ui.components.whisperMetaText(c),
         body = c.body,
         accent = accent,
       )
@@ -548,23 +548,5 @@ private fun WhispersList(
   }
 }
 
-@Composable
-private fun whisperMetaText(c: CombinedComm): AnnotatedString {
-  val from = c.fromClan?.let { clanDisplayName(it) }
-    ?: c.speaker
-    ?: when (c.kind) {
-      "orch" -> "Orchestrator"
-      "human" -> "Owner"
-      else -> "—"
-    }
-  val to = c.targetClan?.let { clanDisplayName(it) }
-  val tickStr = c.tick?.let { "%04d".format(it) } ?: "—"
-  val raw = when (c.kind) {
-    "whisper" -> if (to != null) "*$from* · whispered to · *$to* · $tickStr"
-                 else "*$from* · whispered · $tickStr"
-    "orch" -> "*Orchestrator* · $tickStr"
-    "human" -> "*$from* · steered · $tickStr"
-    else -> "*$from* · $tickStr"
-  }
-  return boldedMeta(raw.uppercase())
-}
+// whisperMetaText was lifted to ui.components.WhisperMeta so Hearth +
+// WhispersScreen + InftDetail all share the same comm-meta formatting.

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -580,10 +580,16 @@ private fun VaultPanel(
             color = ClanWorldTheme.colors.parchment,
             modifier = Modifier.weight(1f),
           )
+          val sign = if (mv.type == "spend") "−" else "+"
+          val amountColor = when (mv.type) {
+            "spend" -> ClanWorldTheme.colors.danger
+            "transfer" -> ClanWorldTheme.colors.rune
+            else -> ClanWorldTheme.colors.gold
+          }
           Text(
-            text = "${if (mv.type == "spend") "−" else "+"}%.2f".format(mv.amount),
+            text = "$sign%.2f".format(mv.amount),
             style = ClanWorldTheme.type.monoData,
-            color = if (mv.type == "spend") ClanWorldTheme.colors.danger else ClanWorldTheme.colors.gold,
+            color = amountColor,
           )
         }
       }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -61,7 +61,6 @@ import world.clan.app.ui.components.Sigil
 import world.clan.app.ui.components.WhisperAccent
 import world.clan.app.ui.components.WhisperRow
 import world.clan.app.ui.components.bigSigilSpec
-import world.clan.app.ui.components.boldedMeta
 import world.clan.app.ui.components.inlineCodeBody
 import world.clan.app.ui.theme.ClanWorldTheme
 import world.clan.app.ui.theme.Ink

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -629,14 +629,8 @@ private fun WhispersPanel(
           "human" -> WhisperAccent.Ember
           else -> WhisperAccent.Default
         }
-        val from = c.fromClan?.let { clanDisplayName(it) }
-          ?: c.speaker
-          ?: when (c.kind) {
-            "orch" -> "Orchestrator"; "human" -> "Owner"; else -> "—"
-          }
-        val tickStr = c.tick?.let { "%04d".format(it) } ?: "—"
         WhisperRow(
-          meta = boldedMeta("*$from* · $tickStr".uppercase()),
+          meta = world.clan.app.ui.components.whisperMetaText(c),
           body = c.body,
           accent = accent,
         )

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/InftDetailScreen.kt
@@ -677,6 +677,10 @@ private fun BulletinPanel(bulletins: List<world.clan.app.data.Bulletin>) {
             // Right-side meta: written-tick + truncated tx-hash if present.
             val meta = buildString {
               b.updatedAt?.let { append("T %04d".format(it)) }
+              b.dataHash?.takeIf { it.length > 6 }?.let {
+                if (isNotEmpty()) append(" · ")
+                append("0g·${it.takeLast(6)}")
+              }
               b.txHash?.takeIf { it.length > 6 }?.let {
                 if (isNotEmpty()) append(" · ")
                 append("tx ${it.takeLast(6)}")

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -34,7 +34,6 @@ import world.clan.app.R
 import world.clan.app.data.CombinedComm
 import world.clan.app.ui.components.WhisperAccent
 import world.clan.app.ui.components.WhisperRow
-import world.clan.app.ui.components.boldedMeta
 import world.clan.app.ui.theme.ClanWorldTheme
 import world.clan.app.viewmodel.WhispersFilter
 import world.clan.app.viewmodel.WhispersUiState

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -276,14 +276,8 @@ private fun InboxRow(comm: CombinedComm) {
     "human" -> WhisperAccent.Ember
     else -> WhisperAccent.Default
   }
-  val from = comm.fromClan?.let { clanDisplayName(it) }
-    ?: comm.speaker
-    ?: when (comm.kind) {
-      "orch" -> "Orchestrator"; "human" -> "Owner"; else -> "—"
-    }
-  val tickStr = comm.tick?.let { "%04d".format(it) } ?: "—"
   WhisperRow(
-    meta = boldedMeta("*$from* · $tickStr".uppercase()),
+    meta = world.clan.app.ui.components.whisperMetaText(comm),
     body = comm.body,
     accent = accent,
   )

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/HearthViewModel.kt
@@ -89,6 +89,7 @@ class HearthViewModel(
         val snap = convex.getSnapshot()
         val comms = runCatching { convex.getCombinedComms(selectedClan, limit = 3) }
           .getOrDefault(emptyList())
+          .sortedByDescending { it.tick ?: it.timestamp ?: 0L }
         snap to comms
       }.onSuccess { (snap, comms) ->
         _state.update { _ ->

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/InftDetailViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/InftDetailViewModel.kt
@@ -47,7 +47,9 @@ class InftDetailViewModel(
     viewModelScope.launch {
       _state.update { it.copy(isLoading = true, errorMessage = null) }
       val demo = runCatching { convex.getInftDemoState(clanId) }.getOrNull()
-      val comms = runCatching { convex.getCombinedComms(clanId, limit = 20) }.getOrDefault(emptyList())
+      val comms = runCatching { convex.getCombinedComms(clanId, limit = 20) }
+        .getOrDefault(emptyList())
+        .sortedByDescending { it.tick ?: it.timestamp ?: 0L }
       val vault = runCatching { convex.getVaultMovements(clanId, limit = 20) }.getOrDefault(emptyList())
       _state.update {
         it.copy(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/InftDetailViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/InftDetailViewModel.kt
@@ -50,7 +50,9 @@ class InftDetailViewModel(
       val comms = runCatching { convex.getCombinedComms(clanId, limit = 20) }
         .getOrDefault(emptyList())
         .sortedByDescending { it.tick ?: it.timestamp ?: 0L }
-      val vault = runCatching { convex.getVaultMovements(clanId, limit = 20) }.getOrDefault(emptyList())
+      val vault = runCatching { convex.getVaultMovements(clanId, limit = 20) }
+        .getOrDefault(emptyList())
+        .sortedByDescending { it.tick }
       _state.update {
         it.copy(
           isLoading = false,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/TreasuryViewModel.kt
@@ -72,6 +72,7 @@ class TreasuryViewModel(
           val moves = async {
             runCatching { convex.getVaultMovements(clanId, limit = 24) }
               .getOrDefault(emptyList())
+              .sortedByDescending { it.tick }
           }
           snap.await() to moves.await()
         }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/WhispersViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/WhispersViewModel.kt
@@ -52,8 +52,11 @@ class WhispersViewModel(
       _state.update { it.copy(isLoading = true, errorMessage = null) }
       runCatching { convex.getCombinedComms(clanId, limit = 80) }
         .onSuccess { comms ->
+          // Newest-first by tick. Server order isn't guaranteed; this
+          // makes the inbox chat-like regardless.
+          val sorted = comms.sortedByDescending { it.tick ?: it.timestamp ?: 0L }
           _state.update {
-            it.copy(isLoading = false, items = comms, errorMessage = null)
+            it.copy(isLoading = false, items = sorted, errorMessage = null)
           }
         }
         .onFailure { e ->


### PR DESCRIPTION
Stale imports left over from the #138 whisperMetaText refactor. Pure cleanup.

Stacked on #138.