### PR TITLE
fix(indexer): remove legacy getWorldState fallback path

### DIFF
--- a/apps/server/convex/indexer.test.ts
+++ b/apps/server/convex/indexer.test.ts
@@ -191,7 +191,9 @@ describe("pollLogs range planning", () => {
     const range = planPollLogRange(null, 20_000n);
 
     expect(range.fromBlock).toBe(12_345n);
-    expect(range.toBlock).toBe(19_995n);
+    // Capped at fromBlock + MAX_LOG_BLOCK_RANGE (9n for Alchemy free tier)
+    // rather than safeLatest (19_995n).
+    expect(range.toBlock).toBe(12_354n);
     expect(range.shouldPoll).toBe(true);
 
     if (previousStartBlock === undefined)

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -617,9 +617,6 @@ export const refreshSnapshot = internalAction({
       args.blockNumber ?? Number(await client.getBlockNumber());
 
     const [worldRaw, market, bandit] = await Promise.all([
-      // getWorldSnapshot may fail on legacy diamonds with older struct shapes
-      // (e.g. backup diamond 0x2709eEB at the time of writing). Fall back to
-      // getWorldState below which has a stable older subset.
       client
         .readContract({
           address,
@@ -646,61 +643,10 @@ export const refreshSnapshot = internalAction({
         .catch(() => undefined),
     ]);
 
-    // Legacy fallback: read getWorldState with a minimal struct shape that
-    // matches both v4 and the older deployed diamond. Only the fields we
-    // actually consume are listed; missing newer fields default to safe
-    // values below.
-    let world = worldRaw as Record<string, unknown> | undefined;
-    if (!world) {
-      const legacy = (await client
-        .readContract({
-          address,
-          abi: [
-            {
-              type: "function",
-              name: "getWorldState",
-              inputs: [],
-              stateMutability: "view",
-              outputs: [
-                {
-                  type: "tuple",
-                  components: [
-                    { name: "currentTick", type: "uint64" },
-                    { name: "seasonStartTick", type: "uint64" },
-                    { name: "seasonEndTick", type: "uint64" },
-                    { name: "seasonFinalized", type: "bool" },
-                    { name: "currentSeasonNumber", type: "uint64" },
-                    { name: "nextHeartbeatAtTick", type: "uint64" },
-                    { name: "nextHeartbeatAtTs", type: "uint64" },
-                    { name: "nextBanditSpawnEligibleTick", type: "uint64" },
-                    { name: "currentBanditSpawnChanceBps", type: "uint16" },
-                    { name: "currentTickSeed", type: "bytes32" },
-                  ],
-                },
-              ],
-            },
-          ] as const,
-          functionName: "getWorldState",
-          blockNumber: pinnedBlockNumber,
-        })
-        .catch(() => undefined)) as Record<string, unknown> | undefined;
-      if (legacy) {
-        world = {
-          ...legacy,
-          // Newer fields not on legacy diamond — safe defaults
-          worldPaused: false,
-          pausedAtTs: 0n,
-          winterActive: false,
-          winterStartsAtTick: 0n,
-          winterEndsAtTick: 0n,
-          activeBanditId: 0,
-          leaderboard: [],
-        };
-      }
-    }
+    const world = worldRaw as Record<string, unknown> | undefined;
     if (!world) {
       console.warn(
-        "[indexer] both getWorldSnapshot and getWorldState failed; skipping refresh",
+        "[indexer] getWorldSnapshot failed; skipping refresh",
       );
       return { tick: 0, clans: 0 };
     }


### PR DESCRIPTION
Removes the world-state legacy fallback in indexer.ts that's been silently producing `currentSeasonNumber: null` on the Convex worldSnapshot table.

## Why

The fallback was added to bridge to a backup diamond (`0x2709eEB…`) whose older ABI shape didn't match `getWorldSnapshot`. After we deployed fresh v2.2.0 diamond `0x14392f…` with the canonical full ABI, the fallback should never trigger — but viem sometimes returns positionally-decoded fields, leaving `world.currentSeasonNumber` undefined → null in Convex.

Per [no-backcompat policy](https://github.com/clan-world/clan-world-game/blob/main/CHANGELOG.md): pre-prod ClanWorld doesn't keep dead compat shims. Pin to the canonical contract ABI.

## Changes

- `apps/server/convex/indexer.ts` — delete the `getWorldState` legacy fallback block (~50 lines). Primary path `getWorldSnapshot` only.
- `apps/server/convex/indexer.test.ts` — fix pre-existing failing test that expected `MAX_LOG_BLOCK_RANGE=9_999` semantics. Now expects `toBlock = fromBlock + 9` (the Alchemy free-tier cap that's been live for weeks).

Diff: 2 files, +5 / -57.

## Verification

- `pnpm test` in `apps/server` — 27/27 pass after the test fix
- Convex `worldSnapshot.currentSeasonNumber` should populate to a real number after deploy + indexer recovery
- If a future redeploy ever lands on a diamond with an incompatible `getWorldSnapshot` ABI, indexer will warn-and-skip rather than fall back. That's the right behavior — refuse to lie about state.

Closes the seasonNumber:null issue Liam flagged 2026-05-10. Bigger refactor (move snapshot-trigger logic into a Convex action triggered by worldSnapshot insert) tracked at #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)