### PR TITLE
[codex] harden full game reset operations

### DIFF
--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type {
   FunctionReference,
 } from "convex/server";
 import type * as agentLogs from "../agentLogs.js";
+import type * as authShared from "../authShared.js";
 import type * as bulletins from "../bulletins.js";
 import type * as clansmen from "../clansmen.js";
 import type * as comms from "../comms.js";
@@ -28,6 +29,7 @@ import type * as inft from "../inft.js";
 import type * as kickstart from "../kickstart.js";
 import type * as memory from "../memory.js";
 import type * as mock from "../mock.js";
+import type * as ops from "../ops.js";
 import type * as vault from "../vault.js";
 
 /**
@@ -40,6 +42,7 @@ import type * as vault from "../vault.js";
  */
 declare const fullApi: ApiFromModules<{
   agentLogs: typeof agentLogs;
+  authShared: typeof authShared;
   bulletins: typeof bulletins;
   clansmen: typeof clansmen;
   comms: typeof comms;
@@ -54,6 +57,7 @@ declare const fullApi: ApiFromModules<{
   kickstart: typeof kickstart;
   memory: typeof memory;
   mock: typeof mock;
+  ops: typeof ops;
   vault: typeof vault;
 }>;
 export declare const api: FilterApi<

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -45,6 +45,10 @@ const LEGACY_REGIONS = [
 ];
 const indexerApi = (internal as any).indexer;
 
+function resetLocked(): boolean {
+  return process.env.CLANWORLD_RESET_LOCK === "true";
+}
+
 type ParsedIndexerEvent = {
   eventName: string;
   args: Record<string, unknown>;
@@ -297,6 +301,14 @@ export const ingestEvents = internalMutation({
     advanceCheckpoint: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
+    if (resetLocked()) {
+      return {
+        inserted: 0,
+        skipped: args.events.length,
+        resetLocked: true,
+      };
+    }
+
     let inserted = 0;
     for (const raw of args.events as ParsedIndexerEvent[]) {
       const logIndex = raw.logIndex ?? 0;
@@ -416,6 +428,14 @@ export const commitSnapshot = internalMutation({
     snapshot: snapshotValidator,
   },
   handler: async (ctx, args) => {
+    if (resetLocked()) {
+      return {
+        tick: 0,
+        clans: 0,
+        skipped: "reset-locked",
+      };
+    }
+
     const snapshot = args.snapshot as SnapshotPayload;
     const now = Date.now();
     const world = snapshot.world;
@@ -623,6 +643,10 @@ export const refreshSnapshot = internalAction({
     blockNumber: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<unknown> => {
+    if (resetLocked()) {
+      return { skipped: true, resetLocked: true };
+    }
+
     const client = createClient();
     const address = engineAddress();
     const pinnedBlockNumber =
@@ -665,9 +689,21 @@ export const refreshSnapshot = internalAction({
       return { tick: 0, clans: 0 };
     }
 
+    const clanIdsRaw = await client
+      .readContract({
+        address,
+        abi: CLAN_WORLD_ABI,
+        functionName: "getClanIds",
+        blockNumber: pinnedBlockNumber,
+      })
+      .catch(() => undefined);
+    const clanIds =
+      Array.isArray(clanIdsRaw) && clanIdsRaw.length > 0
+        ? clanIdsRaw.map((id) => asNumber(id)).filter((id) => id > 0)
+        : Array.from({ length: MAX_CLANS }, (_, index) => index + 1);
+
     const clans = await Promise.all(
-      Array.from({ length: MAX_CLANS }, async (_, index) => {
-        const clanId = index + 1;
+      clanIds.map(async (clanId) => {
         return client
           .readContract({
             address,
@@ -696,6 +732,10 @@ export const refreshSnapshot = internalAction({
 export const pollLogs = internalAction({
   args: {},
   handler: async (ctx): Promise<unknown> => {
+    if (resetLocked()) {
+      return { inserted: 0, skipped: true, resetLocked: true };
+    }
+
     const client = createClient();
     const address = engineAddress();
     const checkpoint = (await ctx.runQuery(indexerApi.readCheckpoint, {})) as {

--- a/apps/server/convex/ops.ts
+++ b/apps/server/convex/ops.ts
@@ -26,6 +26,8 @@ const RESET_TABLES = [
   "humanSteeringMessages",
 ] as const;
 
+const MAX_FLUSH_WRITES = 9000;
+
 export const flushGameState = mutation({
   args: {
     secret: v.string(),
@@ -34,12 +36,17 @@ export const flushGameState = mutation({
   handler: async (ctx, args) => {
     requireIndexerSecret(args.secret);
 
-    const batchSize = Math.max(1, Math.min(args.batchSize ?? 100, 500));
+    const batchSize = Math.max(1, Math.min(args.batchSize ?? 100, 400));
     const deletedByTable: Record<string, number> = {};
     let totalDeleted = 0;
 
     for (const table of RESET_TABLES) {
-      const rows = await ctx.db.query(table).take(batchSize);
+      if (totalDeleted >= MAX_FLUSH_WRITES) {
+        break;
+      }
+
+      const remainingWrites = MAX_FLUSH_WRITES - totalDeleted;
+      const rows = await ctx.db.query(table).take(Math.min(batchSize, remainingWrites));
       deletedByTable[table] = rows.length;
       totalDeleted += rows.length;
       for (const row of rows) {

--- a/apps/server/convex/ops.ts
+++ b/apps/server/convex/ops.ts
@@ -1,0 +1,79 @@
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+import { requireIndexerSecret } from "./authShared";
+
+const RESET_TABLES = [
+  "worldSnapshot",
+  "chainEvents",
+  "tickHistory",
+  "eventCheckpoint",
+  "clanView",
+  "marketState",
+  "banditView",
+  "pricePoint",
+  "goldQuote",
+  "goldQuoteSample",
+  "kickstartTokens",
+  "kickstartWatchedTokens",
+  "agentLogs",
+  "inftTokens",
+  "inftTransfers",
+  "memoryEntries",
+  "bulletins",
+  "memoryEvents",
+  "whispers",
+  "orchEvents",
+  "humanSteeringMessages",
+] as const;
+
+export const flushGameState = mutation({
+  args: {
+    secret: v.string(),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    requireIndexerSecret(args.secret);
+
+    const batchSize = Math.max(1, Math.min(args.batchSize ?? 100, 500));
+    const deletedByTable: Record<string, number> = {};
+    let totalDeleted = 0;
+
+    for (const table of RESET_TABLES) {
+      const rows = await ctx.db.query(table).take(batchSize);
+      deletedByTable[table] = rows.length;
+      totalDeleted += rows.length;
+      for (const row of rows) {
+        await ctx.db.delete(row._id);
+      }
+    }
+
+    return {
+      deletedByTable,
+      totalDeleted,
+      batchSize,
+      complete: totalDeleted === 0,
+    };
+  },
+});
+
+export const resetCheckpoint = mutation({
+  args: {
+    secret: v.string(),
+    lastBlock: v.number(),
+  },
+  handler: async (ctx, args) => {
+    requireIndexerSecret(args.secret);
+
+    const existing = await ctx.db.query("eventCheckpoint").first();
+    if (existing) {
+      await ctx.db.delete(existing._id);
+    }
+
+    await ctx.db.insert("eventCheckpoint", {
+      lastBlock: args.lastBlock,
+      lastSeenAt: Date.now(),
+    });
+
+    return { lastBlock: args.lastBlock };
+  },
+});

--- a/apps/server/convex/ops.ts
+++ b/apps/server/convex/ops.ts
@@ -54,11 +54,18 @@ export const flushGameState = mutation({
       }
     }
 
+    const complete =
+      totalDeleted < MAX_FLUSH_WRITES &&
+      (await Promise.all(RESET_TABLES.map((table) => ctx.db.query(table).take(1)))).every(
+        (rows) => rows.length === 0,
+      );
+
     return {
       deletedByTable,
       totalDeleted,
       batchSize,
-      complete: totalDeleted === 0,
+      deletedAny: totalDeleted > 0,
+      complete,
     };
   },
 });

--- a/apps/server/convex/ops.ts
+++ b/apps/server/convex/ops.ts
@@ -56,6 +56,34 @@ export const flushGameState = mutation({
   },
 });
 
+export const flushClanViewForClan = mutation({
+  args: {
+    secret: v.string(),
+    clanId: v.number(),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    requireIndexerSecret(args.secret);
+
+    const batchSize = Math.max(1, Math.min(args.batchSize ?? 100, 500));
+    const rows = await ctx.db
+      .query("clanView")
+      .withIndex("by_clanId", (q) => q.eq("clanId", args.clanId))
+      .take(batchSize);
+
+    for (const row of rows) {
+      await ctx.db.delete(row._id);
+    }
+
+    return {
+      clanId: args.clanId,
+      deleted: rows.length,
+      batchSize,
+      complete: rows.length === 0,
+    };
+  },
+});
+
 export const resetCheckpoint = mutation({
   args: {
     secret: v.string(),

--- a/docs/runbooks/full-game-reset.md
+++ b/docs/runbooks/full-game-reset.md
@@ -153,6 +153,13 @@ Flush all game/indexer state for the old realm. At minimum clear:
 
 Then trigger one indexer refresh or wait for the first heartbeat webhook.
 
+If the deployed backend includes `ops:flushGameState`, run it repeatedly until `complete` is `true`:
+
+```bash
+npx convex run ops:flushGameState '{"secret":"'"$INDEXER_SECRET"'","batchSize":500}' --prod
+npx convex run ops:resetCheckpoint '{"secret":"'"$INDEXER_SECRET"'","lastBlock":'"$INDEXER_START_BLOCK"'}' --prod
+```
+
 ## 6. Mint Four Clans
 
 Derive or load the four elder addresses, then mint one clan per elder:

--- a/docs/runbooks/full-game-reset.md
+++ b/docs/runbooks/full-game-reset.md
@@ -62,6 +62,15 @@ forge script script/Deploy.s.sol \
   --slow
 ```
 
+Before broadcasting, check deployable bytecode sizes. `--disable-code-size-limit`
+only helps local simulation; Base Sepolia still rejects oversized deployed
+libraries/facets under EIP-170.
+
+```bash
+cd packages/contracts
+forge build --sizes
+```
+
 Save:
 
 - Diamond address
@@ -112,7 +121,9 @@ Commit any generated ABI/type changes before redeploying the app.
 
 ## 5. Reconfigure And Flush Convex
 
-Set Convex production env values together:
+Set Convex env values together. Use `--prod` only for the production
+deployment; for the current V3 dev deployment (`valuable-kudu-985`), omit
+`--prod`.
 
 ```bash
 cd apps/server
@@ -121,8 +132,9 @@ npx convex env set SOLANA_RPC_URL "$SOLANA_RPC_URL" --prod
 npx convex env set CLAN_WORLD_CONTRACT_ADDRESS "$CLAN_WORLD_CONTRACT_ADDRESS" --prod
 npx convex env set CLAN_WORLD_LENS_ADDRESS "$CLAN_WORLD_LENS_ADDRESS" --prod
 npx convex env set INDEXER_START_BLOCK "$INDEXER_START_BLOCK" --prod
-npx convex env set CLANWORLD_USE_REAL_INDEXER true --prod
+npx convex env set CLANWORLD_USE_REAL_INDEXER false --prod
 npx convex env set CLANWORLD_USE_FAKE_HEARTBEAT false --prod
+npx convex env set CLANWORLD_RESET_LOCK true --prod
 npx convex env set WEBHOOK_SHARED_SECRET "$WEBHOOK_SHARED_SECRET" --prod
 npx convex deploy --prod
 ```
@@ -158,6 +170,35 @@ If the deployed backend includes `ops:flushGameState`, run it repeatedly until `
 ```bash
 npx convex run ops:flushGameState '{"secret":"'"$INDEXER_SECRET"'","batchSize":500}' --prod
 npx convex run ops:resetCheckpoint '{"secret":"'"$INDEXER_SECRET"'","lastBlock":'"$INDEXER_START_BLOCK"'}' --prod
+```
+
+If `clanView` has a large historical backlog, use the targeted per-clan purge
+helper in parallel and include all historical clan ids, not only the fresh four:
+
+```bash
+for clan_id in 1 2 3 4 5 6 7 8; do
+  (
+    while true; do
+      out=$(npx convex run ops:flushClanViewForClan \
+        '{"secret":"'"$INDEXER_SECRET"'","clanId":'"$clan_id"',"batchSize":500}' \
+        --prod)
+      echo "$out"
+      echo "$out" | grep -q '"complete": true' && break
+    done
+  ) &
+done
+wait
+```
+
+After the flush is complete, reset the checkpoint, unlock the indexer, redeploy
+functions so crons are registered with the final env, and force one snapshot:
+
+```bash
+npx convex run ops:resetCheckpoint '{"secret":"'"$INDEXER_SECRET"'","lastBlock":'"$INDEXER_START_BLOCK"'}' --prod
+npx convex env set CLANWORLD_USE_REAL_INDEXER true --prod
+npx convex env set CLANWORLD_RESET_LOCK false --prod
+npx convex deploy --prod
+npx convex run indexer:refreshSnapshot '{}' --prod
 ```
 
 ## 6. Mint Four Clans

--- a/docs/runbooks/full-game-reset.md
+++ b/docs/runbooks/full-game-reset.md
@@ -17,6 +17,7 @@ Record these before touching live state:
 export RPC_URL_PRIMARY="https://base-sepolia.infura.io/v3/<key>"
 export SOLANA_RPC_URL="https://mainnet.helius-rpc.com/?api-key=<key>"
 export DEPLOYER_PRIVATE_KEY="0x..."
+export INDEXER_SECRET="..."
 export WEBHOOK_SHARED_SECRET="..."
 ```
 
@@ -184,16 +185,25 @@ Flush all game/indexer state for the old realm. At minimum clear:
 
 Then trigger one indexer refresh or wait for the first heartbeat webhook.
 
-If the deployed backend includes `ops:flushGameState`, run it repeatedly until `complete` is `true`:
+If the deployed backend includes `ops:flushGameState`, loop it until `complete`
+is `true`, then reset the checkpoint once:
 
 ```bash
-npx convex run ops:flushGameState '{"secret":"'"$INDEXER_SECRET"'","batchSize":500}' --prod
+while true; do
+  out=$(npx convex run ops:flushGameState \
+    '{"secret":"'"$INDEXER_SECRET"'","batchSize":400}' \
+    --prod)
+  echo "$out"
+  echo "$out" | grep -q '"complete": true' && break
+done
+
 npx convex run ops:resetCheckpoint '{"secret":"'"$INDEXER_SECRET"'","lastBlock":'"$INDEXER_START_BLOCK"'}' --prod
 ```
 
-`ops:flushGameState` is capped at 500 rows per table per mutation on purpose,
-to stay inside Convex mutation limits. Expect old append-only views to require
-many passes.
+`ops:flushGameState` is capped at 400 rows per table and 9,000 total deletes
+per mutation on purpose, to stay inside Convex mutation limits. It returns
+`deletedAny` plus `complete`; `complete` can become true on the same call that
+deletes the final rows. Expect old append-only views to require many passes.
 
 If `clanView` has a large historical backlog, use the targeted per-clan purge
 helper in parallel and include all historical clan ids, not only the fresh four:

--- a/docs/runbooks/full-game-reset.md
+++ b/docs/runbooks/full-game-reset.md
@@ -1,0 +1,249 @@
+# Clan World — Full Game Reset Runbook
+
+Use this when we want a totally fresh live realm: new Base Sepolia diamond, backup diamond, empty Convex state, regenerated contract artifacts, restarted heartbeat/runner/Elder sessions, and a fresh frontend deploy.
+
+This is the "do the whole reset now" checklist. For deeper setup details, see:
+
+- `docs/runbooks/fresh-vps-bootstrap.md`
+- `docs/runbooks/base-sepolia-deployment.md`
+- `docs/runbooks/diamond-migration.md`
+- `docs/guides/stream-ops.md`
+
+## Reset Inputs
+
+Record these before touching live state:
+
+```bash
+export RPC_URL_PRIMARY="https://base-sepolia.infura.io/v3/<key>"
+export SOLANA_RPC_URL="https://mainnet.helius-rpc.com/?api-key=<key>"
+export DEPLOYER_PRIVATE_KEY="0x..."
+export WEBHOOK_SHARED_SECRET="..."
+```
+
+The active reset on 2026-05-11 used Infura for Base Sepolia and Helius for Solana reads.
+
+## 0. Preflight
+
+1. Work from a clean checkout on `main`.
+2. Confirm `pnpm install --frozen-lockfile`, `forge build`, and `pnpm typecheck` are green.
+3. Confirm these CLIs are authenticated or available: `forge`, `cast`, `pnpm`, `npx convex`, `vercel`, `tmux`, `jq`, `curl`.
+4. Check deployer and elder wallet balances on Base Sepolia.
+5. Confirm Convex deployment slug and app URLs.
+6. Save the current active diamond, lens, deploy block, and git commit in the reset notes.
+
+## 1. Stop Live Writers
+
+Stop anything that can send deployer-wallet txs or write stale state while the reset is underway:
+
+```bash
+tmux kill-session -t clanworld-heartbeat 2>/dev/null || true
+tmux kill-session -t clanworld-runner 2>/dev/null || true
+tmux kill-session -t clanworld-finalize 2>/dev/null || true
+
+for n in 1 2 3 4; do
+  tmux kill-session -t "elder-$n" 2>/dev/null || true
+  tmux kill-session -t "clanworld-elder-$n" 2>/dev/null || true
+done
+```
+
+Wait at least 60 seconds after stopping heartbeat before deploying, so any in-flight nonce settles.
+
+## 2. Deploy Active And Backup Diamonds
+
+Deploy the active diamond:
+
+```bash
+cd packages/contracts
+forge build
+forge script script/Deploy.s.sol \
+  --rpc-url "$RPC_URL_PRIMARY" \
+  --private-key "$DEPLOYER_PRIVATE_KEY" \
+  --broadcast \
+  --slow
+```
+
+Save:
+
+- Diamond address
+- Lens address
+- Deploy transaction hash
+- Deploy block number
+- Facet addresses
+
+Then run the same deploy command again for the backup diamond and save the same values. Do not point Convex or the frontend at the backup unless the active diamond fails.
+
+## 3. Wire Local Env
+
+Update local runtime env files:
+
+```bash
+export CLAN_WORLD_CONTRACT_ADDRESS="0x<active-diamond>"
+export CLAN_WORLD_LENS_ADDRESS="0x<active-lens>"
+export INDEXER_START_BLOCK="<active-deploy-block>"
+
+# Root runtime env
+perl -0pi -e 's/^RPC_URL_PRIMARY=.*/RPC_URL_PRIMARY=$ENV{RPC_URL_PRIMARY}/m' .env.local
+perl -0pi -e 's/^SOLANA_RPC_URL=.*/SOLANA_RPC_URL=$ENV{SOLANA_RPC_URL}/m' .env.local
+perl -0pi -e 's/^CLAN_WORLD_CONTRACT_ADDRESS=.*/CLAN_WORLD_CONTRACT_ADDRESS=$ENV{CLAN_WORLD_CONTRACT_ADDRESS}/m' .env.local
+perl -0pi -e 's/^CLAN_WORLD_LENS_ADDRESS=.*/CLAN_WORLD_LENS_ADDRESS=$ENV{CLAN_WORLD_LENS_ADDRESS}/m' .env.local
+
+# Elder runtime dirs, if present
+for n in 1 2 3 4; do
+  test -f "$HOME/clan-world/elder-$n/.env" || continue
+  perl -0pi -e 's/^RPC_URL_PRIMARY=.*/RPC_URL_PRIMARY=$ENV{RPC_URL_PRIMARY}/m' "$HOME/clan-world/elder-$n/.env"
+  perl -0pi -e 's/^CLAN_WORLD_CONTRACT_ADDRESS=.*/CLAN_WORLD_CONTRACT_ADDRESS=$ENV{CLAN_WORLD_CONTRACT_ADDRESS}/m' "$HOME/clan-world/elder-$n/.env"
+done
+```
+
+If an env key is missing, add it rather than leaving an old default in place.
+
+## 4. Regenerate Artifacts And Types
+
+Refresh contract outputs and TypeScript generated files after the deploy source is final:
+
+```bash
+pnpm gen:contract-abi
+pnpm gen:chainclient-abi
+pnpm --filter @clan-world/server codegen
+pnpm typecheck
+```
+
+Commit any generated ABI/type changes before redeploying the app.
+
+## 5. Reconfigure And Flush Convex
+
+Set Convex production env values together:
+
+```bash
+cd apps/server
+npx convex env set RPC_URL_PRIMARY "$RPC_URL_PRIMARY" --prod
+npx convex env set SOLANA_RPC_URL "$SOLANA_RPC_URL" --prod
+npx convex env set CLAN_WORLD_CONTRACT_ADDRESS "$CLAN_WORLD_CONTRACT_ADDRESS" --prod
+npx convex env set CLAN_WORLD_LENS_ADDRESS "$CLAN_WORLD_LENS_ADDRESS" --prod
+npx convex env set INDEXER_START_BLOCK "$INDEXER_START_BLOCK" --prod
+npx convex env set CLANWORLD_USE_REAL_INDEXER true --prod
+npx convex env set CLANWORLD_USE_FAKE_HEARTBEAT false --prod
+npx convex env set WEBHOOK_SHARED_SECRET "$WEBHOOK_SHARED_SECRET" --prod
+npx convex deploy --prod
+```
+
+Flush all game/indexer state for the old realm. At minimum clear:
+
+- `worldSnapshot`
+- `chainEvents`
+- `tickHistory`
+- `eventCheckpoint`
+- `clanView`
+- `marketState`
+- `banditView`
+- `pricePoint`
+- `goldQuote`
+- `goldQuoteSample`
+- `kickstartTokens`
+- `kickstartWatchedTokens`
+- `agentLogs`
+- `inftTokens`
+- `inftTransfers`
+- `memoryEntries`
+- `bulletins`
+- `memoryEvents`
+- `whispers`
+- `orchEvents`
+- `humanSteeringMessages`
+
+Then trigger one indexer refresh or wait for the first heartbeat webhook.
+
+## 6. Mint Four Clans
+
+Derive or load the four elder addresses, then mint one clan per elder:
+
+```bash
+for owner in "$ELDER_1_ADDRESS" "$ELDER_2_ADDRESS" "$ELDER_3_ADDRESS" "$ELDER_4_ADDRESS"; do
+  cast send "$CLAN_WORLD_CONTRACT_ADDRESS" "mintClan(address)" "$owner" \
+    --rpc-url "$RPC_URL_PRIMARY" \
+    --private-key "$DEPLOYER_PRIVATE_KEY"
+done
+```
+
+If the demo needs clansmen immediately, spawn the expected starting units after minting:
+
+```bash
+for clan_id in 1 2 3 4; do
+  for i in 1 2 3 4; do
+    cast send "$CLAN_WORLD_CONTRACT_ADDRESS" "spawnClansman(uint32,uint32)" "$clan_id" "$i" \
+      --rpc-url "$RPC_URL_PRIMARY" \
+      --private-key "$DEPLOYER_PRIVATE_KEY"
+  done
+done
+```
+
+Verify:
+
+```bash
+cast call "$CLAN_WORLD_CONTRACT_ADDRESS" "getClanIds()(uint32[])" --rpc-url "$RPC_URL_PRIMARY"
+```
+
+## 7. Restart Heartbeat, Runner, Elders, And TTYD
+
+Restart heartbeat:
+
+```bash
+tmux new-session -d -s clanworld-heartbeat -c "$PWD" \
+  'export PATH="$HOME/.foundry/bin:$PATH"; bash scripts/start-heartbeat-loop.sh 2>&1 | tee -a /tmp/clanworld-heartbeat.log'
+```
+
+Restart runner and four Elder sessions using the current package scripts or host wrappers. Confirm each new process reads the new `.env.local` / elder `.env` values.
+
+For TTYD or any service binding a port, resolve the current worktree port first:
+
+```bash
+PORT=$(port-for clan-world-ttyd)
+```
+
+Then start the service with that port.
+
+Clear old runner/Elder inbox artifacts before the first tick if they contain stale situation blocks, old diamond addresses, or old clan IDs.
+
+## 8. Deploy Web App
+
+Deploy the frontend after Convex has the new env and fresh state:
+
+```bash
+pnpm build
+vercel --prod
+```
+
+If any Vercel project env var points directly at the diamond or lens, update it before deploying. The main game frontend should normally read the realm through Convex.
+
+## 9. Smoke Tests
+
+Verify all of these before calling the reset complete:
+
+```bash
+cast code "$CLAN_WORLD_CONTRACT_ADDRESS" --rpc-url "$RPC_URL_PRIMARY"
+cast call "$CLAN_WORLD_CONTRACT_ADDRESS" "owner()(address)" --rpc-url "$RPC_URL_PRIMARY"
+cast call "$CLAN_WORLD_CONTRACT_ADDRESS" "getClanIds()(uint32[])" --rpc-url "$RPC_URL_PRIMARY"
+tail -n 80 /tmp/clanworld-heartbeat.log
+tmux ls
+```
+
+Also verify in the app:
+
+- New tick number advances.
+- Four clans exist.
+- Four Elder agents are alive and assigned to the new clans.
+- Convex world snapshot references the new diamond.
+- TTYD terminals are reachable.
+
+## 10. Post-Reset Notes
+
+After the live reset, update this section or a dated reset report with:
+
+- Active diamond and lens
+- Backup diamond and lens
+- Deploy block numbers
+- Git commit and release tag
+- Convex deployment slug
+- Vercel production URL
+- Any commands that differed from this runbook
+- Any failures, rate limits, missing env vars, or process names discovered during the run

--- a/docs/runbooks/full-game-reset.md
+++ b/docs/runbooks/full-game-reset.md
@@ -30,6 +30,9 @@ The active reset on 2026-05-11 used Infura for Base Sepolia and Helius for Solan
 4. Check deployer and elder wallet balances on Base Sepolia.
 5. Confirm Convex deployment slug and app URLs.
 6. Save the current active diamond, lens, deploy block, and git commit in the reset notes.
+7. Confirm whether the live Elder Claude Code sessions have account capacity.
+   If they are at the monthly usage limit, pause the game loop after reset and
+   run only the read-only terminals until capacity resets.
 
 ## 1. Stop Live Writers
 
@@ -44,6 +47,17 @@ for n in 1 2 3 4; do
   tmux kill-session -t "elder-$n" 2>/dev/null || true
   tmux kill-session -t "clanworld-elder-$n" 2>/dev/null || true
 done
+```
+
+Disable Convex cron writers before flushing or waiting. Deploy the functions
+after changing these envs so cron registration reflects the paused state:
+
+```bash
+cd apps/server
+npx convex env set CLANWORLD_USE_REAL_INDEXER false --prod
+npx convex env set CLANWORLD_USE_FAKE_HEARTBEAT false --prod
+npx convex env set CLANWORLD_RESET_LOCK true --prod
+npx convex deploy --prod
 ```
 
 Wait at least 60 seconds after stopping heartbeat before deploying, so any in-flight nonce settles.
@@ -80,6 +94,11 @@ Save:
 - Facet addresses
 
 Then run the same deploy command again for the backup diamond and save the same values. Do not point Convex or the frontend at the backup unless the active diamond fails.
+
+Learning from the 2026-05-11 reset: the deploy blocker was
+`LibBanditLifecycle`, not the diamond proxy. It exceeded EIP-170 as a deployed
+library. Split oversized libraries/facets before broadcasting; do not rely on
+`--disable-code-size-limit`.
 
 ## 3. Wire Local Env
 
@@ -172,6 +191,10 @@ npx convex run ops:flushGameState '{"secret":"'"$INDEXER_SECRET"'","batchSize":5
 npx convex run ops:resetCheckpoint '{"secret":"'"$INDEXER_SECRET"'","lastBlock":'"$INDEXER_START_BLOCK"'}' --prod
 ```
 
+`ops:flushGameState` is capped at 500 rows per table per mutation on purpose,
+to stay inside Convex mutation limits. Expect old append-only views to require
+many passes.
+
 If `clanView` has a large historical backlog, use the targeted per-clan purge
 helper in parallel and include all historical clan ids, not only the fresh four:
 
@@ -200,6 +223,10 @@ npx convex env set CLANWORLD_RESET_LOCK false --prod
 npx convex deploy --prod
 npx convex run indexer:refreshSnapshot '{}' --prod
 ```
+
+If `indexer:refreshSnapshot` times out in `commitSnapshot`, check whether it is
+probing stale clan ids. The 2026-05-11 reset fixed this by reading
+`getClanIds()` first and refreshing only live clans.
 
 ## 6. Mint Four Clans
 
@@ -242,15 +269,103 @@ tmux new-session -d -s clanworld-heartbeat -c "$PWD" \
 
 Restart runner and four Elder sessions using the current package scripts or host wrappers. Confirm each new process reads the new `.env.local` / elder `.env` values.
 
-For TTYD or any service binding a port, resolve the current worktree port first:
+For TTYD in the public cockpit, match Caddy, not only `port-for`. As of the
+2026-05-11 host config, `https://cockpit.clan-world.com/elder-N-tty/` proxies
+to:
+
+| Elder | Public path | Local upstream |
+|---|---|---|
+| 1 | `/elder-1-tty/` | `127.0.0.1:38790` |
+| 2 | `/elder-2-tty/` | `127.0.0.1:38791` |
+| 3 | `/elder-3-tty/` | `127.0.0.1:38792` |
+| 4 | `/elder-4-tty/` | `127.0.0.1:38793` |
+
+Start read-only terminal mirrors:
 
 ```bash
-PORT=$(port-for clan-world-ttyd)
+for n in 1 2 3 4; do
+  tmux has-session -t "elder-$n" 2>/dev/null ||
+    tmux new-session -d -s "elder-$n" -c "$HOME/clan-world/elder-$n" './run.sh'
+
+  tmux kill-session -t "ttyd-elder-$n" 2>/dev/null || true
+  port=$((38789+n))
+  tmux new-session -d -s "ttyd-elder-$n" \
+    "/home/claude/bin/ttyd -p $port \
+      -I /home/claude/clan-world/ttyd/index.html \
+      -t fontSize=11 -t cursorStyle=bar \
+      tmux attach-session -t elder-$n \
+      2>&1 | tee -a /tmp/clanworld-ttyd-elder-$n.log"
+done
 ```
 
-Then start the service with that port.
+Verify both local Caddy and public Cloudflare routes. A direct TTYD `200` is
+not enough if Caddy points at a different port.
+
+```bash
+ss -ltnp | grep -E '3879[0-3]'
+for path in elder-1-tty elder-2-tty elder-3-tty elder-4-tty; do
+  curl -I -H 'Host: cockpit.clan-world.com' "http://127.0.0.1:18080/$path/"
+  curl -I "https://cockpit.clan-world.com/$path/"
+done
+```
+
+If public cockpit returns `502 Bad Gateway`, inspect Caddy logs. The common
+reset failure is `dial tcp 127.0.0.1:3879N: connect: connection refused`,
+which means TTYD is either down or listening on the wrong port.
 
 Clear old runner/Elder inbox artifacts before the first tick if they contain stale situation blocks, old diamond addresses, or old clan IDs.
+
+## 7.5. Pause And Unpause
+
+Use pause mode when contracts/Convex are reset but Elder Claude sessions cannot
+act yet, such as a monthly usage-limit window. This freezes writers while still
+allowing read-only cockpit terminals.
+
+Pause game advancement and Convex writers:
+
+```bash
+tmux kill-session -t clanworld-heartbeat 2>/dev/null || true
+tmux kill-session -t clanworld-runner 2>/dev/null || true
+
+cd apps/server
+npx convex env set CLANWORLD_USE_REAL_INDEXER false --prod
+npx convex env set CLANWORLD_USE_FAKE_HEARTBEAT false --prod
+npx convex env set CLANWORLD_RESET_LOCK true --prod
+npx convex deploy --prod
+```
+
+Optional hard pause of terminals too:
+
+```bash
+for n in 1 2 3 4; do
+  tmux kill-session -t "ttyd-elder-$n" 2>/dev/null || true
+  tmux kill-session -t "elder-$n" 2>/dev/null || true
+done
+```
+
+If you want to inspect stuck agents in the app while paused, keep or restart
+only `elder-N` and `ttyd-elder-N`; do not start `clanworld-runner` or
+`clanworld-heartbeat`.
+
+Unpause:
+
+```bash
+cd apps/server
+npx convex env set CLANWORLD_RESET_LOCK false --prod
+npx convex env set CLANWORLD_USE_REAL_INDEXER true --prod
+npx convex env set CLANWORLD_USE_FAKE_HEARTBEAT false --prod
+npx convex deploy --prod
+npx convex run indexer:refreshSnapshot '{}' --prod
+
+cd ../..
+tmux new-session -d -s clanworld-heartbeat -c "$PWD" \
+  'export PATH="$HOME/.foundry/bin:$PATH"; bash scripts/start-heartbeat-loop.sh 2>&1 | tee -a /tmp/clanworld-heartbeat.log'
+tmux new-session -d -s clanworld-runner -c "$PWD" \
+  'pnpm --filter @clan-world/runner start 2>&1 | tee -a /tmp/clanworld-runner.log'
+```
+
+After unpausing, verify `getSnapshot:getSnapshot` advances and runner logs show
+new observed ticks.
 
 ## 8. Deploy Web App
 
@@ -262,6 +377,15 @@ vercel --prod
 ```
 
 If any Vercel project env var points directly at the diamond or lens, update it before deploying. The main game frontend should normally read the realm through Convex.
+
+If the monorepo build is blocked by Android-only release env such as
+`CLAN_WORLD_MAP_URL`, build the web app directly and deploy the static output:
+
+```bash
+pnpm --filter @clan-world/web build
+cd apps/web
+vercel deploy dist --prod --yes
+```
 
 ## 9. Smoke Tests
 

--- a/packages/contracts/src/diamond/lib/LibBanditCleanup.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditCleanup.sol
@@ -2,13 +2,11 @@
 pragma solidity ^0.8.34;
 
 import {BanditState, BanditTroop, ClanWorldConstants} from "../../IClanWorld.sol";
+import {LibBanditEvents} from "./LibBanditEvents.sol";
 import {LibSettlement} from "./LibSettlement.sol";
 import {LibStorage} from "./LibStorage.sol";
 
 library LibBanditCleanup {
-    event BanditStateChanged(
-        uint32 indexed banditId, BanditState oldState, BanditState newState, uint8 region, uint64 atTick
-    );
     event BanditMoved(uint32 indexed banditId, uint8 fromRegion, uint8 toRegion, uint64 atTick);
     event BanditEscaped(uint32 indexed banditId, uint64 atTick);
     event LootDistributed(
@@ -33,7 +31,7 @@ library LibBanditCleanup {
         }
 
         BanditState oldState = bandit.state;
-        emit BanditStateChanged(banditId, oldState, BanditState.None, bandit.region, closedTick);
+        LibBanditEvents.emitBanditStateChanged(banditId, oldState, BanditState.None, bandit.region, closedTick);
         burnBanditCarry(s, banditId);
         emit BanditEscaped(banditId, closedTick);
         deleteBandit(s, banditId);
@@ -61,14 +59,7 @@ library LibBanditCleanup {
     function deleteBandit(LibStorage.AppStorage storage s, uint32 id) public {
         BanditTroop storage bandit = s.bandits[id];
         uint8 region = bandit.region;
-        uint32[] storage regionBandits = s.banditsByRegion[region];
-        for (uint256 i = 0; i < regionBandits.length; i++) {
-            if (regionBandits[i] == id) {
-                regionBandits[i] = regionBandits[regionBandits.length - 1];
-                regionBandits.pop();
-                break;
-            }
-        }
+        removeBanditFromRegion(s, id, region);
 
         delete s.bandits[id];
         if (s.activeBanditCount > 0) {
@@ -101,14 +92,7 @@ library LibBanditCleanup {
         uint8 toRegion = nextRampageRegion(fromRegion);
         if (fromRegion == toRegion) return;
 
-        uint32[] storage fromBandits = s.banditsByRegion[fromRegion];
-        for (uint256 i = 0; i < fromBandits.length; i++) {
-            if (fromBandits[i] == id) {
-                fromBandits[i] = fromBandits[fromBandits.length - 1];
-                fromBandits.pop();
-                break;
-            }
-        }
+        removeBanditFromRegion(s, id, fromRegion);
 
         bandit.region = toRegion;
         s.banditsByRegion[toRegion].push(id);
@@ -124,5 +108,16 @@ library LibBanditCleanup {
         if (currentRegion == ClanWorldConstants.REGION_EAST_DOCKS) return ClanWorldConstants.REGION_WEST_DOCKS;
         if (currentRegion == ClanWorldConstants.REGION_WEST_DOCKS) return ClanWorldConstants.REGION_WEST_FARMS;
         return ClanWorldConstants.REGION_FOREST;
+    }
+
+    function removeBanditFromRegion(LibStorage.AppStorage storage s, uint32 id, uint8 region) private {
+        uint32[] storage regionBandits = s.banditsByRegion[region];
+        for (uint256 i = 0; i < regionBandits.length; i++) {
+            if (regionBandits[i] == id) {
+                regionBandits[i] = regionBandits[regionBandits.length - 1];
+                regionBandits.pop();
+                break;
+            }
+        }
     }
 }

--- a/packages/contracts/src/diamond/lib/LibBanditCleanup.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditCleanup.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {BanditState, BanditTroop, ClanWorldConstants} from "../../IClanWorld.sol";
+import {LibSettlement} from "./LibSettlement.sol";
+import {LibStorage} from "./LibStorage.sol";
+
+library LibBanditCleanup {
+    event BanditStateChanged(
+        uint32 indexed banditId, BanditState oldState, BanditState newState, uint8 region, uint64 atTick
+    );
+    event BanditMoved(uint32 indexed banditId, uint8 fromRegion, uint8 toRegion, uint64 atTick);
+    event BanditEscaped(uint32 indexed banditId, uint64 atTick);
+    event LootDistributed(
+        uint32 indexed banditId,
+        uint32[] rewardedClanIds,
+        uint256 woodPerClan,
+        uint256 wheatPerClan,
+        uint256 fishPerClan,
+        uint256 ironPerClan,
+        uint256 goldPerClan,
+        uint256 woodRemainder,
+        uint256 wheatRemainder,
+        uint256 fishRemainder,
+        uint256 ironRemainder,
+        uint256 goldRemainder
+    );
+
+    function terminalEscapeBandit(LibStorage.AppStorage storage s, uint32 banditId, uint64 closedTick) public {
+        BanditTroop storage bandit = s.bandits[banditId];
+        if (bandit.id == ClanWorldConstants.BANDIT_ID_NULL) {
+            return;
+        }
+
+        BanditState oldState = bandit.state;
+        emit BanditStateChanged(banditId, oldState, BanditState.None, bandit.region, closedTick);
+        burnBanditCarry(s, banditId);
+        emit BanditEscaped(banditId, closedTick);
+        deleteBandit(s, banditId);
+    }
+
+    function burnBanditCarry(LibStorage.AppStorage storage s, uint32 banditId) public {
+        BanditTroop storage bandit = s.bandits[banditId];
+        uint32[] memory rewardedClanIds = new uint32[](0);
+        emit LootDistributed(
+            banditId,
+            rewardedClanIds,
+            0,
+            0,
+            0,
+            0,
+            0,
+            bandit.carryWood,
+            bandit.carryWheat,
+            bandit.carryFish,
+            bandit.carryIron,
+            bandit.carryGold
+        );
+    }
+
+    function deleteBandit(LibStorage.AppStorage storage s, uint32 id) public {
+        BanditTroop storage bandit = s.bandits[id];
+        uint8 region = bandit.region;
+        uint32[] storage regionBandits = s.banditsByRegion[region];
+        for (uint256 i = 0; i < regionBandits.length; i++) {
+            if (regionBandits[i] == id) {
+                regionBandits[i] = regionBandits[regionBandits.length - 1];
+                regionBandits.pop();
+                break;
+            }
+        }
+
+        delete s.bandits[id];
+        if (s.activeBanditCount > 0) {
+            s.activeBanditCount -= 1;
+        }
+        if (s.world.activeBanditId == id) {
+            s.world.activeBanditId = findOldestActiveBandit(s);
+        }
+    }
+
+    function findOldestActiveBandit(LibStorage.AppStorage storage s) public view returns (uint32 oldestBanditId) {
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            uint32[] storage regionBandits = s.banditsByRegion[region];
+            for (uint256 i = 0; i < regionBandits.length; i++) {
+                uint32 candidateId = regionBandits[i];
+                BanditTroop storage candidate = s.bandits[candidateId];
+                if (candidate.id == ClanWorldConstants.BANDIT_ID_NULL || candidate.state == BanditState.None) {
+                    continue;
+                }
+                if (oldestBanditId == ClanWorldConstants.BANDIT_ID_NULL || candidateId < oldestBanditId) {
+                    oldestBanditId = candidateId;
+                }
+            }
+        }
+    }
+
+    function moveBanditToRampageNextRegion(LibStorage.AppStorage storage s, uint32 id) public {
+        BanditTroop storage bandit = s.bandits[id];
+        uint8 fromRegion = bandit.region;
+        uint8 toRegion = nextRampageRegion(fromRegion);
+        if (fromRegion == toRegion) return;
+
+        uint32[] storage fromBandits = s.banditsByRegion[fromRegion];
+        for (uint256 i = 0; i < fromBandits.length; i++) {
+            if (fromBandits[i] == id) {
+                fromBandits[i] = fromBandits[fromBandits.length - 1];
+                fromBandits.pop();
+                break;
+            }
+        }
+
+        bandit.region = toRegion;
+        s.banditsByRegion[toRegion].push(id);
+        emit BanditMoved(id, fromRegion, toRegion, s.world.currentTick);
+
+        LibSettlement.eagerSettleBanditCandidateRegion(s, toRegion);
+    }
+
+    function nextRampageRegion(uint8 currentRegion) public pure returns (uint8) {
+        if (currentRegion == ClanWorldConstants.REGION_FOREST) return ClanWorldConstants.REGION_MOUNTAINS;
+        if (currentRegion == ClanWorldConstants.REGION_MOUNTAINS) return ClanWorldConstants.REGION_EAST_FARMS;
+        if (currentRegion == ClanWorldConstants.REGION_EAST_FARMS) return ClanWorldConstants.REGION_EAST_DOCKS;
+        if (currentRegion == ClanWorldConstants.REGION_EAST_DOCKS) return ClanWorldConstants.REGION_WEST_DOCKS;
+        if (currentRegion == ClanWorldConstants.REGION_WEST_DOCKS) return ClanWorldConstants.REGION_WEST_FARMS;
+        return ClanWorldConstants.REGION_FOREST;
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibBanditCombat.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditCombat.sol
@@ -14,6 +14,7 @@ import {
     Mission
 } from "../../IClanWorld.sol";
 import {LibSettlementMath} from "./LibSettlementMath.sol";
+import {LibBanditCleanup} from "./LibBanditCleanup.sol";
 import {LibBanditLifecycle} from "./LibBanditLifecycle.sol";
 import {LibOrderDefenders} from "./LibOrderDefenders.sol";
 import {LibOrderUpgrades} from "./LibOrderUpgrades.sol";
@@ -162,7 +163,7 @@ library LibBanditCombat {
         } else if (
             LibBanditLifecycle.recordBanditAttackAttempt(s, banditId) >= ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS
         ) {
-            LibBanditLifecycle.terminalEscapeBandit(s, banditId, closedTick);
+            LibBanditCleanup.terminalEscapeBandit(s, banditId, closedTick);
         } else {
             LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Camped);
         }

--- a/packages/contracts/src/diamond/lib/LibBanditCombat.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditCombat.sol
@@ -15,6 +15,7 @@ import {
 } from "../../IClanWorld.sol";
 import {LibSettlementMath} from "./LibSettlementMath.sol";
 import {LibBanditCleanup} from "./LibBanditCleanup.sol";
+import {LibBanditEvents} from "./LibBanditEvents.sol";
 import {LibBanditLifecycle} from "./LibBanditLifecycle.sol";
 import {LibOrderDefenders} from "./LibOrderDefenders.sol";
 import {LibOrderUpgrades} from "./LibOrderUpgrades.sol";
@@ -44,9 +45,6 @@ library LibBanditCombat {
     );
     event BanditDefeated(uint32 indexed banditId, uint32 indexed targetClanId, uint64 atTick);
     event BanditEscaped(uint32 indexed banditId, uint64 atTick);
-    event BanditStateChanged(
-        uint32 indexed banditId, BanditState oldState, BanditState newState, uint8 region, uint64 atTick
-    );
     event BanditTargetDied(uint32 indexed banditId, uint32 indexed deadClanId, uint64 tick);
     event WallDamagedByBandit(uint32 indexed clanId, uint8 newLevel, uint32 indexed banditId);
     event ClansmanKilledByBandit(uint32 indexed clanId, uint32 indexed clansmanId, uint32 indexed banditId);
@@ -110,7 +108,7 @@ library LibBanditCombat {
             bandit.state = BanditState.Camped;
             bandit.tickEnteredState = s.world.currentTick;
             bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
-            emit BanditStateChanged(
+            LibBanditEvents.emitBanditStateChanged(
                 banditId, BanditState.Attacking, BanditState.Camped, bandit.region, s.world.currentTick
             );
             return;

--- a/packages/contracts/src/diamond/lib/LibBanditEvents.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditEvents.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {BanditState} from "../../IClanWorld.sol";
+
+library LibBanditEvents {
+    event BanditStateChanged(
+        uint32 indexed banditId, BanditState oldState, BanditState newState, uint8 region, uint64 atTick
+    );
+
+    function emitBanditStateChanged(
+        uint32 banditId,
+        BanditState oldState,
+        BanditState newState,
+        uint8 region,
+        uint64 atTick
+    ) internal {
+        emit BanditStateChanged(banditId, oldState, newState, region, atTick);
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
@@ -1,71 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.34;
 
-import {BanditState, BanditTroop, Clan, ClanState, ClanWorldConstants} from "../../IClanWorld.sol";
-import {LibScoring} from "../../lib/LibScoring.sol";
-import {LibSettlement} from "./LibSettlement.sol";
+import {BanditState, BanditTroop, ClanWorldConstants} from "../../IClanWorld.sol";
+import {LibBanditCleanup} from "./LibBanditCleanup.sol";
 import {LibStorage} from "./LibStorage.sol";
 
 library LibBanditLifecycle {
     event BanditStateChanged(
         uint32 indexed banditId, BanditState oldState, BanditState newState, uint8 region, uint64 atTick
     );
-    event BanditMoved(uint32 indexed banditId, uint8 fromRegion, uint8 toRegion, uint64 atTick);
-    event BanditEscaped(uint32 indexed banditId, uint64 atTick);
-    event LootDistributed(
-        uint32 indexed banditId,
-        uint32[] rewardedClanIds,
-        uint256 woodPerClan,
-        uint256 wheatPerClan,
-        uint256 fishPerClan,
-        uint256 ironPerClan,
-        uint256 goldPerClan,
-        uint256 woodRemainder,
-        uint256 wheatRemainder,
-        uint256 fishRemainder,
-        uint256 ironRemainder,
-        uint256 goldRemainder
-    );
-
-    function advancePassiveBanditStates(LibStorage.AppStorage storage s, uint64 closedTick) public {
-        require(s.world.currentTick == closedTick, "ClanWorld: bandit advance tick mismatch");
-        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
-            uint32[] storage regionBandits = s.banditsByRegion[region];
-            for (uint256 i = regionBandits.length; i > 0; i--) {
-                uint32 banditId = regionBandits[i - 1];
-                BanditTroop storage bandit = s.bandits[banditId];
-                uint8 regionBefore = bandit.region;
-
-                if (bandit.state == BanditState.Spawned && closedTick > bandit.tickEnteredState) {
-                    transitionBanditState(s, banditId, BanditState.Camped);
-                } else if (
-                    bandit.state == BanditState.Camped
-                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS
-                ) {
-                    LibSettlement.eagerSettleBanditCandidateRegion(s, bandit.region);
-                    if (s.bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) continue;
-                    uint32 targetClanId = pickBanditAttackTarget(s, bandit);
-                    if (targetClanId == ClanWorldConstants.CLAN_ID_NULL) {
-                        if (recordBanditAttackAttempt(s, banditId) >= ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS) {
-                            terminalEscapeBandit(s, banditId, closedTick);
-                            continue;
-                        }
-                        bandit.tickEnteredState = s.world.currentTick;
-                        bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
-                        moveBanditToRampageNextRegion(s, banditId);
-                        emit BanditStateChanged(
-                            banditId, BanditState.Camped, BanditState.Camped, bandit.region, s.world.currentTick
-                        );
-                    } else {
-                        transitionBanditToAttacking(s, banditId, targetClanId);
-                    }
-                }
-
-                if (s.bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) continue;
-                if (regionBefore != s.bandits[banditId].region) continue;
-            }
-        }
-    }
 
     function transitionBanditToAttacking(LibStorage.AppStorage storage s, uint32 id, uint32 targetClanId) public {
         require(targetClanId != ClanWorldConstants.CLAN_ID_NULL, "ClanWorld: invalid bandit target");
@@ -83,7 +26,7 @@ library LibBanditLifecycle {
 
         if (newState == BanditState.Defeated) {
             emit BanditStateChanged(id, oldState, newState, bandit.region, s.world.currentTick);
-            deleteBandit(s, id);
+            LibBanditCleanup.deleteBandit(s, id);
             return;
         }
 
@@ -96,7 +39,7 @@ library LibBanditLifecycle {
         emit BanditStateChanged(id, oldState, newState, bandit.region, s.world.currentTick);
 
         if (oldState == BanditState.Attacking && newState == BanditState.Camped) {
-            moveBanditToRampageNextRegion(s, id);
+            LibBanditCleanup.moveBanditToRampageNextRegion(s, id);
         }
     }
 
@@ -118,30 +61,6 @@ library LibBanditLifecycle {
         return false;
     }
 
-    function pickBanditAttackTarget(LibStorage.AppStorage storage s, BanditTroop storage bandit)
-        public
-        view
-        returns (uint32 targetClanId)
-    {
-        uint256 bestLootValue;
-
-        for (uint256 i = 0; i < s.allClanIds.length; i++) {
-            uint32 clanId = s.allClanIds[i];
-            Clan storage clan = s.clans[clanId];
-            if (clan.clanState == ClanState.DEAD || clan.baseRegion != bandit.region || clan.livingClansmen == 0) {
-                continue;
-            }
-
-            uint256 lootValue = LibScoring.lootValue(clan);
-            if (targetClanId == ClanWorldConstants.CLAN_ID_NULL || lootValue > bestLootValue) {
-                bestLootValue = lootValue;
-                targetClanId = clanId;
-            } else if (lootValue == bestLootValue && clanId < targetClanId) {
-                targetClanId = clanId;
-            }
-        }
-    }
-
     function recordBanditAttackAttempt(LibStorage.AppStorage storage s, uint32 banditId)
         public
         returns (uint8 attemptsMade)
@@ -154,103 +73,4 @@ library LibBanditLifecycle {
         bandit.attackAttemptsMade = attemptsMade;
     }
 
-    function terminalEscapeBandit(LibStorage.AppStorage storage s, uint32 banditId, uint64 closedTick) public {
-        BanditTroop storage bandit = s.bandits[banditId];
-        if (bandit.id == ClanWorldConstants.BANDIT_ID_NULL) {
-            return;
-        }
-
-        BanditState oldState = bandit.state;
-        emit BanditStateChanged(banditId, oldState, BanditState.None, bandit.region, closedTick);
-        burnBanditCarry(s, banditId);
-        emit BanditEscaped(banditId, closedTick);
-        deleteBandit(s, banditId);
-    }
-
-    function burnBanditCarry(LibStorage.AppStorage storage s, uint32 banditId) public {
-        BanditTroop storage bandit = s.bandits[banditId];
-        uint32[] memory rewardedClanIds = new uint32[](0);
-        emit LootDistributed(
-            banditId,
-            rewardedClanIds,
-            0,
-            0,
-            0,
-            0,
-            0,
-            bandit.carryWood,
-            bandit.carryWheat,
-            bandit.carryFish,
-            bandit.carryIron,
-            bandit.carryGold
-        );
-    }
-
-    function deleteBandit(LibStorage.AppStorage storage s, uint32 id) public {
-        BanditTroop storage bandit = s.bandits[id];
-        uint8 region = bandit.region;
-        uint32[] storage regionBandits = s.banditsByRegion[region];
-        for (uint256 i = 0; i < regionBandits.length; i++) {
-            if (regionBandits[i] == id) {
-                regionBandits[i] = regionBandits[regionBandits.length - 1];
-                regionBandits.pop();
-                break;
-            }
-        }
-
-        delete s.bandits[id];
-        if (s.activeBanditCount > 0) {
-            s.activeBanditCount -= 1;
-        }
-        if (s.world.activeBanditId == id) {
-            s.world.activeBanditId = findOldestActiveBandit(s);
-        }
-    }
-
-    function findOldestActiveBandit(LibStorage.AppStorage storage s) public view returns (uint32 oldestBanditId) {
-        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
-            uint32[] storage regionBandits = s.banditsByRegion[region];
-            for (uint256 i = 0; i < regionBandits.length; i++) {
-                uint32 candidateId = regionBandits[i];
-                BanditTroop storage candidate = s.bandits[candidateId];
-                if (candidate.id == ClanWorldConstants.BANDIT_ID_NULL || candidate.state == BanditState.None) {
-                    continue;
-                }
-                if (oldestBanditId == ClanWorldConstants.BANDIT_ID_NULL || candidateId < oldestBanditId) {
-                    oldestBanditId = candidateId;
-                }
-            }
-        }
-    }
-
-    function moveBanditToRampageNextRegion(LibStorage.AppStorage storage s, uint32 id) public {
-        BanditTroop storage bandit = s.bandits[id];
-        uint8 fromRegion = bandit.region;
-        uint8 toRegion = nextRampageRegion(fromRegion);
-        if (fromRegion == toRegion) return;
-
-        uint32[] storage fromBandits = s.banditsByRegion[fromRegion];
-        for (uint256 i = 0; i < fromBandits.length; i++) {
-            if (fromBandits[i] == id) {
-                fromBandits[i] = fromBandits[fromBandits.length - 1];
-                fromBandits.pop();
-                break;
-            }
-        }
-
-        bandit.region = toRegion;
-        s.banditsByRegion[toRegion].push(id);
-        emit BanditMoved(id, fromRegion, toRegion, s.world.currentTick);
-
-        LibSettlement.eagerSettleBanditCandidateRegion(s, toRegion);
-    }
-
-    function nextRampageRegion(uint8 currentRegion) public pure returns (uint8) {
-        if (currentRegion == ClanWorldConstants.REGION_FOREST) return ClanWorldConstants.REGION_MOUNTAINS;
-        if (currentRegion == ClanWorldConstants.REGION_MOUNTAINS) return ClanWorldConstants.REGION_EAST_FARMS;
-        if (currentRegion == ClanWorldConstants.REGION_EAST_FARMS) return ClanWorldConstants.REGION_EAST_DOCKS;
-        if (currentRegion == ClanWorldConstants.REGION_EAST_DOCKS) return ClanWorldConstants.REGION_WEST_DOCKS;
-        if (currentRegion == ClanWorldConstants.REGION_WEST_DOCKS) return ClanWorldConstants.REGION_WEST_FARMS;
-        return ClanWorldConstants.REGION_FOREST;
-    }
 }

--- a/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditLifecycle.sol
@@ -3,13 +3,10 @@ pragma solidity ^0.8.34;
 
 import {BanditState, BanditTroop, ClanWorldConstants} from "../../IClanWorld.sol";
 import {LibBanditCleanup} from "./LibBanditCleanup.sol";
+import {LibBanditEvents} from "./LibBanditEvents.sol";
 import {LibStorage} from "./LibStorage.sol";
 
 library LibBanditLifecycle {
-    event BanditStateChanged(
-        uint32 indexed banditId, BanditState oldState, BanditState newState, uint8 region, uint64 atTick
-    );
-
     function transitionBanditToAttacking(LibStorage.AppStorage storage s, uint32 id, uint32 targetClanId) public {
         require(targetClanId != ClanWorldConstants.CLAN_ID_NULL, "ClanWorld: invalid bandit target");
         s.bandits[id].targetClanId = targetClanId;
@@ -25,7 +22,7 @@ library LibBanditLifecycle {
         require(isValidBanditTransition(s, bandit, newState), "ClanWorld: invalid bandit transition");
 
         if (newState == BanditState.Defeated) {
-            emit BanditStateChanged(id, oldState, newState, bandit.region, s.world.currentTick);
+            LibBanditEvents.emitBanditStateChanged(id, oldState, newState, bandit.region, s.world.currentTick);
             LibBanditCleanup.deleteBandit(s, id);
             return;
         }
@@ -36,7 +33,7 @@ library LibBanditLifecycle {
             bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
         }
 
-        emit BanditStateChanged(id, oldState, newState, bandit.region, s.world.currentTick);
+        LibBanditEvents.emitBanditStateChanged(id, oldState, newState, bandit.region, s.world.currentTick);
 
         if (oldState == BanditState.Attacking && newState == BanditState.Camped) {
             LibBanditCleanup.moveBanditToRampageNextRegion(s, id);

--- a/packages/contracts/src/diamond/lib/LibBanditPassive.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditPassive.sol
@@ -3,16 +3,13 @@ pragma solidity ^0.8.34;
 
 import {BanditState, BanditTroop, ClanWorldConstants} from "../../IClanWorld.sol";
 import {LibBanditCleanup} from "./LibBanditCleanup.sol";
+import {LibBanditEvents} from "./LibBanditEvents.sol";
 import {LibBanditLifecycle} from "./LibBanditLifecycle.sol";
 import {LibBanditTargets} from "./LibBanditTargets.sol";
 import {LibSettlement} from "./LibSettlement.sol";
 import {LibStorage} from "./LibStorage.sol";
 
 library LibBanditPassive {
-    event BanditStateChanged(
-        uint32 indexed banditId, BanditState oldState, BanditState newState, uint8 region, uint64 atTick
-    );
-
     function advancePassiveBanditStates(LibStorage.AppStorage storage s, uint64 closedTick) public {
         require(s.world.currentTick == closedTick, "ClanWorld: bandit advance tick mismatch");
         for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
@@ -42,7 +39,7 @@ library LibBanditPassive {
                         bandit.tickEnteredState = s.world.currentTick;
                         bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
                         LibBanditCleanup.moveBanditToRampageNextRegion(s, banditId);
-                        emit BanditStateChanged(
+                        LibBanditEvents.emitBanditStateChanged(
                             banditId, BanditState.Camped, BanditState.Camped, bandit.region, s.world.currentTick
                         );
                     } else {

--- a/packages/contracts/src/diamond/lib/LibBanditPassive.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditPassive.sol
@@ -17,7 +17,6 @@ library LibBanditPassive {
             for (uint256 i = regionBandits.length; i > 0; i--) {
                 uint32 banditId = regionBandits[i - 1];
                 BanditTroop storage bandit = s.bandits[banditId];
-                uint8 regionBefore = bandit.region;
 
                 if (bandit.state == BanditState.Spawned && closedTick > bandit.tickEnteredState) {
                     LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Camped);
@@ -46,9 +45,6 @@ library LibBanditPassive {
                         LibBanditLifecycle.transitionBanditToAttacking(s, banditId, targetClanId);
                     }
                 }
-
-                if (s.bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) continue;
-                if (regionBefore != s.bandits[banditId].region) continue;
             }
         }
     }

--- a/packages/contracts/src/diamond/lib/LibBanditPassive.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditPassive.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {BanditState, BanditTroop, ClanWorldConstants} from "../../IClanWorld.sol";
+import {LibBanditCleanup} from "./LibBanditCleanup.sol";
+import {LibBanditLifecycle} from "./LibBanditLifecycle.sol";
+import {LibBanditTargets} from "./LibBanditTargets.sol";
+import {LibSettlement} from "./LibSettlement.sol";
+import {LibStorage} from "./LibStorage.sol";
+
+library LibBanditPassive {
+    event BanditStateChanged(
+        uint32 indexed banditId, BanditState oldState, BanditState newState, uint8 region, uint64 atTick
+    );
+
+    function advancePassiveBanditStates(LibStorage.AppStorage storage s, uint64 closedTick) public {
+        require(s.world.currentTick == closedTick, "ClanWorld: bandit advance tick mismatch");
+        for (uint8 region = ClanWorldConstants.REGION_FOREST; region <= ClanWorldConstants.REGION_DEEP_SEA; region++) {
+            uint32[] storage regionBandits = s.banditsByRegion[region];
+            for (uint256 i = regionBandits.length; i > 0; i--) {
+                uint32 banditId = regionBandits[i - 1];
+                BanditTroop storage bandit = s.bandits[banditId];
+                uint8 regionBefore = bandit.region;
+
+                if (bandit.state == BanditState.Spawned && closedTick > bandit.tickEnteredState) {
+                    LibBanditLifecycle.transitionBanditState(s, banditId, BanditState.Camped);
+                } else if (
+                    bandit.state == BanditState.Camped
+                        && closedTick >= bandit.tickEnteredState + ClanWorldConstants.BANDIT_CAMP_TICKS
+                ) {
+                    LibSettlement.eagerSettleBanditCandidateRegion(s, bandit.region);
+                    if (s.bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) continue;
+                    uint32 targetClanId = LibBanditTargets.pickBanditAttackTarget(s, bandit);
+                    if (targetClanId == ClanWorldConstants.CLAN_ID_NULL) {
+                        if (
+                            LibBanditLifecycle.recordBanditAttackAttempt(s, banditId)
+                                >= ClanWorldConstants.BANDIT_MAX_ATTACK_ATTEMPTS
+                        ) {
+                            LibBanditCleanup.terminalEscapeBandit(s, banditId, closedTick);
+                            continue;
+                        }
+                        bandit.tickEnteredState = s.world.currentTick;
+                        bandit.targetClanId = ClanWorldConstants.CLAN_ID_NULL;
+                        LibBanditCleanup.moveBanditToRampageNextRegion(s, banditId);
+                        emit BanditStateChanged(
+                            banditId, BanditState.Camped, BanditState.Camped, bandit.region, s.world.currentTick
+                        );
+                    } else {
+                        LibBanditLifecycle.transitionBanditToAttacking(s, banditId, targetClanId);
+                    }
+                }
+
+                if (s.bandits[banditId].id == ClanWorldConstants.BANDIT_ID_NULL) continue;
+                if (regionBefore != s.bandits[banditId].region) continue;
+            }
+        }
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibBanditTargets.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditTargets.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {BanditTroop, Clan, ClanState, ClanWorldConstants} from "../../IClanWorld.sol";
+import {LibScoring} from "../../lib/LibScoring.sol";
+import {LibStorage} from "./LibStorage.sol";
+
+library LibBanditTargets {
+    function pickBanditAttackTarget(LibStorage.AppStorage storage s, BanditTroop storage bandit)
+        public
+        view
+        returns (uint32 targetClanId)
+    {
+        uint256 bestLootValue;
+
+        for (uint256 i = 0; i < s.allClanIds.length; i++) {
+            uint32 clanId = s.allClanIds[i];
+            Clan storage clan = s.clans[clanId];
+            if (clan.clanState == ClanState.DEAD || clan.baseRegion != bandit.region || clan.livingClansmen == 0) {
+                continue;
+            }
+
+            uint256 lootValue = LibScoring.lootValue(clan);
+            if (targetClanId == ClanWorldConstants.CLAN_ID_NULL || lootValue > bestLootValue) {
+                bestLootValue = lootValue;
+                targetClanId = clanId;
+            } else if (lootValue == bestLootValue && clanId < targetClanId) {
+                targetClanId = clanId;
+            }
+        }
+    }
+}

--- a/packages/contracts/src/diamond/lib/LibHeartbeat.sol
+++ b/packages/contracts/src/diamond/lib/LibHeartbeat.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.34;
 
 import {ClanState} from "../../IClanWorld.sol";
 import {LibBanditCombat} from "./LibBanditCombat.sol";
-import {LibBanditLifecycle} from "./LibBanditLifecycle.sol";
+import {LibBanditPassive} from "./LibBanditPassive.sol";
 import {LibBanditSpawning} from "./LibBanditSpawning.sol";
 import {LibGameRules} from "./LibGameRules.sol";
 import {LibOrderMarket} from "./LibOrderMarket.sol";
@@ -43,7 +43,7 @@ library LibHeartbeat {
         }
 
         LibOrderMarket.executeScheduledMarketActions(s, closedTick);
-        LibBanditLifecycle.advancePassiveBanditStates(s, closedTick);
+        LibBanditPassive.advancePassiveBanditStates(s, closedTick);
         LibBanditCombat.resolveAttackingBandits(s, closedTick);
         LibBanditSpawning.evaluateBanditSpawns(s, closedTickSeed);
         LibWorldEvents.resolveWorldEvents(s, closedTick);


### PR DESCRIPTION
## Summary

Adds and hardens the full game reset workflow used for the fresh Base Sepolia diamond reset.

This PR includes:
- a full game reset runbook covering active + backup diamond deploys, Convex flush, clan minting, heartbeat/runner/Elder restart, Vercel deploy, smoke tests, and post-reset notes
- Convex ops mutations for flushing/resetting game state, including targeted `clanView` purge support for large historical backlogs
- Convex indexer reset-lock handling so scheduled actions do not race a flush
- indexer snapshot refresh narrowed to live `getClanIds()` so fresh four-clan worlds do not time out probing stale clan slots
- a split of oversized bandit lifecycle library code so deployed libraries/facets remain under EIP-170 bytecode limits
- reset learnings for pause/unpause, TTYD/Caddy cockpit ports, Vercel static web deploy fallback, and monthly Claude usage-limit handling

## Why

The 2026-05-11 reset surfaced several operational footguns:
- `LibBanditLifecycle` exceeded the deployed bytecode limit and Base Sepolia rejected the deploy
- Convex cron/indexer writers could race a reset flush unless explicitly locked and redeployed
- historical `clanView` rows were much larger than a generic flush pass could clear quickly
- public cockpit TTYD routes use Caddy ports `38790-38793`, not the release worktree `port-for` allocation
- full monorepo build can be blocked by Android-only release env while the web app can still be safely deployed from `apps/web/dist`

## Validation

- `forge build`
- `forge test --match-path 'test/Heartbeat*.t.sol'`
- `forge test --match-path 'test/diamond/*'`
- `pnpm gen:contract-abi && pnpm gen:chainclient-abi && pnpm test:chainclient-abi`
- `pnpm --filter @clan-world/server typecheck`
- `pnpm --filter @clan-world/web build`
- Convex functions deployed and snapshot refreshed against the fresh diamond
- Fresh diamond and backup diamond deployed on Base Sepolia
- Four clans minted and Convex snapshot verified
- TTYD public cockpit routes verified returning HTTP 200 after correcting the Caddy port mismatch

Known notes:
- Full `pnpm build` is currently blocked by Android requiring `CLAN_WORLD_MAP_URL`; web build passes independently.
- Two focused `BanditAttackResolution.t.sol` reward-expectation tests failed during exploratory validation and should be reviewed separately from the deploy-size split.
