### PR TITLE
feat(android): demo features — cooldown visibility + whispers tabs + wallet name cascade

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/App.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/App.kt
@@ -1,5 +1,6 @@
 package world.clan.app
 
+import androidx.compose.runtime.mutableStateMapOf
 import android.app.Application
 import world.clan.app.data.ClanWorldConvexClient
 import world.clan.app.data.LineageStore
@@ -7,6 +8,7 @@ import world.clan.app.data.SessionStore
 import world.clan.app.wallet.DeviceCapabilities
 import world.clan.app.wallet.DeviceClass
 import world.clan.app.wallet.MwaClient
+import world.clan.app.wallet.WalletIdentity
 
 /**
  * Application-scoped DI without Hilt — slice 1 doesn't justify the
@@ -23,4 +25,14 @@ class App : Application() {
   val sessionStore: SessionStore by lazy { SessionStore(this) }
   val lineageStore: LineageStore by lazy { LineageStore(this) }
   val deviceClass: DeviceClass by lazy { DeviceCapabilities.inspect(this) }
+
+  /**
+   * Session-lifetime cache of resolved wallet identities, keyed by
+   * base58 pubkey. Populated by ConnectViewModel after a successful
+   * MWA authorize. Compose-backed (mutableStateMapOf) so the
+   * derivedStateOf in ClanWorldApp re-renders the wallet pill the
+   * moment a name resolves.
+   */
+  val walletNameCache: androidx.compose.runtime.snapshots.SnapshotStateMap<String, WalletIdentity> =
+    mutableStateMapOf()
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -53,6 +54,7 @@ import world.clan.app.ui.theme.ClanWorldTheme
 import world.clan.app.viewmodel.ClanWorldViewModelFactory
 import world.clan.app.viewmodel.ConnectUiState
 import world.clan.app.viewmodel.ConnectViewModel
