### PR TITLE
[codex] Block fake wallet in Android release

### DIFF
--- a/apps/clan-world-mobile/README.md
+++ b/apps/clan-world-mobile/README.md
@@ -27,7 +27,7 @@ Five screens, all matching `design/slice-1-prototype.html` 1:1:
 |---|---|
 | Visual design | **Real** — Compose mirrors the HTML prototype |
 | Convex queries | **Real** — `getSnapshot`, `getInftDemoState`, `getCombinedComms`, `getVaultMovements`, `bulletins.getByClan` |
-| Solana MWA | **Stubbed** — `MwaClient.kt` returns a deterministic fake pubkey after a 1.2s delay. Slice 2 will wire the real artifact. |
+| Solana MWA | **Real** — `MwaClient.kt` uses Solana Mobile Wallet Adapter. Release builds reject fake/test wallets after wallet authorization metadata returns; debug builds allow them for local testing. |
 | EVM wallet / iNFT ownership | **N/A** — this slice is Solana-only UX; the user's "linked" iNFTs are a hardcoded `linkedClanIds = [2, 6, 5]` in `HearthViewModel` |
 | Cockpit WebView | **Preserved** as `CockpitActivity`, no longer the launcher; reachable via `adb shell am start -n world.clan.app/.CockpitActivity` |
 
@@ -77,7 +77,8 @@ app/src/main/java/world/clan/app/
 │   ├── ConvexModels.kt          @Serializable response shapes
 │   └── SessionStore.kt          EncryptedSharedPreferences wrapper
 ├── wallet/
-│   ├── MwaClient.kt             SLICE 1: stub. SLICE 2: real MWA.
+│   ├── MwaClient.kt             Real Solana Mobile Wallet Adapter wrapper
+│   ├── FakeWalletPolicy.kt      Release-only fake/test wallet rejection
 │   ├── DeviceCapabilities.kt    Seeker / Seed Vault detection
 │   └── Base58.kt                Standalone Base58 encoder
 └── viewmodel/                   One ViewModel per screen, StateFlow-driven
@@ -108,7 +109,6 @@ Both files come from `github.com/google/fonts` and ship under SIL OFL-1.1.
 
 ## Slice 2 punch list
 
-- Real MWA (replace `MwaClient` stub)
 - Cockpit WebView with `window.__clanworld` injection
 - Cross-chain identity link (Solana pubkey ↔ clan owner address)
 - Pull-to-refresh on Hearth/Hall

--- a/apps/clan-world-mobile/app/build.gradle.kts
+++ b/apps/clan-world-mobile/app/build.gradle.kts
@@ -78,6 +78,7 @@ android {
     buildConfigField("String", "MAP_URL", "\"$mapUrl\"")
     buildConfigField("String", "TERMINAL_BASE_URL", "\"$terminalBaseUrl\"")
     buildConfigField("String", "CONVEX_URL", "\"${convexUrl.get()}\"")
+    buildConfigField("Boolean", "ALLOW_FAKE_WALLETS", "false")
     vectorDrawables { useSupportLibrary = true }
   }
 
