### PR TITLE
[codex] Publish Android release and debug APKs

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,9 +1,7 @@
-# NOTE: this workflow currently builds an UNSIGNED debug APK
-# (`assembleDebug`), not a signed release artifact. The job name reflects that
-# so the GitHub UI doesn't imply a signed Play-Store-ready build is being cut.
-# When release signing is provisioned, switch to `assembleRelease` + signing
-# config and rename this back to "Android Release".
-name: Android Internal Build (Debug APK)
+# Builds the public release APK and a separate internal debug APK. The release
+# APK keeps the public package id (`world.clan.app`); debug uses
+# `world.clan.app.debug` so it can be installed beside release builds.
+name: Android APK Release
 
 on:
   push:
@@ -22,7 +20,7 @@ permissions:
   attestations: write
 
 jobs:
-  build-debug-apks:
+  build-apks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,46 +40,65 @@ jobs:
           else
             version="${GITHUB_REF_NAME}"
           fi
+          semver="${version#v}"
+          if ! [[ "$semver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error ::Android APK versions must be semver tags like v2.3.2; got '${version}'."
+            exit 1
+          fi
+          IFS=. read -r major minor patch <<< "$semver"
+          version_code=$((major * 1000000 + minor * 1000 + patch))
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "version_name=${semver}" >> "$GITHUB_OUTPUT"
+          echo "version_code=${version_code}" >> "$GITHUB_OUTPUT"
 
       - name: Decode signing keystore
         id: keystore
         run: |
+          if [ -z "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" ]; then
+            echo "::error ::RELEASE_KEYSTORE_BASE64 is required to build the public release APK."
+            exit 1
+          fi
           path="$RUNNER_TEMP/release.keystore"
           echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 --decode > "$path"
           echo "path=$path" >> "$GITHUB_OUTPUT"
 
-      - name: Build Clan World APK
+      - name: Build Clan World APKs
         id: build-clan-world
-        continue-on-error: true
         working-directory: apps/clan-world-mobile
         env:
           # build.gradle.kts now refuses to fall back to a hardcoded URL —
           # promote these to actual repo secrets when prod URLs change.
           CLAN_WORLD_MAP_URL: ${{ secrets.CLAN_WORLD_MAP_URL || 'https://app.clan-world.com' }}
           CLAN_WORLD_TERMINAL_BASE_URL: ${{ secrets.CLAN_WORLD_TERMINAL_BASE_URL || 'https://cockpit.clan-world.com' }}
+          CLAN_WORLD_VERSION_NAME: ${{ steps.release.outputs.version_name }}
+          CLAN_WORLD_VERSION_CODE: ${{ steps.release.outputs.version_code }}
           RELEASE_KEYSTORE_PATH: ${{ steps.keystore.outputs.path }}
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-        run: ./gradlew --no-daemon assembleDebug
+        run: ./gradlew --no-daemon assembleRelease assembleDebug
 
       - name: Prepare release assets
         id: prepare-assets
         run: |
           mkdir -p release-assets
-          # continue-on-error on the build step means a failed build leaves
-          # no APK at the expected path, so we test before copying.
+          if [ -f apps/clan-world-mobile/app/build/outputs/apk/release/app-release.apk ]; then
+            cp apps/clan-world-mobile/app/build/outputs/apk/release/app-release.apk \
+              "release-assets/clan-world-${{ steps.release.outputs.version }}-release.apk"
+          else
+            echo "::error ::Clan World release APK missing — nothing to release."
+            exit 1
+          fi
           if [ -f apps/clan-world-mobile/app/build/outputs/apk/debug/app-debug.apk ]; then
             cp apps/clan-world-mobile/app/build/outputs/apk/debug/app-debug.apk \
               "release-assets/clan-world-${{ steps.release.outputs.version }}-debug.apk"
           else
-            echo "::error ::Clan World APK missing — nothing to release."
+            echo "::error ::Clan World debug APK missing — nothing to release."
             exit 1
           fi
           cd release-assets
           sha256sum *.apk > SHA256SUMS.txt
-          echo "::notice ::Shipping clan-world APK in release ${{ steps.release.outputs.version }}."
+          echo "::notice ::Shipping clan-world release and debug APKs in ${{ steps.release.outputs.version }}."
 
       - name: Attest APK build provenance
         continue-on-error: true

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -41,12 +41,23 @@ jobs:
             version="${GITHUB_REF_NAME}"
           fi
           semver="${version#v}"
-          if ! [[ "$semver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if ! [[ "$semver" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "::error ::Android APK versions must be semver tags like v2.3.2; got '${version}'."
             exit 1
           fi
           IFS=. read -r major minor patch <<< "$semver"
+          major=$((10#$major))
+          minor=$((10#$minor))
+          patch=$((10#$patch))
+          if [ "$minor" -ge 1000 ] || [ "$patch" -ge 1000 ]; then
+            echo "::error ::Android APK version minor and patch must be below 1000 to avoid versionCode collisions; got '${semver}'."
+            exit 1
+          fi
           version_code=$((major * 1000000 + minor * 1000 + patch))
+          if [ "$version_code" -gt 2100000000 ]; then
+            echo "::error ::Android APK versionCode must be <= 2100000000; got '${version_code}' from '${semver}'."
+            exit 1
+          fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "version_name=${semver}" >> "$GITHUB_OUTPUT"
           echo "version_code=${version_code}" >> "$GITHUB_OUTPUT"

--- a/apps/clan-world-mobile/README.md
+++ b/apps/clan-world-mobile/README.md
@@ -38,16 +38,26 @@ The full reasoning is in `/home/claude/.claude/plans/my-purpose-here-is-delightf
 ```sh
 # From the worktree root:
 cd apps/clan-world-mobile
-ANDROID_HOME=/opt/android-sdk ./gradlew assembleDebug
+ANDROID_HOME=/opt/android-sdk \
+  CLAN_WORLD_MAP_URL=https://app.clan-world.com \
+  CLAN_WORLD_TERMINAL_BASE_URL=https://cockpit.clan-world.com \
+  CLAN_WORLD_VERSION_NAME=2.3.3 \
+  CLAN_WORLD_VERSION_CODE=2003003 \
+  ./gradlew assembleDebug
 
 # APK lands at:
 ls app/build/outputs/apk/debug/app-debug.apk
 ```
 
+Release tags build two GitHub release artifacts:
+
+- `clan-world-vX.Y.Z-release.apk` — public app id `world.clan.app`, stable-signed, non-debuggable.
+- `clan-world-vX.Y.Z-debug.apk` — internal app id `world.clan.app.debug`, debuggable, side-by-side installable.
+
 Optionally, point the app at a different Convex deployment:
 
 ```sh
-CLANWORLD_CONVEX_URL=https://your-deploy.convex.cloud ./gradlew assembleDebug
+CLAN_WORLD_CONVEX_URL=https://your-deploy.convex.cloud ./gradlew assembleDebug
 ```
 
 ## Architecture

--- a/apps/clan-world-mobile/app/build.gradle.kts
+++ b/apps/clan-world-mobile/app/build.gradle.kts
@@ -33,13 +33,26 @@ fun resolveBuildConfigUrl(envName: String, propName: String): String {
   )
 }
 
+fun optionalEnvOrProperty(envName: String, propName: String): String? =
+  System.getenv(envName)?.takeIf { it.isNotBlank() }
+    ?: (project.findProperty(propName) as? String)?.takeIf { it.isNotBlank() }
+
 val mapUrl = resolveBuildConfigUrl("CLAN_WORLD_MAP_URL", "clanWorldMapUrl")
 val terminalBaseUrl = resolveBuildConfigUrl("CLAN_WORLD_TERMINAL_BASE_URL", "clanWorldTerminalBaseUrl")
 val convexUrl = providers.environmentVariable("CLAN_WORLD_CONVEX_URL")
   .orElse("https://valuable-kudu-985.convex.cloud")
+val clanWorldVersionName = optionalEnvOrProperty("CLAN_WORLD_VERSION_NAME", "clanWorldVersionName")
+  ?: "0.0.0-local"
+val clanWorldVersionCode = optionalEnvOrProperty("CLAN_WORLD_VERSION_CODE", "clanWorldVersionCode")
+  ?.toIntOrNull()
+  ?: 1
 
-// for details — both apps share the same secret names so one CI step can
-// provision both.
+require(clanWorldVersionCode > 0) {
+  "CLAN_WORLD_VERSION_CODE / clanWorldVersionCode must be a positive integer."
+}
+
+// Release signing is required only for release APKs. Debug builds use the
+// normal Android debug key and the `.debug` app id suffix.
 val releaseKeystorePath: String? = System.getenv("RELEASE_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }
 val releaseKeystorePassword: String? = System.getenv("RELEASE_KEYSTORE_PASSWORD")
 val releaseKeyAlias: String? = System.getenv("RELEASE_KEY_ALIAS")
@@ -57,8 +70,8 @@ android {
     applicationId = "world.clan.app"
     minSdk = 26
     targetSdk = 35
-    versionCode = 7
-    versionName = "0.1.14"
+    versionCode = clanWorldVersionCode
+    versionName = clanWorldVersionName
     buildConfigField("String", "MAP_URL", "\"$mapUrl\"")
     buildConfigField("String", "TERMINAL_BASE_URL", "\"$terminalBaseUrl\"")
     buildConfigField("String", "CONVEX_URL", "\"${convexUrl.get()}\"")
@@ -78,6 +91,11 @@ android {
 
   buildTypes {
     debug {
+      applicationIdSuffix = ".debug"
+      versionNameSuffix = "-debug"
+    }
+    release {
+      isMinifyEnabled = false
       if (hasStableSigning) {
         signingConfig = signingConfigs.getByName("stable")
       }
@@ -104,6 +122,16 @@ android {
     resources {
       excludes += "/META-INF/{AL2.0,LGPL2.1}"
     }
+  }
+}
+
+gradle.taskGraph.whenReady {
+  val releaseTaskRequested = allTasks.any { it.name.contains("Release") }
+  if (releaseTaskRequested && !hasStableSigning) {
+    error(
+      "Release APK builds require RELEASE_KEYSTORE_PATH, RELEASE_KEYSTORE_PASSWORD, " +
+        "RELEASE_KEY_ALIAS, and RELEASE_KEY_PASSWORD.",
+    )
   }
 }
 

--- a/apps/clan-world-mobile/app/build.gradle.kts
+++ b/apps/clan-world-mobile/app/build.gradle.kts
@@ -44,7 +44,10 @@ val convexUrl = providers.environmentVariable("CLAN_WORLD_CONVEX_URL")
 val clanWorldVersionName = optionalEnvOrProperty("CLAN_WORLD_VERSION_NAME", "clanWorldVersionName")
   ?: "0.0.0-local"
 val clanWorldVersionCode = optionalEnvOrProperty("CLAN_WORLD_VERSION_CODE", "clanWorldVersionCode")
-  ?.toIntOrNull()
+  ?.let { value ->
+    value.toIntOrNull()
+      ?: error("CLAN_WORLD_VERSION_CODE / clanWorldVersionCode must be a valid integer, but found: '$value'.")
+  }
   ?: 1
 
 require(clanWorldVersionCode > 0) {
@@ -95,7 +98,12 @@ android {
       versionNameSuffix = "-debug"
     }
     release {
-      isMinifyEnabled = false
+      isMinifyEnabled = true
+      isShrinkResources = true
+      proguardFiles(
+        getDefaultProguardFile("proguard-android-optimize.txt"),
+        "proguard-rules.pro",
+      )
       if (hasStableSigning) {
         signingConfig = signingConfigs.getByName("stable")
       }
@@ -126,7 +134,15 @@ android {
 }
 
 gradle.taskGraph.whenReady {
-  val releaseTaskRequested = allTasks.any { it.name.contains("Release") }
+  val releaseTaskRequested = gradle.startParameter.taskNames.any { requested ->
+    val name = requested.substringAfterLast(":")
+    name == "assemble" ||
+      name == "build" ||
+      name == "assembleRelease" ||
+      name == "bundleRelease" ||
+      name == "installRelease" ||
+      name == "packageRelease"
+  }
   if (releaseTaskRequested && !hasStableSigning) {
     error(
       "Release APK builds require RELEASE_KEYSTORE_PATH, RELEASE_KEYSTORE_PASSWORD, " +

--- a/apps/clan-world-mobile/app/proguard-rules.pro
+++ b/apps/clan-world-mobile/app/proguard-rules.pro
@@ -1,0 +1,7 @@
+# Keep app-specific release rules here if R8 exposes reflection/runtime needs.
+
+# Tink references Error Prone annotations used only at compile time.
+-dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue
+-dontwarn com.google.errorprone.annotations.CheckReturnValue
+-dontwarn com.google.errorprone.annotations.Immutable
+-dontwarn com.google.errorprone.annotations.RestrictedApi

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/HearthScreen.kt
@@ -26,8 +26,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -286,12 +290,12 @@ private fun HearthBanner(
           Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             Text("TICK", style = ClanWorldTheme.type.monoMicro, color = gold)
             if (nextTickAtEpochMs != null) {
-              val countdownMs by androidx.compose.runtime.produceState(
-                initialValue = (nextTickAtEpochMs - System.currentTimeMillis()).coerceAtLeast(0L),
-                key1 = nextTickAtEpochMs,
-              ) {
+              var countdownMs by remember(nextTickAtEpochMs) {
+                mutableStateOf((nextTickAtEpochMs - System.currentTimeMillis()).coerceAtLeast(0L))
+              }
+              LaunchedEffect(nextTickAtEpochMs) {
                 while (true) {
-                  value = (nextTickAtEpochMs - System.currentTimeMillis()).coerceAtLeast(0L)
+                  countdownMs = (nextTickAtEpochMs - System.currentTimeMillis()).coerceAtLeast(0L)
                   kotlinx.coroutines.delay(1000L)
                 }
               }


### PR DESCRIPTION
## What changed

- Builds both Android APK variants from release tags: a public `release` APK and a separate internal `debug` APK.
- Derives Android `versionName` and monotonically increasing `versionCode` from the GitHub release tag instead of hardcoding stale `0.1.14` / `7` metadata.
- Keeps the public package id as `world.clan.app`, while debug now installs as `world.clan.app.debug` so it can live beside the public app.
- Requires release signing secrets for release APKs and prevents unsigned public artifacts from being published.
- Documents local debug build inputs and the two GitHub release artifacts.

## Why

The latest GitHub APK was named `v2.3.2` but internally reported `versionCode=7` and `versionName=0.1.14`, which can make Android reject updates as an invalid package when a device has a newer installed build. Publishing a real signed release APK with current version metadata fixes the update path, and keeping debug separate avoids poisoning public installs.

## Validation

- `git diff --check`
- `ANDROID_HOME=/opt/android-sdk CLAN_WORLD_MAP_URL=https://app.clan-world.com CLAN_WORLD_TERMINAL_BASE_URL=https://cockpit.clan-world.com CLAN_WORLD_VERSION_NAME=2.3.3 CLAN_WORLD_VERSION_CODE=2003003 ./gradlew --no-daemon assembleDebug`
- `ANDROID_HOME=/opt/android-sdk CLAN_WORLD_MAP_URL=https://app.clan-world.com CLAN_WORLD_TERMINAL_BASE_URL=https://cockpit.clan-world.com CLAN_WORLD_VERSION_NAME=2.3.3 CLAN_WORLD_VERSION_CODE=2003003 RELEASE_KEYSTORE_PATH=/tmp/clan-world-test-release.jks RELEASE_KEYSTORE_PASSWORD=android-test-pass RELEASE_KEY_ALIAS=clan-world-test RELEASE_KEY_PASSWORD=android-test-pass ./gradlew --no-daemon assembleRelease`
- Inspected APK metadata with `aapt` / `apksigner`:
  - debug: `world.clan.app.debug`, `versionCode=2003003`, `versionName=2.3.3-debug`, Android debug cert
  - release: `world.clan.app`, `versionCode=2003003`, `versionName=2.3.3`, throwaway test release cert