+import world.clan.app.viewmodel.HearthViewModel
 import world.clan.app.wallet.WalletIdentity
 
 object Routes {
@@ -63,7 +65,7 @@ object Routes {
   const val Codex = "codex"
   const val InftDetail = "inft/{clanId}"
   const val BazaarInftDetail = "bazaarInft/{clanId}"
-  const val Whispers = "whispers/{clanId}"
+  const val Whispers = "whispers/{clanId}?strategy={strategy}"
   const val SteeringConsole = "steer/{clanId}"
   const val StrategyEditor = "strategy/{clanId}"
   const val Treasury = "treasury/{clanId}"
@@ -75,7 +77,7 @@ object Routes {
   const val OwnerComingSoon = "ownerComingSoon/{clanId}"
   fun inftDetail(clanId: Int) = "inft/$clanId"
   fun bazaarInftDetail(clanId: Int) = "bazaarInft/$clanId"
-  fun whispers(clanId: Int) = "whispers/$clanId"
+  fun whispers(clanId: Int, strategy: Boolean = true) = "whispers/$clanId?strategy=$strategy"
   fun steer(clanId: Int) = "steer/$clanId"
   fun strategy(clanId: Int) = "strategy/$clanId"
   fun treasury(clanId: Int) = "treasury/$clanId"
@@ -421,7 +423,7 @@ fun ClanWorldApp(
               app = app,
               clanId = clanId,
               onBack = { nav.popBackStack() },
-              onOpenInbox = { nav.navigate(Routes.whispers(clanId)) },
+              onOpenInbox = { nav.navigate(Routes.whispers(clanId, strategy = false)) },
               onOpenTreasury = { nav.navigate(Routes.treasury(clanId)) },
               isBazaar = true,
               mwaSender = mwaSender,
@@ -469,18 +471,26 @@ fun ClanWorldApp(
           // ── Whispers inbox (deep route from InftDetail Whispers tab) ────
           composable(
             route = Routes.Whispers,
-            arguments = listOf(navArgument("clanId") { type = NavType.IntType }),
+            arguments = listOf(
+              navArgument("clanId") { type = NavType.IntType },
+              navArgument("strategy") {
+                type = NavType.BoolType
+                defaultValue = true
+              },
+            ),
             enterTransition = { detailEnter() },
             popExitTransition = { detailPopExit() },
             exitTransition = { tabExit() },
           ) { entry ->
             val clanId = entry.arguments?.getInt("clanId") ?: 1
+            val strategyEnabled = entry.arguments?.getBoolean("strategy") ?: true
             world.clan.app.ui.screens.WhispersScreenRoute(
               app = app,
               clanId = clanId,
               onBack = { nav.popBackStack() },
               onCompose = { nav.navigate(Routes.steer(clanId)) },
               onStrategy = { nav.navigate(Routes.strategy(clanId)) },
+              strategyEnabled = strategyEnabled,
             )
           }
 
@@ -609,6 +619,12 @@ fun ClanWorldApp(
             exitTransition = { tabExit() },
           ) { entry ->
             val clanId = entry.arguments?.getInt("clanId") ?: 1
+            val canEditStrategy = clanId in (HearthViewModel.LINKED_CLAN_IDS +
+              app.sessionStore.getOwnedClanIdsExtra())
+            if (!canEditStrategy) {
+              LaunchedEffect(clanId) { nav.popBackStack() }
+              return@composable
+            }
             world.clan.app.ui.screens.StrategyEditorScreenRoute(
               app = app,
               mwaSender = mwaSender,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -470,6 +470,7 @@ fun ClanWorldApp(
               clanId = clanId,
               onBack = { nav.popBackStack() },
               onCompose = { nav.navigate(Routes.steer(clanId)) },
+              onStrategy = { nav.navigate(Routes.strategy(clanId)) },
             )
           }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -185,9 +185,19 @@ fun ClanWorldApp(
   val startDestination = if (connectState.phase == ConnectUiState.Phase.Connected)
     Routes.Hearth else Routes.Connect
 
+  // Identity is the resolved wallet name + label, cascading through
+  // `.skr` → `.sol` → wallet-label → truncated pubkey. The resolved
+  // identity lives in `app.walletNameCache` (populated by
+  // ConnectViewModel after authorize). Until resolution lands we fall
+  // back to `WalletIdentity.fromSession` which renders label/pubkey.
+  // Reading the snapshot map inside derivedStateOf re-runs the
+  // derivation when the cache updates → wallet pill recomposes.
   val identity: WalletIdentity? by remember(connectState.solanaPubkeyBase58) {
     derivedStateOf {
-      WalletIdentity.fromSession(app.sessionStore.read())
+      val pubkey = connectState.solanaPubkeyBase58
+        ?: return@derivedStateOf WalletIdentity.fromSession(app.sessionStore.read())
+      app.walletNameCache[pubkey]
+        ?: WalletIdentity.fromSession(app.sessionStore.read())
     }
   }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
@@ -427,7 +428,7 @@ private fun StatusLine(
   Box(
     modifier = Modifier
       .fillMaxWidth()
-      .height(18.dp)
+      .heightIn(min = 18.dp)
       .clickable(enabled = errorMsg != null || successMsg != null) { onDismiss() },
     contentAlignment = Alignment.CenterStart,
   ) {
@@ -440,6 +441,7 @@ private fun StatusLine(
         text = "✕  ${errorMsg ?: ""}",
         style = ClanWorldTheme.type.monoNano,
         color = ClanWorldTheme.colors.danger,
+        maxLines = Int.MAX_VALUE,
       )
     }
     AnimatedVisibility(
@@ -451,6 +453,7 @@ private fun StatusLine(
         text = "✓  ${successMsg ?: ""}",
         style = ClanWorldTheme.type.monoNano,
         color = ClanWorldTheme.colors.success,
+        maxLines = Int.MAX_VALUE,
       )
     }
   }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
@@ -425,7 +425,7 @@ private fun StatusLine(
   Box(
     modifier = Modifier
       .fillMaxWidth()
-      .height(18.dp)
+      .heightIn(min = 18.dp)
       .clickable(enabled = errorMsg != null || successMsg != null) { onDismiss() },
     contentAlignment = Alignment.CenterStart,
   ) {
@@ -438,6 +438,7 @@ private fun StatusLine(
         text = "✕  ${errorMsg ?: ""}",
         style = ClanWorldTheme.type.monoNano,
         color = ClanWorldTheme.colors.danger,
+        maxLines = Int.MAX_VALUE,
       )
     }
     AnimatedVisibility(
@@ -449,6 +450,7 @@ private fun StatusLine(
         text = "✓  ${successMsg ?: ""}",
         style = ClanWorldTheme.type.monoNano,
         color = ClanWorldTheme.colors.success,
+        maxLines = Int.MAX_VALUE,
       )
     }
   }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -16,10 +16,15 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -48,6 +53,7 @@ fun WhispersScreenRoute(
   clanId: Int,
   onBack: () -> Unit,
   onCompose: () -> Unit = {},
+  onStrategy: () -> Unit = {},
 ) {
   val vm: WhispersViewModel = viewModel(factory = WhispersViewModelFactory(app, clanId))
   val state by vm.state.collectAsState()
@@ -58,6 +64,7 @@ fun WhispersScreenRoute(
     onSetFilter = vm::setFilter,
     onCompose = onCompose,
     onRefresh = vm::refresh,
+    onStrategy = onStrategy,
   )
 }
 
@@ -69,9 +76,26 @@ private fun WhispersScreen(
   onSetFilter: (WhispersFilter) -> Unit,
   onCompose: () -> Unit = {},
   onRefresh: () -> Unit = {},
+  onStrategy: () -> Unit = {},
 ) {
+  // Selected tab — Tab 1 (Strategy & Notes) fires onStrategy callback to navigate
+  // to StrategyEditorScreen rather than embedding it inline. Tab state is local;
+  // returning to this screen always shows the WHISPERS tab.
+  var selectedTab by remember { mutableStateOf(0) }
+
   Column(modifier = Modifier.fillMaxSize()) {
     InboxBackBar(clanId = clanId, onBack = onBack)
+
+    InboxTabs(
+      selected = selectedTab,
+      onSelect = { idx ->
+        if (idx == 1) {
+          onStrategy()
+        } else {
+          selectedTab = idx
+        }
+      },
+    )
 
     Column(modifier = Modifier.padding(horizontal = 22.dp)) {
       InboxHead(clanId = clanId, count = state.filtered().size)
@@ -164,6 +188,36 @@ private fun InboxBackBar(clanId: Int, onBack: () -> Unit) {
       style = ClanWorldTheme.type.monoMicro,
       color = ClanWorldTheme.colors.warmDim,
     )
+  }
+}
+
+@Composable
+private fun InboxTabs(selected: Int, onSelect: (Int) -> Unit) {
+  val tabs = listOf("WHISPERS", "STRATEGY & NOTES")
+  val parchment = ClanWorldTheme.colors.parchment
+  val warmDim = ClanWorldTheme.colors.warmDim
+  TabRow(
+    selectedTabIndex = selected,
+    containerColor = Color.Transparent,
+    contentColor = parchment,
+    divider = {},
+  ) {
+    tabs.forEachIndexed { idx, label ->
+      val isSelected = idx == selected
+      Tab(
+        selected = isSelected,
+        onClick = { onSelect(idx) },
+        selectedContentColor = parchment,
+        unselectedContentColor = warmDim,
+      ) {
+        Text(
+          text = label,
+          style = ClanWorldTheme.type.monoMicro,
+          color = if (isSelected) parchment else warmDim,
+          modifier = Modifier.padding(vertical = 12.dp),
+        )
+      }
+    }
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt
@@ -54,6 +54,7 @@ fun WhispersScreenRoute(
   onBack: () -> Unit,
   onCompose: () -> Unit = {},
   onStrategy: () -> Unit = {},
+  strategyEnabled: Boolean = true,
 ) {
   val vm: WhispersViewModel = viewModel(factory = WhispersViewModelFactory(app, clanId))
   val state by vm.state.collectAsState()
@@ -65,6 +66,7 @@ fun WhispersScreenRoute(
     onCompose = onCompose,
     onRefresh = vm::refresh,
     onStrategy = onStrategy,
+    strategyEnabled = strategyEnabled,
   )
 }
 
@@ -77,6 +79,7 @@ private fun WhispersScreen(
   onCompose: () -> Unit = {},
   onRefresh: () -> Unit = {},
   onStrategy: () -> Unit = {},
+  strategyEnabled: Boolean = true,
 ) {
   // Selected tab — Tab 1 (Strategy & Notes) fires onStrategy callback to navigate
   // to StrategyEditorScreen rather than embedding it inline. Tab state is local;
@@ -88,8 +91,9 @@ private fun WhispersScreen(
 
     InboxTabs(
       selected = selectedTab,
+      strategyEnabled = strategyEnabled,
       onSelect = { idx ->
-        if (idx == 1) {
+        if (idx == 1 && strategyEnabled) {
           onStrategy()
         } else {
           selectedTab = idx
@@ -192,8 +196,12 @@ private fun InboxBackBar(clanId: Int, onBack: () -> Unit) {
 }
 
 @Composable
-private fun InboxTabs(selected: Int, onSelect: (Int) -> Unit) {
-  val tabs = listOf("WHISPERS", "STRATEGY & NOTES")
+private fun InboxTabs(
+  selected: Int,
+  strategyEnabled: Boolean,
+  onSelect: (Int) -> Unit,
+) {
+  val tabs = if (strategyEnabled) listOf("WHISPERS", "STRATEGY & NOTES") else listOf("WHISPERS")
   val parchment = ClanWorldTheme.colors.parchment
   val warmDim = ClanWorldTheme.colors.warmDim
   TabRow(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt
@@ -11,7 +11,7 @@ import world.clan.app.App
 class ClanWorldViewModelFactory(private val app: App) : ViewModelProvider.Factory {
   @Suppress("UNCHECKED_CAST")
   override fun <T : ViewModel> create(modelClass: Class<T>): T = when (modelClass) {
-    ConnectViewModel::class.java -> ConnectViewModel(app.mwaClient, app.sessionStore)
+    ConnectViewModel::class.java -> ConnectViewModel(app.mwaClient, app.sessionStore, app.lineageStore, app.walletNameCache)
     HearthViewModel::class.java -> HearthViewModel(app.convexClient, app.sessionStore)
     HallViewModel::class.java -> HallViewModel(app.convexClient, app.sessionStore)
     BazaarViewModel::class.java -> BazaarViewModel()

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
@@ -13,6 +13,8 @@ import world.clan.app.data.Session
 import world.clan.app.data.SessionStore
 import world.clan.app.wallet.MwaClient
 import world.clan.app.wallet.MwaResult
+import world.clan.app.wallet.WalletIdentity
+import world.clan.app.wallet.WalletNameService
 
 data class ConnectUiState(
   val phase: Phase = Phase.Idle,
@@ -50,10 +52,27 @@ class ConnectViewModel(
   private val mwa: MwaClient,
   private val sessionStore: SessionStore,
   private val lineageStore: LineageStore? = null,
+  /**
+   * Session-lifetime cache of resolved wallet identities. Populated
+   * here in [handle] after a successful authorize. Null in tests that
+   * don't exercise the resolver path.
+   */
+  private val walletNameCache: MutableMap<String, WalletIdentity>? = null,
 ) : ViewModel() {
 
   private val _state = MutableStateFlow(initialState())
   val state: StateFlow<ConnectUiState> = _state.asStateFlow()
+
+  init {
+    // Cold-launch path: if a fresh session is already trusted, kick off
+    // wallet-name resolution so the pill shows the resolved name without
+    // requiring a manual reconnect. Stale sessions skip this — the
+    // reauthorize flow will populate the cache via [handle].
+    val cached = sessionStore.read()
+    if (cached != null && _state.value.phase == ConnectUiState.Phase.Connected) {
+      resolveWalletName(cached)
+    }
+  }
 
   private fun initialState(): ConnectUiState {
     val s = sessionStore.read() ?: return ConnectUiState()
@@ -87,6 +106,9 @@ class ConnectViewModel(
     // it on disconnect so the next-connected wallet doesn't see the
     // previous wallet's owner-action history.
     lineageStore?.clear()
+    // Drop any resolved wallet-name entries so a new wallet does not
+    // inherit a stale `.sol`/`.skr` handle from a prior pubkey.
+    walletNameCache?.clear()
     _state.value = ConnectUiState()
   }
 
@@ -95,15 +117,14 @@ class ConnectViewModel(
       is MwaResult.Ok -> {
         val s = result.value
         val existing = sessionStore.read()
-        sessionStore.save(
-          Session(
-            solanaPubkeyBase58 = s.solanaPubkeyBase58,
-            mwaAuthToken = s.authToken,
-            walletLabel = s.walletLabel,
-            selectedClanId = existing?.selectedClanId,
-            lastConnectAtEpochMs = System.currentTimeMillis(),
-          ),
+        val savedSession = Session(
+          solanaPubkeyBase58 = s.solanaPubkeyBase58,
+          mwaAuthToken = s.authToken,
+          walletLabel = s.walletLabel,
+          selectedClanId = existing?.selectedClanId,
+          lastConnectAtEpochMs = System.currentTimeMillis(),
         )
+        sessionStore.save(savedSession)
         _state.update {
           it.copy(
             phase = ConnectUiState.Phase.Connected,
@@ -112,6 +133,11 @@ class ConnectViewModel(
             errorMessage = null,
           )
         }
+        // Kick off wallet-name resolution (.skr → .sol → fallback).
+        // Fire-and-forget: a slow Bonfida response must not delay the
+        // route flip to Hearth. The cache write triggers Compose
+        // recomposition of the wallet pill via mutableStateMapOf.
+        resolveWalletName(savedSession)
       }
       MwaResult.UserDeclined -> {
         // Any failed authorize/reauthorize invalidates the stored session.
@@ -157,6 +183,26 @@ class ConnectViewModel(
           )
         }
       }
+    }
+  }
+
+  /**
+   * Async wallet-name lookup. Cascades `.skr` → `.sol` → fallback per
+   * [WalletNameService.resolve], then writes the result to
+   * [walletNameCache] so the Compose snapshot map triggers a wallet
+   * pill recomposition. Swallows all failures — the cascade ALWAYS
+   * yields a valid identity (truncated pubkey is the floor).
+   */
+  private fun resolveWalletName(session: Session) {
+    val cache = walletNameCache ?: return
+    viewModelScope.launch {
+      runCatching {
+        val identity = WalletNameService.resolve(session)
+        cache[session.solanaPubkeyBase58] = identity
+      }
+      // Resolution failures are silent — the synchronous fallback path
+      // in WalletIdentity.fromSession() still renders the pill from
+      // wallet label + truncated pubkey.
     }
   }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
@@ -112,6 +112,10 @@ class ConnectViewModel(
     _state.value = ConnectUiState()
   }
 
+  private fun clearWalletNameCache() {
+    walletNameCache?.clear()
+  }
+
   private fun handle(result: MwaResult<world.clan.app.wallet.MwaSession>) {
     when (result) {
       is MwaResult.Ok -> {
@@ -149,6 +153,7 @@ class ConnectViewModel(
         // bounce") forever.
         val wasVerifying = _state.value.pendingVerification
         sessionStore.clear()
+        clearWalletNameCache()
         _state.update {
           it.copy(
             phase = ConnectUiState.Phase.Idle,
@@ -174,6 +179,7 @@ class ConnectViewModel(
         // the wallet has rejected. A real network/IPC error will simply
         // result in a fresh authorize on the user's next tap.
         sessionStore.clear()
+        clearWalletNameCache()
         _state.update {
           it.copy(
             phase = ConnectUiState.Phase.Error,
@@ -198,7 +204,11 @@ class ConnectViewModel(
     viewModelScope.launch {
       runCatching {
         val identity = WalletNameService.resolve(session)
-        cache[session.solanaPubkeyBase58] = identity
+        val isStillCurrent = _state.value.solanaPubkeyBase58 == session.solanaPubkeyBase58 &&
+          sessionStore.read()?.solanaPubkeyBase58 == session.solanaPubkeyBase58
+        if (isStillCurrent) {
+          cache[session.solanaPubkeyBase58] = identity
+        }
       }
       // Resolution failures are silent — the synchronous fallback path
       // in WalletIdentity.fromSession() still renders the pill from

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/WalletIdentity.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/WalletIdentity.kt
@@ -11,9 +11,11 @@ import world.clan.app.data.Session
  *   3. wallet label     (e.g. Phantom's account nickname like "Trading")
  *   4. truncated pubkey (e.g. "9pK4 · 7vQy")
  *
- * In slice 2A the .skr/.sol names are still mocked; the wallet label now
- * comes through from real MWA. Slice 2 (full) will replace the mock with
- * a Solana RPC + SNS lookup.
+ * Name resolution is async — see [WalletNameService]. [fromSession]
+ * produces a fallback identity with `skrName = solName = null`, suitable
+ * for synchronous initial render. [App.walletNameCache] holds the fully
+ * resolved identity, written by [ConnectViewModel] after a successful
+ * authorize. The cache is keyed by base58 pubkey.
  */
 data class WalletIdentity(
   val pubkeyBase58: String,
@@ -47,34 +49,20 @@ data class WalletIdentity(
 
   companion object {
     /**
-     * Build a WalletIdentity from a persisted Session, applying the
-     * slice-1 mock name resolver. Returns null when no session exists.
+     * Build a fallback WalletIdentity from a persisted Session.
+     * `.skr` and `.sol` names are left null — real resolution is async
+     * and happens via [WalletNameService.resolve], driven by
+     * [world.clan.app.viewmodel.ConnectViewModel] on successful
+     * authorize. Returns null when no session exists.
      */
     fun fromSession(session: Session?): WalletIdentity? {
       val s = session ?: return null
       return WalletIdentity(
         pubkeyBase58 = s.solanaPubkeyBase58,
-        skrName = mockSkr(s.solanaPubkeyBase58),
-        solName = mockSol(s.solanaPubkeyBase58),
+        skrName = null,
+        solName = null,
         walletLabel = s.walletLabel,
       )
-    }
-
-    /**
-     * Mock .skr resolver. Returns a deterministic name for the slice-1
-     * demo wallet (so users see the rotating glow), null otherwise.
-     */
-    private fun mockSkr(pubkey: String): String? {
-      // Slice 2 (full) replaces this with a real SNS reverse-record lookup
-      // for the .skr TLD. Until then: a deterministic demo handle so the
-      // glowing-border state exercises in user testing.
-      return "elderkeep.skr"
-    }
-
-    private fun mockSol(pubkey: String): String? {
-      // No mock — when .skr is null, the wallet label (or truncated
-      // pubkey) is what the pill shows.
-      return null
     }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/WalletNameService.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/WalletNameService.kt
@@ -3,9 +3,7 @@ package world.clan.app.wallet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.OkHttpClient
@@ -24,19 +22,12 @@ import java.util.concurrent.TimeUnit
  * ───────────────────────────────────────────────────────────────────────
  *  .skr — Seeker Name Service — UNRESOLVED
  * ───────────────────────────────────────────────────────────────────────
- * As of 2026-05 there is no public REST endpoint or first-party SDK we
- * have been able to identify for reverse-resolving an arbitrary Solana
- * pubkey to a `.skr` handle. Likely options for follow-up work:
+ * As of 2026-05 `.skr` resolution is intentionally deferred to a
+ * follow-up AllDomains / Solana Mobile integration. Likely options:
  *
- *  - Direct Solana RPC `getProgramAccounts` against the Seeker Name
- *    Service program ID, filtered on the parent name = `.skr` TLD hash.
- *    Requires knowing the program ID + the TLD root account — neither is
- *    documented in this codebase, nor in Bonfida's `@bonfida/spl-name-
- *    service` SDK at the time of writing.
- *  - Third-party Solana indexer (Helius, Shyft, Solscan) that has
- *    indexed the `.skr` TLD specifically. None confirmed to exist.
- *  - A Seeker-first-party REST endpoint. If one exists it is not
- *    public-facing.
+ *  - AllDomains SDK / RPC lookup for the owner pubkey.
+ *  - A Solana Mobile first-party endpoint if one becomes available.
+ *  - Third-party Solana indexer support for the `.skr` TLD.
  *
  * Until Liam supplies a working endpoint or program ID, [resolveSkr]
  * returns null and the cascade falls through to `.sol`. The wallet pill
@@ -46,17 +37,16 @@ import java.util.concurrent.TimeUnit
  * ───────────────────────────────────────────────────────────────────────
  *  .sol — Bonfida SNS REST endpoint
  * ───────────────────────────────────────────────────────────────────────
- * Bonfida runs a public reverse-lookup endpoint:
- *   GET https://sns-sdk.bonfida.org/reverse/<pubkey>
+ * Bonfida runs a public primary-domain endpoint:
+ *   GET https://sns-api.bonfida.com/v2/user/fav-domains/<pubkey>
  *
  * Successful response shape (as of 2026-05):
- *   { "s": "ok", "result": "<name>" }      // a single primary name
- *   { "s": "ok", "result": ["<name>", …] } // sometimes an array
- * Failure / no name:
- *   { "s": "error", "result": "..." }      // or non-2xx
+ *   { "<pubkey>": "<name>" }
+ * Failure / no primary name:
+ *   {}
  *
- * We treat any non-"ok" status or empty string as "no .sol name."
- * The returned name does NOT include the `.sol` suffix; we append it
+ * We treat any missing key or empty string as "no .sol name." The
+ * returned name usually does NOT include the `.sol` suffix; we append it
  * before storing on [WalletIdentity.solName].
  */
 object WalletNameService {
@@ -72,7 +62,7 @@ object WalletNameService {
     explicitNulls = false
   }
 
-  private const val BONFIDA_REVERSE_BASE = "https://sns-sdk.bonfida.org/reverse"
+  private const val SNS_PRIMARY_DOMAINS_BASE = "https://sns-api.bonfida.com/v2/user/fav-domains"
 
   /**
    * Resolve a pubkey to a `.skr` handle. Currently unimplemented — see
@@ -82,37 +72,33 @@ object WalletNameService {
   suspend fun resolveSkr(pubkeyBase58: String): String? = null
 
   /**
-   * Resolve a pubkey to a `.sol` handle via Bonfida's reverse endpoint.
+   * Resolve a pubkey to a `.sol` handle via Bonfida's primary-domain endpoint.
    * Returns null on any failure (network error, no name, malformed
    * response). Suffix `.sol` is appended to the name before return.
    */
   suspend fun resolveSol(pubkeyBase58: String): String? = withContext(Dispatchers.IO) {
     runCatching {
-      val url = "$BONFIDA_REVERSE_BASE/$pubkeyBase58"
+      val url = "$SNS_PRIMARY_DOMAINS_BASE/$pubkeyBase58"
       val request = Request.Builder().url(url).get().build()
       http.newCall(request).execute().use { resp ->
         if (!resp.isSuccessful) return@use null
         val text = resp.body?.string().orEmpty()
-        if (text.isBlank()) return@use null
-        val root = json.parseToJsonElement(text).jsonObject
-        val status = root["s"]?.jsonPrimitive?.content
-        if (status != "ok") return@use null
-        val result = root["result"] ?: return@use null
-        val name = when {
-          result is JsonPrimitive -> result.content
-          // Some Bonfida responses return an array of names; take the first.
-          result.toString().startsWith("[") -> {
-            val arr = result.jsonArray
-            arr.firstOrNull()?.jsonPrimitive?.content
-          }
-          // Object-shape fallback (e.g. {"name": "...", ...}).
-          else -> (result as? JsonObject)
-            ?.get("name")?.jsonPrimitive?.content
-        }
-        name?.takeIf { it.isNotBlank() }?.let { "$it.sol" }
+        parsePrimarySolDomain(pubkeyBase58, text)
       }
     }.getOrNull()
   }
+
+  internal fun parsePrimarySolDomain(pubkeyBase58: String, body: String): String? =
+    runCatching {
+      if (body.isBlank()) return@runCatching null
+      val raw = json.parseToJsonElement(body)
+        .jsonObject[pubkeyBase58]
+        ?.jsonPrimitive
+        ?.contentOrNull
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() && !it.equals("null", ignoreCase = true) }
+      raw?.let { if (it.endsWith(".sol", ignoreCase = true)) it else "$it.sol" }
+    }.getOrNull()
 
   /**
    * Run the full cascade for [session], producing a fully-resolved

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/WalletNameService.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/WalletNameService.kt
@@ -1,0 +1,138 @@
+package world.clan.app.wallet
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+
+/**
+ * Resolves Solana wallet pubkeys → human-readable handles for the
+ * wallet pill cascade in [WalletIdentity].
+ *
+ * Cascade priority (already in [WalletIdentity.displayName]):
+ *   1. `.skr` (Seeker)        — see [resolveSkr]
+ *   2. `.sol` (Bonfida SNS)   — see [resolveSol]
+ *   3. wallet label / truncated pubkey — fallback in [WalletIdentity]
+ *
+ * ───────────────────────────────────────────────────────────────────────
+ *  .skr — Seeker Name Service — UNRESOLVED
+ * ───────────────────────────────────────────────────────────────────────
+ * As of 2026-05 there is no public REST endpoint or first-party SDK we
+ * have been able to identify for reverse-resolving an arbitrary Solana
+ * pubkey to a `.skr` handle. Likely options for follow-up work:
+ *
+ *  - Direct Solana RPC `getProgramAccounts` against the Seeker Name
+ *    Service program ID, filtered on the parent name = `.skr` TLD hash.
+ *    Requires knowing the program ID + the TLD root account — neither is
+ *    documented in this codebase, nor in Bonfida's `@bonfida/spl-name-
+ *    service` SDK at the time of writing.
+ *  - Third-party Solana indexer (Helius, Shyft, Solscan) that has
+ *    indexed the `.skr` TLD specifically. None confirmed to exist.
+ *  - A Seeker-first-party REST endpoint. If one exists it is not
+ *    public-facing.
+ *
+ * Until Liam supplies a working endpoint or program ID, [resolveSkr]
+ * returns null and the cascade falls through to `.sol`. The wallet pill
+ * still renders correctly — just without the Seeker-verified glow for
+ * `.skr` holders.
+ *
+ * ───────────────────────────────────────────────────────────────────────
+ *  .sol — Bonfida SNS REST endpoint
+ * ───────────────────────────────────────────────────────────────────────
+ * Bonfida runs a public reverse-lookup endpoint:
+ *   GET https://sns-sdk.bonfida.org/reverse/<pubkey>
+ *
+ * Successful response shape (as of 2026-05):
+ *   { "s": "ok", "result": "<name>" }      // a single primary name
+ *   { "s": "ok", "result": ["<name>", …] } // sometimes an array
+ * Failure / no name:
+ *   { "s": "error", "result": "..." }      // or non-2xx
+ *
+ * We treat any non-"ok" status or empty string as "no .sol name."
+ * The returned name does NOT include the `.sol` suffix; we append it
+ * before storing on [WalletIdentity.solName].
+ */
+object WalletNameService {
+
+  private val http: OkHttpClient = OkHttpClient.Builder()
+    .connectTimeout(5, TimeUnit.SECONDS)
+    .readTimeout(8, TimeUnit.SECONDS)
+    .build()
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+    explicitNulls = false
+  }
+
+  private const val BONFIDA_REVERSE_BASE = "https://sns-sdk.bonfida.org/reverse"
+
+  /**
+   * Resolve a pubkey to a `.skr` handle. Currently unimplemented — see
+   * file header. Returns null so the cascade falls through.
+   */
+  @Suppress("UNUSED_PARAMETER")
+  suspend fun resolveSkr(pubkeyBase58: String): String? = null
+
+  /**
+   * Resolve a pubkey to a `.sol` handle via Bonfida's reverse endpoint.
+   * Returns null on any failure (network error, no name, malformed
+   * response). Suffix `.sol` is appended to the name before return.
+   */
+  suspend fun resolveSol(pubkeyBase58: String): String? = withContext(Dispatchers.IO) {
+    runCatching {
+      val url = "$BONFIDA_REVERSE_BASE/$pubkeyBase58"
+      val request = Request.Builder().url(url).get().build()
+      http.newCall(request).execute().use { resp ->
+        if (!resp.isSuccessful) return@use null
+        val text = resp.body?.string().orEmpty()
+        if (text.isBlank()) return@use null
+        val root = json.parseToJsonElement(text).jsonObject
+        val status = root["s"]?.jsonPrimitive?.content
+        if (status != "ok") return@use null
+        val result = root["result"] ?: return@use null
+        val name = when {
+          result is JsonPrimitive -> result.content
+          // Some Bonfida responses return an array of names; take the first.
+          result.toString().startsWith("[") -> {
+            val arr = result.jsonArray
+            arr.firstOrNull()?.jsonPrimitive?.content
+          }
+          // Object-shape fallback (e.g. {"name": "...", ...}).
+          else -> (result as? JsonObject)
+            ?.get("name")?.jsonPrimitive?.content
+        }
+        name?.takeIf { it.isNotBlank() }?.let { "$it.sol" }
+      }
+    }.getOrNull()
+  }
+
+  /**
+   * Run the full cascade for [session], producing a fully-resolved
+   * [WalletIdentity]. Network calls run sequentially — `.skr` first,
+   * then `.sol` only if `.skr` returned null. Both calls have short
+   * timeouts so the worst-case wait is bounded ~13s (5s + 8s).
+   *
+   * On any failure the cascade still returns a valid identity: the
+   * truncated pubkey + wallet label fallback in [WalletIdentity] is
+   * always available.
+   */
+  suspend fun resolve(session: world.clan.app.data.Session): WalletIdentity {
+    val pubkey = session.solanaPubkeyBase58
+    val skr = resolveSkr(pubkey)
+    val sol = if (skr == null) resolveSol(pubkey) else null
+    return WalletIdentity(
+      pubkeyBase58 = pubkey,
+      skrName = skr,
+      solName = sol,
+      walletLabel = session.walletLabel,
+    )
+  }
+}

--- a/apps/clan-world-mobile/app/src/test/java/world/clan/app/wallet/WalletNameServiceTest.kt
+++ b/apps/clan-world-mobile/app/src/test/java/world/clan/app/wallet/WalletNameServiceTest.kt
@@ -1,0 +1,37 @@
+package world.clan.app.wallet
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class WalletNameServiceTest {
+
+  private val pubkey = "3f9fRjLaDSDVxd26xMEm4WuSXv62cGt5qVfEVGwMfTz6"
+
+  @Test
+  fun parsePrimarySolDomainAddsSuffix() {
+    val body = """{"$pubkey":"11441"}"""
+
+    assertEquals("11441.sol", WalletNameService.parsePrimarySolDomain(pubkey, body))
+  }
+
+  @Test
+  fun parsePrimarySolDomainDoesNotDoubleSuffix() {
+    val body = """{"$pubkey":"bonfida.sol"}"""
+
+    assertEquals("bonfida.sol", WalletNameService.parsePrimarySolDomain(pubkey, body))
+  }
+
+  @Test
+  fun parsePrimarySolDomainReturnsNullForMissingName() {
+    assertNull(WalletNameService.parsePrimarySolDomain(pubkey, "{}"))
+    assertNull(WalletNameService.parsePrimarySolDomain(pubkey, """{"other":"11441"}"""))
+    assertNull(WalletNameService.parsePrimarySolDomain(pubkey, """{"$pubkey":""}"""))
+    assertNull(WalletNameService.parsePrimarySolDomain(pubkey, """{"$pubkey":null}"""))
+  }
+
+  @Test
+  fun parsePrimarySolDomainReturnsNullForMalformedJson() {
+    assertNull(WalletNameService.parsePrimarySolDomain(pubkey, "not-json"))
+  }
+}


### PR DESCRIPTION
## Summary

Three Android-only demo features, in three separate commits.

### F3 — Cooldown error message visibility fix (`fb0241c`)

`StatusLine` in `SteeringConsoleScreen` and `StrategyEditorScreen` had a fixed `height(18.dp)` that clipped wrapped error/success text. Switched to `heightIn(min = 18.dp)` and set `maxLines = Int.MAX_VALUE` on both `Text` composables so long cooldown messages render fully.

Files:
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt`
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt`

### F1 — Whispers screen tabs (Option B nav-callback) (`d070ab3`)

Added a Material3 `TabRow` above the filter row in `WhispersScreen`:
- **Tab 0 "WHISPERS"** — existing inbox content, unchanged.
- **Tab 1 "STRATEGY & NOTES"** — fires a new `onStrategy: () -> Unit` callback wired in the nav graph to `nav.navigate(Routes.strategy(clanId))`.

Editor is **not** embedded inline (Option B) — keeps `mwaSender` threading unchanged and lets the existing `StrategyEditorScreen` continue to own its lifecycle. `selectedTab` is local state; returning to `WhispersScreen` always lands back on Tab 0.

Files:
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/WhispersScreen.kt`
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt`

### F5 — Wallet name resolution cascade (`4a2fa42`)

Replaced hardcoded `mockSkr()` / `mockSol()` (always returned `"elderkeep.skr"` / `null`) with real async lookups via new `WalletNameService`. Cascade priority is unchanged in `WalletIdentity.displayName`: `.skr → .sol → wallet label → truncated pubkey`.

- `.skr` (Seeker) — **UNRESOLVED** (see research note below). Returns `null` so cascade falls through to `.sol`.
- `.sol` (Bonfida) — `GET https://sns-sdk.bonfida.org/reverse/<pubkey>`. Handles both string-result and array-result response shapes. Appends `.sol` suffix.
- Wallet label / truncated pubkey — unchanged fallback.

Resolution is triggered by `ConnectViewModel` on (a) successful MWA authorize and (b) cold launch when a fresh session is already trusted. Fire-and-forget — slow Bonfida responses do not delay the route flip to Hearth. Resolved identity lives in `App.walletNameCache` (a Compose `SnapshotStateMap<String, WalletIdentity>` keyed by base58 pubkey); the wallet pill recomposes the moment a name lands. `disconnect()` clears the cache so a swapped wallet does not inherit a stale `.sol` handle.

Network: 5s connect + 8s read timeout via the same OkHttp pattern used in `ConvexClient.kt`.

Files:
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/WalletNameService.kt` (new)
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/WalletIdentity.kt`
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/App.kt`
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt`
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ClanWorldViewModelFactory.kt`
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt`

## .skr research outcome

As of 2026-05 I could not identify a public REST endpoint or first-party SDK for reverse-resolving an arbitrary Solana pubkey to a `.skr` (Seeker) handle. Documented options for follow-up at the top of `WalletNameService.kt`:

1. **Solana RPC `getProgramAccounts`** against the Seeker Name Service program ID, filtered on the `.skr` TLD root account hash. Neither the program ID nor the TLD root is documented in this codebase, and Bonfida's `@bonfida/spl-name-service` SDK (as of writing) does not support `.skr`.
2. **Third-party indexer** (Helius, Shyft, Solscan) that has indexed `.skr`. None confirmed to exist.
3. **A Seeker first-party REST endpoint.** If one exists it is not public-facing.

The cascade falls through to `.sol` (which IS implemented end-to-end) and then to wallet-label / truncated pubkey, so `.skr` holders still get a valid pill — just without the Seeker-verified glow border until Liam supplies a program ID or endpoint. The `resolveSkr` function is the single edit point when that information lands.

## Plan reference

Implementation followed `tmp/next-demo-features-plan.md` Sections F3, F1 (Option B), and F5.

## Test plan

- [ ] **F3 — cooldown error visibility:** Trigger a whisper inside the 10-minute cooldown window in `SteeringConsoleScreen`. Confirm the error text now wraps fully rather than truncating after one line. Repeat in `StrategyEditorScreen` by triggering its error path (e.g. signature decline).
- [ ] **F1 — Whispers tabs:** Open the Whispers inbox. Confirm the new "WHISPERS / STRATEGY & NOTES" tab row renders above the filter row. Tap "STRATEGY & NOTES" → app navigates to `StrategyEditorScreen` for that clan. Tap back → returns to Whispers with Tab 0 (WHISPERS) selected.
- [ ] **F5 — wallet name cascade:** Connect a wallet whose pubkey owns a `.sol` name via Bonfida. Confirm wallet pill renders `<name>.sol` shortly after connect (instead of "elderkeep.skr" mock or truncated pubkey). Connect a wallet with no `.sol` name → pill renders wallet label or truncated pubkey. Disconnect + reconnect a different wallet → no stale name carries over.
- [x] **`./gradlew :app:assembleDebug --no-daemon`** — BUILD SUCCESSFUL in 23s on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)