### PR TITLE
fix(android): home screen JSON decode + devnet cluster routing (#229)

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/ClanWorldConvexClient.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/ClanWorldConvexClient.kt
@@ -139,7 +139,8 @@ class ClanWorldConvexClient(private val convexUrl: String) {
       }
       val value = root["value"]
         ?: throw ConvexException("Convex $path returned no `value`: $body")
-      runCatching { json.decodeFromJsonElement<T>(value) }
+      val normalized = value.normalizeConvexNumbers()
+      runCatching { json.decodeFromJsonElement<T>(normalized) }
         .getOrElse {
           throw ConvexException(
             "Could not decode $path response into ${T::class.simpleName}: $body",

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/ConvexJsonNumber.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/ConvexJsonNumber.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.doubleOrNull
 
 /**
  * Convex's JSON output renders ALL numeric fields as floats — e.g. an
@@ -17,6 +16,13 @@ import kotlinx.serialization.json.doubleOrNull
  * rewrites every whole-number Double primitive (e.g. `1.0` → `1`) so the
  * default `Long`/`Int` decoders accept it. Fractional values are passed
  * through untouched so `Double`-typed fields still decode correctly.
+ *
+ * The matcher is intentionally string-based — going through Double would
+ * silently collapse 64-bit integers > 2^53 (e.g. timestamps in
+ * nanoseconds) since `asLong.toDouble() == d` is still true after the
+ * binary64 precision floor. We only rewrite tokens of the literal shape
+ * `<digits>.0` (optionally signed), which is exactly the shape Convex
+ * emits for v.number()-typed integer columns.
  */
 internal fun JsonElement.normalizeConvexNumbers(): JsonElement = when (this) {
   is JsonObject -> JsonObject(mapValues { (_, v) -> v.normalizeConvexNumbers() })
@@ -24,13 +30,15 @@ internal fun JsonElement.normalizeConvexNumbers(): JsonElement = when (this) {
   is JsonPrimitive -> if (isString) this else coerceWholeDouble(this)
 }
 
+private val WHOLE_DOUBLE = Regex("""^-?\d+\.0+$""")
+
 private fun coerceWholeDouble(p: JsonPrimitive): JsonPrimitive {
-  val d = p.doubleOrNull ?: return p
-  // Skip ints already-encoded as ints; only rewrite when source has a '.'.
-  if ('.' !in p.content && 'e' !in p.content && 'E' !in p.content) return p
-  // NaN / Infinity are not whole numbers — leave alone (will fail Long parse
-  // later if a Long field is hit, but that's a true data error).
-  if (!d.isFinite()) return p
-  val asLong = d.toLong()
-  return if (asLong.toDouble() == d) JsonPrimitive(asLong) else p
+  val s = p.content
+  // Bare integers, exponents, NaN/Infinity, fractional digits — all left alone.
+  if (!WHOLE_DOUBLE.matches(s)) return p
+  // Strip the trailing `.0`(s) and let the standard Long parser bound-check.
+  // Outside Long range → fall back to the original token so a Double-typed
+  // field can still decode it.
+  val asLong = s.substringBefore('.').toLongOrNull() ?: return p
+  return JsonPrimitive(asLong)
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/ConvexJsonNumber.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/ConvexJsonNumber.kt
@@ -1,0 +1,36 @@
+package world.clan.app.data
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.doubleOrNull
+
+/**
+ * Convex's JSON output renders ALL numeric fields as floats — e.g. an
+ * integer-typed `bandit.id` arrives as `1.0`, not `1`. kotlinx.serialization
+ * rejects that when the Kotlin field is `Int`/`Long`, surfacing the v2.4.0
+ * "Could not decode getSnapshot:getSnapshot response" crash on the Hearth
+ * home screen (issue #229).
+ *
+ * Walking the parsed JsonElement tree once before `decodeFromJsonElement`
+ * rewrites every whole-number Double primitive (e.g. `1.0` → `1`) so the
+ * default `Long`/`Int` decoders accept it. Fractional values are passed
+ * through untouched so `Double`-typed fields still decode correctly.
+ */
+internal fun JsonElement.normalizeConvexNumbers(): JsonElement = when (this) {
+  is JsonObject -> JsonObject(mapValues { (_, v) -> v.normalizeConvexNumbers() })
+  is JsonArray -> JsonArray(map { it.normalizeConvexNumbers() })
+  is JsonPrimitive -> if (isString) this else coerceWholeDouble(this)
+}
+
+private fun coerceWholeDouble(p: JsonPrimitive): JsonPrimitive {
+  val d = p.doubleOrNull ?: return p
+  // Skip ints already-encoded as ints; only rewrite when source has a '.'.
+  if ('.' !in p.content && 'e' !in p.content && 'E' !in p.content) return p
+  // NaN / Infinity are not whole numbers — leave alone (will fail Long parse
+  // later if a Long field is hit, but that's a true data error).
+  if (!d.isFinite()) return p
+  val asLong = d.toLong()
+  return if (asLong.toDouble() == d) JsonPrimitive(asLong) else p
+}

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/ConvexModels.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/ConvexModels.kt
@@ -24,7 +24,6 @@ data class WorldSnapshot(
   val seasonEndTick: Long? = null,
   val winterActive: Boolean = false,
   val winterStartsAtTick: Long? = null,
-  val leaderboard: List<LeaderboardEntry>? = null,
 )
 
 @Serializable
@@ -43,6 +42,12 @@ data class Region(
 /**
  * One clan's summary inside getSnapshot. Wei amounts (`treasury`,
  * `goldBalance`, `vault*`) are `String` — parse with `String.weiToWhole()`.
+ *
+ * Server-side numeric clan-level fields (`baseLevel`, `baseRegion`,
+ * `wallLevel`, `monumentLevel`, `livingClansmen`) are intentionally
+ * NOT modelled — they arrive as bare JSON numbers (e.g. `1.0`) which
+ * conflict with the `String?` shape the cockpit demo previously assumed.
+ * `ignoreUnknownKeys = true` on the deserializer drops them silently.
  */
 @Serializable
 data class ClanSummary(
@@ -55,12 +60,6 @@ data class ClanSummary(
   val vaultIron: String? = null,
   val vaultWheat: String? = null,
   val vaultFish: String? = null,
-  /** May arrive as numeric string ("1.0") from Convex BigDecimal serialization — use [.toIntFlexible]. */
-  val baseRegion: String? = null,
-  val baseLevel: String? = null,
-  val wallLevel: String? = null,
-  val monumentLevel: String? = null,
-  val livingClansmen: String? = null,
   val owner: String? = null,
 )
 
@@ -74,14 +73,6 @@ data class BanditSummary(
   val stateEnteredTick: Long? = null,
   val nextActionTick: Long? = null,
   val projectedTargetClanId: Int? = null,
-)
-
-@Serializable
-data class LeaderboardEntry(
-  val clanId: Int,
-  val name: String? = null,
-  val gold: String? = null,
-  val rank: Int? = null,
 )
 
 // ─── inft:getInftDemoState ──────────────────────────────────────────────

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/Mwa.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/Mwa.kt
@@ -45,7 +45,7 @@ object Mwa {
     elder: Elder,
   ): SignInResult {
     val mwa = MobileWalletAdapter(connectionIdentity = identity)
-    mwa.blockchain = Solana.Mainnet
+    mwa.blockchain = Solana.Devnet
 
     val message = ("Sign in as Ælder of ${elder.name} (clan ${elder.clanId})")
       .toByteArray(Charsets.UTF_8)

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/Mwa.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/Mwa.kt
@@ -4,10 +4,10 @@ import android.net.Uri
 import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
 import com.solana.mobilewalletadapter.clientlib.ConnectionIdentity
 import com.solana.mobilewalletadapter.clientlib.MobileWalletAdapter
-import com.solana.mobilewalletadapter.clientlib.Solana
 import com.solana.mobilewalletadapter.clientlib.TransactionResult
 import world.clan.app.BuildConfig
 import world.clan.app.data.Elder
+import world.clan.app.wallet.ClanWorldMwaCluster
 import world.clan.app.wallet.FakeWalletBlockedException
 import world.clan.app.wallet.FakeWalletPolicy
 
@@ -45,7 +45,7 @@ object Mwa {
     elder: Elder,
   ): SignInResult {
     val mwa = MobileWalletAdapter(connectionIdentity = identity)
-    mwa.blockchain = Solana.Devnet
+    mwa.blockchain = ClanWorldMwaCluster
 
     val message = ("Sign in as Ælder of ${elder.name} (clan ${elder.clanId})")
       .toByteArray(Charsets.UTF_8)

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -283,6 +283,12 @@ fun ClanWorldApp(
           Toast.makeText(hostActivity, "No wallet found on device.", Toast.LENGTH_LONG).show()
         is MwaResult.WalletNotAllowed ->
           Toast.makeText(hostActivity, "Demo wallets are blocked in this build.", Toast.LENGTH_LONG).show()
+        is MwaResult.WrongNetwork ->
+          Toast.makeText(
+            hostActivity,
+            "Open your wallet and switch to Solana Devnet, then tap MINT again.",
+            Toast.LENGTH_LONG,
+          ).show()
         is MwaResult.Error ->
           Toast.makeText(hostActivity, result.cause.message ?: "Faucet tx failed.", Toast.LENGTH_LONG).show()
       }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/HireModal.kt
@@ -137,6 +137,10 @@ fun HireModal(
                   state.value = HireState.Failed
                   errorMessage.value = FakeWalletPolicy.BLOCKED_MESSAGE
                 }
+                is MwaResult.WrongNetwork -> {
+                  state.value = HireState.Failed
+                  errorMessage.value = "switch your wallet to Solana Devnet, then try again."
+                }
                 is MwaResult.Error -> {
                   state.value = HireState.Failed
                   errorMessage.value = result.cause.message ?: "the wallet refused the seal."

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ForgeScreen.kt
@@ -117,6 +117,8 @@ fun ForgeScreenRoute(
             vm.setMintPhase(SendPhase.Failed, "no wallet found on device.")
           is MwaResult.WalletNotAllowed ->
             vm.setMintPhase(SendPhase.Failed, FakeWalletPolicy.BLOCKED_MESSAGE)
+          is MwaResult.WrongNetwork ->
+            vm.setMintPhase(SendPhase.Failed, "switch your wallet to Solana Devnet, then try again.")
           is MwaResult.Error ->
             vm.setMintPhase(SendPhase.Failed, r.cause.message ?: "the wallet refused the seal.")
         }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -173,6 +173,9 @@ fun SteeringConsoleScreenRoute(
           is MwaResult.UserDeclined -> vm.setSending(false)
           is MwaResult.WalletNotFound -> vm.setError("no wallet found on device.")
           is MwaResult.WalletNotAllowed -> vm.setError(FakeWalletPolicy.BLOCKED_MESSAGE)
+          is MwaResult.WrongNetwork -> vm.setError(
+            "switch your wallet to Solana Devnet, then try again.",
+          )
           is MwaResult.Error -> vm.setError(
             result.cause.message ?: "the wallet refused the seal.",
           )

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/StrategyEditorScreen.kt
@@ -163,6 +163,8 @@ fun StrategyEditorScreenRoute(
             vm.setSavePhase(SendPhase.Failed, "no wallet found on device.")
           is MwaResult.WalletNotAllowed ->
             vm.setSavePhase(SendPhase.Failed, FakeWalletPolicy.BLOCKED_MESSAGE)
+          is MwaResult.WrongNetwork ->
+            vm.setSavePhase(SendPhase.Failed, "switch your wallet to Solana Devnet, then try again.")
           is MwaResult.Error ->
             vm.setSavePhase(SendPhase.Failed, result.cause.message ?: "the wallet refused the seal.")
         }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/viewmodel/ConnectViewModel.kt
@@ -187,6 +187,18 @@ class ConnectViewModel(
           )
         }
       }
+      MwaResult.WrongNetwork -> {
+        sessionStore.clear()
+        clearWalletNameCache()
+        _state.update {
+          it.copy(
+            phase = ConnectUiState.Phase.Error,
+            solanaPubkeyBase58 = null,
+            pendingVerification = false,
+            errorMessage = "Switch your wallet to Solana Devnet, then reconnect.",
+          )
+        }
+      }
       is MwaResult.Error -> {
         // Same rationale as UserDeclined: clear so we never retry a token
         // the wallet has rejected. A real network/IPC error will simply

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/MwaClient.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/MwaClient.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import com.solana.mobilewalletadapter.clientlib.ActivityResultSender
 import com.solana.mobilewalletadapter.clientlib.ConnectionIdentity
 import com.solana.mobilewalletadapter.clientlib.MobileWalletAdapter
-import com.solana.mobilewalletadapter.clientlib.Solana
 import com.solana.mobilewalletadapter.clientlib.TransactionParams
 import com.solana.mobilewalletadapter.clientlib.TransactionResult
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignAndSendTransactionsResult
@@ -35,8 +34,9 @@ sealed class MwaResult<out T> {
  * disconnect calls. signMessage is wired but unused; slice 2 (full) will
  * exercise it for the SIWS identity-link challenge.
  *
- * V3 doesn't transact on Solana, so [Solana.Devnet] is cosmetic — a
- * wallet may surface "Connect to Devnet" but we never broadcast anything.
+ * The MWA session targets [ClanWorldMwaCluster] (devnet); GOLD mint /
+ * faucet transactions are broadcast against the devnet RPC declared in
+ * `build.gradle.kts`.
  *
  * Callers pass an [ActivityResultSender] constructed in MainActivity.onCreate;
  * registering activity-results post-RESUMED throws.
@@ -54,7 +54,7 @@ class MwaClient(
       identityName = identityName,
     ),
   ).apply {
-    blockchain = Solana.Devnet
+    blockchain = ClanWorldMwaCluster
   }
 
   // ── Connect (first time) ───────────────────────────────────────────────
@@ -198,10 +198,16 @@ class MwaClient(
         "user_canceled" in msg -> MwaResult.UserDeclined
       // Wallet (e.g. Phantom on mainnet) refused because the dApp asked for
       // a different cluster. Surfacing as a distinct result lets the UI show
-      // a clear in-app message instead of the raw wallet dialog.
+      // a clear in-app message instead of the raw wallet dialog. The match
+      // is intentionally narrow — generic "network request failed" plumbing
+      // errors must continue to fall through to the Error branch.
       "network mismatch" in msg ||
-        ("network" in msg && ("switch" in msg || "wrong" in msg)) ||
-        ("cluster" in msg && "mismatch" in msg) -> MwaResult.WrongNetwork
+        "wrong network" in msg ||
+        "cluster mismatch" in msg ||
+        "wrong cluster" in msg ||
+        "invalid cluster" in msg ||
+        "switch to the correct network" in msg ||
+        "incorrect network" in msg -> MwaResult.WrongNetwork
       else -> MwaResult.Error(result.e)
     }
   }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/MwaClient.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/MwaClient.kt
@@ -23,6 +23,7 @@ sealed class MwaResult<out T> {
   data object UserDeclined : MwaResult<Nothing>()
   data object WalletNotFound : MwaResult<Nothing>()
   data object WalletNotAllowed : MwaResult<Nothing>()
+  data object WrongNetwork : MwaResult<Nothing>()
   data class Error(val cause: Throwable) : MwaResult<Nothing>()
 }
 
@@ -190,15 +191,18 @@ class MwaClient(
       return MwaResult.WalletNotAllowed
     }
     val msg = result.message.lowercase() + " " + (result.e.message?.lowercase().orEmpty())
-    return if (
+    return when {
       "declin" in msg ||
-      "cancel" in msg ||
-      "user did not approve" in msg ||
-      "user_canceled" in msg
-    ) {
-      MwaResult.UserDeclined
-    } else {
-      MwaResult.Error(result.e)
+        "cancel" in msg ||
+        "user did not approve" in msg ||
+        "user_canceled" in msg -> MwaResult.UserDeclined
+      // Wallet (e.g. Phantom on mainnet) refused because the dApp asked for
+      // a different cluster. Surfacing as a distinct result lets the UI show
+      // a clear in-app message instead of the raw wallet dialog.
+      "network mismatch" in msg ||
+        ("network" in msg && ("switch" in msg || "wrong" in msg)) ||
+        ("cluster" in msg && "mismatch" in msg) -> MwaResult.WrongNetwork
+      else -> MwaResult.Error(result.e)
     }
   }
 }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/MwaCluster.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/wallet/MwaCluster.kt
@@ -1,0 +1,19 @@
+package world.clan.app.wallet
+
+import com.solana.mobilewalletadapter.clientlib.Blockchain
+import com.solana.mobilewalletadapter.clientlib.Solana
+
+/**
+ * Canonical Solana cluster every MWA session in this app MUST request.
+ *
+ * Clan World is a devnet-only deployment (GOLD mint, faucet program, RPC
+ * URL are all devnet). Authorizing against [Solana.Mainnet] anywhere —
+ * even just for an Ælder sign-in message — primes the wallet's
+ * remembered network to mainnet and surfaces a confusing
+ * "Network mismatch (mainnet vs devnet)" dialog when the user then tries
+ * to mint. Issue #229.
+ *
+ * Routing every site through this constant lets a single unit test
+ * (`MwaClusterTest`) trap an accidental Mainnet swap.
+ */
+val ClanWorldMwaCluster: Blockchain = Solana.Devnet

--- a/apps/clan-world-mobile/app/src/test/java/world/clan/app/data/ConvexJsonNumberTest.kt
+++ b/apps/clan-world-mobile/app/src/test/java/world/clan/app/data/ConvexJsonNumberTest.kt
@@ -144,4 +144,39 @@ class ConvexJsonNumberTest {
     assertEquals(JsonNull, element.jsonObject["missing"])
     assertEquals(0L, element.jsonObject["count"]!!.jsonPrimitive.longOrNull)
   }
+
+  @Test
+  fun normalizePreservesExponentNotation() {
+    // Exponent literals (`1e2`) could be whole-numbered but the matcher only
+    // accepts `<digits>.0` to avoid Double precision collapse on 1e308.
+    // Convex never emits this shape today; the assertion locks behaviour so
+    // a future regex broadening can't accidentally suck in exponents.
+    val raw = """{"a":1e2,"b":1.5e2,"c":2E1}"""
+    val element = json.parseToJsonElement(raw).normalizeConvexNumbers()
+    assertEquals("1e2", element.jsonObject["a"]!!.jsonPrimitive.content)
+    assertEquals("1.5e2", element.jsonObject["b"]!!.jsonPrimitive.content)
+    assertEquals("2E1", element.jsonObject["c"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun normalizeHandlesNegativeWholeNumbers() {
+    val raw = """{"delta":-42.0,"zero":-0.0}"""
+    val element = json.parseToJsonElement(raw).normalizeConvexNumbers()
+    assertEquals(-42L, element.jsonObject["delta"]!!.jsonPrimitive.longOrNull)
+    assertEquals(0L, element.jsonObject["zero"]!!.jsonPrimitive.longOrNull)
+  }
+
+  @Test
+  fun normalizeLeavesOutOfLongRangeAlone() {
+    // 1e20 exceeds Long.MAX_VALUE (~9.2e18). Going through Double.toLong()
+    // would clamp/saturate silently and corrupt data — the normalizer must
+    // leave such tokens as-is so a `Double`-typed field can still take them.
+    val raw = """{"big":"99999999999999999999.0"}"""
+    // (Convex doesn't emit this shape today, but the precision-guard matters
+    //  for any future high-precision numeric column.)
+    val parsed = json.parseToJsonElement(raw)
+    // Above is a JSON string, not a number — confirm it stays a string.
+    val element = parsed.normalizeConvexNumbers()
+    assertTrue(element.jsonObject["big"]!!.jsonPrimitive.isString)
+  }
 }

--- a/apps/clan-world-mobile/app/src/test/java/world/clan/app/data/ConvexJsonNumberTest.kt
+++ b/apps/clan-world-mobile/app/src/test/java/world/clan/app/data/ConvexJsonNumberTest.kt
@@ -168,15 +168,20 @@ class ConvexJsonNumberTest {
 
   @Test
   fun normalizeLeavesOutOfLongRangeAlone() {
-    // 1e20 exceeds Long.MAX_VALUE (~9.2e18). Going through Double.toLong()
-    // would clamp/saturate silently and corrupt data — the normalizer must
-    // leave such tokens as-is so a `Double`-typed field can still take them.
-    val raw = """{"big":"99999999999999999999.0"}"""
+    // 99999999999999999999.0 exceeds Long.MAX_VALUE (~9.2e18). The
+    // string-based `toLongOrNull()` returns null on overflow, so the
+    // normalizer falls back to the original primitive — a `Double`-typed
+    // field can still consume the token, and an `Int`/`Long`-typed field
+    // will surface a real decode error rather than a silently-truncated 0.
     // (Convex doesn't emit this shape today, but the precision-guard matters
     //  for any future high-precision numeric column.)
-    val parsed = json.parseToJsonElement(raw)
-    // Above is a JSON string, not a number — confirm it stays a string.
-    val element = parsed.normalizeConvexNumbers()
-    assertTrue(element.jsonObject["big"]!!.jsonPrimitive.isString)
+    val raw = """{"big":99999999999999999999.0}"""
+    val element = json.parseToJsonElement(raw).normalizeConvexNumbers()
+    val primitive = element.jsonObject["big"]!!.jsonPrimitive
+    // Not coerced to Long — out-of-range guard kicked in.
+    assertNull(primitive.longOrNull)
+    // The original token shape is preserved (still a non-string primitive
+    // carrying the original `.0` text).
+    assertEquals("99999999999999999999.0", primitive.content)
   }
 }

--- a/apps/clan-world-mobile/app/src/test/java/world/clan/app/data/ConvexJsonNumberTest.kt
+++ b/apps/clan-world-mobile/app/src/test/java/world/clan/app/data/ConvexJsonNumberTest.kt
@@ -1,0 +1,147 @@
+package world.clan.app.data
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConvexJsonNumberTest {
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    coerceInputValues = true
+    explicitNulls = false
+  }
+
+  @Test
+  fun normalizeWholeNumberFloatToLong() {
+    val raw = """{"tick":1.0,"id":60.0}"""
+    val element = json.parseToJsonElement(raw).normalizeConvexNumbers()
+    assertEquals(1L, element.jsonObject["tick"]!!.jsonPrimitive.longOrNull)
+    assertEquals(60L, element.jsonObject["id"]!!.jsonPrimitive.longOrNull)
+  }
+
+  @Test
+  fun normalizePreservesFractionalDoubles() {
+    val raw = """{"amount":1.5,"ratio":0.25}"""
+    val element = json.parseToJsonElement(raw).normalizeConvexNumbers()
+    // Fractional doubles MUST remain doubles — Long-truncation would silently
+    // discard `0.5` and break `vault.amount` and similar fields.
+    assertNull(element.jsonObject["amount"]!!.jsonPrimitive.longOrNull)
+    assertEquals(1.5, element.jsonObject["amount"]!!.jsonPrimitive.content.toDouble(), 0.0)
+    assertEquals(0.25, element.jsonObject["ratio"]!!.jsonPrimitive.content.toDouble(), 0.0)
+  }
+
+  @Test
+  fun normalizePreservesStrings() {
+    val raw = """{"goldBalance":"1000000000000000000","name":"clan-alpha"}"""
+    val element = json.parseToJsonElement(raw).normalizeConvexNumbers()
+    assertTrue(element.jsonObject["goldBalance"]!!.jsonPrimitive.isString)
+    assertEquals("1000000000000000000", element.jsonObject["goldBalance"]!!.jsonPrimitive.content)
+    assertEquals("clan-alpha", element.jsonObject["name"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun normalizePreservesBareIntegers() {
+    val raw = """{"tick":42,"region":3}"""
+    val element = json.parseToJsonElement(raw).normalizeConvexNumbers()
+    assertEquals(42L, element.jsonObject["tick"]!!.jsonPrimitive.longOrNull)
+    assertEquals(3L, element.jsonObject["region"]!!.jsonPrimitive.longOrNull)
+  }
+
+  @Test
+  fun normalizeNestedObjectsAndArrays() {
+    val raw = """
+      {
+        "tick": 12.0,
+        "bandit": {
+          "id": 1.0,
+          "attackPower": 60.0,
+          "tier": 3.0
+        },
+        "clans": [
+          {"id": "clan-1", "baseLevel": 1.0},
+          {"id": "clan-2", "baseLevel": 2.0}
+        ]
+      }
+    """.trimIndent()
+    val element = json.parseToJsonElement(raw).normalizeConvexNumbers()
+    val bandit = element.jsonObject["bandit"]!!.jsonObject
+    assertEquals(1L, bandit["id"]!!.jsonPrimitive.longOrNull)
+    assertEquals(60L, bandit["attackPower"]!!.jsonPrimitive.longOrNull)
+    assertEquals(3L, bandit["tier"]!!.jsonPrimitive.longOrNull)
+  }
+
+  @Test
+  fun decodeWorldSnapshotWithFloatIntegers() {
+    // Replicates the v2.4.0 Hearth error payload from issue #229.
+    val raw = """
+      {
+        "tick": 12.0,
+        "activeBanditId": 1.0,
+        "bandit": {
+          "attackPower": 60.0,
+          "id": 1.0,
+          "nextActionTick": 12.0,
+          "projectedTargetClanId": 0.0,
+          "region": 4.0,
+          "state": 1.0,
+          "stateEnteredTick": 11.0,
+          "tier": 3.0
+        },
+        "clans": [
+          {
+            "id": "clan-1",
+            "blueprintBalance": "0",
+            "goldBalance": "1000000000000000000",
+            "name": "Sample Clan"
+          }
+        ],
+        "seasonStartTick": 0.0,
+        "seasonEndTick": 100.0,
+        "winterActive": false
+      }
+    """.trimIndent()
+    val element = json.parseToJsonElement(raw).normalizeConvexNumbers()
+    val snapshot = json.decodeFromJsonElement<WorldSnapshot>(element)
+    assertEquals(12L, snapshot.tick)
+    assertEquals(1, snapshot.activeBanditId)
+    assertNotNull(snapshot.bandit)
+    assertEquals(1, snapshot.bandit!!.id)
+    assertEquals(60, snapshot.bandit!!.attackPower)
+    assertEquals(3, snapshot.bandit!!.tier)
+    assertEquals(12L, snapshot.bandit!!.nextActionTick)
+    assertEquals(0L, snapshot.seasonStartTick)
+    assertEquals(100L, snapshot.seasonEndTick)
+    assertEquals(1, snapshot.clans.size)
+    assertEquals("Sample Clan", snapshot.clans[0].name)
+  }
+
+  @Test
+  fun normalizeLeavesNonWholeNumbersAlone() {
+    val raw = """[1.0, 1.5, 2.0, 2.7, 3]"""
+    val element = json.parseToJsonElement(raw).normalizeConvexNumbers()
+    val arr = (element as kotlinx.serialization.json.JsonArray).map { it.jsonPrimitive }
+    assertEquals(1L, arr[0].longOrNull)
+    assertNull(arr[1].longOrNull)
+    assertEquals(2L, arr[2].longOrNull)
+    assertNull(arr[3].longOrNull)
+    assertEquals(3L, arr[4].longOrNull)
+  }
+
+  @Test
+  fun normalizePreservesBooleansAndNulls() {
+    val raw = """{"flag":true,"missing":null,"count":0.0}"""
+    val element = json.parseToJsonElement(raw).normalizeConvexNumbers()
+    assertEquals("true", element.jsonObject["flag"]!!.jsonPrimitive.content)
+    assertEquals(JsonNull, element.jsonObject["missing"])
+    assertEquals(0L, element.jsonObject["count"]!!.jsonPrimitive.longOrNull)
+  }
+}

--- a/apps/clan-world-mobile/app/src/test/java/world/clan/app/wallet/MwaClusterTest.kt
+++ b/apps/clan-world-mobile/app/src/test/java/world/clan/app/wallet/MwaClusterTest.kt
@@ -2,6 +2,7 @@ package world.clan.app.wallet
 
 import com.solana.mobilewalletadapter.clientlib.Solana
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Test
 
 /**
@@ -10,25 +11,27 @@ import org.junit.Test
  * prompt) do so against the correct network instead of producing a raw
  * "Network mismatch — mainnet vs devnet" dialog mid-mint.
  *
- * This is a contract test against the Solana Mobile SDK's [Solana] object —
- * it documents the cluster identifier we depend on and traps any future
- * SDK upgrade that renames the field or constant.
+ * Pinning [ClanWorldMwaCluster] (which both [world.clan.app.wallet.MwaClient]
+ * and [world.clan.app.owner.Mwa] read from) traps any accidental
+ * Mainnet/Testnet swap. Pinning the underlying SDK identifiers also traps
+ * an SDK upgrade that renames the constants.
  */
 class MwaClusterTest {
 
   @Test
-  fun solanaDevnetIdentifierMatchesMwaSpec() {
-    // The MWA wallet identifies the requested network via these two fields.
-    // The combined CAIP-2-style identifier is "solana:devnet".
-    assertEquals("solana", Solana.Devnet.name)
-    assertEquals("devnet", Solana.Devnet.cluster)
+  fun clanWorldClusterIsDevnet() {
+    // The single source of truth every MWA call site uses. If someone ever
+    // points this at Solana.Mainnet again, mint flow regresses to the
+    // network-mismatch dialog Liam reported in v2.4.0.
+    assertSame(Solana.Devnet, ClanWorldMwaCluster)
+    assertEquals("solana", ClanWorldMwaCluster.name)
+    assertEquals("devnet", ClanWorldMwaCluster.cluster)
   }
 
   @Test
   fun solanaMainnetIsNotDevnet() {
-    // Sanity guard — if someone ever swaps Solana.Devnet for Solana.Mainnet
-    // in MwaClient again, the cluster identifier will silently match the
-    // wallet's default and the mismatch dialog will return.
+    // Sanity guard against an SDK rename that could make Mainnet alias
+    // back onto Devnet (extremely unlikely but cheap to assert).
     assertEquals("mainnet", Solana.Mainnet.cluster)
   }
 }

--- a/apps/clan-world-mobile/app/src/test/java/world/clan/app/wallet/MwaClusterTest.kt
+++ b/apps/clan-world-mobile/app/src/test/java/world/clan/app/wallet/MwaClusterTest.kt
@@ -1,0 +1,34 @@
+package world.clan.app.wallet
+
+import com.solana.mobilewalletadapter.clientlib.Solana
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression test for issue #229 Bug B: the MWA session MUST request the
+ * `solana:devnet` cluster so wallets that auto-switch (or surface a switch
+ * prompt) do so against the correct network instead of producing a raw
+ * "Network mismatch — mainnet vs devnet" dialog mid-mint.
+ *
+ * This is a contract test against the Solana Mobile SDK's [Solana] object —
+ * it documents the cluster identifier we depend on and traps any future
+ * SDK upgrade that renames the field or constant.
+ */
+class MwaClusterTest {
+
+  @Test
+  fun solanaDevnetIdentifierMatchesMwaSpec() {
+    // The MWA wallet identifies the requested network via these two fields.
+    // The combined CAIP-2-style identifier is "solana:devnet".
+    assertEquals("solana", Solana.Devnet.name)
+    assertEquals("devnet", Solana.Devnet.cluster)
+  }
+
+  @Test
+  fun solanaMainnetIsNotDevnet() {
+    // Sanity guard — if someone ever swaps Solana.Devnet for Solana.Mainnet
+    // in MwaClient again, the cluster identifier will silently match the
+    // wallet's default and the mismatch dialog will return.
+    assertEquals("mainnet", Solana.Mainnet.cluster)
+  }
+}


### PR DESCRIPTION
Closes #229

## Summary

Two v2.4.0 Android regressions:

**Bug A — Hearth home screen JSON decode error.** Convex serializes integer-typed fields (`bandit.id`, `bandit.tier`, `seasonStartTick`, etc.) as JSON floats (`1.0`, `60.0`), and kotlinx.serialization's default `Int`/`Long` decoders reject them. Result: home screen showed raw error text on every launch.

- New `ConvexJsonNumber.normalizeConvexNumbers()` walks the parsed `JsonElement` tree once before `decodeFromJsonElement` and rewrites tokens of literal shape `^-?\d+\.0+$` to `Long` via `substringBefore('.').toLongOrNull()`. **String-based on purpose** — going through `Double` would silently collapse 64-bit integers > 2^53.
- Out-of-Long-range tokens fall back to the original primitive so `Double`-typed fields still decode.
- Wired into `ClanWorldConvexClient.callConvex()` (the home/Hearth code path).
- Dropped now-incompatible `ClanSummary.baseLevel` / `baseRegion` / `wallLevel` / `monumentLevel` / `livingClansmen` (Convex emits these as bare numbers but the cockpit demo had typed them `String?` — they were unused).
- Dropped unused `WorldSnapshot.leaderboard` + `LeaderboardEntry` (UI builds rows from `snap.clans`).

**Bug B — Mint flow surfaced wallet "Network mismatch (mainnet vs devnet)".** Owner sign-in opened a `Solana.Mainnet` MWA session that primed the wallet on mainnet, then the devnet GOLD mint tripped the wallet's network-mismatch dialog.

- Introduced `ClanWorldMwaCluster = Solana.Devnet` as the single source of truth for every MWA session. Both `MwaClient.kt` (mint/sign-and-send) and `owner/Mwa.kt` (Ælder sign-in) now read from it.
- Added `MwaResult.WrongNetwork`. `classifyFailure()` detects narrow keyword set: `"network mismatch"`, `"wrong network"`, `"cluster mismatch"`, `"wrong cluster"`, `"invalid cluster"`, `"switch to the correct network"`, `"incorrect network"` — generic `"network request failed"` errors fall through to `Error`.
- Surfaced `WrongNetwork` in every call site (`ConnectViewModel`, `ClanWorldApp` mint flow, `SteeringConsole`, `ForgeScreen`, `StrategyEditor`, `HireModal`) with in-app guidance: "switch your wallet to Solana Devnet, then try again".

Local 3-tier swarm review (gemini-3-pro) ran two rounds; both pre-merge fix-rounds landed:
- r1 → r2: tightened `WrongNetwork` regex, switched normalizer to string-based parse, extracted `ClanWorldMwaCluster` constant.
- r2 → r3: fixed `normalizeLeavesOutOfLongRangeAlone` test to use an unquoted JSON number so the overflow guard actually fires.

22 unit tests, 0 failures. Debug APK assembles clean.

## Test plan
- [x] Mobile gradle build (`./gradlew :app:assembleDebug`) succeeds with map/terminal URLs set
- [x] Unit tests (`./gradlew :app:testDebugUnitTest`) — 22 pass, 0 fail
- [x] `ConvexJsonNumberTest` replays the v2.4.0 error payload through normalizer + WorldSnapshot decode
- [x] `MwaClusterTest` pins `ClanWorldMwaCluster == Solana.Devnet` (assertSame) so future Mainnet swap fails CI
- [ ] UAT: home screen loads without parse error on v2.4.1 build
- [ ] UAT: mint 100K GOLD without seeing wallet mainnet/devnet mismatch dialog (or sees clear in-app guidance if wallet refuses to switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)