### PR TITLE
feat(contracts): AdminRecoveryFacet — owner-only revive + inject for ops recovery

### DIFF
--- a/apps/web/src/EventTicker.tsx
+++ b/apps/web/src/EventTicker.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useEffect, useState } from 'react';
+import { BanditState } from '@clan-world/shared/generated/enums';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { api } from '../../server/convex/_generated/api';
 import { useAgentLogs } from './useAgentLogs';
@@ -156,8 +157,7 @@ function formatChainEvent(ev: ChainEvent): TickerEntry | null {
     }
     case 'BanditStateChanged': {
       const newState = safeNum(args.newState, 0);
-      if (newState === 4) {
-        // Attacking
+      if (newState === BanditState.Attacking) {
         return { text: `⚔ Bandits attacking in ${regionName}!`, clanColor: '#b23a48', highlight: true };
       }
       return null;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gen:contract-abi": "node scripts/gen-contract-abi.mjs",
     "gen:constants": "node scripts/gen-constants.mjs",
     "gen:enums": "node scripts/gen-enums.mjs",
+    "check:abi": "pnpm --dir packages/contracts run check:abi && pnpm test:chainclient-abi",
     "lint": "turbo run lint",
     "test:chainclient-abi": "node scripts/gen-chainclient-abi.mjs --check",
     "test:abi-parity": "node packages/shared/scripts/check-chain-abi-parity.mjs",

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2683,6 +2683,16 @@
           "name": "fish",
           "type": "uint256",
           "internalType": "uint256"
+        },
+        {
+          "name": "gold",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "blueprint",
+          "type": "uint256",
+          "internalType": "uint256"
         }
       ],
       "outputs": [],
@@ -4422,6 +4432,18 @@
         },
         {
           "name": "fish",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "gold",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "blueprint",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2657,6 +2657,39 @@
     },
     {
       "type": "function",
+      "name": "injectClanResources",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        },
+        {
+          "name": "wood",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "iron",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheat",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "fish",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
       "name": "isWinter",
       "inputs": [],
       "outputs": [
@@ -2778,6 +2811,32 @@
         }
       ],
       "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "reviveClansman",
