### PR TITLE
feat(web): position bandit camp far from region bases

### DIFF
--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -2295,12 +2295,16 @@ export function WorldMap() {
     if (!region) return null;
     const { scaleX, scaleY, offsetX, offsetY } = layoutRef.current;
 
+    const seen = new Set<string>();
     const basePositions: Array<[number, number]> = [];
     for (const entry of drawnRef.current.bases) {
       if (entry.clan.homeRegion !== regionKey) continue;
-      const baseRegion = REGIONS.find(r => r.id === entry.clan.homeRegion);
-      if (!baseRegion) continue;
-      basePositions.push([baseRegion.nx * REF_W, baseRegion.ny * REF_H]);
+      const bx = region.nx * REF_W;
+      const by = region.ny * REF_H;
+      const key = `${bx},${by}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      basePositions.push([bx, by]);
     }
 
     if (basePositions.length === 0) {

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -2286,6 +2286,74 @@ export function WorldMap() {
     };
   }
 
+  // Bandit camp sits in the region's polygon at the point farthest from all bases
+  // anchored there. Avoids the visual collision where camp + base both render at
+  // the region center. Falls back to the region anchor when the region has no
+  // bases (no behavior change). Computed in REF coords for layout stability.
+  function projectedBanditCampAnchor(regionKey: string): Point2 | null {
+    const region = REGIONS.find(r => r.id === regionKey);
+    if (!region) return null;
+    const { scaleX, scaleY, offsetX, offsetY } = layoutRef.current;
+
+    const basePositions: Array<[number, number]> = [];
+    for (const entry of drawnRef.current.bases) {
+      if (entry.clan.homeRegion !== regionKey) continue;
+      const baseRegion = REGIONS.find(r => r.id === entry.clan.homeRegion);
+      if (!baseRegion) continue;
+      basePositions.push([baseRegion.nx * REF_W, baseRegion.ny * REF_H]);
+    }
+
+    if (basePositions.length === 0) {
+      return {
+        x: offsetX + region.nx * REF_W * scaleX,
+        y: offsetY + region.ny * REF_H * scaleY,
+      };
+    }
+
+    const xs = region.polygon.map(([x]) => x);
+    const ys = region.polygon.map(([, y]) => y);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+    // Margin keeps the camp visually inside the region rather than hugging the boundary.
+    const insetX = (maxX - minX) * 0.08;
+    const insetY = (maxY - minY) * 0.08;
+    const sampleMinX = minX + insetX;
+    const sampleMaxX = maxX - insetX;
+    const sampleMinY = minY + insetY;
+    const sampleMaxY = maxY - insetY;
+
+    const STEPS = 6;
+    let bestX = region.nx * REF_W;
+    let bestY = region.ny * REF_H;
+    let bestMinDistSq = -Infinity;
+    for (let i = 0; i <= STEPS; i++) {
+      for (let j = 0; j <= STEPS; j++) {
+        const x = sampleMinX + ((sampleMaxX - sampleMinX) * i) / STEPS;
+        const y = sampleMinY + ((sampleMaxY - sampleMinY) * j) / STEPS;
+        if (!pointInPolygon(x, y, region.polygon)) continue;
+        let minDistSq = Infinity;
+        for (const [bx, by] of basePositions) {
+          const dx = x - bx;
+          const dy = y - by;
+          const d = dx * dx + dy * dy;
+          if (d < minDistSq) minDistSq = d;
+        }
+        if (minDistSq > bestMinDistSq) {
+          bestMinDistSq = minDistSq;
+          bestX = x;
+          bestY = y;
+        }
+      }
+    }
+
+    return {
+      x: offsetX + bestX * scaleX,
+      y: offsetY + bestY * scaleY,
+    };
+  }
+
   function routeControlPoints(route: TravelRoute) {
     const from = projectedRegionAnchor(route.fromRegionKey);
     const to = projectedRegionAnchor(route.toRegionKey);
@@ -2758,7 +2826,7 @@ export function WorldMap() {
     const deathScale = BANDIT_SPRITE_DEATH_SCALE * layoutScale;
 
     if (phase.kind === 'camp_idle') {
-      const anchor = projectedRegionAnchor(phase.regionKey);
+      const anchor = projectedBanditCampAnchor(phase.regionKey);
       if (!anchor) return;
       if (animState.campSprite) {
         animState.campSprite.visible = true;
@@ -2778,7 +2846,7 @@ export function WorldMap() {
     }
 
     if (phase.kind === 'camp_telegraph') {
-      const anchor = projectedRegionAnchor(phase.regionKey);
+      const anchor = projectedBanditCampAnchor(phase.regionKey);
       if (!anchor) return;
       // Three standing bandits with phase-offset jitter (sin ±1px).
       const standTextures = animState.walkTextures.se.length > 0
@@ -2811,8 +2879,8 @@ export function WorldMap() {
     }
 
     if (phase.kind === 'no_battle_advance') {
-      const from = projectedRegionAnchor(phase.fromRegionKey);
-      const to = projectedRegionAnchor(phase.toRegionKey);
+      const from = projectedBanditCampAnchor(phase.fromRegionKey);
+      const to = projectedBanditCampAnchor(phase.toRegionKey);
       if (!from || !to) return;
       const dir = pickWalkDirection(from, to);
       const dirTextures = animState.walkTextures[dir.textures];
@@ -2841,7 +2909,7 @@ export function WorldMap() {
   ) {
     const animState = banditAnimRef.current;
     const drawn = drawnRef.current;
-    const fromAnchor = projectedRegionAnchor(phase.regionKey);
+    const fromAnchor = projectedBanditCampAnchor(phase.regionKey);
     if (!fromAnchor) return;
 
     // Locate the old-region target base. Won outcomes still battle at the
@@ -2970,7 +3038,7 @@ export function WorldMap() {
       // 18.5–25.5s: walk to next region.
       // 25.5+: render new camp at toRegion (handled by phase becoming camp_idle once snapshot updates).
       const toRegionKey = REGION_KEY_BY_CHAIN_ID[phase.outcome.toRegion];
-      const toAnchor = toRegionKey ? projectedRegionAnchor(toRegionKey) : null;
+      const toAnchor = toRegionKey ? projectedBanditCampAnchor(toRegionKey) : null;
 
       if (t < BATTLE_T_WIN_CLUSTER_END) {
         // Cluster pause near target base.


### PR DESCRIPTION
Closes #228

## Summary

When a region has at least one base, the bandit camp now anchors at the polygon-interior point that maximizes the minimum distance to all base centers in that region — instead of the region's nominal center. Regions with no bases keep the current center anchor, so there's no visual regression elsewhere.

## Algorithm

`projectedBanditCampAnchor(regionKey)` in `apps/web/src/WorldMap.tsx`:

1. Collect base positions for the region in REF (native map) coordinates.
2. If none — fall back to `projectedRegionAnchor` (no behavior change).
3. Sample a 7×7 grid (`STEPS=6`) inside the region polygon's bounding box, inset 8% from the edges so the camp doesn't kiss the boundary.
4. Filter candidates by `pointInPolygon` against the region's authored polygon (ensures the camp stays "inside" the region and doesn't drift into a neighbor).
5. Pick the candidate with the largest minimum squared-distance to any base.
6. Project the winner through the current `layoutRef` (so it scales with viewport resize, just like the region anchor).

REF-coord computation gives stable positioning across `layoutScale` changes — no jitter on resize.

## Call sites switched

All bandit camp phases now read from `projectedBanditCampAnchor` for a single source of truth:

- `camp_idle` — sprite + glow
- `camp_telegraph` — 3 standing bandits + glow crossfade
- `no_battle_advance` — from/to (bandits walking between camps)
- `battle` — `fromAnchor` (bandits start at camp, march to base)
- `won` outcome — `toAnchor` (new camp at destination after win)

Clansman travel routes and ensureLiveRoute still use `projectedRegionAnchor` — those are unrelated to bandits.

## Visual verification

Captured with DEMO_MODE=true. The mountain region holds Ember Hand (red Lv 3 keep, upper-right corner of region):

- **Before**: red bandit glow renders directly on top of the keep.
- **After**: bandit glow sits at the polygon's far corner, well clear of the keep.

## Test plan

- [x] `pnpm --filter @clan-world/web run typecheck` passes
- [x] dev server loads, canvas renders, no console errors from the new function
- [x] camp no longer overlaps base in mountains region (DEMO_MODE smoke)
- [x] regions with no bases keep current center position (early-return preserves `projectedRegionAnchor` shape)