### PR TITLE
feat(contracts): bandit 3-tick attack cycle (remove Escaped + Resting states)

### DIFF
--- a/apps/server/convex/getSnapshot.ts
+++ b/apps/server/convex/getSnapshot.ts
@@ -77,7 +77,6 @@ export const getSnapshot = query({
       && activeBandit.exists
       && activeBandit.state !== BanditState.None
       && activeBandit.state !== BanditState.Defeated
-      && activeBandit.state !== BanditState.Escaped
         ? {
           id: activeBandit.id,
           region: activeBandit.region,

--- a/apps/web/src/EventTicker.tsx
+++ b/apps/web/src/EventTicker.tsx
@@ -3,6 +3,7 @@ import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { api } from '../../server/convex/_generated/api';
 import { useAgentLogs } from './useAgentLogs';
 import { DEMO_MODE } from './config/env';
+import { BanditState } from '@clan-world/shared/generated/enums';
 
 // --- Region + action label tables (mirrors WorldMap.tsx) ---
 
@@ -156,8 +157,7 @@ function formatChainEvent(ev: ChainEvent): TickerEntry | null {
     }
     case 'BanditStateChanged': {
       const newState = safeNum(args.newState, 0);
-      if (newState === 4) {
-        // Attacking
+      if (newState === BanditState.Attacking) {
         return { text: `⚔ Bandits attacking in ${regionName}!`, clanColor: '#b23a48', highlight: true };
       }
       return null;

--- a/docs/planning/clanworld_v4_6_bandit_phase9_redesign.md
+++ b/docs/planning/clanworld_v4_6_bandit_phase9_redesign.md
@@ -38,27 +38,31 @@ This doc canonizes the as-built mechanics. The eight largest drifted mechanics a
 
 ## 2. As-built bandit lifecycle
 
+> **Updated 2026-05-10**: removed `Escaped` and `Resting` states; cycle is 3 ticks between attacks. v2.3.0 deploy required.
+
 ### 2.1 State machine
 
-The implementation defines **7 states** (vs. 5 in v4 §6.5):
+The implementation defines **5 states**:
 
 ```
-None → Spawned → Camped → Attacking → (Defeated | Escaped) → Resting → Camped → Attacking → ...
+None → Spawned (1) → Camped (3) → Attacking-instant
+                                        │
+                                        ├─── Defeated (terminal)
+                                        │
+                                        └─── Escape outcome → Camped (3, NEXT region) → ...
 ```
 
-| State | Duration | Transition trigger | Notes |
-|---|---|---|---|
-| `None` | (sentinel) | Default zero value, indicates no troop | Defensive — prevents zero-init from looking like a real state |
-| `Spawned` | 1 tick | Heartbeat `_advanceBanditStates` | Settles candidate region, then transitions to `Camped` |
-| `Camped` | 3 ticks (`BANDIT_CAMP_TICKS`) | Tick counter expires | Picks attack target on exit (NOT at attack resolution time) |
-| `Attacking` | 1 tick | Heartbeat resolves attack via `_resolveBanditAttack` | Either Defeated (if defenders win threshold) or Escaped (if attack lands as damage event) |
-| `Defeated` | terminal | n/a | Bandit removed; carry distributed; blueprint awarded to target clan |
-| `Escaped` | 2 ticks | Tick counter expires → `Resting` | NON-TERMINAL — distinguishes from spec's terminal escape |
-| `Resting` | 2 ticks | Tick counter expires → `Camped` | Bandit stays in the same region; no rampage |
+| State | Duration | Notes |
+|---|---|---|
+| `None` | sentinel | Default zero value, indicates no troop |
+| `Spawned` | 1 tick | One-tick init before the first `Camped` |
+| `Camped` | 3 ticks (`BANDIT_CAMP_TICKS`) | Same duration whether first camp or rampage recamp |
+| `Attacking` | instant (resolves in same heartbeat as `Camped` → `Attacking` transition) | Never visible as a separate phase |
+| `Defeated` | terminal | Bandit removed from storage |
 
-**Effective spawn-to-attack interval = 4 ticks** (1 Spawned + 3 Camped). After the first attack, the steady-state cycle is `Attacking → Escaped(2) → Resting(2) → Camped(3) → Attacking` = 7 ticks per attempt.
+**Cycle math:** first attack = 4 ticks (1 Spawned + 3 Camped). Subsequent attacks happen every 3 ticks. After 6 attempts, terminal escape burns carry and removes the bandit.
 
-**Bandit `region` is set on spawn and never changes.** A bandit lives in its spawn region for its entire lifecycle. There is no rampage path, no inter-region movement.
+On a successful attack escape outcome, `Attacking → Camped` moves the bandit to the next rampage region in the same transition. `Camped` then lasts 3 ticks in that new region before the next attack attempt.
 
 ### 2.2 Spawn cadence
 
@@ -112,7 +116,7 @@ At `Camped → Attacking` transition (one tick before resolution), the implement
 - Eager-settles the eventually-picked target (per-target settlement; does NOT eager-settle ALL bases in region as v4_1 A4 demands)
 - Ranks remaining bases by loot value: `wood + wheat + 2*fish + 4*iron` (matches spec §6.9 — gold is NOT counted)
 - Tiebreak among equal-loot bases: **uniform random across ties** (NOT lowest-clanId as spec §6.8 requires)
-- If no eligible base in region → bandit transitions to `Escaped` (spec wanted noop "stay in region, try next tick"; impl marks Escaped which is non-terminal here, so functionally similar but surfaces as Escaped state in ABI)
+- If no eligible base in region → attack attempt count increments. If attempts are exhausted, terminal escape removes the bandit; otherwise it remains `Camped` and retries after another `BANDIT_CAMP_TICKS`.
 
 ---
 
@@ -146,7 +150,7 @@ Compare `totalClansmanDefense` vs `2 * attackPower`:
   2. Base HP next: `BASE_HP_PER_LEVEL = 25`. Base absorbs up to `baseLevel * 25` damage.
   3. Clansman casualties: if damage exceeds combined wall+base HP, **clansmen die** to absorb the residual. This contradicts spec §6.15 which says no clansman casualties from bandits in v1.
   4. If all clansmen die → clan is marked dead.
-- Bandit transitions to `Escaped` (which is non-terminal in this impl).
+- Bandit transitions directly `Attacking → Camped`, which moves it to the next rampage region.
 
 ### 3.3 No vault loot theft
 
@@ -158,9 +162,9 @@ Compare `totalClansmanDefense` vs `2 * attackPower`:
 
 **Net effect:** target clan vaults are unchanged by bandit attacks. Bandits do damage to wall/base/clansmen but never extract physical loot.
 
-### 3.4 No attack-attempt cap
+### 3.4 Attack-attempt cap
 
-Spec §6.12 requires bandits to be removed from the world after 6 attempts (7th = ESCAPED + carried loot burned + troop deleted). The impl has no `attackAttemptsMade` counter; the field is absent from the struct (`IClanWorld.sol:303-315`) and the ABI returns `attackAttemptsMade: 0` always. Bandits cycle indefinitely until either the target clan dies or defenders defeat them.
+Spec §6.12 requires bandits to be removed from the world after 6 attempts. The 2026-05-10 update implements this with `attackAttemptsMade`: each no-target retry or resolved failed attack increments the counter, and once it reaches `BANDIT_MAX_ATTACK_ATTEMPTS` the bandit terminally escapes, burns carry, emits `BanditEscaped`, and is deleted from storage.
 
 ---
 
@@ -197,7 +201,7 @@ On `Defeated` outcome:
 
 - `DefendBase` is a persistent mission — a clansman set to defend stays defending across multiple bandit attacks until reassigned, killed, or until the defended clan dies (matches v4.2 §8.2).
 - Defender registries are cleaned on clansman death (`_clearDefender` at `ClanWorld.sol:565-588`) and on defended-clan death (`_releaseDefendersForDeadTarget` at `ClanWorld.sol:2771-2792`).
-- Dead-target cleanup transitions any active bandit attack against a dead clan to `Escaped` (`_abortBanditAttacksForDeadTarget` at `ClanWorld.sol:590-608`).
+- Dead-target cleanup transitions any active bandit attack against a dead clan to `Camped` (`_abortBanditAttacksForDeadTarget`), which clears the target and follows the same `Attacking → Camped` rampage path.
 
 ---
 
@@ -209,8 +213,7 @@ These supersede the bandit-related constants in `clanworld_v4_2_state_schema_int
 |---|---|---|---|
 | `BANDIT_COOLDOWN_TICKS` | 10 | 10 | `ClanWorld.sol:90` ✅ unchanged |
 | `BANDIT_CAMP_TICKS` | 3 | 3 | `ClanWorld.sol:1605, 1612` ✅ unchanged |
-| `BANDIT_REST_TICKS` | 2 (post-attack) | 2 (in `Resting`); 2 additional in `Escaped` | `ClanWorld.sol:1689-1697` |
-| `BANDIT_MAX_ATTEMPTS` | 6 | not implemented | — |
+| `BANDIT_MAX_ATTEMPTS` | 6 | 6 | `IClanWorld.sol` ✅ unchanged |
 | `BANDIT_BASE_STEAL_BPS` | 2000 (20%) | declared, not referenced | `IClanWorld.sol:71` |
 | `BANDIT_DROP_TO_DEFENDERS_BPS` | 5000 (50%) | declared, not referenced; impl uses 100% | `IClanWorld.sol:72` |
 | Spawn base chance | 5% | 10% | `ClanWorld.sol:91` |
@@ -223,33 +226,31 @@ These supersede the bandit-related constants in `clanworld_v4_2_state_schema_int
 | `WALL_HP_PER_LEVEL` | (n/a; threshold = 10×wall) | 100 | `ClanWorld.sol:111` |
 | `BASE_HP_PER_LEVEL` | (n/a; threshold = 5×base) | 25 | `ClanWorld.sol:112` |
 
-The state enum is also expanded:
+The state enum is:
 
 | State | v4 spec (§6.5) | As-built (`IClanWorld.sol:107-115`) |
 |---|---|---|
 | `None` | — | 0 (sentinel) |
 | `Spawned` | — | 1 (1-tick pre-camp) |
 | `CAMPING` / `Camped` | yes | 2 |
-| `RESTING` / `Resting` | yes | 3 |
-| `ATTACKING` / `Attacking` | yes | 4 |
-| `DEFEATED` / `Defeated` | yes (terminal) | 5 (terminal) |
-| `ESCAPED` / `Escaped` | yes (terminal in spec) | 6 (NON-terminal in impl; cycles back to Resting) |
+| `ATTACKING` / `Attacking` | yes | 3 |
+| `DEFEATED` / `Defeated` | yes (terminal) | 4 (terminal) |
 
 ---
 
 ## 6. Deferred to restoration milestone (`spec-v4-restoration-post-hackathon`)
 
-The following v4 mechanics are **explicitly NOT being implemented for the hackathon submissions**. They are tracked for evaluation under the `spec-v4-restoration-post-hackathon` GH milestone. Restoration is conditional on hackathon timeline and the post-hackathon evaluation that the original v4 mechanics deliver more gameplay value than the as-built simpler model.
+The following v4 mechanics remain tracked for post-hackathon restoration or have been closed by the 2026-05-10 lifecycle update:
 
 | # | v4 spec mechanic | As-built behavior | Restoration cost (rough) |
 |---|---|---|---|
 | 1 | **Vault loot theft** (§6.15C, §6.16) — bandits steal 20% of wood/wheat/fish/iron on failed defense, accumulate carry until defeat/escape | Bandits never extract loot; carry remains 0 in production | Medium — re-wire `_resolveBanditAttack`, write carry update path, plumb through `BanditAttackResolved` event |
-| 2 | **Rampage path** (§6.10, §6.11) — bandit moves 1→2→5→7→6→4→1 clockwise on completion of each attack-rest cycle | Bandit stays in spawn region forever | Medium — add region-transition logic on rest-end, ensure single-troop-per-rampage invariant if combined with #5 |
-| 3 | **Attack-attempt cap** (§6.12) — 6 attempts max, 7th = ESCAPED + carry burned + troop removed | No counter; bandits cycle indefinitely | Small — add `attackAttemptsMade` field to `BanditTroop`, increment on each Attacking-tick, terminal-Escape branch when ≥ 6 |
+| 2 | **Rampage path** (§6.10, §6.11) — bandit moves 1→2→5→7→6→4→1 clockwise on each successful attack escape | Implemented on `Attacking → Camped` | Done |
+| 3 | **Attack-attempt cap** (§6.12) — 6 attempts max, terminal escape burns carry and deletes troop | Implemented via `attackAttemptsMade` | Done |
 | 4 | **Tier-based attack power** (§6.14, v4.3 G) — `tier` 1..5 with `attackPower` ∈ {30, 45, 60, 80, 95}, derivation via `getBanditAttackPower(tier)` | Random uniform `[100, 250]` strength; no tier field | Small — add `tier` field, derivation helper, replace strength roll |
 | 5 | **Lowest-clanId tiebreak** (§6.8) — when multiple bases tied for highest loot value, lowest clanId targeted (deterministic) | RNG-bounded uniform pick (non-deterministic across replay) | Tiny — replace RNG pick with min-clanId scan |
 | 6 | **WAITING-at-home defense contribution** (§6.13) — clansmen passively at home contribute 5 defense each (vs 10 for explicit `DefendBase`) | Only `DefendBase` mission counts; passive home clansmen contribute 0 | Small — extend `_collectDefenderContribution` to include WAITING-at-home, add 5-or-10 dispatch on mission state |
-| 7 | **Terminal Escaped state** (§6.12) — Escaped is a removal event; troop deleted from world; carry burned | Escaped is a 2-tick transient that cycles back into Resting | Small — when terminal-escape branch fires (e.g. from #3), remove troop instead of cycling |
+| 7 | **Terminal escape** (§6.12) — escape is a removal event; troop deleted from world; carry burned | Implemented without a persistent `Escaped` enum state | Done |
 | 8 | **Single-troop global limit** (§6.1) — at most ONE active bandit globally | Up to 8 globally; up to 3 per region | Small — set `MAX_TOTAL_BANDITS = 1`; remove per-region cap (or set both to 1); collapse multi-troop spawn loop |
 
 **Additional smaller drifts** noted in the UAT report but bundled with the above on restoration (no separate tracking):
@@ -271,8 +272,8 @@ The following v4 mechanics are **explicitly NOT being implemented for the hackat
 When Liam (or anyone running interactive UAT against this contract) observes bandit behavior, **expect the as-built mechanics, not the v4 spec mechanics.** Specifically:
 
 - ✅ Bandits spawn frequently (10% per region per tick, ramping to 80%) and can stack up to 8 globally / 3 per region
-- ✅ Bandits stay in their spawn region for their entire lifecycle
-- ✅ Bandits attack the same region repeatedly until their target clan dies, defenders defeat them, or you stop watching
+- ✅ Bandits rampage to the next region after each successful attack escape
+- ✅ Bandits attack every 3 ticks after the first attack until defenders defeat them or they hit the 6-attempt terminal escape cap
 - ✅ Bandits do damage to wall, base, and clansmen (clansmen DO die from bandit attacks in this impl)
 - ✅ Bandits do NOT steal vault resources; vault wood/wheat/fish/iron are unchanged after bandit attacks
 - ✅ Defeated bandits drop only the blueprint (no carry, no gold) to the target clan vault

--- a/docs/planning/clanworld_v5_animation_spec.md
+++ b/docs/planning/clanworld_v5_animation_spec.md
@@ -533,16 +533,11 @@ The combat outcome is known onchain at tick start. The animation just plays out 
 ```
 T+0s   ── Combat tick begins. World filter dims.
 T+1s   ── "Combat begin" visual cue.
-T+2s   ── Bandits start march toward base.
-T+3s   ── Defenders converge from base perimeter.
-T+15s  ── All combatants arrive at combat ring radius.
-T+16s  ── Slow circle begins. ~15° per second.
-T+30s  ── Circle accelerates. ~45° per second.
-T+45s  ── Whirlwind phase. ~180° per second, motion blur.
-T+55s  ── Whirlwind peaks. Camera shakes subtly.
-T+58s  ── FLASH (full screen, 200ms).
-T+58.2s ── Resolution animation begins (success or failure).
-T+59.5s ── Resolution completes.
+T+1s   ── Bandits start slow march toward base.
+T+45s  ── All combatants arrive at combat ring radius.
+T+46s  ── Slow circle begins and accelerates into whirlwind.
+T+56s  ── FLASH + resolution window begins.
+T+58s  ── Bandit-win outcome converges at base center.
 T+60s  ── Tick closes, world filter releases, normal state.
 ```
 
@@ -551,12 +546,10 @@ Combat phase derived value:
 ```
 function computeCombatPhase(now: number, tickStartMs: number, tickDurationMs: number): CombatPhase {
   const p = (now - tickStartMs) / tickDurationMs
-  if (p < 0.025) return 'dim'
-  if (p < 0.25)  return 'advance'
-  if (p < 0.5)   return 'slow_circle'
-  if (p < 0.75)  return 'accelerate'
-  if (p < 0.92)  return 'whirlwind'
-  if (p < 0.97)  return 'flash'
+  if (p < 1 / 60)   return 'dim'
+  if (p < 45 / 60)  return 'advance'
+  if (p < 46 / 60)  return 'wait'
+  if (p < 56 / 60)  return 'accelerate'
   return 'resolution'
 }
 ```
@@ -586,58 +579,47 @@ stage.addChild(worldCombatHighlight)
 // On combat end: move them back, fade dimOverlay alpha 0.55 → 0 over 600ms
 ```
 
-### 9.3 Phase 2 — Bandit advance (T+2s to T+15s)
+### 9.3 Phase 2 — Bandit advance (T+1s to T+45s)
 
 - Bandits start at staging position (bandit camp tile or just outside base region).
 - Each bandit's combat-ring target position: baseAngle + (i / N) * 2π. Spread evenly.
 - March uses bandit_march (4 frames, 6fps).
 - Pulse glow during march: tint = lerp(0xff8888, 0xffffff, sin(now/400)). Period 800ms, 1.25Hz.
-- Bandits move slowly. Cover the distance over 13 seconds. Suspense, not action-paced.
+- Bandits move slowly. Cover the distance over 44 seconds. Suspense, not action-paced.
 
-### 9.4 Phase 3 — Defender convergence (T+3s, parallel with Phase 2)
+### 9.4 Phase 3 — Defender convergence (parallel with Phase 2)
 
 - Defenders (clansmen on defend_base + idle clansmen at home + mercenaries from other clans) leave wander positions, walk toward combat ring on the *opposite side* from each bandit.
 - If 5 defenders vs 3 bandits, defenders fill arc gaps between bandits.
 - walk_* animation, 4-direction. Face ring center.
 - Stagger: each defender starts 200ms after previous so they don't all kick off in sync.
 
-### 9.5 Phase 4 — The wait (T+15s to T+16s)
+### 9.5 Phase 4 — The wait (T+45s to T+46s)
 
 Brief 1-second beat. Everyone in position, idle, facing base. World dim, combat circle bright. Nothing moves except 4-fps idle bobs and bandit pulse glow.
 
 This pause is critical — the calm before.
 
-### 9.6 Phase 5 — Slow circle (T+16s to T+30s)
+### 9.6 Phase 5 — Slow circle → whirlwind acceleration (T+46s to T+56s)
 
 - Bandits and defenders orbit the base. Alternate around the ring (B D B D B D…).
-- Angular velocity: 15°/s clockwise. Quarter-rotation = 6 seconds.
+- Angular velocity starts at 15°/s clockwise and accelerates to 180°/s over 10 seconds.
 - Position: (baseX + r·cos(angle), baseY + r·sin(angle)). Combat ring radius ~80px.
 - Sprites face *tangent* to circle (direction of motion). 4-way walk reads correctly as they orbit.
 - walk_* animation throughout.
 - Camera *very gently* zooms in by 5% over this phase. Imperceptible per-frame.
-
-### 9.7 Phase 6 — Whirlwind acceleration (T+30s to T+45s)
-
-- Angular velocity ramps 15°/s → 180°/s over 15 seconds. Easing: cubic.
 - At ~60°/s, sprite frame rate accelerates: walk frames advance at 12fps instead of 8fps.
 - At ~120°/s, motion blur: pre-rendered radial smear sprites overlay each combatant. Or use Pixi's BlurFilter with blur = lerp(0, 4, accelProgress).
 - Particles spin out tangentially: small dust/spark sprites emit from ring, 4-frame, fade fast.
 - Subtle whirlwind shape (concentric semi-transparent rings) appears underneath, rotating in *opposite* direction. Sells the vortex.
 
-### 9.8 Phase 7 — Whirlwind peak (T+45s to T+55s)
+### 9.7 Phase 6 — Flash + resolution (T+56s to T+60s)
 
-- Angular velocity holds at 180°/s.
-- Blur maxes out. Combatants are unrecognizable streaks.
-- Camera shakes: subtle, ±2px offset, 3Hz.
-- Base in center dims and glitches (1px x-offset jitter, 4Hz).
-
-### 9.9 Phase 8 — The flash (T+55s to T+58s)
-
-- Whirlwind continues but adds an *outer* expanding white ring at T+55s — shockwave warning.
-- At T+58s exactly: full-screen white flash. Alpha 0→1 in 80ms (2 frames at 60fps), held 100ms, fade to 0 over 800ms.
+- Whirlwind continues but adds an *outer* expanding white ring at T+56s — shockwave warning.
+- Full-screen white flash. Alpha 0→1 in 80ms (2 frames at 60fps), held 100ms, fade to 0 over 800ms.
 - During the flash, combatant positions snap to resolution starting positions. Flash hides the snap.
 
-### 9.10 Phase 9a — Defense success (T+58.2s to T+59.5s)
+#### 9.7a Defense success
 
 - Bandits launch radially outward from base center. Initial velocity ~200px/s.
 - Bandits decelerate over 600ms (drag), travel ~60px, come to rest.
@@ -645,21 +627,36 @@ This pause is critical — the calm before.
   - Frames 1–2: ground pose, dazed.
   - Frames 3–4: white flash overlay (full sprite alpha-tinted white).
   - Frames 5–6: shrink to 30% scale, fade alpha 1→0.
-- After death anim (~750ms), coin_explode spawns at each bandit's last position.
+- Bandit death sprites oscillate brightness, then fade over the next ~12s into the following tick. Actual chain removal happens at T+60s on the heartbeat.
+- After death anim starts, coin_explode spawns at each bandit's last position.
 - Defenders play cheer (4 frames, 6fps, 2 loops = ~1.3s).
 - Blueprint Fragment (if awarded): icon rises from bandit corpse, drifts to base, fades into vault. ~1.5s.
 
-### 9.11 Phase 9b — Defense failure (T+58.2s to T+59.5s)
+#### 9.7b Bandits win
 
 - Clansmen jump backward 20–30px (much less than bandits would be thrown). easeOutQuad over 300ms.
 - On landing, each clansman's tile gets dust_puff (4 frames, 8fps, 500ms).
 - Stagger: clansmen play idle with 1px horizontal jitter for 500ms (shaking it off).
 - Wall sprite drops one level *visibly*: scale.y interpolates 1.0 → newRatio over 400ms easeInQuad. Small chunk-of-stone sprite falls from wall top, hits ground, dust.
 - Resources fly out of base as small icon sprites (one per 20% stolen), drift to bandit positions over 800ms. Each bandit "absorbs" them (sprite shrinks to bandit, fades).
-- Bandits converge to base center: brief huddle, sprites overlap at center 500ms.
-- Bandits then march out toward next region. bandit_march. Camera doesn't follow.
+- Bandits converge to base center at T+58s: brief huddle, sprites overlap at center 500ms.
+- Starting at T+60s, bandits walk visibly to the next region into the next 3-tick `Camped` phase. bandit_march. Camera doesn't follow.
 
-### 9.12 Phase 10 — Cleanup (T+59.5s to T+60s)
+### 9.8 Bandit cycle UI mapping
+
+```
+Tick 1 (Spawned): camp sprite appears, faint red glow ramping
+Ticks 2-3 (Camped): camp sprite, full ominous red glow
+Tick 4 (Camped, last): all 60s = combat animation (march+circle+flash+resolve)
+
+After a successful escape:
+Tick 5 (Camped, in NEW region): walk-in animation 0-15s + camp glow ramping
+Ticks 6-7 (Camped): full glow
+Tick 8 (Camped, last): combat animation again
+... repeat
+```
+
+### 9.9 Cleanup (T+59.5s to T+60s)
 
 - World dim overlay fades to 0 over 600ms.
 - Surviving combatants return to wander positions (smooth walk).

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -462,7 +462,6 @@ BANDITS
 ================================================================
   BANDIT_COOLDOWN_TICKS         = 10
   BANDIT_CAMP_TICKS             = 3   (bandit camps for N ticks before attacking)
-  BANDIT_REST_TICKS             = 2   (rest between attacks)
   BANDIT_MAX_ATTACK_ATTEMPTS    = 6
   BANDIT_BASE_STEAL_BPS         = 2000 (steal 20% on success)
   BANDIT_DROP_TO_DEFENDERS_BPS  = 5000 (defenders recover 50% on kill)
@@ -563,7 +562,7 @@ export function resolveHelp(args: string[]): string | undefined {
   const two = positional.slice(0, 2).join(' ');
   if (SUBCOMMAND_HELP[two]) return SUBCOMMAND_HELP[two];
   const one = positional[0];
-  if (SUBCOMMAND_HELP[one]) return SUBCOMMAND_HELP[one];
+  if (one && SUBCOMMAND_HELP[one]) return SUBCOMMAND_HELP[one];
   return TOP_LEVEL_HELP;
 }
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -2126,6 +2126,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                         }
                         bandit.tickEnteredState = _world.currentTick;
                         bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
+                        emit BanditStateChanged(
+                            banditId, BanditState.Camped, BanditState.Camped, bandit.region, _world.currentTick
+                        );
                     } else {
                         _transitionBanditToAttacking(banditId, targetClanId);
                     }
@@ -2193,18 +2196,14 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     function _resolveAttackingBandits(uint64 closedTick) internal {
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
             uint32[] storage regionBandits = _banditsByRegion[region];
-            uint256 i = 0;
-            while (i < regionBandits.length) {
-                uint32 banditId = regionBandits[i];
+            uint32[] memory banditIdsToProcess = regionBandits;
+            for (uint256 i = 0; i < banditIdsToProcess.length; i++) {
+                uint32 banditId = banditIdsToProcess[i];
                 BanditTroop storage bandit = _bandits[banditId];
                 bool shouldResolve = bandit.state == BanditState.Attacking && bandit.tickEnteredState == closedTick;
                 if (shouldResolve) {
                     _resolveBanditAttack(banditId, closedTick);
-                    if (_bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) {
-                        continue;
-                    }
                 }
-                i++;
             }
         }
     }
@@ -2237,7 +2236,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             return;
         }
         if (targetClan.lastSettledTick < _world.currentTick) {
-            _transitionBanditState(banditId, BanditState.Camped);
+            bandit.state = BanditState.Camped;
+            bandit.tickEnteredState = _world.currentTick;
+            bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
+            emit BanditStateChanged(
+                banditId, BanditState.Attacking, BanditState.Camped, bandit.region, _world.currentTick
+            );
             return;
         }
 

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -552,8 +552,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             fishNeeded = fishNeeded * ClanWorldConstants.WINTER_UPKEEP_MULTIPLIER_BPS / 10000;
         }
 
-        uint256 spendableWheat =
-            _spendableAfterReleasing(clan.vaultWheat, _reservedWheatByClan[clan.clanId], 0);
+        uint256 spendableWheat = _spendableAfterReleasing(clan.vaultWheat, _reservedWheatByClan[clan.clanId], 0);
         bool hadEnoughWheat = spendableWheat >= wheatNeeded;
         bool hadEnoughFish = clan.vaultFish >= fishNeeded;
 
@@ -591,8 +590,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (winter) {
             uint256 woodNeeded = ClanWorldConstants.WINTER_WOOD_BURN_PER_BASE + uint256(livingBeforeStarvation)
                 * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
-            uint256 spendableWood =
-                _spendableAfterReleasing(clan.vaultWood, _reservedWoodByClan[clan.clanId], 0);
+            uint256 spendableWood = _spendableAfterReleasing(clan.vaultWood, _reservedWoodByClan[clan.clanId], 0);
             if (spendableWood >= woodNeeded) {
                 clan.vaultWood -= woodNeeded;
             } else {
@@ -760,9 +758,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             for (uint256 j = 0; j < csIds.length; j++) {
                 uint32 clansmanId = csIds[j];
                 Mission storage mission = _missions[clansmanId];
-                if (
-                    mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == deadClanId
-                ) {
+                if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == deadClanId) {
                     if (_clansmanDefendingRegion[clansmanId] == baseRegion) {
                         _clearDefender(clansmanId);
                     }
@@ -787,7 +783,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
                 BanditTroop storage bandit = _bandits[banditId];
                 if (bandit.state == BanditState.Attacking && bandit.targetClanId == deadClanId) {
-                    _transitionBanditState(banditId, BanditState.Escaped);
+                    _transitionBanditState(banditId, BanditState.Camped);
                     emit BanditEscaped(banditId, tick);
                     emit BanditTargetDied(banditId, deadClanId, tick);
                 }
@@ -1730,10 +1726,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         WithdrawResourcesData memory req = m.withdrawResources;
         if (!_hasWithdrawRequest(req)) return _simulateCompleteMission(cs, m);
 
-        uint256 spendableWood =
-            _spendableAfterReleasing(sim.clan.vaultWood, _reservedWoodByClan[sim.clan.clanId], 0);
-        uint256 spendableIron =
-            _spendableAfterReleasing(sim.clan.vaultIron, _reservedIronByClan[sim.clan.clanId], 0);
+        uint256 spendableWood = _spendableAfterReleasing(sim.clan.vaultWood, _reservedWoodByClan[sim.clan.clanId], 0);
+        uint256 spendableIron = _spendableAfterReleasing(sim.clan.vaultIron, _reservedIronByClan[sim.clan.clanId], 0);
         uint256 spendableWheat = sim.clan.vaultWheat > sim.reservedWheat ? sim.clan.vaultWheat - sim.reservedWheat : 0;
 
         if (
@@ -2011,7 +2005,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         emit BanditStateChanged(id, oldState, newState, bandit.region, _world.currentTick);
 
-        if (oldState == BanditState.Resting && newState == BanditState.Camped) {
+        if (oldState == BanditState.Attacking && newState == BanditState.Camped) {
             _moveBanditToRampageNextRegion(id);
         }
     }
@@ -2020,35 +2014,20 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (bandit.state == BanditState.Spawned) return _canBanditLeaveSpawned(bandit, newState);
         if (bandit.state == BanditState.Camped) return _canBanditLeaveCamped(bandit, newState);
         if (bandit.state == BanditState.Attacking) return _canBanditLeaveAttacking(newState);
-        if (bandit.state == BanditState.Escaped) return _canBanditLeaveEscaped(newState);
-        if (bandit.state == BanditState.Resting) return _canBanditLeaveResting(bandit, newState);
         return false;
     }
 
     function _canBanditLeaveSpawned(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
-        return newState == BanditState.Escaped
-            || (newState == BanditState.Camped && _world.currentTick >= bandit.tickEnteredState + 1);
+        return newState == BanditState.Camped && _world.currentTick >= bandit.tickEnteredState + 1;
     }
 
     function _canBanditLeaveCamped(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
-        return newState == BanditState.Escaped || newState == BanditState.Resting
-            || (newState == BanditState.Attacking
-                && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
-                && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS);
+        return newState == BanditState.Attacking && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
+            && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
     }
 
     function _canBanditLeaveAttacking(BanditState newState) internal pure returns (bool) {
-        return newState == BanditState.Defeated || newState == BanditState.Escaped || newState == BanditState.Resting;
-    }
-
-    function _canBanditLeaveEscaped(BanditState newState) internal pure returns (bool) {
-        return newState == BanditState.Resting;
-    }
-
-    function _canBanditLeaveResting(BanditTroop storage bandit, BanditState newState) internal view returns (bool) {
-        return newState == BanditState.Escaped
-            || (newState == BanditState.Camped
-                && _world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS);
+        return newState == BanditState.Defeated || newState == BanditState.Camped;
     }
 
     function _moveBanditToRampageNextRegion(uint32 id) internal {
@@ -2145,20 +2124,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                             _terminalEscapeBandit(banditId, closedTick);
                             continue;
                         }
-                        _transitionBanditState(banditId, BanditState.Resting);
+                        bandit.tickEnteredState = _world.currentTick;
+                        bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
                     } else {
                         _transitionBanditToAttacking(banditId, targetClanId);
                     }
-                } else if (
-                    bandit.state == BanditState.Escaped
-                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
-                ) {
-                    _transitionBanditState(banditId, BanditState.Resting);
-                } else if (
-                    bandit.state == BanditState.Resting
-                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
-                ) {
-                    _transitionBanditState(banditId, BanditState.Camped);
                 }
 
                 if (_bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) {
@@ -2208,7 +2178,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
 
         BanditState oldState = bandit.state;
-        emit BanditStateChanged(banditId, oldState, BanditState.Escaped, bandit.region, closedTick);
+        emit BanditStateChanged(banditId, oldState, BanditState.None, bandit.region, closedTick);
         _burnBanditCarry(banditId);
         emit BanditEscaped(banditId, closedTick);
         _deleteBandit(banditId);
@@ -2253,7 +2223,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 targetClanId = bandit.targetClanId;
         Clan storage targetClan = _clans[targetClanId];
         if (targetClan.clanId == ClanWorldConstants.CLAN_ID_NULL || targetClan.clanState == ClanState.DEAD) {
-            _transitionBanditState(banditId, BanditState.Escaped);
+            _transitionBanditState(banditId, BanditState.Camped);
             emit BanditEscaped(banditId, closedTick);
             return;
         }
@@ -2262,12 +2232,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             return;
         }
         if (targetClan.clanState == ClanState.DEAD) {
-            _transitionBanditState(banditId, BanditState.Escaped);
+            _transitionBanditState(banditId, BanditState.Camped);
             emit BanditEscaped(banditId, closedTick);
             return;
         }
         if (targetClan.lastSettledTick < _world.currentTick) {
-            _transitionBanditState(banditId, BanditState.Resting);
+            _transitionBanditState(banditId, BanditState.Camped);
             return;
         }
 
@@ -2327,7 +2297,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             if (_recordBanditAttackAttempt(banditId) >= ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
                 _terminalEscapeBandit(banditId, closedTick);
             } else {
-                _transitionBanditState(banditId, BanditState.Resting);
+                _transitionBanditState(banditId, BanditState.Camped);
             }
         }
     }
@@ -2433,8 +2403,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 targetClanId = targetClan.clanId;
         uint256 spendableWood = _spendableAfterReleasing(targetClan.vaultWood, _reservedWoodByClan[targetClanId], 0);
         uint256 spendableIron = _spendableAfterReleasing(targetClan.vaultIron, _reservedIronByClan[targetClanId], 0);
-        uint256 spendableWheat =
-            _spendableAfterReleasing(targetClan.vaultWheat, _reservedWheatByClan[targetClanId], 0);
+        uint256 spendableWheat = _spendableAfterReleasing(targetClan.vaultWheat, _reservedWheatByClan[targetClanId], 0);
 
         stolenWood = _banditStealAmount(spendableWood);
         stolenIron = _banditStealAmount(spendableIron);
@@ -4991,14 +4960,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
         if (wood > 0) {
             require(
-                _spendableVaultResource(fromClanId, fromClan, ResourceType.Wood) >= wood,
-                "ClanWorld: insufficient wood"
+                _spendableVaultResource(fromClanId, fromClan, ResourceType.Wood) >= wood, "ClanWorld: insufficient wood"
             );
         }
         if (iron > 0) {
             require(
-                _spendableVaultResource(fromClanId, fromClan, ResourceType.Iron) >= iron,
-                "ClanWorld: insufficient iron"
+                _spendableVaultResource(fromClanId, fromClan, ResourceType.Iron) >= iron, "ClanWorld: insufficient iron"
             );
         }
         if (wheat > 0) {
@@ -5009,8 +4976,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
         if (fish > 0) {
             require(
-                _spendableVaultResource(fromClanId, fromClan, ResourceType.Fish) >= fish,
-                "ClanWorld: insufficient fish"
+                _spendableVaultResource(fromClanId, fromClan, ResourceType.Fish) >= fish, "ClanWorld: insufficient fish"
             );
         }
 
@@ -5026,7 +4992,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             require(_deductVaultResource(fromClanId, fromClan, ResourceType.Iron, iron), "ClanWorld: insufficient iron");
         }
         if (wheat > 0) {
-            require(_deductVaultResource(fromClanId, fromClan, ResourceType.Wheat, wheat), "ClanWorld: insufficient wheat");
+            require(
+                _deductVaultResource(fromClanId, fromClan, ResourceType.Wheat, wheat), "ClanWorld: insufficient wheat"
+            );
         }
         if (fish > 0) {
             require(_deductVaultResource(fromClanId, fromClan, ResourceType.Fish, fish), "ClanWorld: insufficient fish");
@@ -5654,8 +5622,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 nextActionTick = bandit.tickEnteredState + 1;
             } else if (bandit.state == BanditState.Camped) {
                 nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
-            } else if (bandit.state == BanditState.Resting) {
-                nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS;
             }
             if (bandit.attackAttemptsMade < ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
                 maxAttemptsRemaining = ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS - bandit.attackAttemptsMade;

--- a/packages/contracts/src/ClanWorldLens.sol
+++ b/packages/contracts/src/ClanWorldLens.sol
@@ -173,8 +173,6 @@ contract ClanWorldLens is IClanWorldLens {
                 nextActionTick = bandit.tickEnteredState + 1;
             } else if (bandit.state == BanditState.Camped) {
                 nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
-            } else if (bandit.state == BanditState.Resting) {
-                nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS;
             }
             if (bandit.attackAttemptsMade < ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
                 maxAttemptsRemaining = ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS - bandit.attackAttemptsMade;
@@ -274,5 +272,4 @@ contract ClanWorldLens is IClanWorldLens {
             leaderboard: leaderboard
         });
     }
-
 }

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -35,7 +35,6 @@ library ClanWorldConstants {
     // Bandit cadence
     uint64 internal constant BANDIT_COOLDOWN_TICKS = 10;
     uint64 internal constant BANDIT_CAMP_TICKS = 3;
-    uint64 internal constant BANDIT_REST_TICKS = 2;
     uint8 internal constant BANDIT_MAX_ATTACK_ATTEMPTS = 6;
 
     // Clansman cadence
@@ -125,10 +124,8 @@ enum BanditState {
     None,
     Spawned,
     Camped,
-    Resting,
     Attacking,
-    Defeated,
-    Escaped
+    Defeated
 }
 
 enum WheatPlotState {

--- a/packages/contracts/src/diamond/facets/BanditViewsFacet.sol
+++ b/packages/contracts/src/diamond/facets/BanditViewsFacet.sol
@@ -17,8 +17,6 @@ contract BanditViewsFacet {
                 nextActionTick = bandit.tickEnteredState + 1;
             } else if (bandit.state == BanditState.Camped) {
                 nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
-            } else if (bandit.state == BanditState.Resting) {
-                nextActionTick = bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS;
             }
             if (bandit.attackAttemptsMade < ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
                 maxAttemptsRemaining = ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS - bandit.attackAttemptsMade;

--- a/packages/contracts/src/diamond/lib/LibBanditCombat.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditCombat.sol
@@ -102,12 +102,12 @@ library LibBanditCombat {
         uint32 targetClanId = bandit.targetClanId;
         Clan storage targetClan = s.clans[targetClanId];
         if (targetClan.clanId == ClanWorldConstants.CLAN_ID_NULL || targetClan.clanState == ClanState.DEAD) {
-            LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Escaped);
+            LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Camped);
             emit BanditEscaped(banditId, closedTick);
             return;
         }
         if (targetClan.lastSettledTick < s.world.currentTick) {
-            LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Resting);
+            LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Camped);
             return;
         }
 
@@ -160,7 +160,7 @@ library LibBanditCombat {
         ) {
             LibBanditLifecycle.terminalEscapeBandit(s, banditId, closedTick);
         } else {
-            LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Resting);
+            LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Camped);
         }
     }
 
@@ -498,7 +498,9 @@ library LibBanditCombat {
         emit ClanDied(clanId, tick, reason);
     }
 
-    function releaseDefendersForDeadTarget(LibStorage.AppStorage storage s, uint32 deadClanId, uint8 baseRegion) internal {
+    function releaseDefendersForDeadTarget(LibStorage.AppStorage storage s, uint32 deadClanId, uint8 baseRegion)
+        internal
+    {
         for (uint256 i = 0; i < s.allClanIds.length; i++) {
             uint32 defenderClanId = s.allClanIds[i];
             if (defenderClanId == deadClanId) continue;
@@ -507,9 +509,7 @@ library LibBanditCombat {
             for (uint256 j = 0; j < csIds.length; j++) {
                 uint32 clansmanId = csIds[j];
                 Mission storage mission = s.missions[clansmanId];
-                if (
-                    mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == deadClanId
-                ) {
+                if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == deadClanId) {
                     if (s.clansmanDefendingRegion[clansmanId] == baseRegion) {
                         LibOrderDefenders.clearDefender(s, clansmanId);
                     }
@@ -538,7 +538,7 @@ library LibBanditCombat {
 
                 BanditTroop storage bandit = s.bandits[banditId];
                 if (bandit.state == BanditState.Attacking && bandit.targetClanId == deadClanId) {
-                    LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Escaped);
+                    LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Camped);
                     emit BanditEscaped(banditId, tick);
                     emit BanditTargetDied(banditId, deadClanId, tick);
                 }

--- a/packages/contracts/src/diamond/lib/LibBanditCombat.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditCombat.sol
@@ -43,6 +43,9 @@ library LibBanditCombat {
     );
     event BanditDefeated(uint32 indexed banditId, uint32 indexed targetClanId, uint64 atTick);
     event BanditEscaped(uint32 indexed banditId, uint64 atTick);
+    event BanditStateChanged(
+        uint32 indexed banditId, BanditState oldState, BanditState newState, uint8 region, uint64 atTick
+    );
     event BanditTargetDied(uint32 indexed banditId, uint32 indexed deadClanId, uint64 tick);
     event WallDamagedByBandit(uint32 indexed clanId, uint8 newLevel, uint32 indexed banditId);
     event ClansmanKilledByBandit(uint32 indexed clanId, uint32 indexed clansmanId, uint32 indexed banditId);
@@ -76,18 +79,14 @@ library LibBanditCombat {
     function resolveAttackingBandits(LibStorage.AppStorage storage s, uint64 closedTick) public {
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
             uint32[] storage regionBandits = s.banditsByRegion[region];
-            uint256 i = 0;
-            while (i < regionBandits.length) {
-                uint32 banditId = regionBandits[i];
+            uint32[] memory banditIdsToProcess = regionBandits;
+            for (uint256 i = 0; i < banditIdsToProcess.length; i++) {
+                uint32 banditId = banditIdsToProcess[i];
                 BanditTroop storage bandit = s.bandits[banditId];
                 bool shouldResolve = bandit.state == BanditState.Attacking && bandit.tickEnteredState == closedTick;
                 if (shouldResolve) {
                     resolveBanditAttack(s, banditId, closedTick);
-                    if (s.bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) {
-                        continue;
-                    }
                 }
-                i++;
             }
         }
     }
@@ -107,7 +106,12 @@ library LibBanditCombat {
             return;
         }
         if (targetClan.lastSettledTick < s.world.currentTick) {
-            LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Camped);
+            bandit.state = BanditState.Camped;
+            bandit.tickEnteredState = s.world.currentTick;
+            bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
+            emit BanditStateChanged(
+                banditId, BanditState.Attacking, BanditState.Camped, bandit.region, s.world.currentTick
+            );
             return;
         }
 

--- a/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
@@ -50,6 +50,9 @@ library LibBanditLifecycle {
                         }
                         bandit.tickEnteredState = s.world.currentTick;
                         bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
+                        emit BanditStateChanged(
+                            banditId, BanditState.Camped, BanditState.Camped, bandit.region, s.world.currentTick
+                        );
                     } else {
                         transitionBanditToAttacking(s, banditId, targetClanId);
                     }

--- a/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
@@ -48,20 +48,11 @@ library LibBanditLifecycle {
                             terminalEscapeBandit(s, banditId, closedTick);
                             continue;
                         }
-                        transitionBanditState(s, banditId, BanditState.Resting);
+                        bandit.tickEnteredState = s.world.currentTick;
+                        bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
                     } else {
                         transitionBanditToAttacking(s, banditId, targetClanId);
                     }
-                } else if (
-                    bandit.state == BanditState.Escaped
-                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
-                ) {
-                    transitionBanditState(s, banditId, BanditState.Resting);
-                } else if (
-                    bandit.state == BanditState.Resting
-                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS
-                ) {
-                    transitionBanditState(s, banditId, BanditState.Camped);
                 }
 
                 if (s.bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) continue;
@@ -99,7 +90,7 @@ library LibBanditLifecycle {
 
         emit BanditStateChanged(id, oldState, newState, bandit.region, s.world.currentTick);
 
-        if (oldState == BanditState.Resting && newState == BanditState.Camped) {
+        if (oldState == BanditState.Attacking && newState == BanditState.Camped) {
             moveBanditToRampageNextRegion(s, id);
         }
     }
@@ -110,26 +101,14 @@ library LibBanditLifecycle {
         returns (bool)
     {
         if (bandit.state == BanditState.Spawned) {
-            return newState == BanditState.Escaped
-                || (newState == BanditState.Camped && s.world.currentTick >= bandit.tickEnteredState + 1);
+            return newState == BanditState.Camped && s.world.currentTick >= bandit.tickEnteredState + 1;
         }
         if (bandit.state == BanditState.Attacking) {
-            return
-                newState == BanditState.Defeated || newState == BanditState.Escaped || newState == BanditState.Resting;
-        }
-        if (bandit.state == BanditState.Escaped) {
-            return newState == BanditState.Resting;
-        }
-        if (bandit.state == BanditState.Resting) {
-            return newState == BanditState.Escaped
-                || (newState == BanditState.Camped
-                    && s.world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_REST_TICKS);
+            return newState == BanditState.Defeated || newState == BanditState.Camped;
         }
         if (bandit.state == BanditState.Camped) {
-            return newState == BanditState.Escaped || newState == BanditState.Resting
-                || (newState == BanditState.Attacking
-                    && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
-                    && s.world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS);
+            return newState == BanditState.Attacking && bandit.targetClanId != ClanWorldConstants.CLAN_ID_NULL
+                && s.world.currentTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS;
         }
         return false;
     }
@@ -177,7 +156,7 @@ library LibBanditLifecycle {
         }
 
         BanditState oldState = bandit.state;
-        emit BanditStateChanged(banditId, oldState, BanditState.Escaped, bandit.region, closedTick);
+        emit BanditStateChanged(banditId, oldState, BanditState.None, bandit.region, closedTick);
         burnBanditCarry(s, banditId);
         emit BanditEscaped(banditId, closedTick);
         deleteBandit(s, banditId);

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -21,6 +21,7 @@ contract BanditHarness is ClanWorld {
 
 contract BanditTest is Test {
     BanditHarness world;
+    uint160 nextElder = 0xA11CE;
 
     function setUp() public {
         world = new BanditHarness();
@@ -35,6 +36,24 @@ contract BanditTest is Test {
         for (uint64 i = 0; i < ticks; i++) {
             _advanceTick();
         }
+    }
+
+    function _advanceUntil(uint64 tick) internal {
+        while (world.getWorldState().currentTick < tick) {
+            _advanceTick();
+        }
+    }
+
+    function _closeTick(uint64 tick) internal {
+        while (world.getWorldState().currentTick <= tick) {
+            _advanceTick();
+        }
+    }
+
+    function _mintClan() internal returns (uint32 clanId) {
+        address elder = address(nextElder++);
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
     }
 
     function _spawnAndCamp() internal returns (uint32 id) {
@@ -162,40 +181,43 @@ contract BanditTest is Test {
         assertEq(world.getBandit(id3).id, id3, "newer bandit remains live");
     }
 
-    function test_attackingToEscapedRestingCampedCycleWorks() public {
+    function test_attackingEscapeMovesBanditToNextRegion() public {
         uint32 id = _spawnCampAndAttack(77);
 
-        world.transitionBandit(id, BanditState.Escaped);
-        BanditTroop memory escaped = world.getBandit(id);
-        assertEq(uint8(escaped.state), uint8(BanditState.Escaped), "escaped");
-        assertEq(escaped.targetClanId, 0, "target cleared on escape");
-
-        world.transitionBandit(id, BanditState.Resting);
-        BanditTroop memory resting = world.getBandit(id);
-        assertEq(uint8(resting.state), uint8(BanditState.Resting), "resting");
-        assertEq(resting.tickEnteredState, world.getWorldState().currentTick, "resting tick");
-
-        _advanceTicks(ClanWorldConstants.BANDIT_REST_TICKS + 1);
-
+        world.transitionBandit(id, BanditState.Camped);
         BanditTroop memory camped = world.getBandit(id);
-        assertEq(uint8(camped.state), uint8(BanditState.Camped), "camped again");
+        assertEq(uint8(camped.state), uint8(BanditState.Camped), "camped");
         assertEq(camped.targetClanId, 0, "target remains clear");
         assertEq(camped.region, ClanWorldConstants.REGION_MOUNTAINS, "rampaged to next region");
         assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, 0, "left forest index");
         assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_MOUNTAINS)[0], id, "entered mountain index");
     }
 
-    function test_restingToCampedFollowsRampagePath() public {
-        uint32 id = _spawnCampAndAttack(77);
-        world.transitionBandit(id, BanditState.Escaped);
-        world.transitionBandit(id, BanditState.Resting);
+    function test_steadyStateCycleIs3Ticks() public {
+        for (uint256 i = 0; i < 6; i++) {
+            _mintClan();
+        }
 
-        _advanceTicks(ClanWorldConstants.BANDIT_REST_TICKS + 1);
-        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_MOUNTAINS, "forest to mountains");
+        uint32 id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 1000);
+        uint64 spawnedAt = world.getWorldState().currentTick;
 
-        world.transitionBandit(id, BanditState.Resting);
-        _advanceTicks(ClanWorldConstants.BANDIT_REST_TICKS + 1);
-        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_EAST_FARMS, "mountains to east farms");
+        _closeTick(spawnedAt + 4);
+        assertEq(uint8(world.getBandit(id).state), uint8(BanditState.Camped), "first attack recamped");
+        assertEq(world.getBandit(id).attackAttemptsMade, 1, "first attempt");
+        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_MOUNTAINS, "first move");
+        assertEq(world.getBandit(id).tickEnteredState, spawnedAt + 4, "first recamp tick");
+
+        _closeTick(spawnedAt + 7);
+        assertEq(uint8(world.getBandit(id).state), uint8(BanditState.Camped), "second attack recamped");
+        assertEq(world.getBandit(id).attackAttemptsMade, 2, "second attempt");
+        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_EAST_FARMS, "second move");
+        assertEq(world.getBandit(id).tickEnteredState, spawnedAt + 7, "second recamp tick");
+
+        _closeTick(spawnedAt + 10);
+        assertEq(uint8(world.getBandit(id).state), uint8(BanditState.Camped), "third attack recamped");
+        assertEq(world.getBandit(id).attackAttemptsMade, 3, "third attempt");
+        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_EAST_DOCKS, "third move");
+        assertEq(world.getBandit(id).tickEnteredState, spawnedAt + 10, "third recamp tick");
     }
 
     function test_invalidTransitionsRevert() public {

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -193,6 +193,29 @@ contract BanditTest is Test {
         assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_MOUNTAINS)[0], id, "entered mountain index");
     }
 
+    function test_multipleBanditsSameRegionAttackResolution() public {
+        uint32 id1 = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        uint32 id2 = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 200);
+        uint32 id3 = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 300);
+
+        _advanceTicks(2);
+        _advanceTicks(ClanWorldConstants.BANDIT_CAMP_TICKS - 1);
+
+        world.transitionBanditToAttacking(id1, 77);
+        world.transitionBanditToAttacking(id2, 77);
+        world.transitionBanditToAttacking(id3, 77);
+
+        _advanceTick();
+
+        assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, 0, "all left forest");
+        uint32[] memory mountainBandits = world.getBanditsInRegion(ClanWorldConstants.REGION_MOUNTAINS);
+        assertEq(mountainBandits.length, 3, "all entered mountains");
+
+        _assertResolvedInMountains(id1, mountainBandits, "id1");
+        _assertResolvedInMountains(id2, mountainBandits, "id2");
+        _assertResolvedInMountains(id3, mountainBandits, "id3");
+    }
+
     function test_steadyStateCycleIs3Ticks() public {
         for (uint256 i = 0; i < 6; i++) {
             _mintClan();
@@ -258,5 +281,22 @@ contract BanditTest is Test {
         forestBandits = world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST);
         assertEq(forestBandits.length, 1, "forest count after delete");
         assertEq(forestBandits[0], id2, "remaining forest bandit");
+    }
+
+    function _assertResolvedInMountains(uint32 id, uint32[] memory mountainBandits, string memory label) internal view {
+        BanditTroop memory bandit = world.getBandit(id);
+        assertEq(uint8(bandit.state), uint8(BanditState.Camped), label);
+        assertEq(bandit.targetClanId, 0, label);
+        assertEq(bandit.region, ClanWorldConstants.REGION_MOUNTAINS, label);
+        assertTrue(_containsBandit(mountainBandits, id), label);
+    }
+
+    function _containsBandit(uint32[] memory banditIds, uint32 id) internal pure returns (bool) {
+        for (uint256 i = 0; i < banditIds.length; i++) {
+            if (banditIds[i] == id) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -335,13 +335,8 @@ contract BanditAttackResolutionTest is Test {
         Vm.Log[] memory logs = vm.getRecordedLogs();
         _assertBanditAttackResolvedLog(logs, banditId, clanId);
 
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "attack resolved to resting");
-
-        for (uint64 i = 0; i < ClanWorldConstants.BANDIT_REST_TICKS; i++) {
-            _advanceTick();
-        }
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "resting recovered to camped");
-        assertEq(world.getBandit(banditId).region, ClanWorldConstants.REGION_MOUNTAINS, "rampaged after rest");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "attack resolved to camped");
+        assertEq(world.getBandit(banditId).region, ClanWorldConstants.REGION_MOUNTAINS, "rampaged after attack");
     }
 
     function test_deadTargetCleanupReleasesDefendersAndEscapesBandit() public {
@@ -392,7 +387,8 @@ contract BanditAttackResolutionTest is Test {
         assertFalse(world.getActiveMission(defenderId).active, "defender mission cleared");
         assertEq(world.getActiveDefenders(targetClanId).length, 0, "target defender registry cleared");
 
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "bandit recamped");
+        assertEq(world.getBandit(banditId).region, ClanWorldConstants.REGION_EAST_FARMS, "bandit moved");
         assertEq(world.getBandit(banditId).targetClanId, 0, "bandit target cleared");
 
         Clan memory unaffectedAfter = world.getClan(unaffectedClanId);
@@ -429,16 +425,8 @@ contract BanditAttackResolutionTest is Test {
         for (uint256 i = 0; i < clanIds.length; i++) {
             Clan memory clan = world.getClan(clanIds[i]);
             assertEq(clan.vaultWood, woodBefore[i], "wood stays out of vault");
-            assertEq(
-                clan.vaultWheat,
-                wheatBefore[i] > 4e18 ? wheatBefore[i] - 4e18 : 0,
-                "wheat pays heartbeat upkeep"
-            );
-            assertEq(
-                clan.vaultFish,
-                fishBefore[i] > 4e17 ? fishBefore[i] - 4e17 : 0,
-                "fish pays heartbeat upkeep"
-            );
+            assertEq(clan.vaultWheat, wheatBefore[i] > 4e18 ? wheatBefore[i] - 4e18 : 0, "wheat pays heartbeat upkeep");
+            assertEq(clan.vaultFish, fishBefore[i] > 4e17 ? fishBefore[i] - 4e17 : 0, "fish pays heartbeat upkeep");
             assertEq(clan.vaultIron, ironBefore[i], "iron stays out of vault");
             assertEq(clan.goldBalance, goldBefore[i] + (i == 0 ? 29e18 : 7e18), "gold share");
         }
@@ -560,7 +548,7 @@ contract BanditAttackResolutionTest is Test {
         _advanceTick();
 
         assertEq(uint8(world.getClan(targetClanId).clanState), uint8(ClanState.DEAD), "target starved");
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Escaped), "bandit escaped once");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "bandit recamped once");
         assertEq(world.getBandit(banditId).targetClanId, 0, "bandit target cleared");
     }
 
@@ -580,7 +568,7 @@ contract BanditAttackResolutionTest is Test {
         assertEq(afterClan.lastSettledTick, attackTick - 50, "settlement capped before attack tick");
         assertEq(afterClan.wallLevel, beforeClan.wallLevel, "no wall damage");
         assertEq(uint8(afterClan.clanState), uint8(ClanState.ACTIVE), "target remains alive");
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "bandit deferred to resting");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "bandit deferred to camped");
         assertEq(world.getBandit(banditId).targetClanId, 0, "target cleared for later pick");
         assertEq(world.getBandit(banditId).attackAttemptsMade, 0, "deferred attack not counted");
         assertEq(world.getBandit(banditId).carryWood, 0, "bandit carry unchanged");
@@ -643,7 +631,7 @@ contract BanditAttackResolutionTest is Test {
         assertEq(world.getClansman(_csId(clanIds[1], 0)).carryWood, 10e18, "helper defender share");
     }
 
-    function test_failedDefenseStealsVaultLootAndKeepsCarryWhileResting() public {
+    function test_failedDefenseStealsVaultLootAndKeepsCarryWhileCamped() public {
         uint32 clanId = _mintClan();
         Clan memory beforeClan = world.getClan(clanId);
         uint32 banditId = _forceAttack(clanId, 100);
@@ -659,7 +647,7 @@ contract BanditAttackResolutionTest is Test {
         assertEq(world.getBandit(banditId).carryWood, 4e18, "bandit carry wood");
         assertEq(world.getBandit(banditId).carryWheat, 32e17, "bandit carry wheat after upkeep");
         assertEq(world.getBandit(banditId).carryFish, 32e16, "bandit carry fish after upkeep");
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "bandit resting");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "bandit camped");
     }
 
     function test_escapedBanditDoesNotAwardBlueprint() public {
@@ -670,7 +658,7 @@ contract BanditAttackResolutionTest is Test {
         _advanceTick();
 
         assertEq(world.getClan(clanId).blueprintBalance, blueprintBefore, "blueprint unchanged");
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "bandit resting");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "bandit camped");
     }
 
     function test_sixthFailedAttackTerminallyEscapesAndBurnsCarry() public {
@@ -686,7 +674,7 @@ contract BanditAttackResolutionTest is Test {
             if (attempt < ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
                 assertEq(world.getBandit(banditId).id, banditId, "bandit remains before cap");
                 assertEq(world.getBandit(banditId).attackAttemptsMade, attempt, "attempt counted");
-                assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "nonterminal rest");
+                assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "nonterminal camp");
             }
         }
 
@@ -719,7 +707,7 @@ contract BanditAttackResolutionTest is Test {
 
         assertEq(world.getClan(clanId).wallLevel, 0, "wall level decreased");
         assertEq(world.getClan(clanId).livingClansmen, 4, "wall absorbed full hit");
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "bandit resting");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "bandit camped");
     }
 
     function test_wallZeroWeakDefenseKillsClansmanDeterministically() public {
@@ -729,7 +717,7 @@ contract BanditAttackResolutionTest is Test {
         _advanceTick();
 
         assertEq(world.getClan(clanId).livingClansmen, 3, "one clansman died");
-        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Resting), "bandit resting");
+        assertEq(uint8(world.getBandit(banditId).state), uint8(BanditState.Camped), "bandit camped");
     }
 
     function test_allClansmenDeadMarksClanDead() public {

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -817,7 +817,7 @@ contract DiamondSkeletonTest is Test {
 
         _assertWorldStateEq(IClanWorld(address(diamond)).getWorldState(), core.getWorldState());
         _assertBanditEq(IClanWorld(address(diamond)).getBandit(diamondBanditId), core.getBandit(coreBanditId));
-        assertEq(uint8(IClanWorld(address(diamond)).getBandit(diamondBanditId).state), uint8(BanditState.Resting));
+        assertEq(uint8(IClanWorld(address(diamond)).getBandit(diamondBanditId).state), uint8(BanditState.Camped));
         assertEq(IClanWorld(address(diamond)).getBandit(diamondBanditId).attackAttemptsMade, 1);
     }
 
@@ -851,7 +851,7 @@ contract DiamondSkeletonTest is Test {
         _assertWorldStateEq(IClanWorld(address(diamond)).getWorldState(), core.getWorldState());
         _assertClanEq(IClanWorld(address(diamond)).getClan(diamondClanId), core.getClan(coreClanId));
         _assertBanditEq(IClanWorld(address(diamond)).getBandit(diamondBanditId), core.getBandit(coreBanditId));
-        assertEq(uint8(IClanWorld(address(diamond)).getBandit(diamondBanditId).state), uint8(BanditState.Resting));
+        assertEq(uint8(IClanWorld(address(diamond)).getBandit(diamondBanditId).state), uint8(BanditState.Camped));
         assertEq(IClanWorld(address(diamond)).getBandit(diamondBanditId).targetClanId, 0);
     }
 
@@ -887,7 +887,7 @@ contract DiamondSkeletonTest is Test {
         assertEq(uint8(IClanWorld(address(diamond)).getClansman(defenderId).state), uint8(ClansmanState.WAITING));
         assertFalse(IClanWorld(address(diamond)).getActiveMission(defenderId).active, "defender mission cleared");
         assertEq(IClanWorld(address(diamond)).getActiveDefenders(targetClanId).length, 0, "defender registry cleared");
-        assertEq(uint8(IClanWorld(address(diamond)).getBandit(banditId).state), uint8(BanditState.Escaped));
+        assertEq(uint8(IClanWorld(address(diamond)).getBandit(banditId).state), uint8(BanditState.Camped));
         assertEq(IClanWorld(address(diamond)).getBandit(banditId).targetClanId, 0, "bandit target cleared");
     }
 

--- a/packages/shared/src/generated/constants.ts
+++ b/packages/shared/src/generated/constants.ts
@@ -7,7 +7,6 @@ export const WINTER_PERIOD_TICKS = 110n;
 export const SEASON_DURATION_TICKS = 360n;
 export const BANDIT_COOLDOWN_TICKS = 10n;
 export const BANDIT_CAMP_TICKS = 3n;
-export const BANDIT_REST_TICKS = 2n;
 export const BANDIT_MAX_ATTACK_ATTEMPTS = 6n;
 export const CLANSMAN_COOLDOWN_SECONDS = 60n;
 export const CLANSMAN_CARRY_CAP = 10000000000000000000n;

--- a/packages/shared/src/generated/enums.ts
+++ b/packages/shared/src/generated/enums.ts
@@ -83,10 +83,8 @@ export const BanditState = {
   None: 0,
   Spawned: 1,
   Camped: 2,
-  Resting: 3,
-  Attacking: 4,
-  Defeated: 5,
-  Escaped: 6,
+  Attacking: 3,
+  Defeated: 4,
 } as const;
 export type BanditState = (typeof BanditState)[keyof typeof BanditState];
 

--- a/packages/shared/src/mocks/clanWorldFixture.ts
+++ b/packages/shared/src/mocks/clanWorldFixture.ts
@@ -75,7 +75,7 @@ export interface AgentLog {
  */
 export interface BanditState {
   banditId: string;
-  state: 'CAMPING' | 'RESTING' | 'ATTACKING' | 'DEFEATED' | 'ESCAPED';
+  state: 'CAMPING' | 'ATTACKING' | 'DEFEATED';
   currentRegion: string;
   /** Tick at which the troop entered its current state. */
   stateEnteredTick: Tick;


### PR DESCRIPTION
Per Liam directive 2026-05-10 — bandit recovery cycle was 8 ticks between attacks (Escaped 2 + Resting 2 + Camped 3 + Attacking instant). Target was 3 ticks. This PR removes the `Escaped` and `Resting` states entirely so the cycle becomes `Camped (3) → Attacking (instant) → Camped (3, next region) → Attacking ...`.

## State machine

```
Spawned (1 tick) → Camped (3 ticks) → Attacking-instant
                                            │
                                            ├── Defeated (terminal)
                                            │
                                            └── Escape outcome → Camped (3, NEXT region) → ...
```

## Cadence
- First attack resolves at end of tick **4** (1 Spawned + 3 Camped)
- Subsequent attacks at end of ticks **7, 10, 13...** (3-tick cycle)
- After 6 attempts: terminal escape (`BANDIT_MAX_ATTACK_ATTEMPTS`)

## Changes (12 files, +178 / −235)

- **`packages/contracts/src/IClanWorld.sol`**: `BanditState` enum reduced to `{None, Spawned, Camped, Attacking, Defeated}` (was 7 values)
- **`packages/contracts/src/diamond/lib/LibBanditLifecycle.sol`**: Drop `Escaped → Resting` and `Resting → Camped` clauses. Move-to-next-region helper now fires on `Attacking → Camped` (escape outcome) instead of Resting → Camped.
- **`packages/contracts/src/diamond/lib/LibBanditCombat.sol`**: On winning attack, transition `Attacking → Camped` directly + move bandit to next rampage region.
- **`packages/contracts/src/ClanWorldLens.sol`** + **`BanditViewsFacet.sol`** + **`ClanWorld.sol`** (legacy monolith): Remove Resting/Escaped branches from view paths.
- **`packages/shared/src/generated/enums.ts`**: BanditState enum regen.
- **Tests**: `Bandit.t.sol`, `BanditAttackResolution.t.sol`, `DiamondSkeleton.t.sol` updated to assert new states.
- **Docs**: `clanworld_v4_6_bandit_phase9_redesign.md` state machine + `clanworld_v5_animation_spec.md` combat phase timing rewritten.

## Verification

- **73/73 targeted tests pass**: BanditTest (13) + BanditAttackResolutionTest (23) + DiamondSkeletonTest (37).
- **Full `forge build --sizes`**: skipped — `solc-0.8.34` stalled in compilation when running the full graph. CI will run it. The targeted test suites all compile and pass, so the affected files are sound.

## Migration

Requires fresh diamond redeploy (v2.3.0). Existing on-chain bandits in `Escaped` or `Resting` states would be invalid post-upgrade — those enum values no longer exist. Plan: complete + merge AdminFacet (recovery PR coming next), then deploy v2.3.0 fresh diamond, then run game on it.

## Test plan

- [x] Targeted bandit tests pass locally
- [ ] CI full forge build + test (will run on push)
- [ ] Local 3-tier swarm review (orchestrator dispatches)
- [ ] Cloud reviewers (Copilot + Gemini-CA)
- [ ] Liam UAT
- [ ] After merge: redeploy v2.3.0 + wire all surfaces (Convex env, dev-ui Vercel env, elder envs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)