+      "inputs": [
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "reviveDeadClansmen",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
     },
     {
       "type": "function",
@@ -3714,6 +3773,31 @@
     },
     {
       "type": "event",
+      "name": "ClansmanRevived",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "clansmanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
       "name": "GoldTransferred",
       "inputs": [
         {
@@ -4295,6 +4379,49 @@
         },
         {
           "name": "goldBonus",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "atTick",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ResourcesInjected",
+      "inputs": [
+        {
+          "name": "clanId",
+          "type": "uint32",
+          "indexed": true,
+          "internalType": "uint32"
+        },
+        {
+          "name": "wood",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "iron",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "wheat",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "fish",
           "type": "uint256",
           "indexed": false,
           "internalType": "uint256"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "bash scripts/forge.sh build script/DeployDiamond.s.sol src/IClanWorld.sol src/IClanWorldLens.sol",
     "codegen": "bash scripts/forge.sh build src/IClanWorld.sol src/IClanWorldLens.sol && node ../../scripts/gen-contract-abi.mjs",
+    "gen:enums": "pnpm --dir ../.. gen:enums",
     "check:abi": "bash -c 'command -v jq >/dev/null 2>&1 || { echo \"jq not installed; cannot check ABI\"; exit 1; }; bash scripts/forge.sh build src/IClanWorld.sol src/IClanWorldLens.sol && diff <(jq \".abi\" out/IClanWorld.sol/IClanWorld.json) <(jq \".abi\" abi/IClanWorld.json) && diff <(jq \".abi\" out/IClanWorldLens.sol/IClanWorldLens.json) <(jq \".abi\" abi/IClanWorldLens.json)'",
     "check:sizes": "node scripts/check-contract-sizes.mjs",
     "test": "pnpm run check:abi && bash scripts/forge.sh test",

--- a/packages/contracts/script/DeployDiamond.s.sol
+++ b/packages/contracts/script/DeployDiamond.s.sol
@@ -10,6 +10,7 @@ import {StubPool} from "../src/StubPool.sol";
 import {Diamond} from "../src/diamond/Diamond.sol";
 import {ClanWorldDiamondInit} from "../src/diamond/ClanWorldDiamondInit.sol";
 import {IDiamondCut} from "../src/diamond/IDiamondCut.sol";
+import {AdminRecoveryFacet} from "../src/diamond/facets/AdminRecoveryFacet.sol";
 import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
 import {BanditViewsFacet} from "../src/diamond/facets/BanditViewsFacet.sol";
@@ -59,6 +60,7 @@ contract DeployDiamond is Script {
         HeartbeatFacet heartbeatFacet = new HeartbeatFacet();
         HeartbeatConfigFacet heartbeatConfigFacet = new HeartbeatConfigFacet();
         WorldPauseFacet worldPauseFacet = new WorldPauseFacet();
+        AdminRecoveryFacet adminRecoveryFacet = new AdminRecoveryFacet();
         FinalizeSeasonFacet finalizeSeasonFacet = new FinalizeSeasonFacet();
         RawWorldViewsFacet rawWorldViewsFacet = new RawWorldViewsFacet();
         RawTreasuryViewsFacet rawTreasuryViewsFacet = new RawTreasuryViewsFacet();
@@ -145,6 +147,7 @@ contract DeployDiamond is Script {
                     address(heartbeatFacet),
                     address(heartbeatConfigFacet),
                     address(worldPauseFacet),
+                    address(adminRecoveryFacet),
                     address(finalizeSeasonFacet),
                     address(rawClanViewsFacet),
                     address(rawBanditViewsFacet),
@@ -193,6 +196,7 @@ contract DeployDiamond is Script {
         console.log("HEARTBEAT_FACET_ADDRESS:          ", address(heartbeatFacet));
         console.log("HEARTBEAT_CONFIG_FACET_ADDRESS:   ", address(heartbeatConfigFacet));
         console.log("WORLD_PAUSE_FACET_ADDRESS:        ", address(worldPauseFacet));
+        console.log("ADMIN_RECOVERY_FACET_ADDRESS:     ", address(adminRecoveryFacet));
         console.log("FINALIZE_SEASON_FACET_ADDRESS:    ", address(finalizeSeasonFacet));
         console.log("CLAN_LIFECYCLE_FACET_ADDRESS:     ", address(lifecycleFacet));
         console.log("RAW_WORLD_VIEWS_FACET_ADDRESS:    ", address(rawWorldViewsFacet));
@@ -256,6 +260,7 @@ contract DeployDiamond is Script {
         address heartbeatFacet,
         address heartbeatConfigFacet,
         address worldPauseFacet,
+        address adminRecoveryFacet,
         address finalizeSeasonFacet,
         address rawClanViewsFacet,
         address rawBanditViewsFacet,
@@ -265,7 +270,7 @@ contract DeployDiamond is Script {
         address settlementFacet,
         address directTransfersFacet
     ) private pure returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](11);
+        cut = new IDiamondCut.FacetCut[](12);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: heartbeatFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -282,41 +287,46 @@ contract DeployDiamond is Script {
             functionSelectors: DiamondSelectors.worldPauseSelectors()
         });
         cut[3] = IDiamondCut.FacetCut({
+            facetAddress: adminRecoveryFacet,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.adminRecoverySelectors()
+        });
+        cut[4] = IDiamondCut.FacetCut({
             facetAddress: finalizeSeasonFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.seasonSelectors()
         });
-        cut[4] = IDiamondCut.FacetCut({
+        cut[5] = IDiamondCut.FacetCut({
             facetAddress: rawClanViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawClanViewsSelectors()
         });
-        cut[5] = IDiamondCut.FacetCut({
+        cut[6] = IDiamondCut.FacetCut({
             facetAddress: rawBanditViewsFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawBanditViewsSelectors()
         });
-        cut[6] = IDiamondCut.FacetCut({
+        cut[7] = IDiamondCut.FacetCut({
             facetAddress: lifecycleFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.lifecycleSelectors()
         });
-        cut[7] = IDiamondCut.FacetCut({
+        cut[8] = IDiamondCut.FacetCut({
             facetAddress: submitOrdersFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.submitOrdersSelectors()
         });
-        cut[8] = IDiamondCut.FacetCut({
+        cut[9] = IDiamondCut.FacetCut({
             facetAddress: clanOwnershipFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.ownershipSelectors()
         });
-        cut[9] = IDiamondCut.FacetCut({
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: settlementFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.settlementSelectors()
         });
-        cut[10] = IDiamondCut.FacetCut({
+        cut[11] = IDiamondCut.FacetCut({
             facetAddress: directTransfersFacet,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.directTransferSelectors()

--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.34;
 
 import {IDiamondLoupe} from "../src/diamond/IDiamondLoupe.sol";
 import {IClanWorld} from "../src/IClanWorld.sol";
+import {AdminRecoveryFacet} from "../src/diamond/facets/AdminRecoveryFacet.sol";
 import {HeartbeatConfigFacet} from "../src/diamond/facets/HeartbeatConfigFacet.sol";
 import {HeartbeatFacet} from "../src/diamond/facets/HeartbeatFacet.sol";
 import {OwnershipFacet} from "../src/diamond/facets/OwnershipFacet.sol";
@@ -42,6 +43,13 @@ library DiamondSelectors {
     function seasonSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](1);
         selectors[0] = IClanWorld.finalizeSeason.selector;
+    }
+
+    function adminRecoverySelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](3);
+        selectors[0] = AdminRecoveryFacet.reviveDeadClansmen.selector;
+        selectors[1] = AdminRecoveryFacet.reviveClansman.selector;
+        selectors[2] = AdminRecoveryFacet.injectClanResources.selector;
     }
 
     function ownershipFacetSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/packages/contracts/script/UpgradeAdminRecoveryFacet.s.sol
+++ b/packages/contracts/script/UpgradeAdminRecoveryFacet.s.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Script, console} from "forge-std/Script.sol";
+import {DiamondSelectors} from "./DiamondSelectors.sol";
+import {IDiamondCut} from "../src/diamond/IDiamondCut.sol";
+import {AdminRecoveryFacet} from "../src/diamond/facets/AdminRecoveryFacet.sol";
+
+/// @notice Add-only DiamondCut for the owner-only admin recovery selectors.
+/// @dev Run with `forge script` first; only use `--broadcast` from an approved ops runbook.
+contract UpgradeAdminRecoveryFacet is Script {
+    function run() external returns (AdminRecoveryFacet facet) {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address diamond = vm.envAddress("CLAN_WORLD_DIAMOND_ADDRESS");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        facet = new AdminRecoveryFacet();
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.adminRecoverySelectors()
+        });
+        IDiamondCut(diamond).diamondCut(cut, address(0), "");
+
+        vm.stopBroadcast();
+
+        console.log("ADMIN_RECOVERY_FACET_ADDRESS: ", address(facet));
+    }
+}

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -67,6 +67,9 @@ struct StoredWorldState {
 ///         deposit, wheat harvest, travel, NOOP bypass, order validation, market execution,
 ///         and Phase 9 bandit spawn/attack/resolution.
 contract ClanWorld is IClanWorld, ReentrancyGuard {
+    error AdminRecoveryClanNotFound(uint32 clanId);
+    error AdminRecoveryClansmanNotFound(uint32 clansmanId);
+
     // =========================================================================
     // STORAGE
     // =========================================================================
@@ -3061,33 +3064,46 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     function reviveDeadClansmen(uint32 clanId) external override nonReentrant {
         require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
         uint32[] storage clansmanIds = _clanClansmanIds[clanId];
+        bool anyRevived = false;
         for (uint256 i = 0; i < clansmanIds.length; i++) {
-            (uint32 revivedClanId, bool revived) = _reviveClansman(clansmanIds[i]);
-            if (revived) emit ClansmanRevived(revivedClanId, clansmanIds[i], _world.currentTick);
+            (uint32 revivedClanId, bool revived) = _reviveClansman(clansmanIds[i], false, false);
+            if (revived) {
+                anyRevived = true;
+                emit ClansmanRevived(revivedClanId, clansmanIds[i], _world.currentTick);
+            }
+        }
+        if (anyRevived) {
+            _clans[clanId].lastSettledTick = _world.currentTick;
         }
     }
 
     function reviveClansman(uint32 clansmanId) external override nonReentrant {
         require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
-        (uint32 clanId, bool revived) = _reviveClansman(clansmanId);
+        (uint32 clanId, bool revived) = _reviveClansman(clansmanId, true, true);
         if (revived) emit ClansmanRevived(clanId, clansmanId, _world.currentTick);
     }
 
-    function injectClanResources(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish)
-        external
-        override
-        nonReentrant
-    {
+    function injectClanResources(
+        uint32 clanId,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish,
+        uint256 gold,
+        uint256 blueprint
+    ) external override nonReentrant {
         require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
         Clan storage clan = _clans[clanId];
-        if (clan.clanId == ClanWorldConstants.CLAN_ID_NULL) return;
+        if (clan.clanId == ClanWorldConstants.CLAN_ID_NULL) revert AdminRecoveryClanNotFound(clanId);
 
         clan.vaultWood += wood;
         clan.vaultIron += iron;
         clan.vaultWheat += wheat;
         clan.vaultFish += fish;
+        clan.goldBalance += gold;
+        clan.blueprintBalance += blueprint;
 
-        emit ResourcesInjected(clanId, wood, iron, wheat, fish, _world.currentTick);
+        emit ResourcesInjected(clanId, wood, iron, wheat, fish, gold, blueprint, _world.currentTick);
     }
 
     /// @dev Resolve world events for the tick that was just closed.
@@ -4689,15 +4705,26 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
     }
 
-    function _reviveClansman(uint32 clansmanId) internal returns (uint32 clanId, bool revived) {
+    function _reviveClansman(uint32 clansmanId, bool resetLastSettledTick, bool revertOnNotFound)
+        internal
+        returns (uint32 clanId, bool revived)
+    {
         Clansman storage cs = _clansmen[clansmanId];
         clanId = cs.clanId;
-        if (clanId == ClanWorldConstants.CLAN_ID_NULL || cs.clansmanId == 0 || cs.state != ClansmanState.DEAD) {
+        if (clanId == ClanWorldConstants.CLAN_ID_NULL || cs.clansmanId == 0) {
+            if (revertOnNotFound) revert AdminRecoveryClansmanNotFound(clansmanId);
+            return (clanId, false);
+        }
+
+        if (cs.state != ClansmanState.DEAD) {
             return (clanId, false);
         }
 
         Clan storage clan = _clans[clanId];
-        if (clan.clanId == ClanWorldConstants.CLAN_ID_NULL) return (clanId, false);
+        if (clan.clanId == ClanWorldConstants.CLAN_ID_NULL) {
+            if (revertOnNotFound) revert AdminRecoveryClansmanNotFound(clansmanId);
+            return (clanId, false);
+        }
 
         uint8 livingBefore = clan.livingClansmen;
         _clearClansmanRecoveryState(clansmanId);
@@ -4705,7 +4732,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         cs.state = ClansmanState.WAITING;
         cs.currentRegion = clan.baseRegion;
         cs.cooldownEndsAtTs = 0;
-        cs.lastMissionNonce = _world.currentTick;
+        if (cs.lastMissionNonce < _world.currentTick) {
+            cs.lastMissionNonce = _world.currentTick;
+        } else {
+            cs.lastMissionNonce += 1;
+        }
         cs.carryWood = 0;
         cs.carryIron = 0;
         cs.carryWheat = 0;
@@ -4716,6 +4747,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         clan.starvationStartsAtTick = 0;
         if (clan.clanState == ClanState.DEAD && livingBefore == 0) {
             clan.clanState = ClanState.ACTIVE;
+        }
+        if (resetLastSettledTick) {
+            clan.lastSettledTick = _world.currentTick;
         }
 
         return (clanId, true);

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -552,8 +552,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             fishNeeded = fishNeeded * ClanWorldConstants.WINTER_UPKEEP_MULTIPLIER_BPS / 10000;
         }
 
-        uint256 spendableWheat =
-            _spendableAfterReleasing(clan.vaultWheat, _reservedWheatByClan[clan.clanId], 0);
+        uint256 spendableWheat = _spendableAfterReleasing(clan.vaultWheat, _reservedWheatByClan[clan.clanId], 0);
         bool hadEnoughWheat = spendableWheat >= wheatNeeded;
         bool hadEnoughFish = clan.vaultFish >= fishNeeded;
 
@@ -591,8 +590,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         if (winter) {
             uint256 woodNeeded = ClanWorldConstants.WINTER_WOOD_BURN_PER_BASE + uint256(livingBeforeStarvation)
                 * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
-            uint256 spendableWood =
-                _spendableAfterReleasing(clan.vaultWood, _reservedWoodByClan[clan.clanId], 0);
+            uint256 spendableWood = _spendableAfterReleasing(clan.vaultWood, _reservedWoodByClan[clan.clanId], 0);
             if (spendableWood >= woodNeeded) {
                 clan.vaultWood -= woodNeeded;
             } else {
@@ -760,9 +758,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             for (uint256 j = 0; j < csIds.length; j++) {
                 uint32 clansmanId = csIds[j];
                 Mission storage mission = _missions[clansmanId];
-                if (
-                    mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == deadClanId
-                ) {
+                if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == deadClanId) {
                     if (_clansmanDefendingRegion[clansmanId] == baseRegion) {
                         _clearDefender(clansmanId);
                     }
@@ -1730,10 +1726,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         WithdrawResourcesData memory req = m.withdrawResources;
         if (!_hasWithdrawRequest(req)) return _simulateCompleteMission(cs, m);
 
-        uint256 spendableWood =
-            _spendableAfterReleasing(sim.clan.vaultWood, _reservedWoodByClan[sim.clan.clanId], 0);
-        uint256 spendableIron =
-            _spendableAfterReleasing(sim.clan.vaultIron, _reservedIronByClan[sim.clan.clanId], 0);
+        uint256 spendableWood = _spendableAfterReleasing(sim.clan.vaultWood, _reservedWoodByClan[sim.clan.clanId], 0);
+        uint256 spendableIron = _spendableAfterReleasing(sim.clan.vaultIron, _reservedIronByClan[sim.clan.clanId], 0);
         uint256 spendableWheat = sim.clan.vaultWheat > sim.reservedWheat ? sim.clan.vaultWheat - sim.reservedWheat : 0;
 
         if (
@@ -2433,8 +2427,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint32 targetClanId = targetClan.clanId;
         uint256 spendableWood = _spendableAfterReleasing(targetClan.vaultWood, _reservedWoodByClan[targetClanId], 0);
         uint256 spendableIron = _spendableAfterReleasing(targetClan.vaultIron, _reservedIronByClan[targetClanId], 0);
-        uint256 spendableWheat =
-            _spendableAfterReleasing(targetClan.vaultWheat, _reservedWheatByClan[targetClanId], 0);
+        uint256 spendableWheat = _spendableAfterReleasing(targetClan.vaultWheat, _reservedWheatByClan[targetClanId], 0);
 
         stolenWood = _banditStealAmount(spendableWood);
         stolenIron = _banditStealAmount(spendableIron);
@@ -3063,6 +3056,38 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
     function isWorldPaused() external view override returns (bool) {
         return _world.worldPaused;
+    }
+
+    function reviveDeadClansmen(uint32 clanId) external override nonReentrant {
+        require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+        uint32[] storage clansmanIds = _clanClansmanIds[clanId];
+        for (uint256 i = 0; i < clansmanIds.length; i++) {
+            (uint32 revivedClanId, bool revived) = _reviveClansman(clansmanIds[i]);
+            if (revived) emit ClansmanRevived(revivedClanId, clansmanIds[i], _world.currentTick);
+        }
+    }
+
+    function reviveClansman(uint32 clansmanId) external override nonReentrant {
+        require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+        (uint32 clanId, bool revived) = _reviveClansman(clansmanId);
+        if (revived) emit ClansmanRevived(clanId, clansmanId, _world.currentTick);
+    }
+
+    function injectClanResources(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish)
+        external
+        override
+        nonReentrant
+    {
+        require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+        Clan storage clan = _clans[clanId];
+        if (clan.clanId == ClanWorldConstants.CLAN_ID_NULL) return;
+
+        clan.vaultWood += wood;
+        clan.vaultIron += iron;
+        clan.vaultWheat += wheat;
+        clan.vaultFish += fish;
+
+        emit ResourcesInjected(clanId, wood, iron, wheat, fish, _world.currentTick);
     }
 
     /// @dev Resolve world events for the tick that was just closed.
@@ -4664,6 +4689,68 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
     }
 
+    function _reviveClansman(uint32 clansmanId) internal returns (uint32 clanId, bool revived) {
+        Clansman storage cs = _clansmen[clansmanId];
+        clanId = cs.clanId;
+        if (clanId == ClanWorldConstants.CLAN_ID_NULL || cs.clansmanId == 0 || cs.state != ClansmanState.DEAD) {
+            return (clanId, false);
+        }
+
+        Clan storage clan = _clans[clanId];
+        if (clan.clanId == ClanWorldConstants.CLAN_ID_NULL) return (clanId, false);
+
+        uint8 livingBefore = clan.livingClansmen;
+        _clearClansmanRecoveryState(clansmanId);
+
+        cs.state = ClansmanState.WAITING;
+        cs.currentRegion = clan.baseRegion;
+        cs.cooldownEndsAtTs = 0;
+        cs.lastMissionNonce = _world.currentTick;
+        cs.carryWood = 0;
+        cs.carryIron = 0;
+        cs.carryWheat = 0;
+        cs.carryFish = 0;
+
+        clan.livingClansmen = livingBefore + 1;
+        clan.coldDamage = 0;
+        clan.starvationStartsAtTick = 0;
+        if (clan.clanState == ClanState.DEAD && livingBefore == 0) {
+            clan.clanState = ClanState.ACTIVE;
+        }
+
+        return (clanId, true);
+    }
+
+    function _clearClansmanRecoveryState(uint32 clansmanId) internal {
+        Mission memory mission = _missions[clansmanId];
+
+        _clearDefender(clansmanId);
+        _refundUpgradeReservation(clansmanId, mission.action);
+        _clearWallUpgradeReservation(clansmanId);
+        _clearBaseUpgradeReservation(clansmanId);
+        _clearMonumentUpgradeReservation(clansmanId);
+
+        if (mission.active && (mission.action == ActionType.MarketBuy || mission.action == ActionType.MarketSell)) {
+            _purgeScheduledMarketActions(clansmanId, mission.settlesAtTick);
+        }
+
+        delete _marketMissionCommitSequence[clansmanId];
+        delete _missions[clansmanId];
+    }
+
+    function _purgeScheduledMarketActions(uint32 clansmanId, uint64 tick) internal {
+        ScheduledMarketAction[] storage actions = _scheduledMarketActions[tick];
+        uint256 i = 0;
+        while (i < actions.length) {
+            if (actions[i].clansmanId == clansmanId) {
+                actions[i] = actions[actions.length - 1];
+                actions.pop();
+            } else {
+                i++;
+            }
+        }
+    }
+
     function _releasedUpgradeResources(uint32 clanId, uint32 clansmanId)
         internal
         view
@@ -4991,14 +5078,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
         if (wood > 0) {
             require(
-                _spendableVaultResource(fromClanId, fromClan, ResourceType.Wood) >= wood,
-                "ClanWorld: insufficient wood"
+                _spendableVaultResource(fromClanId, fromClan, ResourceType.Wood) >= wood, "ClanWorld: insufficient wood"
             );
         }
         if (iron > 0) {
             require(
-                _spendableVaultResource(fromClanId, fromClan, ResourceType.Iron) >= iron,
-                "ClanWorld: insufficient iron"
+                _spendableVaultResource(fromClanId, fromClan, ResourceType.Iron) >= iron, "ClanWorld: insufficient iron"
             );
         }
         if (wheat > 0) {
@@ -5009,8 +5094,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         }
         if (fish > 0) {
             require(
-                _spendableVaultResource(fromClanId, fromClan, ResourceType.Fish) >= fish,
-                "ClanWorld: insufficient fish"
+                _spendableVaultResource(fromClanId, fromClan, ResourceType.Fish) >= fish, "ClanWorld: insufficient fish"
             );
         }
 
@@ -5026,7 +5110,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
             require(_deductVaultResource(fromClanId, fromClan, ResourceType.Iron, iron), "ClanWorld: insufficient iron");
         }
         if (wheat > 0) {
-            require(_deductVaultResource(fromClanId, fromClan, ResourceType.Wheat, wheat), "ClanWorld: insufficient wheat");
+            require(
+                _deductVaultResource(fromClanId, fromClan, ResourceType.Wheat, wheat), "ClanWorld: insufficient wheat"
+            );
         }
         if (fish > 0) {
             require(_deductVaultResource(fromClanId, fromClan, ResourceType.Fish, fish), "ClanWorld: insufficient fish");

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -4743,10 +4743,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         cs.carryFish = 0;
 
         clan.livingClansmen = livingBefore + 1;
-        clan.coldDamage = 0;
-        clan.starvationStartsAtTick = 0;
         if (clan.clanState == ClanState.DEAD && livingBefore == 0) {
             clan.clanState = ClanState.ACTIVE;
+            clan.coldDamage = 0;
+            clan.starvationStartsAtTick = 0;
         }
         if (resetLastSettledTick) {
             clan.lastSettledTick = _world.currentTick;
@@ -4760,9 +4760,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
         _clearDefender(clansmanId);
         _refundUpgradeReservation(clansmanId, mission.action);
-        _clearWallUpgradeReservation(clansmanId);
-        _clearBaseUpgradeReservation(clansmanId);
-        _clearMonumentUpgradeReservation(clansmanId);
 
         if (mission.active && (mission.action == ActionType.MarketBuy || mission.action == ActionType.MarketSell)) {
             _purgeScheduledMarketActions(clansmanId, mission.settlesAtTick);

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -126,18 +126,27 @@ contract ClanWorldStub is IClanWorld {
         return _world.worldPaused;
     }
 
-    function reviveDeadClansmen(uint32) external override {
+    function reviveDeadClansmen(uint32 clanId) external override {
         require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+        // stub: no clansman state lookup
+        emit ClansmanRevived(clanId, 0, _world.currentTick);
     }
 
-    function reviveClansman(uint32) external override {
+    function reviveClansman(uint32 clansmanId) external override {
         require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+        // stub: no state lookup
+        emit ClansmanRevived(0, clansmanId, _world.currentTick);
     }
 
-    function injectClanResources(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish)
-        external
-        override
-    {
+    function injectClanResources(
+        uint32 clanId,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish,
+        uint256 gold,
+        uint256 blueprint
+    ) external override {
         require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
         Clan storage clan = _clans[clanId];
         if (clan.clanId == 0) return;
@@ -145,7 +154,9 @@ contract ClanWorldStub is IClanWorld {
         clan.vaultIron += iron;
         clan.vaultWheat += wheat;
         clan.vaultFish += fish;
-        emit ResourcesInjected(clanId, wood, iron, wheat, fish, _world.currentTick);
+        clan.goldBalance += gold;
+        clan.blueprintBalance += blueprint;
+        emit ResourcesInjected(clanId, wood, iron, wheat, fish, gold, blueprint, _world.currentTick);
     }
 
     // -------------------------------------------------------------------------

--- a/packages/contracts/src/ClanWorldStub.sol
+++ b/packages/contracts/src/ClanWorldStub.sol
@@ -126,6 +126,28 @@ contract ClanWorldStub is IClanWorld {
         return _world.worldPaused;
     }
 
+    function reviveDeadClansmen(uint32) external override {
+        require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+    }
+
+    function reviveClansman(uint32) external override {
+        require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+    }
+
+    function injectClanResources(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish)
+        external
+        override
+    {
+        require(msg.sender == _treasury.treasuryOwner, "ClanWorld: not owner");
+        Clan storage clan = _clans[clanId];
+        if (clan.clanId == 0) return;
+        clan.vaultWood += wood;
+        clan.vaultIron += iron;
+        clan.vaultWheat += wheat;
+        clan.vaultFish += fish;
+        emit ResourcesInjected(clanId, wood, iron, wheat, fish, _world.currentTick);
+    }
+
     // -------------------------------------------------------------------------
     // Clan lifecycle
     // -------------------------------------------------------------------------

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -609,7 +609,14 @@ interface IClanWorldEvents {
         uint64 atTick
     );
     event ResourcesInjected(
-        uint32 indexed clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish, uint64 atTick
+        uint32 indexed clanId,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish,
+        uint256 gold,
+        uint256 blueprint,
+        uint64 atTick
     );
 
     // ----- building -----
@@ -767,7 +774,15 @@ interface IClanWorld is IClanWorldEvents {
     function reviveClansman(uint32 clansmanId) external;
 
     /// @notice Owner-only ops recovery. Adds resources directly to a clan vault.
-    function injectClanResources(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external;
+    function injectClanResources(
+        uint32 clanId,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish,
+        uint256 gold,
+        uint256 blueprint
+    ) external;
 
     // -------------------------------------------------------------------------
     // Clan lifecycle

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -558,6 +558,7 @@ interface IClanWorldEvents {
     event ClanColdShortage(uint32 indexed clanId, uint64 tick, uint256 woodShort);
     event WallDegradedByCold(uint32 indexed clanId, uint8 newWallLevel, uint64 tick);
     event ClansmanColdDeath(uint32 indexed clanId, uint32 csId, uint64 tick);
+    event ClansmanRevived(uint32 indexed clanId, uint32 indexed clansmanId, uint64 atTick);
 
     // ----- missions -----
     event MissionAssigned(
@@ -606,6 +607,9 @@ interface IClanWorldEvents {
         uint256 wheatDelta,
         uint256 fishDelta,
         uint64 atTick
+    );
+    event ResourcesInjected(
+        uint32 indexed clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish, uint64 atTick
     );
 
     // ----- building -----
@@ -755,6 +759,15 @@ interface IClanWorld is IClanWorldEvents {
 
     /// @notice Finalize the current season. Permissionless after seasonEndTick.
     function finalizeSeason() external;
+
+    /// @notice Owner-only ops recovery. Revives all dead clansmen for a clan.
+    function reviveDeadClansmen(uint32 clanId) external;
+
+    /// @notice Owner-only ops recovery. Revives a single dead clansman.
+    function reviveClansman(uint32 clansmanId) external;
+
+    /// @notice Owner-only ops recovery. Adds resources directly to a clan vault.
+    function injectClanResources(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external;
 
     // -------------------------------------------------------------------------
     // Clan lifecycle

--- a/packages/contracts/src/diamond/facets/AdminRecoveryFacet.sol
+++ b/packages/contracts/src/diamond/facets/AdminRecoveryFacet.sol
@@ -13,9 +13,16 @@ contract AdminRecoveryFacet is IClanWorldEvents {
         LibStorage.enterNonReentrant(s);
 
         uint32[] storage clansmanIds = s.clanClansmanIds[clanId];
+        bool anyRevived = false;
         for (uint256 i = 0; i < clansmanIds.length; i++) {
-            (uint32 revivedClanId, bool revived) = LibAdminRecovery.reviveClansman(s, clansmanIds[i]);
-            if (revived) emit ClansmanRevived(revivedClanId, clansmanIds[i], s.world.currentTick);
+            (uint32 revivedClanId, bool revived) = LibAdminRecovery.reviveClansmanForBulk(s, clansmanIds[i]);
+            if (revived) {
+                anyRevived = true;
+                emit ClansmanRevived(revivedClanId, clansmanIds[i], s.world.currentTick);
+            }
+        }
+        if (anyRevived) {
+            s.clans[clanId].lastSettledTick = s.world.currentTick;
         }
 
         LibStorage.exitNonReentrant(s);
@@ -32,13 +39,21 @@ contract AdminRecoveryFacet is IClanWorldEvents {
         LibStorage.exitNonReentrant(s);
     }
 
-    function injectClanResources(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+    function injectClanResources(
+        uint32 clanId,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish,
+        uint256 gold,
+        uint256 blueprint
+    ) external {
         LibDiamond.enforceIsContractOwner();
         LibStorage.AppStorage storage s = LibStorage.appStorage();
         LibStorage.enterNonReentrant(s);
 
-        if (LibAdminRecovery.injectClanResources(s, clanId, wood, iron, wheat, fish)) {
-            emit ResourcesInjected(clanId, wood, iron, wheat, fish, s.world.currentTick);
+        if (LibAdminRecovery.injectClanResources(s, clanId, wood, iron, wheat, fish, gold, blueprint)) {
+            emit ResourcesInjected(clanId, wood, iron, wheat, fish, gold, blueprint, s.world.currentTick);
         }
 
         LibStorage.exitNonReentrant(s);

--- a/packages/contracts/src/diamond/facets/AdminRecoveryFacet.sol
+++ b/packages/contracts/src/diamond/facets/AdminRecoveryFacet.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {IClanWorldEvents} from "../../IClanWorld.sol";
+import {LibAdminRecovery} from "../lib/LibAdminRecovery.sol";
+import {LibDiamond} from "../lib/LibDiamond.sol";
+import {LibStorage} from "../lib/LibStorage.sol";
+
+contract AdminRecoveryFacet is IClanWorldEvents {
+    function reviveDeadClansmen(uint32 clanId) external {
+        LibDiamond.enforceIsContractOwner();
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+
+        uint32[] storage clansmanIds = s.clanClansmanIds[clanId];
+        for (uint256 i = 0; i < clansmanIds.length; i++) {
+            (uint32 revivedClanId, bool revived) = LibAdminRecovery.reviveClansman(s, clansmanIds[i]);
+            if (revived) emit ClansmanRevived(revivedClanId, clansmanIds[i], s.world.currentTick);
+        }
+
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function reviveClansman(uint32 clansmanId) external {
+        LibDiamond.enforceIsContractOwner();
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+
+        (uint32 clanId, bool revived) = LibAdminRecovery.reviveClansman(s, clansmanId);
+        if (revived) emit ClansmanRevived(clanId, clansmanId, s.world.currentTick);
+
+        LibStorage.exitNonReentrant(s);
+    }
+
+    function injectClanResources(uint32 clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish) external {
+        LibDiamond.enforceIsContractOwner();
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        LibStorage.enterNonReentrant(s);
+
+        if (LibAdminRecovery.injectClanResources(s, clanId, wood, iron, wheat, fish)) {
+            emit ResourcesInjected(clanId, wood, iron, wheat, fish, s.world.currentTick);
+        }
+
+        LibStorage.exitNonReentrant(s);
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibAdminRecovery.sol
+++ b/packages/contracts/src/diamond/lib/LibAdminRecovery.sol
@@ -15,16 +15,43 @@ import {LibOrderUpgrades} from "./LibOrderUpgrades.sol";
 import {LibStorage} from "./LibStorage.sol";
 
 library LibAdminRecovery {
+    error AdminRecoveryClanNotFound(uint32 clanId);
+    error AdminRecoveryClansmanNotFound(uint32 clansmanId);
+
     function reviveClansman(LibStorage.AppStorage storage s, uint32 clansmanId)
         internal
         returns (uint32 clanId, bool revived)
     {
+        return _reviveClansman(s, clansmanId, true, true);
+    }
+
+    function reviveClansmanForBulk(LibStorage.AppStorage storage s, uint32 clansmanId)
+        internal
+        returns (uint32 clanId, bool revived)
+    {
+        return _reviveClansman(s, clansmanId, false, false);
+    }
+
+    function _reviveClansman(
+        LibStorage.AppStorage storage s,
+        uint32 clansmanId,
+        bool resetLastSettledTick,
+        bool revertOnNotFound
+    ) private returns (uint32 clanId, bool revived) {
         Clansman storage cs = s.clansmen[clansmanId];
         clanId = cs.clanId;
-        if (clanId == 0 || cs.clansmanId == 0 || cs.state != ClansmanState.DEAD) return (clanId, false);
+        if (clanId == 0 || cs.clansmanId == 0) {
+            if (revertOnNotFound) revert AdminRecoveryClansmanNotFound(clansmanId);
+            return (clanId, false);
+        }
+
+        if (cs.state != ClansmanState.DEAD) return (clanId, false);
 
         Clan storage clan = s.clans[clanId];
-        if (clan.clanId == 0) return (clanId, false);
+        if (clan.clanId == 0) {
+            if (revertOnNotFound) revert AdminRecoveryClansmanNotFound(clansmanId);
+            return (clanId, false);
+        }
 
         uint8 livingBefore = clan.livingClansmen;
         _clearClansmanRecoveryState(s, clansmanId);
@@ -32,7 +59,11 @@ library LibAdminRecovery {
         cs.state = ClansmanState.WAITING;
         cs.currentRegion = clan.baseRegion;
         cs.cooldownEndsAtTs = 0;
-        cs.lastMissionNonce = s.world.currentTick;
+        if (cs.lastMissionNonce < s.world.currentTick) {
+            cs.lastMissionNonce = s.world.currentTick;
+        } else {
+            cs.lastMissionNonce += 1;
+        }
         cs.carryWood = 0;
         cs.carryIron = 0;
         cs.carryWheat = 0;
@@ -44,6 +75,9 @@ library LibAdminRecovery {
         if (clan.clanState == ClanState.DEAD && livingBefore == 0) {
             clan.clanState = ClanState.ACTIVE;
         }
+        if (resetLastSettledTick) {
+            clan.lastSettledTick = s.world.currentTick;
+        }
 
         return (clanId, true);
     }
@@ -54,15 +88,19 @@ library LibAdminRecovery {
         uint256 wood,
         uint256 iron,
         uint256 wheat,
-        uint256 fish
+        uint256 fish,
+        uint256 gold,
+        uint256 blueprint
     ) internal returns (bool injected) {
         Clan storage clan = s.clans[clanId];
-        if (clan.clanId == 0) return false;
+        if (clan.clanId == 0) revert AdminRecoveryClanNotFound(clanId);
 
         clan.vaultWood += wood;
         clan.vaultIron += iron;
         clan.vaultWheat += wheat;
         clan.vaultFish += fish;
+        clan.goldBalance += gold;
+        clan.blueprintBalance += blueprint;
         return true;
     }
 

--- a/packages/contracts/src/diamond/lib/LibAdminRecovery.sol
+++ b/packages/contracts/src/diamond/lib/LibAdminRecovery.sol
@@ -70,10 +70,10 @@ library LibAdminRecovery {
         cs.carryFish = 0;
 
         clan.livingClansmen = livingBefore + 1;
-        clan.coldDamage = 0;
-        clan.starvationStartsAtTick = 0;
         if (clan.clanState == ClanState.DEAD && livingBefore == 0) {
             clan.clanState = ClanState.ACTIVE;
+            clan.coldDamage = 0;
+            clan.starvationStartsAtTick = 0;
         }
         if (resetLastSettledTick) {
             clan.lastSettledTick = s.world.currentTick;
@@ -109,9 +109,6 @@ library LibAdminRecovery {
 
         LibOrderDefenders.clearDefender(s, clansmanId);
         LibOrderUpgrades.refundUpgradeReservation(s, clansmanId, mission.action);
-        LibOrderUpgrades.clearWallUpgradeReservation(s, clansmanId);
-        LibOrderUpgrades.clearBaseUpgradeReservation(s, clansmanId);
-        LibOrderUpgrades.clearMonumentUpgradeReservation(s, clansmanId);
 
         if (mission.active && (mission.action == ActionType.MarketBuy || mission.action == ActionType.MarketSell)) {
             _purgeScheduledMarketActions(s, clansmanId, mission.settlesAtTick);

--- a/packages/contracts/src/diamond/lib/LibAdminRecovery.sol
+++ b/packages/contracts/src/diamond/lib/LibAdminRecovery.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {
+    ActionType,
+    Clan,
+    ClanState,
+    Clansman,
+    ClansmanState,
+    Mission,
+    ScheduledMarketAction
+} from "../../IClanWorld.sol";
+import {LibOrderDefenders} from "./LibOrderDefenders.sol";
+import {LibOrderUpgrades} from "./LibOrderUpgrades.sol";
+import {LibStorage} from "./LibStorage.sol";
+
+library LibAdminRecovery {
+    function reviveClansman(LibStorage.AppStorage storage s, uint32 clansmanId)
+        internal
+        returns (uint32 clanId, bool revived)
+    {
+        Clansman storage cs = s.clansmen[clansmanId];
+        clanId = cs.clanId;
+        if (clanId == 0 || cs.clansmanId == 0 || cs.state != ClansmanState.DEAD) return (clanId, false);
+
+        Clan storage clan = s.clans[clanId];
+        if (clan.clanId == 0) return (clanId, false);
+
+        uint8 livingBefore = clan.livingClansmen;
+        _clearClansmanRecoveryState(s, clansmanId);
+
+        cs.state = ClansmanState.WAITING;
+        cs.currentRegion = clan.baseRegion;
+        cs.cooldownEndsAtTs = 0;
+        cs.lastMissionNonce = s.world.currentTick;
+        cs.carryWood = 0;
+        cs.carryIron = 0;
+        cs.carryWheat = 0;
+        cs.carryFish = 0;
+
+        clan.livingClansmen = livingBefore + 1;
+        clan.coldDamage = 0;
+        clan.starvationStartsAtTick = 0;
+        if (clan.clanState == ClanState.DEAD && livingBefore == 0) {
+            clan.clanState = ClanState.ACTIVE;
+        }
+
+        return (clanId, true);
+    }
+
+    function injectClanResources(
+        LibStorage.AppStorage storage s,
+        uint32 clanId,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish
+    ) internal returns (bool injected) {
+        Clan storage clan = s.clans[clanId];
+        if (clan.clanId == 0) return false;
+
+        clan.vaultWood += wood;
+        clan.vaultIron += iron;
+        clan.vaultWheat += wheat;
+        clan.vaultFish += fish;
+        return true;
+    }
+
+    function _clearClansmanRecoveryState(LibStorage.AppStorage storage s, uint32 clansmanId) private {
+        Mission memory mission = s.missions[clansmanId];
+
+        LibOrderDefenders.clearDefender(s, clansmanId);
+        LibOrderUpgrades.refundUpgradeReservation(s, clansmanId, mission.action);
+        LibOrderUpgrades.clearWallUpgradeReservation(s, clansmanId);
+        LibOrderUpgrades.clearBaseUpgradeReservation(s, clansmanId);
+        LibOrderUpgrades.clearMonumentUpgradeReservation(s, clansmanId);
+
+        if (mission.active && (mission.action == ActionType.MarketBuy || mission.action == ActionType.MarketSell)) {
+            _purgeScheduledMarketActions(s, clansmanId, mission.settlesAtTick);
+        }
+
+        delete s.marketMissionCommitSequence[clansmanId];
+        delete s.missions[clansmanId];
+    }
+
+    function _purgeScheduledMarketActions(LibStorage.AppStorage storage s, uint32 clansmanId, uint64 tick) private {
+        ScheduledMarketAction[] storage actions = s.scheduledMarketActions[tick];
+        uint256 i = 0;
+        while (i < actions.length) {
+            if (actions[i].clansmanId == clansmanId) {
+                actions[i] = actions[actions.length - 1];
+                actions.pop();
+            } else {
+                i++;
+            }
+        }
+    }
+}

--- a/packages/contracts/test/diamond/AdminRecoveryFacet.t.sol
+++ b/packages/contracts/test/diamond/AdminRecoveryFacet.t.sol
@@ -106,6 +106,7 @@ contract AdminRecoveryHarnessFacet {
         s.clans[clanId].clanState = ClanState.DEAD;
         s.clans[clanId].livingClansmen = 3;
         s.clans[clanId].coldDamage = 2;
+        s.clans[clanId].starvationStartsAtTick = 11;
     }
 
     function dirtyClansmanState(uint32 clansmanId) external {
@@ -357,7 +358,8 @@ contract AdminRecoveryFacetTest is Test {
 
         assertEq(uint8(world.getClan(clanId).clanState), uint8(ClanState.DEAD), "other death remains dead");
         assertEq(world.getClan(clanId).livingClansmen, 4, "living increments");
-        assertEq(world.getClan(clanId).coldDamage, 0, "cold reset");
+        assertEq(world.getClan(clanId).coldDamage, 2, "cold preserved");
+        assertEq(world.getClan(clanId).starvationStartsAtTick, 11, "starvation preserved");
     }
 
     function test_reviveClansman_clearsDefenderRegistry() public {

--- a/packages/contracts/test/diamond/AdminRecoveryFacet.t.sol
+++ b/packages/contracts/test/diamond/AdminRecoveryFacet.t.sol
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Test} from "forge-std/Test.sol";
+import {DiamondSelectors} from "../../script/DiamondSelectors.sol";
+import {Diamond} from "../../src/diamond/Diamond.sol";
+import {ClanWorldDiamondInit} from "../../src/diamond/ClanWorldDiamondInit.sol";
+import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
+import {AdminRecoveryFacet} from "../../src/diamond/facets/AdminRecoveryFacet.sol";
+import {ClanLifecycleFacet} from "../../src/diamond/facets/ClanLifecycleFacet.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {RawClanViewsFacet} from "../../src/diamond/facets/RawClanViewsFacet.sol";
+import {RawTreasuryViewsFacet} from "../../src/diamond/facets/RawTreasuryViewsFacet.sol";
+import {RawWorldViewsFacet} from "../../src/diamond/facets/RawWorldViewsFacet.sol";
+import {SubmitOrdersFacet} from "../../src/diamond/facets/SubmitOrdersFacet.sol";
+import {LibOrderDefenders} from "../../src/diamond/lib/LibOrderDefenders.sol";
+import {LibOrderUpgrades} from "../../src/diamond/lib/LibOrderUpgrades.sol";
+import {LibStorage} from "../../src/diamond/lib/LibStorage.sol";
+import {
+    ActionType,
+    Clan,
+    ClanState,
+    Clansman,
+    ClansmanState,
+    IClanWorld,
+    Mission,
+    ScheduledMarketAction
+} from "../../src/IClanWorld.sol";
+
+interface IAdminRecoveryHarness {
+    function setCurrentTick(uint64 tick) external;
+    function markClansmanDead(uint32 clansmanId) external;
+    function markClanDeadFromAllClansmen(uint32 clanId) external;
+    function markClanDeadOtherPath(uint32 clanId) external;
+    function dirtyClansmanState(uint32 clansmanId) external;
+    function setDefenderMission(uint32 clansmanId, uint32 targetClanId) external;
+    function reserveWallUpgrade(uint32 clansmanId) external;
+    function setScheduledMarketMission(uint32 clansmanId, uint64 settlesAtTick) external;
+    function pendingWallUpgrades(uint32 clanId) external view returns (uint8);
+    function reservedWood(uint32 clanId) external view returns (uint256);
+    function reservedIron(uint32 clanId) external view returns (uint256);
+}
+
+contract AdminRecoveryHarnessFacet {
+    function setCurrentTick(uint64 tick) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        s.world.currentTick = tick;
+        s.world.nextHeartbeatAtTick = tick + 1;
+        s.world.currentTickSeed = bytes32(uint256(tick));
+        s.tickSeeds[tick] = bytes32(uint256(tick));
+    }
+
+    function markClansmanDead(uint32 clansmanId) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        Clansman storage cs = s.clansmen[clansmanId];
+        if (cs.state != ClansmanState.DEAD && s.clans[cs.clanId].livingClansmen > 0) {
+            s.clans[cs.clanId].livingClansmen -= 1;
+        }
+        cs.state = ClansmanState.DEAD;
+    }
+
+    function markClanDeadFromAllClansmen(uint32 clanId) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        uint32[] storage ids = s.clanClansmanIds[clanId];
+        for (uint256 i = 0; i < ids.length; i++) {
+            s.clansmen[ids[i]].state = ClansmanState.DEAD;
+        }
+        s.clans[clanId].livingClansmen = 0;
+        s.clans[clanId].clanState = ClanState.DEAD;
+        s.clans[clanId].coldDamage = 2;
+    }
+
+    function markClanDeadOtherPath(uint32 clanId) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        uint32 clansmanId = s.clanClansmanIds[clanId][0];
+        s.clansmen[clansmanId].state = ClansmanState.DEAD;
+        s.clans[clanId].clanState = ClanState.DEAD;
+        s.clans[clanId].livingClansmen = 3;
+        s.clans[clanId].coldDamage = 2;
+    }
+
+    function dirtyClansmanState(uint32 clansmanId) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        Clansman storage cs = s.clansmen[clansmanId];
+        cs.currentRegion = 8;
+        cs.cooldownEndsAtTs = 123;
+        cs.lastMissionNonce = 7;
+        cs.carryWood = 1e18;
+        cs.carryIron = 2e18;
+        cs.carryWheat = 3e18;
+        cs.carryFish = 4e18;
+        Mission storage mission = s.missions[clansmanId];
+        mission.active = true;
+        mission.nonce = 7;
+        mission.submittedAtTick = 1;
+        mission.executesAtTick = 2;
+        mission.settlesAtTick = 9;
+        mission.clansmanId = clansmanId;
+        mission.startRegion = 1;
+        mission.targetRegion = 8;
+        mission.action = ActionType.FishDeepSea;
+        mission.startTick = 1;
+        mission.arrivalTick = 2;
+        mission.actionStartTick = 3;
+        mission.missionSeed = bytes32(uint256(99));
+    }
+
+    function setDefenderMission(uint32 clansmanId, uint32 targetClanId) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        Clansman storage cs = s.clansmen[clansmanId];
+        uint8 region = s.clans[targetClanId].baseRegion;
+        cs.state = ClansmanState.DEAD;
+        cs.currentRegion = region;
+        Mission storage mission = s.missions[clansmanId];
+        mission.active = true;
+        mission.clansmanId = clansmanId;
+        mission.action = ActionType.DefendBase;
+        mission.targetClanId = targetClanId;
+        LibOrderDefenders.registerDefender(s, region, cs.clanId, clansmanId);
+        if (s.clans[cs.clanId].livingClansmen > 0) s.clans[cs.clanId].livingClansmen -= 1;
+    }
+
+    function reserveWallUpgrade(uint32 clansmanId) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        Clansman storage cs = s.clansmen[clansmanId];
+        Clan storage clan = s.clans[cs.clanId];
+        clan.wallLevel = 2;
+        LibOrderUpgrades.reserveWallUpgrade(s, clan, clan.clanId, clansmanId, 7);
+        s.missions[clansmanId].active = true;
+        s.missions[clansmanId].action = ActionType.UpgradeWall;
+        s.missions[clansmanId].nonce = 7;
+        cs.state = ClansmanState.DEAD;
+        if (clan.livingClansmen > 0) clan.livingClansmen -= 1;
+    }
+
+    function setScheduledMarketMission(uint32 clansmanId, uint64 settlesAtTick) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        Clansman storage cs = s.clansmen[clansmanId];
+        cs.state = ClansmanState.DEAD;
+        cs.lastMissionNonce = 1;
+        if (s.clans[cs.clanId].livingClansmen > 0) s.clans[cs.clanId].livingClansmen -= 1;
+
+        Mission storage mission = s.missions[clansmanId];
+        mission.active = true;
+        mission.nonce = 1;
+        mission.settlesAtTick = settlesAtTick;
+        mission.clansmanId = clansmanId;
+        mission.action = ActionType.MarketSell;
+
+        s.marketMissionCommitSequence[clansmanId] = 9;
+        s.scheduledMarketActions[settlesAtTick].push(
+            ScheduledMarketAction({
+                executeAtTick: settlesAtTick,
+                commitSequence: 9,
+                missionNonce: 1,
+                clanId: cs.clanId,
+                clansmanId: clansmanId,
+                action: ActionType.MarketSell,
+                marketToken: address(0xBEEF),
+                marketAmount: 1e18,
+                maxGoldIn: 0
+            })
+        );
+    }
+
+    function pendingWallUpgrades(uint32 clanId) external view returns (uint8) {
+        return LibStorage.appStorage().pendingWallUpgradesByClan[clanId];
+    }
+
+    function reservedWood(uint32 clanId) external view returns (uint256) {
+        return LibStorage.appStorage().reservedWoodByClan[clanId];
+    }
+
+    function reservedIron(uint32 clanId) external view returns (uint256) {
+        return LibStorage.appStorage().reservedIronByClan[clanId];
+    }
+}
+
+contract AdminRecoveryFacetTest is Test {
+    event ClansmanRevived(uint32 indexed clanId, uint32 indexed clansmanId, uint64 atTick);
+    event ResourcesInjected(
+        uint32 indexed clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish, uint64 atTick
+    );
+
+    IClanWorld private world;
+    IAdminRecoveryHarness private harness;
+    address private elder = address(0xA11CE);
+    address private stranger = address(0xB0B);
+
+    function setUp() public {
+        DiamondCutFacet cutFacet = new DiamondCutFacet();
+        Diamond diamond = new Diamond(address(this), address(cutFacet));
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](7);
+        cut[0] = _facetCut(address(new RawWorldViewsFacet()), DiamondSelectors.rawWorldViewsSelectors());
+        cut[1] = _facetCut(address(new RawTreasuryViewsFacet()), DiamondSelectors.rawTreasuryViewsSelectors());
+        cut[2] = _facetCut(address(new RawClanViewsFacet()), DiamondSelectors.rawClanViewsSelectors());
+        cut[3] = _facetCut(address(new ClanLifecycleFacet()), DiamondSelectors.lifecycleSelectors());
+        cut[4] = _facetCut(address(new SubmitOrdersFacet()), DiamondSelectors.submitOrdersSelectors());
+        cut[5] = _facetCut(address(new AdminRecoveryFacet()), DiamondSelectors.adminRecoverySelectors());
+        cut[6] = _facetCut(address(new AdminRecoveryHarnessFacet()), _harnessSelectors());
+
+        IDiamondCut(address(diamond)).diamondCut(cut, address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        world = IClanWorld(address(diamond));
+        harness = IAdminRecoveryHarness(address(diamond));
+    }
+
+    function test_reviveClansman_ownerOnly() public {
+        uint32 clanId = _mint();
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        harness.markClansmanDead(clansmanId);
+
+        vm.prank(stranger);
+        vm.expectRevert();
+        world.reviveClansman(clansmanId);
+    }
+
+    function test_reviveClansman_resetsStateAndEmits() public {
+        uint32 clanId = _mint();
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        uint8 baseRegion = world.getClan(clanId).baseRegion;
+        harness.setCurrentTick(42);
+        harness.markClansmanDead(clansmanId);
+        harness.dirtyClansmanState(clansmanId);
+
+        vm.expectEmit(true, true, false, true);
+        emit ClansmanRevived(clanId, clansmanId, 42);
+        world.reviveClansman(clansmanId);
+
+        Clansman memory cs = world.getClansman(clansmanId);
+        assertEq(uint8(cs.state), uint8(ClansmanState.WAITING), "waiting");
+        assertEq(cs.currentRegion, baseRegion, "base region");
+        assertEq(cs.cooldownEndsAtTs, 0, "cooldown");
+        assertEq(cs.lastMissionNonce, 42, "nonce bumped");
+        assertEq(cs.carryWood, 0, "wood carry");
+        assertEq(cs.carryIron, 0, "iron carry");
+        assertEq(cs.carryWheat, 0, "wheat carry");
+        assertEq(cs.carryFish, 0, "fish carry");
+        assertFalse(world.getActiveMission(clansmanId).active, "mission cleared");
+        assertEq(world.getClan(clanId).livingClansmen, 4, "living restored");
+        assertEq(world.getClan(clanId).coldDamage, 0, "cold reset");
+    }
+
+    function test_reviveDeadClansmen_revivesDeadClan() public {
+        uint32 clanId = _mint();
+        uint32[] memory ids = world.getClanClansmanIds(clanId);
+        harness.markClanDeadFromAllClansmen(clanId);
+
+        world.reviveDeadClansmen(clanId);
+
+        assertEq(uint8(world.getClan(clanId).clanState), uint8(ClanState.ACTIVE), "active");
+        assertEq(world.getClan(clanId).livingClansmen, ids.length, "all living");
+        assertEq(world.getClan(clanId).coldDamage, 0, "cold reset");
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertEq(uint8(world.getClansman(ids[i]).state), uint8(ClansmanState.WAITING), "revived");
+        }
+    }
+
+    function test_reviveClansman_doesNotReactivateOtherDeathPath() public {
+        uint32 clanId = _mint();
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        harness.markClanDeadOtherPath(clanId);
+
+        world.reviveClansman(clansmanId);
+
+        assertEq(uint8(world.getClan(clanId).clanState), uint8(ClanState.DEAD), "other death remains dead");
+        assertEq(world.getClan(clanId).livingClansmen, 4, "living increments");
+        assertEq(world.getClan(clanId).coldDamage, 0, "cold reset");
+    }
+
+    function test_reviveClansman_clearsDefenderRegistry() public {
+        uint32 defenderClanId = _mint();
+        uint32 targetClanId = _mint();
+        uint32 clansmanId = world.getClanClansmanIds(defenderClanId)[0];
+        harness.setDefenderMission(clansmanId, targetClanId);
+
+        assertEq(world.getActiveDefenders(targetClanId).length, 1, "registered");
+        assertGt(world.getClansmanDefendingRegion(clansmanId), 0, "defending");
+
+        world.reviveClansman(clansmanId);
+
+        assertEq(world.getActiveDefenders(targetClanId).length, 0, "active defenders cleared");
+        assertEq(world.getClansmanDefendingRegion(clansmanId), 0, "defending region cleared");
+        assertEq(world.getActiveMission(clansmanId).targetClanId, 0, "target cleared");
+    }
+
+    function test_reviveClansman_releasesWallReservation() public {
+        uint32 clanId = _mint();
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        harness.reserveWallUpgrade(clansmanId);
+
+        assertEq(harness.pendingWallUpgrades(clanId), 1, "pending");
+        assertGt(harness.reservedWood(clanId), 0, "reserved wood");
+        assertGt(harness.reservedIron(clanId), 0, "reserved iron");
+
+        world.reviveClansman(clansmanId);
+
+        assertEq(harness.pendingWallUpgrades(clanId), 0, "pending cleared");
+        assertEq(harness.reservedWood(clanId), 0, "wood released");
+        assertEq(harness.reservedIron(clanId), 0, "iron released");
+    }
+
+    function test_reviveClansman_purgesStaleScheduledMarketActionBeforeNonceBump() public {
+        uint32 clanId = _mint();
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        harness.setCurrentTick(55);
+        harness.setScheduledMarketMission(clansmanId, 80);
+        assertEq(world.getScheduledMarketActionsForTick(80).length, 1, "queued");
+
+        world.reviveClansman(clansmanId);
+
+        assertEq(world.getScheduledMarketActionsForTick(80).length, 0, "purged");
+        assertEq(world.getClansman(clansmanId).lastMissionNonce, 55, "nonce bumped after purge");
+    }
+
+    function test_reviveDeadClansmen_purgesBulkScheduledMarketActions() public {
+        uint32 clanId = _mint();
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        harness.setCurrentTick(60);
+        harness.setScheduledMarketMission(clansmanId, 90);
+
+        world.reviveDeadClansmen(clanId);
+
+        assertEq(world.getScheduledMarketActionsForTick(90).length, 0, "bulk purged");
+        assertEq(world.getClansman(clansmanId).lastMissionNonce, 60, "nonce bumped");
+    }
+
+    function test_injectClanResources_ownerOnly() public {
+        uint32 clanId = _mint();
+
+        vm.prank(stranger);
+        vm.expectRevert();
+        world.injectClanResources(clanId, 1, 2, 3, 4);
+    }
+
+    function test_injectClanResources_addsVaultResourcesForDeadClanAndEmits() public {
+        uint32 clanId = _mint();
+        harness.markClanDeadFromAllClansmen(clanId);
+        Clan memory beforeClan = world.getClan(clanId);
+
+        vm.expectEmit(true, false, false, true);
+        emit ResourcesInjected(clanId, 1e18, 2e18, 3e18, 4e18, 0);
+        world.injectClanResources(clanId, 1e18, 2e18, 3e18, 4e18);
+
+        Clan memory afterClan = world.getClan(clanId);
+        assertEq(afterClan.vaultWood, beforeClan.vaultWood + 1e18, "wood");
+        assertEq(afterClan.vaultIron, beforeClan.vaultIron + 2e18, "iron");
+        assertEq(afterClan.vaultWheat, beforeClan.vaultWheat + 3e18, "wheat");
+        assertEq(afterClan.vaultFish, beforeClan.vaultFish + 4e18, "fish");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "gold");
+        assertEq(afterClan.blueprintBalance, beforeClan.blueprintBalance, "blueprint");
+        assertEq(uint8(afterClan.clanState), uint8(ClanState.DEAD), "still dead");
+    }
+
+    function test_injectClanResources_overflowReverts() public {
+        uint32 clanId = _mint();
+        uint256 max = type(uint256).max;
+        world.injectClanResources(clanId, max - world.getClan(clanId).vaultWood, 0, 0, 0);
+
+        vm.expectRevert();
+        world.injectClanResources(clanId, 1, 0, 0, 0);
+    }
+
+    function test_adminRecoverySelectors() public {
+        bytes4[] memory selectors = DiamondSelectors.adminRecoverySelectors();
+        assertEq(selectors.length, 3, "selector count");
+        assertEq(selectors[0], AdminRecoveryFacet.reviveDeadClansmen.selector, "bulk selector");
+        assertEq(selectors[1], AdminRecoveryFacet.reviveClansman.selector, "single selector");
+        assertEq(selectors[2], AdminRecoveryFacet.injectClanResources.selector, "inject selector");
+    }
+
+    function _mint() private returns (uint32 clanId) {
+        vm.prank(elder);
+        (clanId,) = world.mintClan(elder);
+    }
+
+    function _facetCut(address facet, bytes4[] memory selectors) private pure returns (IDiamondCut.FacetCut memory) {
+        return IDiamondCut.FacetCut({
+            facetAddress: facet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+    }
+
+    function _harnessSelectors() private pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](11);
+        selectors[0] = AdminRecoveryHarnessFacet.setCurrentTick.selector;
+        selectors[1] = AdminRecoveryHarnessFacet.markClansmanDead.selector;
+        selectors[2] = AdminRecoveryHarnessFacet.markClanDeadFromAllClansmen.selector;
+        selectors[3] = AdminRecoveryHarnessFacet.markClanDeadOtherPath.selector;
+        selectors[4] = AdminRecoveryHarnessFacet.dirtyClansmanState.selector;
+        selectors[5] = AdminRecoveryHarnessFacet.setDefenderMission.selector;
+        selectors[6] = AdminRecoveryHarnessFacet.reserveWallUpgrade.selector;
+        selectors[7] = AdminRecoveryHarnessFacet.setScheduledMarketMission.selector;
+        selectors[8] = AdminRecoveryHarnessFacet.pendingWallUpgrades.selector;
+        selectors[9] = AdminRecoveryHarnessFacet.reservedWood.selector;
+        selectors[10] = AdminRecoveryHarnessFacet.reservedIron.selector;
+    }
+}

--- a/packages/contracts/test/diamond/AdminRecoveryFacet.t.sol
+++ b/packages/contracts/test/diamond/AdminRecoveryFacet.t.sol
@@ -12,9 +12,11 @@ import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {RawClanViewsFacet} from "../../src/diamond/facets/RawClanViewsFacet.sol";
 import {RawTreasuryViewsFacet} from "../../src/diamond/facets/RawTreasuryViewsFacet.sol";
 import {RawWorldViewsFacet} from "../../src/diamond/facets/RawWorldViewsFacet.sol";
+import {SettlementFacet} from "../../src/diamond/facets/SettlementFacet.sol";
 import {SubmitOrdersFacet} from "../../src/diamond/facets/SubmitOrdersFacet.sol";
 import {LibOrderDefenders} from "../../src/diamond/lib/LibOrderDefenders.sol";
 import {LibOrderUpgrades} from "../../src/diamond/lib/LibOrderUpgrades.sol";
+import {LibAdminRecovery} from "../../src/diamond/lib/LibAdminRecovery.sol";
 import {LibStorage} from "../../src/diamond/lib/LibStorage.sol";
 import {
     ActionType,
@@ -29,6 +31,8 @@ import {
 
 interface IAdminRecoveryHarness {
     function setCurrentTick(uint64 tick) external;
+    function setWorldPaused(bool paused) external;
+    function setSingleLivingClanAtTick(uint32 clanId, uint32 livingClansmanId, uint64 lastSettledTick) external;
     function markClansmanDead(uint32 clansmanId) external;
     function markClanDeadFromAllClansmen(uint32 clanId) external;
     function markClanDeadOtherPath(uint32 clanId) external;
@@ -48,6 +52,31 @@ contract AdminRecoveryHarnessFacet {
         s.world.nextHeartbeatAtTick = tick + 1;
         s.world.currentTickSeed = bytes32(uint256(tick));
         s.tickSeeds[tick] = bytes32(uint256(tick));
+    }
+
+    function setWorldPaused(bool paused) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        s.world.worldPaused = paused;
+        s.world.pausedAtTs = paused ? uint64(block.timestamp) : 0;
+    }
+
+    function setSingleLivingClanAtTick(uint32 clanId, uint32 livingClansmanId, uint64 lastSettledTick) external {
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        uint32[] storage ids = s.clanClansmanIds[clanId];
+        for (uint256 i = 0; i < ids.length; i++) {
+            s.clansmen[ids[i]].state = ids[i] == livingClansmanId ? ClansmanState.WAITING : ClansmanState.DEAD;
+        }
+
+        Clan storage clan = s.clans[clanId];
+        clan.clanState = ClanState.ACTIVE;
+        clan.livingClansmen = 1;
+        clan.lastSettledTick = lastSettledTick;
+        clan.starvationStartsAtTick = 0;
+        clan.coldDamage = 0;
+        clan.vaultWood = 0;
+        clan.vaultIron = 0;
+        clan.vaultWheat = 0;
+        clan.vaultFish = 0;
     }
 
     function markClansmanDead(uint32 clansmanId) external {
@@ -179,7 +208,14 @@ contract AdminRecoveryHarnessFacet {
 contract AdminRecoveryFacetTest is Test {
     event ClansmanRevived(uint32 indexed clanId, uint32 indexed clansmanId, uint64 atTick);
     event ResourcesInjected(
-        uint32 indexed clanId, uint256 wood, uint256 iron, uint256 wheat, uint256 fish, uint64 atTick
+        uint32 indexed clanId,
+        uint256 wood,
+        uint256 iron,
+        uint256 wheat,
+        uint256 fish,
+        uint256 gold,
+        uint256 blueprint,
+        uint64 atTick
     );
 
     IClanWorld private world;
@@ -192,14 +228,15 @@ contract AdminRecoveryFacetTest is Test {
         Diamond diamond = new Diamond(address(this), address(cutFacet));
         ClanWorldDiamondInit init = new ClanWorldDiamondInit();
 
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](7);
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](8);
         cut[0] = _facetCut(address(new RawWorldViewsFacet()), DiamondSelectors.rawWorldViewsSelectors());
         cut[1] = _facetCut(address(new RawTreasuryViewsFacet()), DiamondSelectors.rawTreasuryViewsSelectors());
         cut[2] = _facetCut(address(new RawClanViewsFacet()), DiamondSelectors.rawClanViewsSelectors());
         cut[3] = _facetCut(address(new ClanLifecycleFacet()), DiamondSelectors.lifecycleSelectors());
         cut[4] = _facetCut(address(new SubmitOrdersFacet()), DiamondSelectors.submitOrdersSelectors());
         cut[5] = _facetCut(address(new AdminRecoveryFacet()), DiamondSelectors.adminRecoverySelectors());
-        cut[6] = _facetCut(address(new AdminRecoveryHarnessFacet()), _harnessSelectors());
+        cut[6] = _facetCut(address(new SettlementFacet()), DiamondSelectors.settlementSelectors());
+        cut[7] = _facetCut(address(new AdminRecoveryHarnessFacet()), _harnessSelectors());
 
         IDiamondCut(address(diamond)).diamondCut(cut, address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
         world = IClanWorld(address(diamond));
@@ -242,9 +279,46 @@ contract AdminRecoveryFacetTest is Test {
         assertEq(world.getClan(clanId).coldDamage, 0, "cold reset");
     }
 
+    function test_reviveClansman_resetsLastSettledTickPreventingRekill() public {
+        uint32 clanId = _mint();
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+
+        harness.setCurrentTick(100);
+        harness.setSingleLivingClanAtTick(clanId, clansmanId, 100);
+        harness.markClansmanDead(clansmanId);
+        harness.setCurrentTick(150);
+
+        world.injectClanResources(clanId, 3e18, 0, 3e18, 3e17, 0, 0);
+        world.reviveClansman(clansmanId);
+        world.settleClan(clanId);
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(uint8(clan.clanState), uint8(ClanState.ACTIVE), "active");
+        assertEq(clan.livingClansmen, 1, "one revived");
+        assertEq(clan.lastSettledTick, 150, "settled tick reset");
+        assertEq(clan.vaultWood, 3e18, "wood intact");
+        assertEq(clan.vaultWheat, 3e18, "wheat intact");
+        assertEq(clan.vaultFish, 3e17, "fish intact");
+    }
+
+    function test_reviveClansman_worksWhenWorldPaused() public {
+        uint32 clanId = _mint();
+        uint32 clansmanId = world.getClanClansmanIds(clanId)[0];
+        harness.markClansmanDead(clansmanId);
+        harness.setWorldPaused(true);
+
+        vm.expectEmit(true, true, false, true);
+        emit ClansmanRevived(clanId, clansmanId, 0);
+        world.reviveClansman(clansmanId);
+
+        assertEq(uint8(world.getClansman(clansmanId).state), uint8(ClansmanState.WAITING), "revived");
+        assertEq(world.getClan(clanId).livingClansmen, 4, "living restored");
+    }
+
     function test_reviveDeadClansmen_revivesDeadClan() public {
         uint32 clanId = _mint();
         uint32[] memory ids = world.getClanClansmanIds(clanId);
+        harness.setCurrentTick(77);
         harness.markClanDeadFromAllClansmen(clanId);
 
         world.reviveDeadClansmen(clanId);
@@ -252,9 +326,26 @@ contract AdminRecoveryFacetTest is Test {
         assertEq(uint8(world.getClan(clanId).clanState), uint8(ClanState.ACTIVE), "active");
         assertEq(world.getClan(clanId).livingClansmen, ids.length, "all living");
         assertEq(world.getClan(clanId).coldDamage, 0, "cold reset");
+        assertEq(world.getClan(clanId).lastSettledTick, 77, "settled tick reset");
         for (uint256 i = 0; i < ids.length; i++) {
             assertEq(uint8(world.getClansman(ids[i]).state), uint8(ClansmanState.WAITING), "revived");
         }
+    }
+
+    function test_reviveDeadClansmen_worksWhenWorldPaused() public {
+        uint32 clanId = _mint();
+        uint32[] memory ids = world.getClanClansmanIds(clanId);
+        harness.markClanDeadFromAllClansmen(clanId);
+        harness.setWorldPaused(true);
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            vm.expectEmit(true, true, false, true);
+            emit ClansmanRevived(clanId, ids[i], 0);
+        }
+        world.reviveDeadClansmen(clanId);
+
+        assertEq(uint8(world.getClan(clanId).clanState), uint8(ClanState.ACTIVE), "active");
+        assertEq(world.getClan(clanId).livingClansmen, ids.length, "all living");
     }
 
     function test_reviveClansman_doesNotReactivateOtherDeathPath() public {
@@ -331,35 +422,80 @@ contract AdminRecoveryFacetTest is Test {
 
         vm.prank(stranger);
         vm.expectRevert();
-        world.injectClanResources(clanId, 1, 2, 3, 4);
+        world.injectClanResources(clanId, 1, 2, 3, 4, 5, 6);
     }
 
-    function test_injectClanResources_addsVaultResourcesForDeadClanAndEmits() public {
+    function test_injectClanResources_revertsForMissingClan() public {
+        vm.expectRevert(abi.encodeWithSelector(LibAdminRecovery.AdminRecoveryClanNotFound.selector, uint32(999)));
+        world.injectClanResources(999, 1, 2, 3, 4, 5, 6);
+    }
+
+    function test_reviveClansman_revertsForMissingClansman() public {
+        vm.expectRevert(abi.encodeWithSelector(LibAdminRecovery.AdminRecoveryClansmanNotFound.selector, uint32(999)));
+        world.reviveClansman(999);
+    }
+
+    function test_injectClanResources_addsAllResourcesForDeadClanAndEmits() public {
         uint32 clanId = _mint();
         harness.markClanDeadFromAllClansmen(clanId);
         Clan memory beforeClan = world.getClan(clanId);
 
         vm.expectEmit(true, false, false, true);
-        emit ResourcesInjected(clanId, 1e18, 2e18, 3e18, 4e18, 0);
-        world.injectClanResources(clanId, 1e18, 2e18, 3e18, 4e18);
+        emit ResourcesInjected(clanId, 1e18, 2e18, 3e18, 4e18, 5e18, 6e18, 0);
+        world.injectClanResources(clanId, 1e18, 2e18, 3e18, 4e18, 5e18, 6e18);
 
         Clan memory afterClan = world.getClan(clanId);
         assertEq(afterClan.vaultWood, beforeClan.vaultWood + 1e18, "wood");
         assertEq(afterClan.vaultIron, beforeClan.vaultIron + 2e18, "iron");
         assertEq(afterClan.vaultWheat, beforeClan.vaultWheat + 3e18, "wheat");
         assertEq(afterClan.vaultFish, beforeClan.vaultFish + 4e18, "fish");
-        assertEq(afterClan.goldBalance, beforeClan.goldBalance, "gold");
-        assertEq(afterClan.blueprintBalance, beforeClan.blueprintBalance, "blueprint");
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance + 5e18, "gold");
+        assertEq(afterClan.blueprintBalance, beforeClan.blueprintBalance + 6e18, "blueprint");
         assertEq(uint8(afterClan.clanState), uint8(ClanState.DEAD), "still dead");
+    }
+
+    function test_injectClanResources_addsGoldAndBlueprintIndependentlyForActiveClan() public {
+        uint32 clanId = _mint();
+        Clan memory beforeClan = world.getClan(clanId);
+
+        vm.expectEmit(true, false, false, true);
+        emit ResourcesInjected(clanId, 0, 0, 0, 0, 7e18, 0, 0);
+        world.injectClanResources(clanId, 0, 0, 0, 0, 7e18, 0);
+
+        vm.expectEmit(true, false, false, true);
+        emit ResourcesInjected(clanId, 0, 0, 0, 0, 0, 8e18, 0);
+        world.injectClanResources(clanId, 0, 0, 0, 0, 0, 8e18);
+
+        Clan memory afterClan = world.getClan(clanId);
+        assertEq(afterClan.goldBalance, beforeClan.goldBalance + 7e18, "gold");
+        assertEq(afterClan.blueprintBalance, beforeClan.blueprintBalance + 8e18, "blueprint");
+        assertEq(uint8(afterClan.clanState), uint8(ClanState.ACTIVE), "still active");
+    }
+
+    function test_injectClanResources_worksWhenWorldPaused() public {
+        uint32 clanId = _mint();
+        harness.setWorldPaused(true);
+
+        vm.expectEmit(true, false, false, true);
+        emit ResourcesInjected(clanId, 1, 2, 3, 4, 5, 6, 0);
+        world.injectClanResources(clanId, 1, 2, 3, 4, 5, 6);
+
+        Clan memory clan = world.getClan(clanId);
+        assertEq(clan.vaultWood, 20e18 + 1, "wood");
+        assertEq(clan.vaultIron, 2, "iron");
+        assertEq(clan.vaultWheat, 20e18 + 3, "wheat");
+        assertEq(clan.vaultFish, 2e18 + 4, "fish");
+        assertEq(clan.goldBalance, 3e18 + 5, "gold");
+        assertEq(clan.blueprintBalance, 6, "blueprint");
     }
 
     function test_injectClanResources_overflowReverts() public {
         uint32 clanId = _mint();
         uint256 max = type(uint256).max;
-        world.injectClanResources(clanId, max - world.getClan(clanId).vaultWood, 0, 0, 0);
+        world.injectClanResources(clanId, max - world.getClan(clanId).vaultWood, 0, 0, 0, 0, 0);
 
         vm.expectRevert();
-        world.injectClanResources(clanId, 1, 0, 0, 0);
+        world.injectClanResources(clanId, 1, 0, 0, 0, 0, 0);
     }
 
     function test_adminRecoverySelectors() public {
@@ -382,17 +518,19 @@ contract AdminRecoveryFacetTest is Test {
     }
 
     function _harnessSelectors() private pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](11);
+        selectors = new bytes4[](13);
         selectors[0] = AdminRecoveryHarnessFacet.setCurrentTick.selector;
-        selectors[1] = AdminRecoveryHarnessFacet.markClansmanDead.selector;
-        selectors[2] = AdminRecoveryHarnessFacet.markClanDeadFromAllClansmen.selector;
-        selectors[3] = AdminRecoveryHarnessFacet.markClanDeadOtherPath.selector;
-        selectors[4] = AdminRecoveryHarnessFacet.dirtyClansmanState.selector;
-        selectors[5] = AdminRecoveryHarnessFacet.setDefenderMission.selector;
-        selectors[6] = AdminRecoveryHarnessFacet.reserveWallUpgrade.selector;
-        selectors[7] = AdminRecoveryHarnessFacet.setScheduledMarketMission.selector;
-        selectors[8] = AdminRecoveryHarnessFacet.pendingWallUpgrades.selector;
-        selectors[9] = AdminRecoveryHarnessFacet.reservedWood.selector;
-        selectors[10] = AdminRecoveryHarnessFacet.reservedIron.selector;
+        selectors[1] = AdminRecoveryHarnessFacet.setWorldPaused.selector;
+        selectors[2] = AdminRecoveryHarnessFacet.setSingleLivingClanAtTick.selector;
+        selectors[3] = AdminRecoveryHarnessFacet.markClansmanDead.selector;
+        selectors[4] = AdminRecoveryHarnessFacet.markClanDeadFromAllClansmen.selector;
+        selectors[5] = AdminRecoveryHarnessFacet.markClanDeadOtherPath.selector;
+        selectors[6] = AdminRecoveryHarnessFacet.dirtyClansmanState.selector;
+        selectors[7] = AdminRecoveryHarnessFacet.setDefenderMission.selector;
+        selectors[8] = AdminRecoveryHarnessFacet.reserveWallUpgrade.selector;
+        selectors[9] = AdminRecoveryHarnessFacet.setScheduledMarketMission.selector;
+        selectors[10] = AdminRecoveryHarnessFacet.pendingWallUpgrades.selector;
+        selectors[11] = AdminRecoveryHarnessFacet.reservedWood.selector;
+        selectors[12] = AdminRecoveryHarnessFacet.reservedIron.selector;
     }
 }

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -36,6 +36,7 @@ import {
 } from "../../src/IClanWorld.sol";
 import {IDiamondCut} from "../../src/diamond/IDiamondCut.sol";
 import {IDiamondLoupe} from "../../src/diamond/IDiamondLoupe.sol";
+import {AdminRecoveryFacet} from "../../src/diamond/facets/AdminRecoveryFacet.sol";
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {BanditViewsFacet} from "../../src/diamond/facets/BanditViewsFacet.sol";
 import {ClanFullViewFacet} from "../../src/diamond/facets/ClanFullViewFacet.sol";
@@ -1450,7 +1451,7 @@ contract DiamondSkeletonTest is Test {
     }
 
     function _productionCut(address loupeFacet) internal returns (IDiamondCut.FacetCut[] memory cut) {
-        cut = new IDiamondCut.FacetCut[](24);
+        cut = new IDiamondCut.FacetCut[](25);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: loupeFacet,
             action: IDiamondCut.FacetCutAction.Add,
@@ -1477,96 +1478,101 @@ contract DiamondSkeletonTest is Test {
             functionSelectors: DiamondSelectors.worldPauseSelectors()
         });
         cut[5] = IDiamondCut.FacetCut({
+            facetAddress: address(new AdminRecoveryFacet()),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: DiamondSelectors.adminRecoverySelectors()
+        });
+        cut[6] = IDiamondCut.FacetCut({
             facetAddress: address(new FinalizeSeasonFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.seasonSelectors()
         });
-        cut[6] = IDiamondCut.FacetCut({
+        cut[7] = IDiamondCut.FacetCut({
             facetAddress: address(new RawWorldViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawWorldViewsSelectors()
         });
-        cut[7] = IDiamondCut.FacetCut({
+        cut[8] = IDiamondCut.FacetCut({
             facetAddress: address(new RawTreasuryViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawTreasuryViewsSelectors()
         });
-        cut[8] = IDiamondCut.FacetCut({
+        cut[9] = IDiamondCut.FacetCut({
             facetAddress: address(new RawClanViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawClanViewsSelectors()
         });
-        cut[9] = IDiamondCut.FacetCut({
+        cut[10] = IDiamondCut.FacetCut({
             facetAddress: address(new RawBanditViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.rawBanditViewsSelectors()
         });
-        cut[10] = IDiamondCut.FacetCut({
+        cut[11] = IDiamondCut.FacetCut({
             facetAddress: address(new ClanLifecycleFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.lifecycleSelectors()
         });
-        cut[11] = IDiamondCut.FacetCut({
+        cut[12] = IDiamondCut.FacetCut({
             facetAddress: address(new SubmitOrdersFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.submitOrdersSelectors()
         });
-        cut[12] = IDiamondCut.FacetCut({
+        cut[13] = IDiamondCut.FacetCut({
             facetAddress: address(new ClanOwnershipFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.ownershipSelectors()
         });
-        cut[13] = IDiamondCut.FacetCut({
+        cut[14] = IDiamondCut.FacetCut({
             facetAddress: address(new TreasuryFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.treasurySelectors()
         });
-        cut[14] = IDiamondCut.FacetCut({
+        cut[15] = IDiamondCut.FacetCut({
             facetAddress: address(new SettlementFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.settlementSelectors()
         });
-        cut[15] = IDiamondCut.FacetCut({
+        cut[16] = IDiamondCut.FacetCut({
             facetAddress: address(new DirectTransfersFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.directTransferSelectors()
         });
-        cut[16] = IDiamondCut.FacetCut({
+        cut[17] = IDiamondCut.FacetCut({
             facetAddress: address(new DerivedViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.derivedViewsSelectors()
         });
-        cut[17] = IDiamondCut.FacetCut({
+        cut[18] = IDiamondCut.FacetCut({
             facetAddress: address(new MarketViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.marketViewsSelectors()
         });
-        cut[18] = IDiamondCut.FacetCut({
+        cut[19] = IDiamondCut.FacetCut({
             facetAddress: address(new BanditViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.banditViewsSelectors()
         });
-        cut[19] = IDiamondCut.FacetCut({
+        cut[20] = IDiamondCut.FacetCut({
             facetAddress: address(new RegionViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.regionViewsSelectors()
         });
-        cut[20] = IDiamondCut.FacetCut({
+        cut[21] = IDiamondCut.FacetCut({
             facetAddress: address(new SnapshotViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.snapshotViewsSelectors()
         });
-        cut[21] = IDiamondCut.FacetCut({
+        cut[22] = IDiamondCut.FacetCut({
             facetAddress: address(new ClanFullViewFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.clanFullViewSelectors()
         });
-        cut[22] = IDiamondCut.FacetCut({
+        cut[23] = IDiamondCut.FacetCut({
             facetAddress: address(new QuoteViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.quoteViewsSelectors()
         });
-        cut[23] = IDiamondCut.FacetCut({
+        cut[24] = IDiamondCut.FacetCut({
             facetAddress: address(new ScoringViewsFacet()),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: DiamondSelectors.scoringViewsSelectors()
@@ -1574,7 +1580,7 @@ contract DiamondSkeletonTest is Test {
     }
 
     function _expectedProductionSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](68);
+        selectors = new bytes4[](71);
         uint256 offset;
         selectors[offset++] = IDiamondCut.diamondCut.selector;
         offset = _copySelectors(selectors, offset, DiamondSelectors.loupeSelectors());
@@ -1582,6 +1588,7 @@ contract DiamondSkeletonTest is Test {
         offset = _copySelectors(selectors, offset, DiamondSelectors.heartbeatSelectors());
         offset = _copySelectors(selectors, offset, DiamondSelectors.heartbeatConfigSelectors());
         offset = _copySelectors(selectors, offset, DiamondSelectors.worldPauseSelectors());
+        offset = _copySelectors(selectors, offset, DiamondSelectors.adminRecoverySelectors());
         offset = _copySelectors(selectors, offset, DiamondSelectors.seasonSelectors());
         offset = _copySelectors(selectors, offset, DiamondSelectors.rawWorldViewsSelectors());
         offset = _copySelectors(selectors, offset, DiamondSelectors.rawTreasuryViewsSelectors());


### PR DESCRIPTION
## Summary

Adds an owner-only `AdminRecoveryFacet` for ops recovery on the existing ClanWorld diamond. The facet is intentionally small and delegates cleanup/revival mechanics into `LibAdminRecovery`, keeping size-tight gameplay facets untouched.

## Liam synthesis picks implemented

1. Three selectors, not two:
   - `reviveDeadClansmen(uint32)`
   - `reviveClansman(uint32)`
   - `injectClanResources(uint32,uint256,uint256,uint256,uint256)`
2. Resource injection argument order is `(wood, iron, wheat, fish)`, matching `Clan` vault field order.
3. Stale scheduled market queue rows are purged before revival completes, and `lastMissionNonce` is bumped to the current tick after purge.
4. `injectClanResources` allows `DEAD` clans so admins can pre-stage vault resources before revival.
5. Revival resets clan-level `coldDamage` to `0` for both single and bulk revival.

## What changed

- Added `AdminRecoveryFacet` and `LibAdminRecovery`.
- Added `ClansmanRevived` and `ResourcesInjected` events to `IClanWorld`.
- Added add-only upgrade script `UpgradeAdminRecoveryFacet.s.sol` for the existing v2.2.0 diamond.
- Wired selectors into `DiamondSelectors`, fresh diamond deploy wiring, and production selector tests.
- Updated canonical `IClanWorld` ABI artifact.
- Added focused diamond tests for owner gating, single/bulk revival, defender cleanup, reservation cleanup, stale market queue purge, dead-clan resource injection, and overflow behavior.

## Notes

`Clansman` on current `main` has no `carryGold` or per-clansman `coldDamage` field, so the implementation resets all existing carry fields (`carryWood`, `carryIron`, `carryWheat`, `carryFish`) and the existing clan-level `coldDamage`.

## Validation

- `forge test --match-path "test/diamond/AdminRecoveryFacet.t.sol" -v` passed: 12/12.
- `forge test --match-path "test/diamond/DiamondSkeleton.t.sol" -v` passed: 37/37.
- `forge build --sizes 2>&1 | grep -E "AdminRecovery|HeartbeatFacet|FinalizeSeasonFacet"` passed; `AdminRecoveryFacet` runtime is 3,692 bytes.
- `pnpm gen:enums --check` passed from `packages/contracts` via a package script pass-through.
- `pnpm run check:abi` passed.
- `pnpm test:abi-parity` passed.
