### PR TITLE
[codex] reduce hand-rolled generated type surfaces

### DIFF
--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -14,8 +14,10 @@ import {
   type Abi,
   type Hex,
   type Log,
+  type ParseEventLogsReturnType,
 } from "viem";
 import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constants";
+import type { Doc } from "./_generated/dataModel";
 
 const CLAN_WORLD_ABI = clanWorldArtifact.abi as Abi;
 const baseSepolia = defineChain({
@@ -69,6 +71,18 @@ type SnapshotPayload = {
   clans: Record<string, unknown>[];
 };
 
+type ParsedClanWorldLog = ParseEventLogsReturnType<
+  typeof CLAN_WORLD_ABI,
+  undefined,
+  false
+>[number];
+
+type LegacyClanView = Partial<Doc<"clanView">> &
+  Pick<Doc<"clanView">, "clanId">;
+
+const isPresent = <T>(value: T | null | undefined): value is T =>
+  value !== null && value !== undefined;
+
 export function bigintSafe(value: unknown): unknown {
   if (typeof value === "bigint") return value.toString();
   if (Array.isArray(value)) return value.map(bigintSafe);
@@ -88,7 +102,7 @@ export function decodeClanWorldLogs(
     abi: CLAN_WORLD_ABI,
     logs: [...logs],
     strict: false,
-  }).map((event) => ({
+  }).map((event: ParsedClanWorldLog) => ({
     eventName: event.eventName,
     args: bigintSafe(event.args ?? {}) as Record<string, unknown>,
     address: event.address,
@@ -230,23 +244,6 @@ export function planPollLogRange(
     shouldPoll: fromBlock <= safeLatest,
   };
 }
-
-type LegacyClanView = {
-  clanId: number;
-  owner?: string;
-  baseRegion?: number;
-  baseLevel?: number;
-  wallLevel?: number;
-  monumentLevel?: number;
-  livingClansmen?: number;
-  goldBalance?: string;
-  blueprintBalance?: string;
-  vaultWood?: string;
-  vaultIron?: string;
-  vaultWheat?: string;
-  vaultFish?: string;
-  clansmen?: unknown[];
-};
 
 export const legacyClansFromClanViews = (clanViews: LegacyClanView[]) =>
   clanViews
@@ -583,7 +580,7 @@ export const commitSnapshot = internalMutation({
       ),
     );
     const legacyClans = legacyClansFromClanViews(
-      latestClanViews.filter(Boolean) as LegacyClanView[],
+      latestClanViews.filter(isPresent),
     );
     const tickEpochStartedAt =
       previousWorldSnapshot?.tick === tick

--- a/apps/web/src/EventTicker.tsx
+++ b/apps/web/src/EventTicker.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useEffect, useState } from 'react';
 import { BanditState } from '@clan-world/shared/generated/enums';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { api } from '../../server/convex/_generated/api';
+import type { Doc } from '../../server/convex/_generated/dataModel';
 import { useAgentLogs } from './useAgentLogs';
 import { DEMO_MODE } from './config/env';
 
@@ -59,16 +60,7 @@ function slotColor(clanId: number): string {
 
 // ---- Chain event → ticker string -----------------------------------------------
 
-type ChainEvent = {
-  _id: string;
-  eventName: string;
-  tick?: number;
-  clanId?: number;
-  banditId?: number;
-  args: unknown;
-  blockNumber: number;
-  logIndex: number;
-};
+type ChainEvent = Doc<'chainEvents'>;
 
 function safeNum(v: unknown, fallback = 0): number {
   if (typeof v === 'number') return Number.isFinite(v) ? v : fallback;
@@ -297,7 +289,7 @@ const SCROLL_PX_PER_SEC = 48;
 
 export function EventTicker() {
   const agentLogs = useAgentLogs();
-  const rawChainEvents = useQuery(api.events.getRecentChainEvents) as ChainEvent[] | undefined;
+  const rawChainEvents = useQuery(api.events.getRecentChainEvents);
 
   const entries = useMemo<TickerEntry[]>(() => {
     if (!DEMO_MODE && rawChainEvents && rawChainEvents.length > 0) {

--- a/packages/shared/src/adapters/IConvexClient.ts
+++ b/packages/shared/src/adapters/IConvexClient.ts
@@ -1,8 +1,7 @@
-import type { FunctionReference } from 'convex/server';
 import { ConvexHttpClient } from 'convex/browser';
-import { anyApi } from 'convex/server';
 import type { ClanFullView, Whisper, WorldSnapshot } from '../types';
 import { readEnv } from './_env';
+import { convexApiRefs } from './convexApiRefs';
 
 export interface IConvexClient {
   getSnapshot(): Promise<WorldSnapshot>;
@@ -74,15 +73,12 @@ class StubConvexClient implements IConvexClient {
   async postBulletin(_args: { clanId: number; slot: number; body: string; dataHash?: string; txHash?: string }): Promise<void> {}
 }
 
-// TODO(handcoded-types-audit): move Convex function references behind a server-owned
-// export shim so shared can use generated API types without depending on apps/server.
-const getSnapshotRef = anyApi.getSnapshot!.getSnapshot as FunctionReference<'query'>;
-// getClanFullView doesn't exist in Phase 4 convex schema yet; use anyApi so it resolves at runtime
-const getClanFullViewRef = anyApi.clan!.getClanFullView as FunctionReference<'query'>;
-const seedWhisperRef = anyApi.comms!.seedWhisper as FunctionReference<'mutation'>;
-const seedOrchEventRef = anyApi.comms!.seedOrchEvent as FunctionReference<'mutation'>;
-const seedHumanSteeringRef = anyApi.comms!.seedHumanSteering as FunctionReference<'mutation'>;
-const seedBulletinRef = anyApi.bulletins!.seedBulletin as FunctionReference<'mutation'>;
+const getSnapshotRef = convexApiRefs.getSnapshot.getSnapshot;
+const getClanFullViewRef = convexApiRefs.clan.getClanFullView;
+const seedWhisperRef = convexApiRefs.comms.seedWhisper;
+const seedOrchEventRef = convexApiRefs.comms.seedOrchEvent;
+const seedHumanSteeringRef = convexApiRefs.comms.seedHumanSteering;
+const seedBulletinRef = convexApiRefs.bulletins.seedBulletin;
 
 class RealConvexClient implements IConvexClient {
   private readonly http: ConvexHttpClient;
@@ -93,7 +89,7 @@ class RealConvexClient implements IConvexClient {
 
   async getSnapshot(): Promise<WorldSnapshot> {
     try {
-      return await this.http.query(getSnapshotRef) as WorldSnapshot;
+      return await this.http.query(getSnapshotRef);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes('not found') || msg.includes('Could not find')) {
@@ -106,7 +102,7 @@ class RealConvexClient implements IConvexClient {
 
   async getClanFullView(clanId: string): Promise<ClanFullView> {
     try {
-      return await this.http.query(getClanFullViewRef, { clanId }) as ClanFullView;
+      return await this.http.query(getClanFullViewRef, { clanId });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes('not found') || msg.includes('Could not find')) {

--- a/packages/shared/src/adapters/convexApiRefs.ts
+++ b/packages/shared/src/adapters/convexApiRefs.ts
@@ -1,0 +1,63 @@
+import type { FunctionReference } from 'convex/server';
+import { anyApi } from 'convex/server';
+import type { ClanFullView, WorldSnapshot } from '../types';
+
+type PublicQuery<Args extends Record<string, unknown>, Result> = FunctionReference<'query', 'public', Args, Result>;
+type PublicMutation<Args extends Record<string, unknown>, Result = null> = FunctionReference<'mutation', 'public', Args, Result>;
+
+type SeedWhisperArgs = {
+  secret: string;
+  tick: number;
+  fromClanId: number;
+  toClanIds: number[];
+  body: string;
+  txHash?: string;
+};
+
+type SeedOrchEventArgs = {
+  secret: string;
+  tick: number;
+  kind: 'world_event' | 'directive' | 'narration';
+  body: string;
+  targetClanId?: number;
+};
+
+type SeedHumanSteeringArgs = {
+  secret: string;
+  tick: number;
+  targetClanId: number;
+  body: string;
+  sentBy?: string;
+};
+
+type SeedBulletinArgs = {
+  secret: string;
+  clanId: number;
+  slot: number;
+  body: string;
+  dataHash?: string;
+  txHash?: string;
+};
+
+type ClanWorldConvexApi = {
+  getSnapshot: {
+    getSnapshot: PublicQuery<Record<string, never>, WorldSnapshot>;
+  };
+  clan: {
+    getClanFullView: PublicQuery<{ clanId: string }, ClanFullView>;
+  };
+  comms: {
+    seedWhisper: PublicMutation<SeedWhisperArgs>;
+    seedOrchEvent: PublicMutation<SeedOrchEventArgs>;
+    seedHumanSteering: PublicMutation<SeedHumanSteeringArgs>;
+  };
+  bulletins: {
+    seedBulletin: PublicMutation<SeedBulletinArgs>;
+  };
+};
+
+// shared cannot import apps/server/convex/_generated/api: the server already
+// depends on shared, and crossing that package boundary would create a cycle.
+// Keep this narrow shim aligned with the public Convex functions this adapter
+// calls, and let ConvexHttpClient enforce args/results from here onward.
+export const convexApiRefs = anyApi as unknown as ClanWorldConvexApi;


### PR DESCRIPTION
## Summary
- replace hand-rolled Convex chain event typing in the web ticker with generated `Doc<"chainEvents">`
- type indexer legacy clan views with generated Convex `Doc<"clanView">` and tighten parsed-log typing
- move shared Convex adapter refs behind a narrow typed shim so HTTP query/mutation args and results are checked after one package-boundary cast

## Why
PR #224 surfaced a few places where reset/runtime code was still manually mirroring generated Convex or ABI surfaces. This keeps behavior the same while shrinking the drift-prone hand-written type layer.

## Validation
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/server typecheck`
- `pnpm --filter @clan-world/web typecheck`
- `pnpm --filter @clan-world/server test -- convex/indexer.test.ts`
- `pnpm --filter @clan-world/agents typecheck`
- `pnpm --filter @clan-world/runner typecheck`
- `pnpm --filter @clan-world/shared build`

## Note
This is stacked on #224 and targets `codex/full-game-reset-ops` so the PR diff stays focused. Once #224 lands, this can be retargeted to `dev`.
