### PR TITLE
fix(contracts): strip unused upkeep events to bring HeartbeatFacet back under EIP-170

### DIFF
--- a/packages/contracts/src/diamond/lib/LibSettlement.sol
+++ b/packages/contracts/src/diamond/lib/LibSettlement.sol
@@ -59,12 +59,6 @@ library LibSettlement {
         uint256 fishDelta,
         uint64 atTick
     );
-    event ClanEliminated(uint32 indexed clanId, uint64 indexed tick);
-    event ClanDied(uint32 indexed clanId, uint64 tick, string reason);
-    event ClanStarvationChanged(uint32 indexed clanId, bool isStarving, uint64 atTick);
-    event ClanColdShortage(uint32 indexed clanId, uint64 tick, uint256 woodShort);
-    event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint64 tick);
-    event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint64 tick);
     // BanditEscaped + BanditTargetDied moved to LibBanditCombat (canonical
     // emitter post-dedup). Same event signatures; ABI consumers unaffected.
 
@@ -73,22 +67,6 @@ library LibSettlement {
         ResourcesGathered,
         ResourcesDeposited,
         ResourcesWithdrawn
-    }
-
-    enum UpkeepLogKind {
-        None,
-        ClanStarvationChanged,
-        ClanColdShortage,
-        WallDegradedByCold,
-        ClansmanColdDeath,
-        ClanEliminated,
-        ClanDied
-    }
-
-    enum ClanDeathReason {
-        None,
-        Starvation,
-        Cold
     }
 
     struct SettlementLog {
@@ -103,25 +81,13 @@ library LibSettlement {
         uint64 tick;
     }
 
-    struct UpkeepLog {
-        UpkeepLogKind kind;
-        uint32 clansmanId;
-        uint64 tick;
-        uint256 amount;
-        uint8 level;
-        bool flag;
-        ClanDeathReason reason;
-    }
-
     struct SettlementSimulation {
         Clan clan;
         Clansman[] clansmen;
         Mission[] missions;
         WheatPlot[2] wheatPlots;
         SettlementLog[] logs;
-        UpkeepLog[] upkeepLogs;
         uint256 logCount;
-        uint256 upkeepLogCount;
         uint64[11] simMonumentReachedAt;
         bool[] simWallReservationCleared;
         bool[] simBaseReservationCleared;
@@ -183,7 +149,6 @@ library LibSettlement {
         }
         uint256 tickCount = toTick - fromTick;
         sim.logs = new SettlementLog[](sim.clansmen.length * tickCount);
-        sim.upkeepLogs = new UpkeepLog[]((sim.clansmen.length + 6) * tickCount);
 
         for (uint64 tick = fromTick; tick < toTick; tick++) {
             applyUpkeep(s, sim, tick);
@@ -208,8 +173,6 @@ library LibSettlement {
         s.clans[clanId] = sim.clan;
         s.wheatPlots[clanId][0] = sim.wheatPlots[0];
         s.wheatPlots[clanId][1] = sim.wheatPlots[1];
-
-        emitUpkeepLogs(sim);
 
         for (uint256 i = 0; i < sim.clansmen.length; i++) {
             uint32 clansmanId = sim.clansmen[i].clansmanId;
@@ -253,25 +216,6 @@ library LibSettlement {
         for (uint8 level = 1; level < sim.simMonumentReachedAt.length; level++) {
             if (sim.simMonumentReachedAt[level] != 0 && s.monumentLevelReachedAt[clanId][level] == 0) {
                 s.monumentLevelReachedAt[clanId][level] = sim.simMonumentReachedAt[level];
-            }
-        }
-    }
-
-    function emitUpkeepLogs(SettlementSimulation memory sim) internal {
-        for (uint256 i = 0; i < sim.upkeepLogCount; i++) {
-            UpkeepLog memory entry = sim.upkeepLogs[i];
-            if (entry.kind == UpkeepLogKind.ClanStarvationChanged) {
-                emit ClanStarvationChanged(sim.clan.clanId, entry.flag, entry.tick);
-            } else if (entry.kind == UpkeepLogKind.ClanColdShortage) {
-                emit ClanColdShortage(sim.clan.clanId, entry.tick, entry.amount);
-            } else if (entry.kind == UpkeepLogKind.WallDegradedByCold) {
-                emit WallDegradedByCold(sim.clan.clanId, entry.level, entry.tick);
-            } else if (entry.kind == UpkeepLogKind.ClansmanColdDeath) {
-                emit ClansmanColdDeath(sim.clan.clanId, entry.clansmanId, entry.tick);
-            } else if (entry.kind == UpkeepLogKind.ClanEliminated) {
-                emit ClanEliminated(sim.clan.clanId, entry.tick);
-            } else if (entry.kind == UpkeepLogKind.ClanDied) {
-                emit ClanDied(sim.clan.clanId, entry.tick, deathReasonString(entry.reason));
             }
         }
     }
@@ -330,34 +274,6 @@ library LibSettlement {
         });
     }
 
-    function recordUpkeepLog(
-        SettlementSimulation memory sim,
-        UpkeepLogKind kind,
-        uint32 clansmanId,
-        uint64 tick,
-        uint256 amount,
-        uint8 level,
-        bool flag,
-        ClanDeathReason reason
-    ) internal pure {
-        if (sim.upkeepLogCount >= sim.upkeepLogs.length) return;
-        sim.upkeepLogs[sim.upkeepLogCount++] = UpkeepLog({
-            kind: kind,
-            clansmanId: clansmanId,
-            tick: tick,
-            amount: amount,
-            level: level,
-            flag: flag,
-            reason: reason
-        });
-    }
-
-    function deathReasonString(ClanDeathReason reason) internal pure returns (string memory) {
-        if (reason == ClanDeathReason.Starvation) return "starvation";
-        if (reason == ClanDeathReason.Cold) return "cold";
-        return "unknown";
-    }
-
     function applyUpkeep(LibStorage.AppStorage storage s, SettlementSimulation memory sim, uint64 tick) internal view {
         bool winter = LibSeason.isWinterActiveAt(tick);
         if (!winter && tick > 0 && LibSeason.isWinterActiveAt(tick - 1)) {
@@ -387,28 +303,8 @@ library LibSettlement {
         bool starving = !hadEnoughWheat || !hadEnoughFish;
         if (starving && sim.clan.starvationStartsAtTick == 0) {
             sim.clan.starvationStartsAtTick = tick + 1;
-            recordUpkeepLog(
-                sim,
-                UpkeepLogKind.ClanStarvationChanged,
-                0,
-                tick + 1,
-                0,
-                0,
-                true,
-                ClanDeathReason.None
-            );
         } else if (!starving && sim.clan.starvationStartsAtTick != 0) {
             sim.clan.starvationStartsAtTick = 0;
-            recordUpkeepLog(
-                sim,
-                UpkeepLogKind.ClanStarvationChanged,
-                0,
-                tick,
-                0,
-                0,
-                false,
-                ClanDeathReason.None
-            );
         }
 
         uint8 livingBeforeStarvation = sim.clan.livingClansmen;
@@ -418,7 +314,7 @@ library LibSettlement {
                 ? sim.clan.starvationStartsAtTick
                 : winterStartsAtTick;
             if (effectiveStarvationStartsAtTick < tick) {
-                killNextClansmanFromStarvation(s, sim, tick);
+                killNextClansmanFromStarvation(s, sim);
             }
         }
         if (sim.clan.clanState == ClanState.DEAD) return;
@@ -431,22 +327,11 @@ library LibSettlement {
             if (spendableWood >= woodNeeded) {
                 sim.clan.vaultWood -= woodNeeded;
             } else {
-                uint256 woodShort = woodNeeded - spendableWood;
                 sim.clan.vaultWood -= spendableWood;
                 uint16 oldColdDamage = sim.clan.coldDamage;
                 if (sim.clan.coldDamage < type(uint16).max) {
                     sim.clan.coldDamage += 1;
                 }
-                recordUpkeepLog(
-                    sim,
-                    UpkeepLogKind.ClanColdShortage,
-                    0,
-                    tick,
-                    woodShort,
-                    0,
-                    false,
-                    ClanDeathReason.None
-                );
                 applyColdDamageConsequence(s, sim, tick, oldColdDamage);
             }
         }
@@ -468,16 +353,6 @@ library LibSettlement {
             ) return;
 
             sim.clan.wallLevel--;
-            recordUpkeepLog(
-                sim,
-                UpkeepLogKind.WallDegradedByCold,
-                0,
-                tick,
-                0,
-                sim.clan.wallLevel,
-                false,
-                ClanDeathReason.None
-            );
             return;
         }
 
@@ -521,27 +396,14 @@ library LibSettlement {
             }
 
             markClansmanDead(s, sim, i);
-            recordUpkeepLog(
-                sim,
-                UpkeepLogKind.ClansmanColdDeath,
-                sim.clansmen[i].clansmanId,
-                tick,
-                0,
-                0,
-                false,
-                ClanDeathReason.None
-            );
             if (sim.clan.livingClansmen == 0) {
-                markClanDead(s, sim, ClanDeathReason.Cold, tick);
+                markClanDead(s, sim);
             }
             return;
         }
     }
 
-    function killNextClansmanFromStarvation(LibStorage.AppStorage storage s, SettlementSimulation memory sim, uint64 tick)
-        internal
-        view
-    {
+    function killNextClansmanFromStarvation(LibStorage.AppStorage storage s, SettlementSimulation memory sim) internal view {
         if (sim.clan.livingClansmen == 0) return;
 
         for (uint256 i = 0; i < sim.clansmen.length; i++) {
@@ -549,7 +411,7 @@ library LibSettlement {
 
             markClansmanDead(s, sim, i);
             if (sim.clan.livingClansmen == 0) {
-                markClanDead(s, sim, ClanDeathReason.Starvation, tick);
+                markClanDead(s, sim);
             }
             return;
         }
@@ -575,12 +437,7 @@ library LibSettlement {
         }
     }
 
-    function markClanDead(
-        LibStorage.AppStorage storage s,
-        SettlementSimulation memory sim,
-        ClanDeathReason reason,
-        uint64 tick
-    ) internal view {
+    function markClanDead(LibStorage.AppStorage storage s, SettlementSimulation memory sim) internal view {
         if (sim.clan.clanId == ClanWorldConstants.CLAN_ID_NULL || sim.clan.clanState == ClanState.DEAD) return;
 
         sim.clan.clanState = ClanState.DEAD;
@@ -603,26 +460,6 @@ library LibSettlement {
             }
         }
         sim.simClanDied = true;
-        recordUpkeepLog(
-            sim,
-            UpkeepLogKind.ClanEliminated,
-            0,
-            tick,
-            0,
-            0,
-            false,
-            ClanDeathReason.None
-        );
-        recordUpkeepLog(
-            sim,
-            UpkeepLogKind.ClanDied,
-            0,
-            tick,
-            0,
-            0,
-            false,
-            reason
-        );
     }
 
     function regrowWheatPlots(SettlementSimulation memory sim, uint64 tick) internal pure {

--- a/packages/contracts/test/diamond/PublicDemoBlockers.t.sol
+++ b/packages/contracts/test/diamond/PublicDemoBlockers.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
-import {Vm} from "forge-std/Vm.sol";
 import {DiamondSelectors} from "../../script/DiamondSelectors.sol";
 import {Diamond} from "../../src/diamond/Diamond.sol";
 import {ClanWorldDiamondInit} from "../../src/diamond/ClanWorldDiamondInit.sol";
@@ -25,6 +24,7 @@ import {StubPool} from "../../src/StubPool.sol";
 import {
     ActionType,
     Clan,
+    ClanState,
     ClanOrder,
     ClanWorldConstants,
     IClanWorld,
@@ -117,12 +117,6 @@ contract PublicDemoHarnessFacet {
 }
 
 contract PublicDemoBlockersTest is Test {
-    event ClanColdShortage(uint32 indexed clanId, uint64 tick, uint256 woodShort);
-    event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint64 tick);
-    event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint64 tick);
-    event ClanEliminated(uint32 indexed clanId, uint64 indexed tick);
-    event ClanDied(uint32 indexed clanId, uint64 tick, string reason);
-
     address private elder = address(0xA11CE);
 
     function test_bootstrapSelectorsHideGameplayUntilTreasurySeeded() public {
@@ -148,7 +142,7 @@ contract PublicDemoBlockersTest is Test {
         assertEq(loupe.facetAddress(IClanWorld.settleClan.selector) != address(0), true, "settlement live");
     }
 
-    function test_settlementUpkeepEmitsWinterColdAndDeathEvents() public {
+    function test_settlementUpkeepAppliesWinterColdAndDeathConsequences() public {
         IClanWorld world = _deploySettlementDiamond();
         IPublicDemoHarness harness = IPublicDemoHarness(address(world));
         uint64 winterStart = ClanWorldConstants.WINTER_START_TICK;
@@ -156,33 +150,28 @@ contract PublicDemoBlockersTest is Test {
         uint32 coldShortClan = _mint(world);
         harness.setCurrentTick(winterStart + 1);
         harness.setClanUpkeepState(coldShortClan, winterStart, 1e18, 100e18, 100e18, 0);
-        vm.expectEmit(true, false, false, true, address(world));
-        emit ClanColdShortage(coldShortClan, winterStart, 2e18);
         world.settleClan(coldShortClan);
+        assertEq(world.getClan(coldShortClan).coldDamage, 1, "cold damage increments");
 
         uint32 wallClan = _mint(world);
         harness.setCurrentTick(winterStart + 1);
         harness.setClanWallLevel(wallClan, 2);
         harness.setClanUpkeepState(wallClan, winterStart, 0, 100e18, 100e18, 1);
-        vm.expectEmit(true, false, false, true, address(world));
-        emit WallDegradedByCold(wallClan, 1, winterStart);
         world.settleClan(wallClan);
+        assertEq(world.getClan(wallClan).wallLevel, 1, "wall degraded");
 
         uint32 coldDeathClan = _mint(world);
         harness.setCurrentTick(winterStart + 1);
         harness.setClanUpkeepState(coldDeathClan, winterStart, 0, 100e18, 100e18, 1);
-        vm.recordLogs();
         world.settleClan(coldDeathClan);
-        assertEq(_countLogs(vm.getRecordedLogs(), keccak256("ClansmanColdDeath(uint32,uint32,uint64)")), 1);
+        assertEq(world.getClan(coldDeathClan).livingClansmen, 3, "cold killed one clansman");
 
         uint32 starvedClan = _mint(world);
         harness.setCurrentTick(winterStart + 6);
         harness.setClanUpkeepState(starvedClan, winterStart, 100e18, 0, 0, 0);
-        vm.expectEmit(true, true, false, true, address(world));
-        emit ClanEliminated(starvedClan, winterStart + 5);
-        vm.expectEmit(true, false, false, true, address(world));
-        emit ClanDied(starvedClan, winterStart + 5, "starvation");
         world.settleClan(starvedClan);
+        assertEq(world.getClan(starvedClan).livingClansmen, 0, "starvation killed clansman");
+        assertEq(uint8(world.getClan(starvedClan).clanState), uint8(ClanState.DEAD), "starvation killed clan");
     }
 
     function test_wallUpgradeReservationClearsWhenColdDegradesWallBeforeCompletion() public {
@@ -330,9 +319,4 @@ contract PublicDemoBlockersTest is Test {
         });
     }
 
-    function _countLogs(Vm.Log[] memory logs, bytes32 topic0) private pure returns (uint256 count) {
-        for (uint256 i = 0; i < logs.length; i++) {
-            if (logs[i].topics.length > 0 && logs[i].topics[0] == topic0) count++;
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Reverts the event-emission scaffolding from `1ef2fd8` (\"close public demo blockers\") that bloated `HeartbeatFacet` from 24,033 bytes (the deployed `0xAd03…` size) to **26,265** (1,689 bytes over EIP-170, blocking redeploy).

The 6 events plus their `UpkeepLog` / `UpkeepLogKind` / `ClanDeathReason` scaffolding were added to `LibSettlement` but **never indexed downstream** — pure dead weight. Stripping them brings the lib stub back to 57 bytes (logic inlines into facets) and the two big facets back under the EIP-170 limit:

| Facet | Before | After | Margin under 24,576 |
|---|---|---|---|
| HeartbeatFacet | 26,265 | **23,938** | 638 |
| FinalizeSeasonFacet | 25,704 | **23,368** | 1,208 |

All 27 facets now build under EIP-170. Verified via `forge build --sizes`.

## What's preserved

The real bug fix from `1ef2fd8` — **unconditional refund of wall-upgrade reservations when `held.fromLevel != current wallLevel`** (previously refunded only on level increase, leaking resources on cold-damage-driven level decrease) — is preserved intact.

## Stripped events

- `ClanEliminated`, `ClanDied`, `ClanStarvationChanged`, `ClanColdShortage`, `WallDegradedByCold`, `ClansmanColdDeath`
- `UpkeepLog`, `UpkeepLogKind`, `ClanDeathReason` types
- `recordUpkeepLog`, `emitUpkeepLogs`, `deathReasonString` helpers

If we ever want indexed event surfaces for these, re-add via a dedicated `LoggingFacet` (separate facet stays under-limit by definition).

## Tests

`packages/contracts/test/diamond/PublicDemoBlockers.t.sol` updated to drop assertions on stripped events while keeping the wall-upgrade-refund test logic.

## Why this is safe

- No on-chain state changes — events are pure observability.
- Wall-upgrade refund logic untouched.
- All other facets unchanged.
- Diff: 2 files, +12 / −191.

## Test plan

- [x] `forge build --sizes` — all facets under EIP-170
- [x] `forge test --match-path test/diamond/PublicDemoBlockers.t.sol` — passes
- [ ] super-swarm review (codex 5.4 + 5.5, gemini 3-pro, opus 4.6 + 4.7) — dispatching now
- [ ] Liam UAT — review post-swarm synthesis before merging
- [ ] If approved + merged: redeploy fresh diamond from this HEAD, swap pointers in indexer + frontend, verify world state migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)