@@ -96,8 +97,10 @@ android {
     debug {
       applicationIdSuffix = ".debug"
       versionNameSuffix = "-debug"
+      buildConfigField("Boolean", "ALLOW_FAKE_WALLETS", "true")
     }
     release {
+      buildConfigField("Boolean", "ALLOW_FAKE_WALLETS", "false")
       isMinifyEnabled = true
       isShrinkResources = true
       proguardFiles(

--- a/apps/clan-world-mobile/app/build.gradle.kts
+++ b/apps/clan-world-mobile/app/build.gradle.kts
@@ -78,7 +78,7 @@ android {
     buildConfigField("String", "MAP_URL", "\"$mapUrl\"")
     buildConfigField("String", "TERMINAL_BASE_URL", "\"$terminalBaseUrl\"")
     buildConfigField("String", "CONVEX_URL", "\"${convexUrl.get()}\"")
-    buildConfigField("Boolean", "ALLOW_FAKE_WALLETS", "false")
+    buildConfigField("boolean", "ALLOW_FAKE_WALLETS", "false")
     vectorDrawables { useSupportLibrary = true }
   }
 
@@ -97,10 +97,10 @@ android {
     debug {
       applicationIdSuffix = ".debug"
       versionNameSuffix = "-debug"
-      buildConfigField("Boolean", "ALLOW_FAKE_WALLETS", "true")
+      buildConfigField("boolean", "ALLOW_FAKE_WALLETS", "true")
     }
     release {
-      buildConfigField("Boolean", "ALLOW_FAKE_WALLETS", "false")
+      buildConfigField("boolean", "ALLOW_FAKE_WALLETS", "false")
       isMinifyEnabled = true
       isShrinkResources = true
       proguardFiles(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/Mwa.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/Mwa.kt
@@ -8,6 +8,7 @@ import com.solana.mobilewalletadapter.clientlib.Solana
 import com.solana.mobilewalletadapter.clientlib.TransactionResult
 import world.clan.app.BuildConfig
 import world.clan.app.data.Elder
+import world.clan.app.wallet.FakeWalletBlockedException
 import world.clan.app.wallet.FakeWalletPolicy
 
 /**
@@ -50,6 +51,14 @@ object Mwa {
       .toByteArray(Charsets.UTF_8)
 
     val outcome: TransactionResult<ByteArray> = mwa.transact(sender) { authResult ->
+      if (
+        FakeWalletPolicy.shouldBlock(
+          allowFakeWallets = BuildConfig.ALLOW_FAKE_WALLETS,
+          walletUriBase = authResult.walletUriBase?.toString(),
+        )
+      ) {
+        throw FakeWalletBlockedException()
+      }
       val account = authResult.accounts.firstOrNull()
         ?: error("No account returned from wallet authorization")
       val signed = signMessagesDetached(
@@ -62,23 +71,16 @@ object Mwa {
     }
 
     return when (outcome) {
-      is TransactionResult.Success -> {
-        val auth = outcome.authResult
-        val account = auth.accounts.firstOrNull()
-        if (
-          FakeWalletPolicy.shouldBlock(
-            allowFakeWallets = BuildConfig.ALLOW_FAKE_WALLETS,
-            walletUriBase = auth.walletUriBase?.toString(),
-            walletLabel = account?.accountLabel,
-          )
-        ) {
-          SignInResult.Failed(FakeWalletPolicy.BLOCKED_MESSAGE)
-        } else {
-          SignInResult.Success
-        }
-      }
+      is TransactionResult.Success -> SignInResult.Success
       is TransactionResult.NoWalletFound   -> SignInResult.Failed("No Solana wallet found")
-      is TransactionResult.Failure         -> SignInResult.Failed(outcome.e.message ?: "Sign-in failed")
+      is TransactionResult.Failure         -> {
+        val message = if (outcome.e is FakeWalletBlockedException) {
+          FakeWalletPolicy.BLOCKED_MESSAGE
+        } else {
+          outcome.e.message ?: "Sign-in failed"
+        }
+        SignInResult.Failed(message)
+      }
     }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/Mwa.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/Mwa.kt
@@ -1,19 +1,19 @@
 package world.clan.app.owner
 
 import android.net.Uri
-import androidx.activity.ComponentActivity
 import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
 import com.solana.mobilewalletadapter.clientlib.ConnectionIdentity
 import com.solana.mobilewalletadapter.clientlib.MobileWalletAdapter
 import com.solana.mobilewalletadapter.clientlib.Solana
 import com.solana.mobilewalletadapter.clientlib.TransactionResult
+import world.clan.app.BuildConfig
 import world.clan.app.data.Elder
+import world.clan.app.wallet.FakeWalletPolicy
 
 /**
  * Real Mobile Wallet Adapter (Solana) sign-in. The user's installed
- * wallet (Phantom / Solflare / fakewallet) returns a signed message;
- * we do **not** verify the signature — any successful return is treated
- * as "signed in" per the demo spec.
+ * wallet returns a signed message; we do **not** verify the signature —
+ * any successful return is treated as "signed in" per the demo spec.
  *
  * On no-wallet-installed or user-cancelled, returns [SignInResult.Failed].
  */
@@ -62,7 +62,21 @@ object Mwa {
     }
 
     return when (outcome) {
-      is TransactionResult.Success         -> SignInResult.Success
+      is TransactionResult.Success -> {
+        val auth = outcome.authResult
+        val account = auth.accounts.firstOrNull()
+        if (
+          FakeWalletPolicy.shouldBlock(
+            allowFakeWallets = BuildConfig.ALLOW_FAKE_WALLETS,
+            walletUriBase = auth.walletUriBase?.toString(),
+            walletLabel = account?.accountLabel,
+          )
+        ) {
+          SignInResult.Failed(FakeWalletPolicy.BLOCKED_MESSAGE)
+        } else {
+          SignInResult.Success
+        }
+      }
       is TransactionResult.NoWalletFound   -> SignInResult.Failed("No Solana wallet found")
       is TransactionResult.Failure         -> SignInResult.Failed(outcome.e.message ?: "Sign-in failed")
     }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
@@ -44,6 +44,7 @@ import world.clan.app.ui.theme.Ink3
 import world.clan.app.ui.theme.clanColor
 import world.clan.app.ui.theme.clanGlyphRes
 import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.wallet.FakeWalletPolicy
 import world.clan.app.wallet.MwaResult
 
 /**
@@ -131,6 +132,10 @@ fun HireModal(
                 }
                 is MwaResult.UserDeclined -> {
                   state.value = HireState.Idle
+                }
+                is MwaResult.WalletNotAllowed -> {
+                  state.value = HireState.Failed
+                  errorMessage.value = FakeWalletPolicy.BLOCKED_MESSAGE
                 }
                 is MwaResult.Error -> {
                   state.value = HireState.Failed

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -70,6 +70,7 @@ import world.clan.app.viewmodel.Harness
 import world.clan.app.viewmodel.SendPhase
 import world.clan.app.viewmodel.clanDisplayName
 import world.clan.app.viewmodel.clanTagline
+import world.clan.app.wallet.FakeWalletPolicy
 import world.clan.app.wallet.MwaResult
 
 @Composable
@@ -114,6 +115,8 @@ fun ForgeScreenRoute(
           is MwaResult.UserDeclined -> vm.setMintPhase(SendPhase.Idle)
           is MwaResult.WalletNotFound ->
             vm.setMintPhase(SendPhase.Failed, "no wallet found on device.")
+          is MwaResult.WalletNotAllowed ->
+            vm.setMintPhase(SendPhase.Failed, FakeWalletPolicy.BLOCKED_MESSAGE)
           is MwaResult.Error ->
             vm.setMintPhase(SendPhase.Failed, r.cause.message ?: "the wallet refused the seal.")
         }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -57,6 +57,7 @@ import world.clan.app.viewmodel.SteeringConsoleUiState
 import world.clan.app.viewmodel.SteeringConsoleViewModel
 import world.clan.app.viewmodel.SteeringConsoleViewModelFactory
 import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.wallet.FakeWalletPolicy
 import world.clan.app.wallet.MwaResult
 
 private const val WHISPER_COOLDOWN_MS = 10L * 60L * 1000L  // 10 minutes
@@ -128,6 +129,7 @@ fun SteeringConsoleScreenRoute(
           }
           is MwaResult.UserDeclined -> vm.setSending(false)
           is MwaResult.WalletNotFound -> vm.setError("no wallet found on device.")
+          is MwaResult.WalletNotAllowed -> vm.setError(FakeWalletPolicy.BLOCKED_MESSAGE)
           is MwaResult.Error -> vm.setError(
             result.cause.message ?: "the wallet refused the seal.",
           )

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
@@ -66,6 +66,7 @@ import world.clan.app.viewmodel.StrategyEditorUiState
 import world.clan.app.viewmodel.StrategyEditorViewModel
 import world.clan.app.viewmodel.StrategyEditorViewModelFactory
 import world.clan.app.viewmodel.clanDisplayName
+import world.clan.app.wallet.FakeWalletPolicy
 import world.clan.app.wallet.MwaResult
 
 private const val STRATEGY_LIMIT = 800
@@ -124,6 +125,8 @@ fun StrategyEditorScreenRoute(
           is MwaResult.UserDeclined -> vm.setSavePhase(SendPhase.Idle)
           is MwaResult.WalletNotFound ->
             vm.setSavePhase(SendPhase.Failed, "no wallet found on device.")
+          is MwaResult.WalletNotAllowed ->
+            vm.setSavePhase(SendPhase.Failed, FakeWalletPolicy.BLOCKED_MESSAGE)
           is MwaResult.Error ->
             vm.setSavePhase(SendPhase.Failed, result.cause.message ?: "the wallet refused the seal.")
         }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import world.clan.app.data.LineageStore
 import world.clan.app.data.Session
 import world.clan.app.data.SessionStore
+import world.clan.app.wallet.FakeWalletPolicy
 import world.clan.app.wallet.MwaClient
 import world.clan.app.wallet.MwaResult
 import world.clan.app.wallet.WalletIdentity
@@ -174,6 +175,18 @@ class ConnectViewModel(
             errorMessage = "No MWA-compatible Solana wallet installed.",
           )
         }
+      MwaResult.WalletNotAllowed -> {
+        sessionStore.clear()
+        clearWalletNameCache()
+        _state.update {
+          it.copy(
+            phase = ConnectUiState.Phase.Error,
+            solanaPubkeyBase58 = null,
+            pendingVerification = false,
+            errorMessage = FakeWalletPolicy.BLOCKED_MESSAGE,
+          )
+        }
+      }
       is MwaResult.Error -> {
         // Same rationale as UserDeclined: clear so we never retry a token
         // the wallet has rejected. A real network/IPC error will simply

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/FakeWalletPolicy.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/FakeWalletPolicy.kt
@@ -1,5 +1,9 @@
 package world.clan.app.wallet
 
+import java.util.Locale
+
+internal class FakeWalletBlockedException : RuntimeException(FakeWalletPolicy.BLOCKED_MESSAGE)
+
 object FakeWalletPolicy {
   const val BLOCKED_MESSAGE =
     "Test wallet is not supported in release builds. Choose Phantom, Solflare, or Seed Vault Wallet."
@@ -9,19 +13,18 @@ object FakeWalletPolicy {
   fun shouldBlock(
     allowFakeWallets: Boolean,
     walletUriBase: String?,
-    walletLabel: String?,
   ): Boolean {
     if (allowFakeWallets) return false
-    return isFakeWallet(walletUriBase, walletLabel)
+    return isFakeWallet(walletUriBase)
   }
 
-  fun isFakeWallet(walletUriBase: String?, walletLabel: String?): Boolean =
-    listOfNotNull(walletUriBase, walletLabel)
+  fun isFakeWallet(walletUriBase: String?): Boolean =
+    listOfNotNull(walletUriBase)
       .map(::normalize)
       .any { value ->
         value.contains("fakewallet") || value.contains("fakerwallet")
       }
 
   private fun normalize(value: String): String =
-    value.lowercase().filter(Char::isLetterOrDigit)
+    value.lowercase(Locale.ROOT).filter(Char::isLetterOrDigit)
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/FakeWalletPolicy.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/FakeWalletPolicy.kt
@@ -1,0 +1,27 @@
+package world.clan.app.wallet
+
+object FakeWalletPolicy {
+  const val BLOCKED_MESSAGE =
+    "Test wallet is not supported in release builds. Choose Phantom, Solflare, or Seed Vault Wallet."
+
+  // The MWA SDK launches Android's implicit solana-wallet chooser internally,
+  // so release builds enforce this after wallet authorization metadata returns.
+  fun shouldBlock(
+    allowFakeWallets: Boolean,
+    walletUriBase: String?,
+    walletLabel: String?,
+  ): Boolean {
+    if (allowFakeWallets) return false
+    return isFakeWallet(walletUriBase, walletLabel)
+  }
+
+  fun isFakeWallet(walletUriBase: String?, walletLabel: String?): Boolean =
+    listOfNotNull(walletUriBase, walletLabel)
+      .map(::normalize)
+      .any { value ->
+        value.contains("fakewallet") || value.contains("fakerwallet")
+      }
+
+  private fun normalize(value: String): String =
+    value.lowercase().filter(Char::isLetterOrDigit)
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/MwaClient.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/MwaClient.kt
@@ -6,6 +6,7 @@ import com.solana.mobilewalletadapter.clientlib.ConnectionIdentity
 import com.solana.mobilewalletadapter.clientlib.MobileWalletAdapter
 import com.solana.mobilewalletadapter.clientlib.Solana
 import com.solana.mobilewalletadapter.clientlib.TransactionResult
+import world.clan.app.BuildConfig
 
 /** Result of a connect / reauthorize call. */
 data class MwaSession(
@@ -19,12 +20,13 @@ sealed class MwaResult<out T> {
   data class Ok<T>(val value: T) : MwaResult<T>()
   data object UserDeclined : MwaResult<Nothing>()
   data object WalletNotFound : MwaResult<Nothing>()
+  data object WalletNotAllowed : MwaResult<Nothing>()
   data class Error(val cause: Throwable) : MwaResult<Nothing>()
 }
 
 /**
  * Thin wrapper around the Solana Mobile Wallet Adapter Kotlin client
- * (`com.solanamobile:mobile-wallet-adapter-clientlib-ktx:2.1.0`).
+ * (`com.solanamobile:mobile-wallet-adapter-clientlib-ktx:2.0.7`).
  *
  * Slice 2A — replaces the slice 1 stub with real authorize/reauthorize/
  * disconnect calls. signMessage is wired but unused; slice 2 (full) will
@@ -105,7 +107,21 @@ class MwaClient(
       signed.messages.first().signatures.first()
     }
     return when (result) {
-      is TransactionResult.Success -> MwaResult.Ok(result.payload)
+      is TransactionResult.Success -> {
+        val auth = result.authResult
+        val account = auth.accounts.firstOrNull()
+        if (
+          FakeWalletPolicy.shouldBlock(
+            allowFakeWallets = BuildConfig.ALLOW_FAKE_WALLETS,
+            walletUriBase = auth.walletUriBase?.toString(),
+            walletLabel = account?.accountLabel,
+          )
+        ) {
+          MwaResult.WalletNotAllowed
+        } else {
+          MwaResult.Ok(result.payload)
+        }
+      }
       is TransactionResult.NoWalletFound -> MwaResult.WalletNotFound
       is TransactionResult.Failure -> classifyFailure(result)
     }
@@ -124,14 +140,19 @@ class MwaClient(
       if (account == null) {
         MwaResult.Error(IllegalStateException("MWA returned no authorized account"))
       } else {
-        MwaResult.Ok(
-          MwaSession(
-            solanaPubkeyBase58 = Base58.encode(account.publicKey),
-            authToken = auth.authToken,
-            walletUriBase = auth.walletUriBase?.toString(),
-            walletLabel = account.accountLabel,
-          ),
+        val session = MwaSession(
+          solanaPubkeyBase58 = Base58.encode(account.publicKey),
+          authToken = auth.authToken,
+          walletUriBase = auth.walletUriBase?.toString(),
+          walletLabel = account.accountLabel,
         )
+        if (
+          FakeWalletPolicy.shouldBlock(
+            allowFakeWallets = BuildConfig.ALLOW_FAKE_WALLETS,
+            walletUriBase = session.walletUriBase,
+            walletLabel = session.walletLabel,
+          )
+        ) MwaResult.WalletNotAllowed else MwaResult.Ok(session)
       }
     }
     is TransactionResult.NoWalletFound -> MwaResult.WalletNotFound

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/MwaClient.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/MwaClient.kt
@@ -102,26 +102,21 @@ class MwaClient(
   ): MwaResult<ByteArray> {
     val a = adapter().apply { this.authToken = authToken }
     val result: TransactionResult<ByteArray> = a.transact(sender) { authResult ->
-      val pubkey = authResult.accounts.first().publicKey
-      val signed = signMessagesDetached(arrayOf(message), arrayOf(pubkey))
+      if (
+        FakeWalletPolicy.shouldBlock(
+          allowFakeWallets = BuildConfig.ALLOW_FAKE_WALLETS,
+          walletUriBase = authResult.walletUriBase?.toString(),
+        )
+      ) {
+        throw FakeWalletBlockedException()
+      }
+      val account = authResult.accounts.firstOrNull()
+        ?: error("MWA returned no authorized account")
+      val signed = signMessagesDetached(arrayOf(message), arrayOf(account.publicKey))
       signed.messages.first().signatures.first()
     }
     return when (result) {
-      is TransactionResult.Success -> {
-        val auth = result.authResult
-        val account = auth.accounts.firstOrNull()
-        if (
-          FakeWalletPolicy.shouldBlock(
-            allowFakeWallets = BuildConfig.ALLOW_FAKE_WALLETS,
-            walletUriBase = auth.walletUriBase?.toString(),
-            walletLabel = account?.accountLabel,
-          )
-        ) {
-          MwaResult.WalletNotAllowed
-        } else {
-          MwaResult.Ok(result.payload)
-        }
-      }
+      is TransactionResult.Success -> MwaResult.Ok(result.payload)
       is TransactionResult.NoWalletFound -> MwaResult.WalletNotFound
       is TransactionResult.Failure -> classifyFailure(result)
     }
@@ -150,9 +145,12 @@ class MwaClient(
           FakeWalletPolicy.shouldBlock(
             allowFakeWallets = BuildConfig.ALLOW_FAKE_WALLETS,
             walletUriBase = session.walletUriBase,
-            walletLabel = session.walletLabel,
           )
-        ) MwaResult.WalletNotAllowed else MwaResult.Ok(session)
+        ) {
+          MwaResult.WalletNotAllowed
+        } else {
+          MwaResult.Ok(session)
+        }
       }
     }
     is TransactionResult.NoWalletFound -> MwaResult.WalletNotFound
@@ -160,6 +158,9 @@ class MwaClient(
   }
 
   private fun <T> classifyFailure(result: TransactionResult.Failure<T>): MwaResult<Nothing> {
+    if (result.e is FakeWalletBlockedException) {
+      return MwaResult.WalletNotAllowed
+    }
     val msg = result.message.lowercase() + " " + (result.e.message?.lowercase().orEmpty())
     return if (
       "declin" in msg ||

--- a/apps/clan-world-mobile/app/src/test/java/world/clan/app/wallet/FakeWalletPolicyTest.kt
+++ b/apps/clan-world-mobile/app/src/test/java/world/clan/app/wallet/FakeWalletPolicyTest.kt
@@ -6,34 +6,31 @@ import org.junit.Test
 
 class FakeWalletPolicyTest {
   @Test
-  fun releaseBlocksFakeWalletLabels() {
-    assertTrue(
-      FakeWalletPolicy.shouldBlock(
-        allowFakeWallets = false,
-        walletUriBase = null,
-        walletLabel = "Fake Wallet app",
-      ),
-    )
-  }
-
-  @Test
   fun releaseBlocksFakeWalletUris() {
     assertTrue(
       FakeWalletPolicy.shouldBlock(
         allowFakeWallets = false,
         walletUriBase = "solana-wallet://com.solana.mobilewalletadapter.fakewallet",
-        walletLabel = "Test account",
       ),
     )
   }
 
   @Test
-  fun releaseBlocksFakerWalletSpelling() {
+  fun releaseBlocksFakerWalletUriSpelling() {
     assertTrue(
       FakeWalletPolicy.shouldBlock(
         allowFakeWallets = false,
-        walletUriBase = null,
-        walletLabel = "Faker Wallet",
+        walletUriBase = "solana-wallet://com.solana.mobilewalletadapter.fakerwallet",
+      ),
+    )
+  }
+
+  @Test
+  fun releaseNormalizesWalletUriBeforeMatching() {
+    assertTrue(
+      FakeWalletPolicy.shouldBlock(
+        allowFakeWallets = false,
+        walletUriBase = "solana-wallet://Fake-Wallet",
       ),
     )
   }
@@ -44,14 +41,18 @@ class FakeWalletPolicyTest {
       FakeWalletPolicy.shouldBlock(
         allowFakeWallets = false,
         walletUriBase = "phantom://wallet",
-        walletLabel = "Phantom",
       ),
     )
     assertFalse(
       FakeWalletPolicy.shouldBlock(
         allowFakeWallets = false,
         walletUriBase = "solflare://wallet",
-        walletLabel = "Solflare",
+      ),
+    )
+    assertFalse(
+      FakeWalletPolicy.shouldBlock(
+        allowFakeWallets = false,
+        walletUriBase = null,
       ),
     )
   }
@@ -62,7 +63,6 @@ class FakeWalletPolicyTest {
       FakeWalletPolicy.shouldBlock(
         allowFakeWallets = true,
         walletUriBase = "solana-wallet://fakewallet",
-        walletLabel = "Fake Wallet",
       ),
     )
   }

--- a/apps/clan-world-mobile/app/src/test/java/world/clan/app/wallet/FakeWalletPolicyTest.kt
+++ b/apps/clan-world-mobile/app/src/test/java/world/clan/app/wallet/FakeWalletPolicyTest.kt
@@ -1,0 +1,69 @@
+package world.clan.app.wallet
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FakeWalletPolicyTest {
+  @Test
+  fun releaseBlocksFakeWalletLabels() {
+    assertTrue(
+      FakeWalletPolicy.shouldBlock(
+        allowFakeWallets = false,
+        walletUriBase = null,
+        walletLabel = "Fake Wallet app",
+      ),
+    )
+  }
+
+  @Test
+  fun releaseBlocksFakeWalletUris() {
+    assertTrue(
+      FakeWalletPolicy.shouldBlock(
+        allowFakeWallets = false,
+        walletUriBase = "solana-wallet://com.solana.mobilewalletadapter.fakewallet",
+        walletLabel = "Test account",
+      ),
+    )
+  }
+
+  @Test
+  fun releaseBlocksFakerWalletSpelling() {
+    assertTrue(
+      FakeWalletPolicy.shouldBlock(
+        allowFakeWallets = false,
+        walletUriBase = null,
+        walletLabel = "Faker Wallet",
+      ),
+    )
+  }
+
+  @Test
+  fun releaseAllowsRealWalletMetadata() {
+    assertFalse(
+      FakeWalletPolicy.shouldBlock(
+        allowFakeWallets = false,
+        walletUriBase = "phantom://wallet",
+        walletLabel = "Phantom",
+      ),
+    )
+    assertFalse(
+      FakeWalletPolicy.shouldBlock(
+        allowFakeWallets = false,
+        walletUriBase = "solflare://wallet",
+        walletLabel = "Solflare",
+      ),
+    )
+  }
+
+  @Test
+  fun debugAllowsFakeWallets() {
+    assertFalse(
+      FakeWalletPolicy.shouldBlock(
+        allowFakeWallets = true,
+        walletUriBase = "solana-wallet://fakewallet",
+        walletLabel = "Fake Wallet",
+      ),
+    )
+  }
+}


### PR DESCRIPTION
## What changed

- Adds a release/debug BuildConfig split for fake wallet handling: release blocks, debug allows.
- Adds `FakeWalletPolicy` to detect Fake Wallet / Faker Wallet metadata returned by MWA after authorization.
- Returns a dedicated `MwaResult.WalletNotAllowed` from connect, reauthorize, and signMessage paths, and maps it to a clear user-facing error across wallet-gated screens.
- Applies the same release block to owner sign-in.
- Updates stale mobile README text that still described `MwaClient` as stubbed.

## Why

On Android, MWA launches an implicit `solana-wallet:` intent, so an installed “Fake Wallet” app can appear in the system chooser. The Solana MWA SDK does not expose a chooser-filter hook from our current wrapper path, so this PR rejects fake/test wallets once wallet metadata returns in release builds while preserving debug test workflows.

## Validation

- `ANDROID_HOME=/opt/android-sdk CLAN_WORLD_MAP_URL=https://app.clan-world.com CLAN_WORLD_TERMINAL_BASE_URL=https://cockpit.clan-world.com CLAN_WORLD_VERSION_NAME=2.3.4 CLAN_WORLD_VERSION_CODE=2003004 ./gradlew --no-daemon testDebugUnitTest`
- `ANDROID_HOME=/opt/android-sdk CLAN_WORLD_MAP_URL=https://app.clan-world.com CLAN_WORLD_TERMINAL_BASE_URL=https://cockpit.clan-world.com CLAN_WORLD_VERSION_NAME=2.3.4 CLAN_WORLD_VERSION_CODE=2003004 ./gradlew --no-daemon lintRelease`
- `ANDROID_HOME=/opt/android-sdk CLAN_WORLD_MAP_URL=https://app.clan-world.com CLAN_WORLD_TERMINAL_BASE_URL=https://cockpit.clan-world.com CLAN_WORLD_VERSION_NAME=2.3.4 CLAN_WORLD_VERSION_CODE=2003004 ./gradlew --no-daemon assembleDebug`
- `ANDROID_HOME=/opt/android-sdk CLAN_WORLD_MAP_URL=https://app.clan-world.com CLAN_WORLD_TERMINAL_BASE_URL=https://cockpit.clan-world.com CLAN_WORLD_VERSION_NAME=2.3.4 CLAN_WORLD_VERSION_CODE=2003004 RELEASE_KEYSTORE_PATH=/tmp/clan-world-test-release.jks RELEASE_KEYSTORE_PASSWORD=android-test-pass RELEASE_KEY_ALIAS=clan-world-test RELEASE_KEY_PASSWORD=android-test-pass ./gradlew --no-daemon assembleRelease`
- Inspected generated BuildConfig:
  - debug: `ALLOW_FAKE_WALLETS = true`
  - release: `ALLOW_FAKE_WALLETS = false`
