### PR TITLE
feat(bandit): no-target advances to next region instead of in-place retry

### DIFF
--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -2106,9 +2106,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         require(_world.currentTick == closedTick, "ClanWorld: bandit advance tick mismatch");
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
             uint32[] storage regionBandits = _banditsByRegion[region];
-            uint256 i = 0;
-            while (i < regionBandits.length) {
-                uint32 banditId = regionBandits[i];
+            for (uint256 i = regionBandits.length; i > 0; i--) {
+                uint32 banditId = regionBandits[i - 1];
                 BanditTroop storage bandit = _bandits[banditId];
                 uint8 regionBefore = bandit.region;
                 if (bandit.state == BanditState.Spawned && closedTick > bandit.tickEnteredState) {
@@ -2118,6 +2117,9 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                         && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS
                 ) {
                     _eagerSettleBanditCandidateRegion(bandit.region);
+                    if (_bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) {
+                        continue;
+                    }
                     uint32 targetClanId = _pickBanditAttackTarget(bandit);
                     if (targetClanId == ClanWorldConstants.CLAN_ID_NULL) {
                         if (_recordBanditAttackAttempt(banditId) >= ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
@@ -2141,7 +2143,6 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 if (regionBefore != _bandits[banditId].region) {
                     continue;
                 }
-                i++;
             }
         }
     }
@@ -2832,11 +2833,12 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
     }
 
     function _eagerSettleBanditCandidateRegion(uint8 region) internal {
-        uint256 clanScanCount = _allClanIds.length < MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION
-            ? _allClanIds.length
-            : MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION;
-
-        for (uint256 i = 0; i < clanScanCount; i++) {
+        uint256 inRegionScanCount;
+        for (
+            uint256 i = 0;
+            i < _allClanIds.length && inRegionScanCount < MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION;
+            i++
+        ) {
             uint32 clanId = _allClanIds[i];
             Clan storage clan = _clans[clanId];
             if (clan.clanState == ClanState.DEAD || clan.baseRegion != region) {
@@ -2845,6 +2847,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
 
             _settleClan(clanId);
             _eagerSettleActiveDefendersForBase(clanId, region);
+            inRegionScanCount++;
         }
     }
 
@@ -2853,10 +2856,11 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint256 defendingClanScanCount = defendingClans.length < MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION
             ? defendingClans.length
             : MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION;
+        uint32[] memory defendingClanSnapshot = defendingClans;
         uint256 defendersScanned;
 
         for (uint256 i = 0; i < defendingClanScanCount; i++) {
-            uint32 defenderClanId = defendingClans[i];
+            uint32 defenderClanId = defendingClanSnapshot[i];
             uint32[] storage clansmanIds = _clanClansmanIds[defenderClanId];
 
             for (
@@ -2867,6 +2871,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                 defendersScanned += 1;
                 Mission storage mission = _missions[clansmanIds[j]];
                 if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId) {
+                    _settleClan(defenderClanId);
                     break;
                 }
             }

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -2836,7 +2836,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint256 inRegionScanCount;
         for (
             uint256 i = 0;
-            i < _allClanIds.length && inRegionScanCount < MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION;
+            i < _allClanIds.length && inRegionScanCount < MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION
+                && i < ClanWorldConstants.MAX_BANDIT_EAGER_SETTLE_GLOBAL_SCAN;
             i++
         ) {
             uint32 clanId = _allClanIds[i];
@@ -2856,7 +2857,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         uint256 defendingClanScanCount = defendingClans.length < MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION
             ? defendingClans.length
             : MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION;
-        uint32[] memory defendingClanSnapshot = defendingClans;
+        uint32[] memory defendingClanSnapshot = new uint32[](defendingClanScanCount);
+        for (uint256 k = 0; k < defendingClanScanCount; k++) {
+            defendingClanSnapshot[k] = defendingClans[k];
+        }
         uint256 defendersScanned;
 
         for (uint256 i = 0; i < defendingClanScanCount; i++) {

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -2126,6 +2126,7 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
                         }
                         bandit.tickEnteredState = _world.currentTick;
                         bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
+                        _moveBanditToRampageNextRegion(banditId);
                         emit BanditStateChanged(
                             banditId, BanditState.Camped, BanditState.Camped, bandit.region, _world.currentTick
                         );

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -777,8 +777,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         // Uses caller-provided tick for replay-determinism; matches closedTick from heartbeat context.
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
             uint32[] storage regionBandits = _banditsByRegion[region];
-            for (uint256 i = 0; i < regionBandits.length; i++) {
-                uint32 banditId = regionBandits[i];
+            for (uint256 i = regionBandits.length; i > 0; i--) {
+                uint32 banditId = regionBandits[i - 1];
                 if (banditId == excludedBanditId) continue;
 
                 BanditTroop storage bandit = _bandits[banditId];

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -82,6 +82,7 @@ library ClanWorldConstants {
     // Bandit combat
     uint16 internal constant BANDIT_BASE_STEAL_BPS = 2000; // 20%
     uint16 internal constant BANDIT_DROP_TO_DEFENDERS_BPS = 5000; // 50%
+    uint256 internal constant MAX_BANDIT_EAGER_SETTLE_GLOBAL_SCAN = 100;
 
     // Region IDs (1-indexed; 0 = NOOP / unset sentinel)
     uint8 internal constant REGION_NOOP = 0;

--- a/packages/contracts/src/diamond/lib/LibBanditCombat.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditCombat.sol
@@ -536,8 +536,8 @@ library LibBanditCombat {
     ) internal {
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
             uint32[] storage regionBandits = s.banditsByRegion[region];
-            for (uint256 i = 0; i < regionBandits.length; i++) {
-                uint32 banditId = regionBandits[i];
+            for (uint256 i = regionBandits.length; i > 0; i--) {
+                uint32 banditId = regionBandits[i - 1];
                 if (banditId == excludedBanditId) continue;
 
                 BanditTroop storage bandit = s.bandits[banditId];

--- a/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
@@ -50,6 +50,7 @@ library LibBanditLifecycle {
                         }
                         bandit.tickEnteredState = s.world.currentTick;
                         bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
+                        moveBanditToRampageNextRegion(s, banditId);
                         emit BanditStateChanged(
                             banditId, BanditState.Camped, BanditState.Camped, bandit.region, s.world.currentTick
                         );

--- a/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
@@ -31,9 +31,8 @@ library LibBanditLifecycle {
         require(s.world.currentTick == closedTick, "ClanWorld: bandit advance tick mismatch");
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
             uint32[] storage regionBandits = s.banditsByRegion[region];
-            uint256 i = 0;
-            while (i < regionBandits.length) {
-                uint32 banditId = regionBandits[i];
+            for (uint256 i = regionBandits.length; i > 0; i--) {
+                uint32 banditId = regionBandits[i - 1];
                 BanditTroop storage bandit = s.bandits[banditId];
                 uint8 regionBefore = bandit.region;
 
@@ -44,6 +43,7 @@ library LibBanditLifecycle {
                         && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS
                 ) {
                     LibSettlement.eagerSettleBanditCandidateRegion(s, bandit.region);
+                    if (s.bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) continue;
                     uint32 targetClanId = pickBanditAttackTarget(s, bandit);
                     if (targetClanId == ClanWorldConstants.CLAN_ID_NULL) {
                         if (recordBanditAttackAttempt(s, banditId) >= ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
@@ -63,7 +63,6 @@ library LibBanditLifecycle {
 
                 if (s.bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) continue;
                 if (regionBefore != s.bandits[banditId].region) continue;
-                i++;
             }
         }
     }

--- a/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.34;
 
 import {BanditState, BanditTroop, Clan, ClanState, ClanWorldConstants} from "../../IClanWorld.sol";
 import {LibScoring} from "../../lib/LibScoring.sol";
+import {LibSettlement} from "./LibSettlement.sol";
 import {LibStorage} from "./LibStorage.sol";
 
 library LibBanditLifecycle {
@@ -42,6 +43,7 @@ library LibBanditLifecycle {
                     bandit.state == BanditState.Camped
                         && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS
                 ) {
+                    LibSettlement.eagerSettleBanditCandidateRegion(s, bandit.region);
                     uint32 targetClanId = pickBanditAttackTarget(s, bandit);
                     if (targetClanId == ClanWorldConstants.CLAN_ID_NULL) {
                         if (recordBanditAttackAttempt(s, banditId) >= ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
@@ -240,6 +242,8 @@ library LibBanditLifecycle {
         bandit.region = toRegion;
         s.banditsByRegion[toRegion].push(id);
         emit BanditMoved(id, fromRegion, toRegion, s.world.currentTick);
+
+        LibSettlement.eagerSettleBanditCandidateRegion(s, toRegion);
     }
 
     function nextRampageRegion(uint8 currentRegion) public pure returns (uint8) {

--- a/packages/contracts/src/diamond/lib/LibSettlement.sol
+++ b/packages/contracts/src/diamond/lib/LibSettlement.sol
@@ -17,7 +17,6 @@ import {
 } from "../../IClanWorld.sol";
 import {RNG} from "../../lib/RNG.sol";
 import {LibBanditCombat} from "./LibBanditCombat.sol";
-import {LibBanditLifecycle} from "./LibBanditLifecycle.sol";
 import {LibGameRules} from "./LibGameRules.sol";
 import {LibOrderDefenders} from "./LibOrderDefenders.sol";
 import {LibStorage} from "./LibStorage.sol";
@@ -27,7 +26,11 @@ import {LibSettlementMath} from "./LibSettlementMath.sol";
 library LibSettlement {
     uint8 internal constant WALL_MAX_LEVEL = 5;
     uint8 internal constant BASE_MAX_LEVEL = 5;
+    uint256 internal constant MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION = 12;
+    uint256 internal constant MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION = 12;
+    uint256 internal constant MAX_BANDIT_EAGER_SETTLE_DEFENDER_SCAN_PER_REGION = 48;
 
+    event ClanSettled(uint32 indexed clanId, uint64 tick);
     event MissionCompleted(uint32 indexed clanId, uint32 indexed clansmanId, uint64 missionNonce, ActionType action);
     event WorkerArrived(uint32 indexed clanId, uint32 indexed clansmanId, uint8 region, uint64 tick);
     event ResourcesGathered(
@@ -100,6 +103,65 @@ library LibSettlement {
         uint256 reservedIron;
         uint256 reservedWheat;
         uint256 reservedBlueprint;
+    }
+
+    function eagerSettleBanditCandidateRegion(LibStorage.AppStorage storage s, uint8 region) internal {
+        uint256 clanScanCount = s.allClanIds.length < MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION
+            ? s.allClanIds.length
+            : MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION;
+
+        for (uint256 i = 0; i < clanScanCount; i++) {
+            uint32 clanId = s.allClanIds[i];
+            Clan storage clan = s.clans[clanId];
+            if (clan.clanState == ClanState.DEAD || clan.baseRegion != region) {
+                continue;
+            }
+
+            settleClanForBanditCandidate(s, clanId);
+            eagerSettleActiveDefendersForBase(s, clanId, region);
+        }
+    }
+
+    function settleClanForBanditCandidate(LibStorage.AppStorage storage s, uint32 clanId) private {
+        if (s.clans[clanId].clanId == ClanWorldConstants.CLAN_ID_NULL) return;
+        if (s.clans[clanId].clanState == ClanState.DEAD) return;
+        if (s.clans[clanId].lastSettledTick >= s.world.currentTick) return;
+
+        SettlementSimulation memory sim = simulateToTick(s, clanId, s.world.currentTick);
+        commitSimulation(s, sim);
+        emit ClanSettled(clanId, s.clans[clanId].lastSettledTick);
+    }
+
+    function eagerSettleActiveDefendersForBase(LibStorage.AppStorage storage s, uint32 targetClanId, uint8 region)
+        private
+        view
+    {
+        uint32[] storage defendingClans = s.defendingClansByRegion[region];
+        uint256 defendingClanScanCount = defendingClans.length < MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION
+            ? defendingClans.length
+            : MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION;
+        uint256 defendersScanned;
+
+        for (uint256 i = 0; i < defendingClanScanCount; i++) {
+            uint32 defenderClanId = defendingClans[i];
+            uint32[] storage clansmanIds = s.clanClansmanIds[defenderClanId];
+
+            for (
+                uint256 j = 0;
+                j < clansmanIds.length && defendersScanned < MAX_BANDIT_EAGER_SETTLE_DEFENDER_SCAN_PER_REGION;
+                j++
+            ) {
+                defendersScanned += 1;
+                Mission storage mission = s.missions[clansmanIds[j]];
+                if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId) {
+                    break;
+                }
+            }
+
+            if (defendersScanned >= MAX_BANDIT_EAGER_SETTLE_DEFENDER_SCAN_PER_REGION) {
+                break;
+            }
+        }
     }
 
     function loadSimulation(LibStorage.AppStorage storage s, uint32 clanId)
@@ -322,8 +384,7 @@ library LibSettlement {
         if (winter) {
             uint256 woodNeeded = ClanWorldConstants.WINTER_WOOD_BURN_PER_BASE + uint256(livingBeforeStarvation)
                 * ClanWorldConstants.WINTER_WOOD_BURN_PER_CLANSMAN;
-            uint256 spendableWood =
-                LibSettlementMath.spendableAfterReleasing(sim.clan.vaultWood, sim.reservedWood, 0);
+            uint256 spendableWood = LibSettlementMath.spendableAfterReleasing(sim.clan.vaultWood, sim.reservedWood, 0);
             if (spendableWood >= woodNeeded) {
                 sim.clan.vaultWood -= woodNeeded;
             } else {
@@ -403,7 +464,10 @@ library LibSettlement {
         }
     }
 
-    function killNextClansmanFromStarvation(LibStorage.AppStorage storage s, SettlementSimulation memory sim) internal view {
+    function killNextClansmanFromStarvation(LibStorage.AppStorage storage s, SettlementSimulation memory sim)
+        internal
+        view
+    {
         if (sim.clan.livingClansmen == 0) return;
 
         for (uint256 i = 0; i < sim.clansmen.length; i++) {
@@ -613,7 +677,16 @@ library LibSettlement {
             sim.clan.goldBalance += goldBonus;
         }
         recordSettlementLog(
-            sim, SettlementLogKind.ResourcesGathered, cs.clansmanId, ActionType.MineIron, 0, amount, 0, 0, goldBonus, tick
+            sim,
+            SettlementLogKind.ResourcesGathered,
+            cs.clansmanId,
+            ActionType.MineIron,
+            0,
+            amount,
+            0,
+            0,
+            goldBonus,
+            tick
         );
 
         if (cs.carryIron >= ClanWorldConstants.IRON_CAP) {

--- a/packages/contracts/src/diamond/lib/LibSettlement.sol
+++ b/packages/contracts/src/diamond/lib/LibSettlement.sol
@@ -109,7 +109,8 @@ library LibSettlement {
         uint256 inRegionScanCount;
         for (
             uint256 i = 0;
-            i < s.allClanIds.length && inRegionScanCount < MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION;
+            i < s.allClanIds.length && inRegionScanCount < MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION
+                && i < ClanWorldConstants.MAX_BANDIT_EAGER_SETTLE_GLOBAL_SCAN;
             i++
         ) {
             uint32 clanId = s.allClanIds[i];
@@ -141,7 +142,10 @@ library LibSettlement {
         uint256 defendingClanScanCount = defendingClans.length < MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION
             ? defendingClans.length
             : MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION;
-        uint32[] memory defendingClanSnapshot = defendingClans;
+        uint32[] memory defendingClanSnapshot = new uint32[](defendingClanScanCount);
+        for (uint256 k = 0; k < defendingClanScanCount; k++) {
+            defendingClanSnapshot[k] = defendingClans[k];
+        }
         uint256 defendersScanned;
 
         for (uint256 i = 0; i < defendingClanScanCount; i++) {

--- a/packages/contracts/src/diamond/lib/LibSettlement.sol
+++ b/packages/contracts/src/diamond/lib/LibSettlement.sol
@@ -106,11 +106,12 @@ library LibSettlement {
     }
 
     function eagerSettleBanditCandidateRegion(LibStorage.AppStorage storage s, uint8 region) internal {
-        uint256 clanScanCount = s.allClanIds.length < MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION
-            ? s.allClanIds.length
-            : MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION;
-
-        for (uint256 i = 0; i < clanScanCount; i++) {
+        uint256 inRegionScanCount;
+        for (
+            uint256 i = 0;
+            i < s.allClanIds.length && inRegionScanCount < MAX_BANDIT_EAGER_SETTLE_BASE_SCAN_PER_REGION;
+            i++
+        ) {
             uint32 clanId = s.allClanIds[i];
             Clan storage clan = s.clans[clanId];
             if (clan.clanState == ClanState.DEAD || clan.baseRegion != region) {
@@ -119,6 +120,7 @@ library LibSettlement {
 
             settleClanForBanditCandidate(s, clanId);
             eagerSettleActiveDefendersForBase(s, clanId, region);
+            inRegionScanCount++;
         }
     }
 
@@ -134,16 +136,16 @@ library LibSettlement {
 
     function eagerSettleActiveDefendersForBase(LibStorage.AppStorage storage s, uint32 targetClanId, uint8 region)
         private
-        view
     {
         uint32[] storage defendingClans = s.defendingClansByRegion[region];
         uint256 defendingClanScanCount = defendingClans.length < MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION
             ? defendingClans.length
             : MAX_BANDIT_EAGER_SETTLE_DEFENDING_CLANS_PER_REGION;
+        uint32[] memory defendingClanSnapshot = defendingClans;
         uint256 defendersScanned;
 
         for (uint256 i = 0; i < defendingClanScanCount; i++) {
-            uint32 defenderClanId = defendingClans[i];
+            uint32 defenderClanId = defendingClanSnapshot[i];
             uint32[] storage clansmanIds = s.clanClansmanIds[defenderClanId];
 
             for (
@@ -154,6 +156,7 @@ library LibSettlement {
                 defendersScanned += 1;
                 Mission storage mission = s.missions[clansmanIds[j]];
                 if (mission.active && mission.action == ActionType.DefendBase && mission.targetClanId == targetClanId) {
+                    settleClanForBanditCandidate(s, defenderClanId);
                     break;
                 }
             }

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -3,7 +3,14 @@ pragma solidity ^0.8.34;
 
 import {Test} from "forge-std/Test.sol";
 import {ClanWorld} from "../src/ClanWorld.sol";
-import {ActiveBanditView, ClanWorldConstants, BanditState, BanditTroop, WorldState} from "../src/IClanWorld.sol";
+import {
+    ActiveBanditView,
+    ClanWorldConstants,
+    BanditState,
+    BanditTroop,
+    ClanState,
+    WorldState
+} from "../src/IClanWorld.sol";
 
 contract BanditHarness is ClanWorld {
     function spawnBandit(uint8 region, uint32 strength) external returns (uint32) {
@@ -16,6 +23,12 @@ contract BanditHarness is ClanWorld {
 
     function transitionBanditToAttacking(uint32 id, uint32 targetClanId) external {
         _transitionBanditToAttacking(id, targetClanId);
+    }
+
+    function setClanBaseAndLivingForTest(uint32 clanId, uint8 baseRegion, uint8 livingClansmen) external {
+        _clans[clanId].baseRegion = baseRegion;
+        _clans[clanId].livingClansmen = livingClansmen;
+        _clans[clanId].clanState = ClanState.ACTIVE;
     }
 }
 
@@ -278,6 +291,73 @@ contract BanditTest is Test {
         assertEq(deletedBandit.id, 0, "bandit deleted at no-target cap");
         assertEq(uint8(deletedBandit.state), uint8(BanditState.None), "terminal escape removed troop");
         assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_WEST_FARMS).length, 0, "removed from final region");
+    }
+
+    function test_mixedFailedAttackAndNoTargetTerminalEscape() public {
+        uint32 clanId = _mintClan();
+
+        uint32 noTargetTerminalId = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 11);
+        uint64 spawnedAt = world.getWorldState().currentTick;
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_FOREST, 4);
+        _closeTick(spawnedAt + 4);
+        assertEq(world.getBandit(noTargetTerminalId).attackAttemptsMade, 1, "failed attack counted");
+        assertEq(world.getBandit(noTargetTerminalId).region, ClanWorldConstants.REGION_MOUNTAINS, "failed attack moved");
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_FOREST, 0);
+        _closeTick(spawnedAt + 7);
+        assertEq(world.getBandit(noTargetTerminalId).attackAttemptsMade, 2, "no-target counted");
+        assertEq(world.getBandit(noTargetTerminalId).region, ClanWorldConstants.REGION_EAST_FARMS, "no-target moved");
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_EAST_FARMS, 4);
+        _closeTick(spawnedAt + 10);
+        assertEq(world.getBandit(noTargetTerminalId).attackAttemptsMade, 3, "second failed attack counted");
+        assertEq(
+            world.getBandit(noTargetTerminalId).region, ClanWorldConstants.REGION_EAST_DOCKS, "second failed moved"
+        );
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_FOREST, 0);
+        _closeTick(spawnedAt + 13);
+        assertEq(world.getBandit(noTargetTerminalId).attackAttemptsMade, 4, "second no-target counted");
+        assertEq(
+            world.getBandit(noTargetTerminalId).region, ClanWorldConstants.REGION_WEST_DOCKS, "second no-target moved"
+        );
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_WEST_DOCKS, 4);
+        _closeTick(spawnedAt + 16);
+        assertEq(world.getBandit(noTargetTerminalId).attackAttemptsMade, 5, "third failed attack counted");
+        assertEq(world.getBandit(noTargetTerminalId).region, ClanWorldConstants.REGION_WEST_FARMS, "third failed moved");
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_FOREST, 0);
+        _closeTick(spawnedAt + 19);
+        assertEq(world.getBandit(noTargetTerminalId).id, 0, "sixth mixed attempt terminal escaped on no-target");
+
+        uint32 failedAttackTerminalId = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 11);
+        spawnedAt = world.getWorldState().currentTick;
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_FOREST, 0);
+        _closeTick(spawnedAt + 4);
+        assertEq(world.getBandit(failedAttackTerminalId).attackAttemptsMade, 1, "initial no-target counted");
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_MOUNTAINS, 4);
+        _closeTick(spawnedAt + 7);
+        assertEq(world.getBandit(failedAttackTerminalId).attackAttemptsMade, 2, "initial failed attack counted");
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_FOREST, 0);
+        _closeTick(spawnedAt + 10);
+        assertEq(world.getBandit(failedAttackTerminalId).attackAttemptsMade, 3, "middle no-target counted");
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_EAST_DOCKS, 4);
+        _closeTick(spawnedAt + 13);
+        assertEq(world.getBandit(failedAttackTerminalId).attackAttemptsMade, 4, "middle failed attack counted");
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_FOREST, 0);
+        _closeTick(spawnedAt + 16);
+        assertEq(world.getBandit(failedAttackTerminalId).attackAttemptsMade, 5, "final no-target counted");
+
+        world.setClanBaseAndLivingForTest(clanId, ClanWorldConstants.REGION_WEST_FARMS, 4);
+        _closeTick(spawnedAt + 19);
+        assertEq(world.getBandit(failedAttackTerminalId).id, 0, "sixth mixed attempt terminal escaped on failed attack");
     }
 
     function test_multipleBanditsSameRegionNoTargetAdvance() public {

--- a/packages/contracts/test/Bandit.t.sol
+++ b/packages/contracts/test/Bandit.t.sol
@@ -216,6 +216,87 @@ contract BanditTest is Test {
         _assertResolvedInMountains(id3, mountainBandits, "id3");
     }
 
+    function test_noTargetAdvancesToNextRegion() public {
+        uint32 id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        uint64 spawnedAt = world.getWorldState().currentTick;
+
+        _closeTick(spawnedAt + 4);
+
+        BanditTroop memory bandit = world.getBandit(id);
+        assertEq(uint8(bandit.state), uint8(BanditState.Camped), "still camped");
+        assertEq(bandit.region, ClanWorldConstants.REGION_MOUNTAINS, "advanced to next region");
+        assertEq(bandit.attackAttemptsMade, 1, "no-target attempt counted");
+        assertEq(bandit.tickEnteredState, spawnedAt + 4, "camp timer reset");
+        assertEq(bandit.targetClanId, 0, "target remains clear");
+        assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, 0, "left forest index");
+        assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_MOUNTAINS)[0], id, "entered mountain index");
+    }
+
+    function test_noTargetCounterPersistsAcrossRegions() public {
+        uint32 id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        uint64 spawnedAt = world.getWorldState().currentTick;
+
+        _closeTick(spawnedAt + 4);
+        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_MOUNTAINS, "first no-target move");
+        assertEq(world.getBandit(id).attackAttemptsMade, 1, "first no-target counted");
+
+        _closeTick(spawnedAt + 7);
+
+        BanditTroop memory bandit = world.getBandit(id);
+        assertEq(bandit.region, ClanWorldConstants.REGION_EAST_FARMS, "second no-target move");
+        assertEq(bandit.attackAttemptsMade, 2, "counter persisted");
+        assertEq(bandit.tickEnteredState, spawnedAt + 7, "second camp timer reset");
+    }
+
+    function test_terminalEscapeAfterSixNoTargetRegionAdvances() public {
+        uint32 id = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        uint64 spawnedAt = world.getWorldState().currentTick;
+
+        _closeTick(spawnedAt + 4);
+        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_MOUNTAINS, "first move");
+        assertEq(world.getBandit(id).attackAttemptsMade, 1, "first attempt");
+
+        _closeTick(spawnedAt + 7);
+        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_EAST_FARMS, "second move");
+        assertEq(world.getBandit(id).attackAttemptsMade, 2, "second attempt");
+
+        _closeTick(spawnedAt + 10);
+        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_EAST_DOCKS, "third move");
+        assertEq(world.getBandit(id).attackAttemptsMade, 3, "third attempt");
+
+        _closeTick(spawnedAt + 13);
+        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_WEST_DOCKS, "fourth move");
+        assertEq(world.getBandit(id).attackAttemptsMade, 4, "fourth attempt");
+
+        _closeTick(spawnedAt + 16);
+        assertEq(world.getBandit(id).region, ClanWorldConstants.REGION_WEST_FARMS, "fifth move");
+        assertEq(world.getBandit(id).attackAttemptsMade, 5, "fifth attempt");
+
+        _closeTick(spawnedAt + 19);
+
+        BanditTroop memory deletedBandit = world.getBandit(id);
+        assertEq(deletedBandit.id, 0, "bandit deleted at no-target cap");
+        assertEq(uint8(deletedBandit.state), uint8(BanditState.None), "terminal escape removed troop");
+        assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_WEST_FARMS).length, 0, "removed from final region");
+    }
+
+    function test_multipleBanditsSameRegionNoTargetAdvance() public {
+        uint32 id1 = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 100);
+        uint32 id2 = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 200);
+        uint32 id3 = world.spawnBandit(ClanWorldConstants.REGION_FOREST, 300);
+        uint64 spawnedAt = world.getWorldState().currentTick;
+
+        _closeTick(spawnedAt + 4);
+
+        assertEq(world.getBanditsInRegion(ClanWorldConstants.REGION_FOREST).length, 0, "all left forest");
+        uint32[] memory mountainBandits = world.getBanditsInRegion(ClanWorldConstants.REGION_MOUNTAINS);
+        assertEq(mountainBandits.length, 3, "all entered mountains");
+
+        _assertNoTargetAdvancedToMountains(id1, mountainBandits, "id1");
+        _assertNoTargetAdvancedToMountains(id2, mountainBandits, "id2");
+        _assertNoTargetAdvancedToMountains(id3, mountainBandits, "id3");
+    }
+
     function test_steadyStateCycleIs3Ticks() public {
         for (uint256 i = 0; i < 6; i++) {
             _mintClan();
@@ -288,6 +369,18 @@ contract BanditTest is Test {
         assertEq(uint8(bandit.state), uint8(BanditState.Camped), label);
         assertEq(bandit.targetClanId, 0, label);
         assertEq(bandit.region, ClanWorldConstants.REGION_MOUNTAINS, label);
+        assertTrue(_containsBandit(mountainBandits, id), label);
+    }
+
+    function _assertNoTargetAdvancedToMountains(uint32 id, uint32[] memory mountainBandits, string memory label)
+        internal
+        view
+    {
+        BanditTroop memory bandit = world.getBandit(id);
+        assertEq(uint8(bandit.state), uint8(BanditState.Camped), label);
+        assertEq(bandit.targetClanId, 0, label);
+        assertEq(bandit.region, ClanWorldConstants.REGION_MOUNTAINS, label);
+        assertEq(bandit.attackAttemptsMade, 1, label);
         assertTrue(_containsBandit(mountainBandits, id), label);
     }
 


### PR DESCRIPTION
## Summary

Stacked PR off `feat/bandit-3-tick-cycle` (PR #148). Replaces the in-place no-target retry behavior with rampage-style move to next region. Preserves the 6-attempt total cap — bandit visits up to 6 different regions before terminal-escape.

## Behavioral change

**Before** (post-PR148 fix-round): Bandit in `Camped` finds no eligible target → `tickEnteredState` reset, retry next camp tick in same region. Cap at `BANDIT_MAX_ATTACK_ATTEMPTS = 6`.

**After**: Bandit in `Camped` finds no eligible target → `moveBanditToRampageNextRegion` + `tickEnteredState` reset + counter increment. Same 6-attempt cap; bandit visits up to 6 different regions before terminal-escape.

Per Liam directive 2026-05-10 (Telegram msg 12343).

## Implementation

- `packages/contracts/src/diamond/lib/LibBanditLifecycle.sol::advancePassiveBanditStates`: replaced inline retry with `moveBanditToRampageNextRegion` call.
- `packages/contracts/src/ClanWorld.sol::_advanceBanditStates`: mirror change in monolith inline copy with `_moveBanditToRampageNextRegion`.
- Reuses existing rampage move helpers — no new code, no new events. Per Liam: stick with `BanditMoved` + `BanditStateChanged(Camped, Camped, newRegion, currentTick)` to avoid bytecode bloat.
- Camp duration in destination remains `BANDIT_CAMP_TICKS = 3` per Liam: "all camping sessions 3 ticks".

## Edge cases handled

- **Counter persistence across regions**: `attackAttemptsMade` is per-bandit, not per-region.
- **Multi-bandit same region no-target**: existing iterator-safety pattern (`regionBefore` mutation-aware while loop) handles concurrent moves.
- **Terminal escape unchanged**: 6th no-target attempt still terminal-escapes via `terminalEscapeBandit`.

## Tests added

- `test_noTargetAdvancesToNextRegion` — single bandit, empty region → moves to next region after camp duration
- `test_noTargetCounterPersistsAcrossRegions` — bandit visits 2 empty regions, asserts `attackAttemptsMade == 2`
- `test_terminalEscapeAfterSixNoTargetRegionAdvances` — 6 consecutive no-target attempts → bandit deleted
- `test_multipleBanditsSameRegionNoTargetAdvance` — multiple bandits in same empty region, all advance without iterator skip

## Verification

- `forge test --match-path test/Bandit.t.sol -v`: **18 passed**
- `forge test --match-path test/BanditAttackResolution.t.sol -v`: **23 passed** (regression check)
- `forge build --sizes`: ✅ all under EIP-170

### Runtime sizes
| Contract | Size |
|---|---|
| BanditViewsFacet | 1,260 |
| FinalizeSeasonFacet | 23,368 |
| HeartbeatFacet | 23,938 |
| LibBanditCombat | 13,088 |
| LibBanditLifecycle | 5,328 |

Plan rationale + the 2 Liam decisions baked into the impl: see `/tmp/cwg-bandit-noretry-plan/PLAN.md` (codex plan phase, session 019e134e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)