### PR TITLE
[codex] Harden Elder runtime tooling

### DIFF
--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -1,10 +1,13 @@
 # packages/agents — AGENTS.md
 
-The `elder` CLI toolbelt. Installed as a `bin` from this package; Elder Claude Code sessions invoke it via Bash tool calls to read game state, submit orders, send whispers.
+The `elder` CLI toolbelt plus `elder-mcp` stdio server. Installed as `bin`
+entries from this package; Elder Claude Code sessions invoke them to read game
+state, submit orders, post bulletins, send whispers, and persist memory.
 
 ## What this package does
 
 - Provides the `elder` CLI executable (mapped via `package.json` `"bin"`).
+- Provides the `elder-mcp` stdio MCP server for structured JSON calls.
 - Wraps `IChainClient` and `IConvexClient` adapter calls in stable shell commands an Elder can invoke without thinking about RPC endpoints, contract addresses, or Convex deployment IDs.
 - Returns JSON on stdout (Elders parse it); writes diagnostics to stderr.
 
@@ -17,10 +20,12 @@ The `elder` CLI toolbelt. Installed as a `bin` from this package; Elder Claude C
 - `elder clan submit-orders <clanId> <ordersJsonFile>` — submit pending orders
 - `elder whisper send <fromClan> <toClan> <text>` — send a whisper
 - `elder whisper inbox <clanId>` — list unread whispers
+- `elder bulletin post <text>` — post a public bulletin
 
 ## Key files
 
-- `src/cli.ts` — entry point. Argv parsing is hand-rolled (no `commander`, keep deps minimal).
+- `src/cli.ts` — CLI entry point. Argv parsing is hand-rolled (no `commander`, keep deps minimal).
+- `src/mcp.ts` — MCP stdio server. Keep tool handlers aligned with CLI behavior.
 - `package.json` — declares `bin: { elder: "./dist/cli.js" }`. Run `pnpm --filter @clan-world/agents build` then `pnpm link --global` to use.
 
 ## Local conventions

--- a/packages/agents/bin/elder-mcp
+++ b/packages/agents/bin/elder-mcp
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+# Resolve symlinks to find the real script directory (POSIX portable).
+SCRIPT="$0"
+while [ -L "$SCRIPT" ]; do
+  LINK="$(readlink "$SCRIPT")"
+  case "$LINK" in
+    /*) SCRIPT="$LINK" ;;
+    *)  SCRIPT="$(dirname "$SCRIPT")/$LINK" ;;
+  esac
+done
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT")" && pwd)"
+
+TSX="${SCRIPT_DIR}/../node_modules/.bin/tsx"
+if [ ! -x "$TSX" ]; then
+  TSX="$(command -v tsx 2>/dev/null || echo tsx)"
+fi
+exec "$TSX" "${SCRIPT_DIR}/../src/mcp.ts" "$@"

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -7,7 +7,8 @@
     "./seams": "./src/seams/index.ts"
   },
   "bin": {
-    "elder": "./bin/elder"
+    "elder": "./bin/elder",
+    "elder-mcp": "./bin/elder-mcp"
   },
   "scripts": {
     "dev": "tsx watch --env-file=../../.env.local src/cli.ts",

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -107,6 +107,7 @@ COMMANDS:
   memory save <key> <value>                   Persist memory across context wipes
   peer whisper <toClanId> <msg>               Send a whisper to another clan's inbox
   peer inbox                                  Read your unread whispers
+  bulletin post <msg>                         Post a public bulletin visible to all clans
   ack-clear                                   Signal runner you're ready for context wipe
   rules                                       Print game rules + capacity constants + action codes
 
@@ -120,6 +121,7 @@ EXAMPLES:
   elder clan submit-orders /tmp/my-orders.json
   elder memory save active-strategy "T19. Food-first; trade iron for wheat with clan 4."
   elder peer whisper 2 "Iron-for-wheat at 1:2, T20+. Confirm?"
+  elder bulletin post "Defense alliance forming. Bring wheat, I bring iron."
   elder rules
 
 For per-command help: elder <command> --help
@@ -292,6 +294,15 @@ EXAMPLES:
   elder peer inbox
 `;
 
+const BULLETIN_POST_HELP = `elder bulletin post <msg...>
+
+Post a public bulletin for your clan. Bulletins are visible to every Elder and
+the iNFT Owner cockpit. Requires ELDER_N env var.
+
+EXAMPLES:
+  elder bulletin post "Defense alliance forming. Bring wheat, I bring iron."
+`;
+
 const ACK_CLEAR_HELP = `elder ack-clear
 
 Signal the runner that you've finished processing this tick and are ready for a
@@ -320,6 +331,7 @@ const SUBCOMMAND_HELP: Record<string, string> = {
   'memory save': MEMORY_SAVE_HELP,
   'peer whisper': PEER_WHISPER_HELP,
   'peer inbox': PEER_INBOX_HELP,
+  'bulletin post': BULLETIN_POST_HELP,
   'ack-clear': ACK_CLEAR_HELP,
   rules: RULES_HELP,
   // also handle bare-namespace help
@@ -347,6 +359,13 @@ Subcommands:
   inbox                                Read your unread whispers
 
 For per-subcommand help: elder peer <subcommand> --help
+`,
+  bulletin: `elder bulletin <subcommand>
+
+Subcommands:
+  post <msg...>                        Post a public bulletin for your clan
+
+For per-subcommand help: elder bulletin <subcommand> --help
 `,
 };
 
@@ -657,6 +676,20 @@ export async function runCommand(
       .join('\n') + '\n';
   }
 
+  if (ns === 'bulletin' && cmd === 'post') {
+    if (rest.length === 0) throw new UsageError('usage: elder bulletin post <msg>');
+    const n = getElderN(env);
+    const body = rest.join(' ').trim();
+    if (!body) throw new UsageError('usage: elder bulletin post <msg>');
+    const snapshot = await deps.convex.getSnapshot();
+    await deps.convex.postBulletin({
+      clanId: n,
+      slot: typeof snapshot.tick === 'number' ? snapshot.tick : 0,
+      body,
+    });
+    return 'bulletin posted\n';
+  }
+
   if (ns === 'ack-clear') {
     const n = getElderN(env);
     const file = ackFile(n, homeBase);
@@ -680,6 +713,7 @@ export async function runCommand(
       '  elder memory save <key> <value>\n' +
       '  elder peer whisper <clanId> <msg>\n' +
       '  elder peer inbox\n' +
+      '  elder bulletin post <msg>\n' +
       '  elder ack-clear\n' +
       '  elder rules\n' +
       '\nFor full help: elder --help\n',

--- a/packages/agents/src/mcp.ts
+++ b/packages/agents/src/mcp.ts
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 import readline from 'node:readline';
 import type { ClanOrder } from '@clan-world/shared';
-import { createChainClient, createConvexClient, type IChainClient, type IConvexClient } from '@clan-world/shared/adapters';
-import { getElderN, readMemory, writeMemory, inboxFile, ackFile, UsageError } from './cli.js';
-import fs from 'node:fs';
+import {
+  createChainClient,
+  createConvexClient,
+  type IChainClient,
+  type IConvexClient,
+  validateSubmitOrderPayload,
+} from '@clan-world/shared/adapters';
+import { getElderN, memoryFile, inboxFile, ackFile, UsageError, runCommand } from './cli.js';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 
 type JsonRpcRequest = {
@@ -25,6 +31,8 @@ export type ElderToolDeps = {
 
 const text = (value: string): ToolResult => ({ content: [{ type: 'text', text: value }] });
 const jsonText = (value: unknown): ToolResult => text(JSON.stringify(value, null, 2));
+const errorText = (value: string): ToolResult => ({ isError: true, content: [{ type: 'text', text: value }] });
+const RESTRICTED_FILE_MODE = 0o600;
 
 function asRecord(value: unknown): Record<string, unknown> {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return {};
@@ -58,6 +66,40 @@ function assertOwnClanId(clanId: string | undefined, env: Record<string, string 
   return resolved;
 }
 
+function isEnoent(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && 'code' in err && (err as { code?: unknown }).code === 'ENOENT';
+}
+
+async function readMemoryAsync(n: number, base?: string): Promise<Record<string, string>> {
+  const file = memoryFile(n, base);
+  try {
+    return JSON.parse(await fs.readFile(file, 'utf8')) as Record<string, string>;
+  } catch (err) {
+    if (isEnoent(err)) return {};
+    if (err instanceof SyntaxError) throw new UsageError(`elder: failed to parse memory file '${file}': ${err.message}`);
+    throw err;
+  }
+}
+
+async function writeRestrictedFileAtomic(file: string, data: string): Promise<void> {
+  const dir = path.dirname(file);
+  await fs.mkdir(dir, { recursive: true });
+  const tmp = path.join(dir, `.${path.basename(file)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    await fs.writeFile(tmp, data, { encoding: 'utf8', mode: RESTRICTED_FILE_MODE });
+    await fs.chmod(tmp, RESTRICTED_FILE_MODE);
+    await fs.rename(tmp, file);
+    await fs.chmod(file, RESTRICTED_FILE_MODE);
+  } catch (err) {
+    await fs.unlink(tmp).catch(() => {});
+    throw err;
+  }
+}
+
+async function writeMemoryAsync(n: number, data: Record<string, string>, base?: string): Promise<void> {
+  await writeRestrictedFileAtomic(memoryFile(n, base), JSON.stringify(data, null, 2) + '\n');
+}
+
 export async function callElderTool(name: string, args: unknown, deps: ElderToolDeps): Promise<ToolResult> {
   const env = deps.env ?? process.env;
   const parsed = asRecord(args);
@@ -75,7 +117,11 @@ export async function callElderTool(name: string, args: unknown, deps: ElderTool
     const clanId = assertOwnClanId(stringArg(parsed, 'clanId'), env);
     const orders = parsed.orders;
     if (!Array.isArray(orders)) throw new UsageError('orders array is required');
-    return jsonText(await deps.chain.submitOrders(clanId, orders as ClanOrder[]));
+    const submitterClanId = Number(clanId);
+    if (!Number.isInteger(submitterClanId)) throw new UsageError('clanId must be numeric');
+    const clanOrders = orders as ClanOrder[];
+    for (const order of clanOrders) validateSubmitOrderPayload(order, submitterClanId);
+    return jsonText(await deps.chain.submitOrders(clanId, clanOrders));
   }
 
   if (name === 'post_bulletin') {
@@ -88,7 +134,7 @@ export async function callElderTool(name: string, args: unknown, deps: ElderTool
 
   if (name === 'memory_recall') {
     const key = requireBody(parsed, 'key');
-    const mem = readMemory(getElderN(env), deps.homeBase);
+    const mem = await readMemoryAsync(getElderN(env), deps.homeBase);
     return text(mem[key] ?? `no memory for ${key}`);
   }
 
@@ -96,40 +142,40 @@ export async function callElderTool(name: string, args: unknown, deps: ElderTool
     const key = requireBody(parsed, 'key');
     const value = requireBody(parsed, 'value');
     const elder = getElderN(env);
-    const mem = readMemory(elder, deps.homeBase);
+    const mem = await readMemoryAsync(elder, deps.homeBase);
     mem[key] = value;
-    writeMemory(elder, mem, deps.homeBase);
+    await writeMemoryAsync(elder, mem, deps.homeBase);
     return text(`saved ${key}`);
   }
 
   if (name === 'peer_inbox') {
     const file = inboxFile(getElderN(env), deps.homeBase);
-    if (!fs.existsSync(file)) return text('inbox empty');
-    const lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+    let raw: string;
+    try {
+      raw = await fs.readFile(file, 'utf8');
+    } catch (err) {
+      if (isEnoent(err)) return text('inbox empty');
+      throw err;
+    }
+    const lines = raw.split('\n').filter(Boolean);
     return text(lines.length === 0 ? 'inbox empty' : lines.join('\n'));
   }
 
   if (name === 'peer_whisper') {
     const toClanId = requireBody(parsed, 'toClanId');
     const body = requireBody(parsed);
-    return text(await import('./cli.js').then(({ runCommand }) =>
-      runCommand('peer', 'whisper', [toClanId, body], deps, env, deps.homeBase),
-    ).then(out => out.trim()));
+    return text((await runCommand('peer', 'whisper', [toClanId, body], deps, env, deps.homeBase)).trim());
   }
 
   if (name === 'ack_clear') {
     const elder = getElderN(env);
     const file = ackFile(elder, deps.homeBase);
-    fs.mkdirSync(path.dirname(file), { recursive: true });
-    fs.writeFileSync(file, new Date().toISOString() + '\n', { encoding: 'utf8', mode: 0o600 });
-    fs.chmodSync(file, 0o600);
+    await writeRestrictedFileAtomic(file, new Date().toISOString() + '\n');
     return text('ack cleared');
   }
 
   if (name === 'rules') {
-    return text(await import('./cli.js').then(({ runCommand }) =>
-      runCommand('rules', undefined, [], deps, env, deps.homeBase),
-    ));
+    return text(await runCommand('rules', undefined, [], deps, env, deps.homeBase));
   }
 
   throw new UsageError(`unknown elder MCP tool: ${name}`);
@@ -216,7 +262,7 @@ function writeError(id: JsonRpcRequest['id'], code: number, message: string): vo
   process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }) + '\n');
 }
 
-async function handleRequest(request: JsonRpcRequest): Promise<void> {
+export async function handleRequest(request: JsonRpcRequest, deps: ElderToolDeps): Promise<void> {
   const id = request.id ?? null;
   if (request.method === 'initialize') {
     writeResponse(id, {
@@ -237,9 +283,16 @@ async function handleRequest(request: JsonRpcRequest): Promise<void> {
   if (request.method === 'tools/call') {
     const params = asRecord(request.params);
     const name = stringArg(params, 'name');
-    if (!name) throw new UsageError('tools/call requires name');
-    const deps = { convex: createConvexClient(), chain: createChainClient() };
-    writeResponse(id, await callElderTool(name, params.arguments, deps));
+    if (!name) {
+      writeResponse(id, errorText('tools/call requires name'));
+      return;
+    }
+    try {
+      writeResponse(id, await callElderTool(name, params.arguments, deps));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      writeResponse(id, errorText(message));
+    }
     return;
   }
 
@@ -248,16 +301,15 @@ async function handleRequest(request: JsonRpcRequest): Promise<void> {
 
 async function main(): Promise<void> {
   const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  const deps = { convex: createConvexClient(), chain: createChainClient() };
   for await (const line of rl) {
     if (!line.trim()) continue;
-    let request: JsonRpcRequest;
+    let request: JsonRpcRequest | undefined;
     try {
       request = JSON.parse(line) as JsonRpcRequest;
-      await handleRequest(request);
+      await handleRequest(request, deps);
     } catch (err) {
-      const id = (() => {
-        try { return (JSON.parse(line) as JsonRpcRequest).id ?? null; } catch { return null; }
-      })();
+      const id = request?.id ?? null;
       const message = err instanceof Error ? err.message : String(err);
       writeError(id, -32000, message);
     }

--- a/packages/agents/src/mcp.ts
+++ b/packages/agents/src/mcp.ts
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+import readline from 'node:readline';
+import type { ClanOrder } from '@clan-world/shared';
+import { createChainClient, createConvexClient, type IChainClient, type IConvexClient } from '@clan-world/shared/adapters';
+import { getElderN, readMemory, writeMemory, inboxFile, ackFile, UsageError } from './cli.js';
+import fs from 'node:fs';
+import path from 'node:path';
+
+type JsonRpcRequest = {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: unknown;
+};
+
+type ToolContent = { type: 'text'; text: string };
+type ToolResult = { content: ToolContent[]; isError?: boolean };
+
+export type ElderToolDeps = {
+  convex: IConvexClient;
+  chain: IChainClient;
+  env?: Record<string, string | undefined>;
+  homeBase?: string;
+};
+
+const text = (value: string): ToolResult => ({ content: [{ type: 'text', text: value }] });
+const jsonText = (value: unknown): ToolResult => text(JSON.stringify(value, null, 2));
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function stringArg(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberArg(args: Record<string, unknown>, key: string): number | undefined {
+  const value = args[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function requireBody(args: Record<string, unknown>, key = 'body'): string {
+  const value = stringArg(args, key)?.trim();
+  if (!value) throw new UsageError(`${key} is required`);
+  return value;
+}
+
+function ownClanId(env: Record<string, string | undefined>): string {
+  return String(getElderN(env));
+}
+
+function assertOwnClanId(clanId: string | undefined, env: Record<string, string | undefined>): string {
+  const own = ownClanId(env);
+  const resolved = clanId ?? own;
+  if (resolved !== own) throw new UsageError(`cross-clan access denied: expected clanId ${own}`);
+  return resolved;
+}
+
+export async function callElderTool(name: string, args: unknown, deps: ElderToolDeps): Promise<ToolResult> {
+  const env = deps.env ?? process.env;
+  const parsed = asRecord(args);
+
+  if (name === 'world_snapshot') {
+    return jsonText(await deps.convex.getSnapshot());
+  }
+
+  if (name === 'clan_view') {
+    const clanId = assertOwnClanId(stringArg(parsed, 'clanId'), env);
+    return jsonText(await deps.chain.getClanFullView(clanId));
+  }
+
+  if (name === 'submit_orders') {
+    const clanId = assertOwnClanId(stringArg(parsed, 'clanId'), env);
+    const orders = parsed.orders;
+    if (!Array.isArray(orders)) throw new UsageError('orders array is required');
+    return jsonText(await deps.chain.submitOrders(clanId, orders as ClanOrder[]));
+  }
+
+  if (name === 'post_bulletin') {
+    const clanId = Number(assertOwnClanId(stringArg(parsed, 'clanId'), env));
+    const slot = numberArg(parsed, 'slot') ?? (await deps.convex.getSnapshot()).tick ?? 0;
+    const body = requireBody(parsed);
+    await deps.convex.postBulletin({ clanId, slot, body });
+    return text('bulletin posted');
+  }
+
+  if (name === 'memory_recall') {
+    const key = requireBody(parsed, 'key');
+    const mem = readMemory(getElderN(env), deps.homeBase);
+    return text(mem[key] ?? `no memory for ${key}`);
+  }
+
+  if (name === 'memory_save') {
+    const key = requireBody(parsed, 'key');
+    const value = requireBody(parsed, 'value');
+    const elder = getElderN(env);
+    const mem = readMemory(elder, deps.homeBase);
+    mem[key] = value;
+    writeMemory(elder, mem, deps.homeBase);
+    return text(`saved ${key}`);
+  }
+
+  if (name === 'peer_inbox') {
+    const file = inboxFile(getElderN(env), deps.homeBase);
+    if (!fs.existsSync(file)) return text('inbox empty');
+    const lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+    return text(lines.length === 0 ? 'inbox empty' : lines.join('\n'));
+  }
+
+  if (name === 'peer_whisper') {
+    const toClanId = requireBody(parsed, 'toClanId');
+    const body = requireBody(parsed);
+    return text(await import('./cli.js').then(({ runCommand }) =>
+      runCommand('peer', 'whisper', [toClanId, body], deps, env, deps.homeBase),
+    ).then(out => out.trim()));
+  }
+
+  if (name === 'ack_clear') {
+    const elder = getElderN(env);
+    const file = ackFile(elder, deps.homeBase);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, new Date().toISOString() + '\n', { encoding: 'utf8', mode: 0o600 });
+    fs.chmodSync(file, 0o600);
+    return text('ack cleared');
+  }
+
+  if (name === 'rules') {
+    return text(await import('./cli.js').then(({ runCommand }) =>
+      runCommand('rules', undefined, [], deps, env, deps.homeBase),
+    ));
+  }
+
+  throw new UsageError(`unknown elder MCP tool: ${name}`);
+}
+
+const tools = [
+  {
+    name: 'world_snapshot',
+    description: 'Read current ClanWorld state.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'clan_view',
+    description: 'Read this Elder clan state. Defaults to ELDER_N.',
+    inputSchema: { type: 'object', properties: { clanId: { type: 'string' } }, additionalProperties: false },
+  },
+  {
+    name: 'submit_orders',
+    description: 'Submit mission orders as direct JSON. Defaults clanId to ELDER_N.',
+    inputSchema: {
+      type: 'object',
+      properties: { clanId: { type: 'string' }, orders: { type: 'array', items: { type: 'object' } } },
+      required: ['orders'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'post_bulletin',
+    description: 'Post a public bulletin for this Elder clan.',
+    inputSchema: {
+      type: 'object',
+      properties: { body: { type: 'string' }, clanId: { type: 'string' }, slot: { type: 'number' } },
+      required: ['body'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'memory_recall',
+    description: 'Recall an Elder memory key.',
+    inputSchema: { type: 'object', properties: { key: { type: 'string' } }, required: ['key'], additionalProperties: false },
+  },
+  {
+    name: 'memory_save',
+    description: 'Save an Elder memory key/value.',
+    inputSchema: {
+      type: 'object',
+      properties: { key: { type: 'string' }, value: { type: 'string' } },
+      required: ['key', 'value'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'peer_inbox',
+    description: 'Read this Elder peer inbox.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'peer_whisper',
+    description: 'Send a private whisper to another clan.',
+    inputSchema: {
+      type: 'object',
+      properties: { toClanId: { type: 'string' }, body: { type: 'string' } },
+      required: ['toClanId', 'body'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'ack_clear',
+    description: 'Signal the runner that this Elder is ready for context wipe.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'rules',
+    description: 'Read game rules, action codes, regions, and constants.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+];
+
+function writeResponse(id: JsonRpcRequest['id'], result: unknown): void {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n');
+}
+
+function writeError(id: JsonRpcRequest['id'], code: number, message: string): void {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }) + '\n');
+}
+
+async function handleRequest(request: JsonRpcRequest): Promise<void> {
+  const id = request.id ?? null;
+  if (request.method === 'initialize') {
+    writeResponse(id, {
+      protocolVersion: '2024-11-05',
+      capabilities: { tools: {} },
+      serverInfo: { name: 'elder', version: '0.1.0' },
+    });
+    return;
+  }
+
+  if (request.method === 'notifications/initialized') return;
+
+  if (request.method === 'tools/list') {
+    writeResponse(id, { tools });
+    return;
+  }
+
+  if (request.method === 'tools/call') {
+    const params = asRecord(request.params);
+    const name = stringArg(params, 'name');
+    if (!name) throw new UsageError('tools/call requires name');
+    const deps = { convex: createConvexClient(), chain: createChainClient() };
+    writeResponse(id, await callElderTool(name, params.arguments, deps));
+    return;
+  }
+
+  writeError(id, -32601, `method not found: ${request.method ?? ''}`);
+}
+
+async function main(): Promise<void> {
+  const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    let request: JsonRpcRequest;
+    try {
+      request = JSON.parse(line) as JsonRpcRequest;
+      await handleRequest(request);
+    } catch (err) {
+      const id = (() => {
+        try { return (JSON.parse(line) as JsonRpcRequest).id ?? null; } catch { return null; }
+      })();
+      const message = err instanceof Error ? err.message : String(err);
+      writeError(id, -32000, message);
+    }
+  }
+}
+
+if (process.argv[1]?.endsWith('/mcp.ts')) {
+  main().catch(err => {
+    process.stderr.write(`elder-mcp: fatal: ${String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/agents/test/bashGuard.test.ts
+++ b/packages/agents/test/bashGuard.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const guardPath = path.join(repoRoot, 'runtime/elders/parent/.claude/hooks/bash-guard.sh');
+
+function runGuard(command: string) {
+  return spawnSync('bash', [guardPath], {
+    cwd: repoRoot,
+    env: { ...process.env, ELDER_N: '1' },
+    input: JSON.stringify({ tool_name: 'Bash', tool_input: { command } }),
+    encoding: 'utf8',
+  });
+}
+
+describe('Elder bash guard', () => {
+  it('blocks bare shell variable expansion', () => {
+    const out = runGuard('elder memory save leak $PRIVATE_KEY');
+
+    expect(out.status).toBe(2);
+    expect(out.stderr).toContain('shell variable expansion is not allowed');
+  });
+
+  it('allows a literal dollar sign that is not a variable reference', () => {
+    const out = runGuard('elder bulletin post "cost $"');
+
+    expect(out.status).toBe(0);
+  });
+});

--- a/packages/agents/test/cli.test.ts
+++ b/packages/agents/test/cli.test.ts
@@ -241,6 +241,32 @@ describe('peer inbox', () => {
 });
 
 // ---------------------------------------------------------------------------
+// bulletin post
+// ---------------------------------------------------------------------------
+
+describe('bulletin post', () => {
+  it('posts a public bulletin for ELDER_N using current snapshot tick as slot', async () => {
+    const posted: Array<{ clanId: number; slot: number; body: string }> = [];
+    deps.convex = makeConvex({
+      async postBulletin(args) {
+        posted.push(args);
+      },
+    });
+
+    const out = await runCommand('bulletin', 'post', ['defense', 'alliance', 'forming'], deps, { ELDER_N: '3' }, tmpDir);
+
+    expect(out).toBe('bulletin posted\n');
+    expect(posted).toEqual([{ clanId: 3, slot: 7, body: 'defense alliance forming' }]);
+  });
+
+  it('throws UsageError when bulletin body is missing', async () => {
+    await expect(
+      runCommand('bulletin', 'post', [], deps, { ELDER_N: '3' }, tmpDir),
+    ).rejects.toBeInstanceOf(UsageError);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ack-clear
 // ---------------------------------------------------------------------------
 
@@ -355,6 +381,12 @@ describe('resolveHelp', () => {
     const out = resolveHelp(['peer', 'whisper', '--help']);
     expect(out).toBeDefined();
     expect(out).toContain('elder peer whisper');
+  });
+
+  it('returns bulletin-post help for `bulletin post --help`', () => {
+    const out = resolveHelp(['bulletin', 'post', '--help']);
+    expect(out).toBeDefined();
+    expect(out).toContain('elder bulletin post');
   });
 
   it('returns memory-save help for `memory save --help`', () => {

--- a/packages/agents/test/mcp.test.ts
+++ b/packages/agents/test/mcp.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { IChainClient, IConvexClient } from '@clan-world/shared/adapters';
+import type { ClanFullView, Tick, Whisper, WorldSnapshot } from '@clan-world/shared';
+import { callElderTool } from '../src/mcp.js';
+
+const STUB_SNAPSHOT: WorldSnapshot = {
+  tick: 9,
+  tickEpoch: { startedAt: 1700000000, durationMs: 60000 },
+  regions: [],
+  clans: [],
+};
+
+const STUB_CLAN_VIEW: ClanFullView = {
+  clan: { id: '1', name: 'Wolfclan', treasury: '1000' },
+  controlledRegions: [],
+  pendingOrders: [],
+  whispers: [],
+};
+
+function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
+  return {
+    async getSnapshot() { return STUB_SNAPSHOT; },
+    async getClanFullView() { return STUB_CLAN_VIEW; },
+    async postLog() {},
+    subscribeWhispers(_clanId: string, _onWhisper: (w: Whisper) => void): () => void { return () => {}; },
+    async postWhisper() {},
+    async postOrchEvent() {},
+    async postHumanSteering() {},
+    async postBulletin() {},
+    ...overrides,
+  };
+}
+
+function makeChain(overrides: Partial<IChainClient> = {}): IChainClient {
+  return {
+    async submitOrders() { return { txHash: '0xorders', results: [] }; },
+    async getCurrentTick(): Promise<Tick> { return 0; },
+    async getClanFullView(clanId: string): Promise<ClanFullView> {
+      return { ...STUB_CLAN_VIEW, clan: { ...STUB_CLAN_VIEW.clan, id: clanId } };
+    },
+    async getWallUpgradeCost() { return { wood: 0n, iron: 0n }; },
+    async getBaseUpgradeCost() { return { wood: 0n, iron: 0n, wheat: 0n }; },
+    async getMonumentUpgradeCost() { return { wood: 0n, iron: 0n, wheat: 0n, blueprint: 0n }; },
+    async quoteTravel() { return { travelTicks: 0, path: '0x0000000000000000' as `0x${string}` }; },
+    async getClanScore() { return { score: 0n, monumentReachedAtTick: 0n, monumentLevel: 0 }; },
+    async getRankings() { return { clanIdsRanked: [], scores: [] }; },
+    ...overrides,
+  };
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'elder-mcp-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('elder MCP tools', () => {
+  it('submit_orders accepts direct JSON and defaults clanId from ELDER_N', async () => {
+    const calls: Array<{ clanId: string; orders: unknown[] }> = [];
+    const deps = {
+      convex: makeConvex(),
+      chain: makeChain({
+        async submitOrders(clanId, orders) {
+          calls.push({ clanId, orders });
+          return { txHash: '0xorders', results: [] };
+        },
+      }),
+      env: { ELDER_N: '2' },
+      homeBase: tmpDir,
+    };
+
+    const out = await callElderTool('submit_orders', { orders: [{ kind: 'mission', payload: { clansmanId: 1 } }] }, deps);
+
+    expect(out.content[0]?.text).toContain('0xorders');
+    expect(calls).toEqual([{ clanId: '2', orders: [{ kind: 'mission', payload: { clansmanId: 1 } }] }]);
+  });
+
+  it('submit_orders rejects cross-clan submissions', async () => {
+    await expect(
+      callElderTool('submit_orders', { clanId: '3', orders: [] }, {
+        convex: makeConvex(),
+        chain: makeChain(),
+        env: { ELDER_N: '2' },
+        homeBase: tmpDir,
+      }),
+    ).rejects.toThrow(/cross-clan access denied/);
+  });
+
+  it('post_bulletin accepts direct JSON and uses the current snapshot tick', async () => {
+    const posted: Array<{ clanId: number; slot: number; body: string }> = [];
+    const out = await callElderTool('post_bulletin', { body: 'public defense bid' }, {
+      convex: makeConvex({
+        async postBulletin(args) {
+          posted.push(args);
+        },
+      }),
+      chain: makeChain(),
+      env: { ELDER_N: '4' },
+      homeBase: tmpDir,
+    });
+
+    expect(out.content[0]?.text).toBe('bulletin posted');
+    expect(posted).toEqual([{ clanId: 4, slot: 9, body: 'public defense bid' }]);
+  });
+});

--- a/runtime/elders/Makefile
+++ b/runtime/elders/Makefile
@@ -27,6 +27,7 @@
 REPO_DIR     := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 ELDER_DIR    := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 DEST         ?= $(HOME)/clan-world
+CLAN_WORLD_REPO ?= $(HOME)/code/clan-world/clan-world-game
 ELDER_NUMBERS := 1 2 3 4
 SYSTEMD_USER_DIR := $(HOME)/.config/systemd/user
 
@@ -64,10 +65,13 @@ help:
 install:
 	@echo "=== installing elder harness to $(DEST) ==="
 	@mkdir -p "$(DEST)"/.claude/skills
+	@mkdir -p "$(DEST)"/.claude/hooks
 	@mkdir -p "$(DEST)"/bin
 	@cp -p "$(REPO_DIR)"/parent/AGENTS.md "$(DEST)"/AGENTS.md
 	@ln -sf AGENTS.md $(DEST)/CLAUDE.md
 	@cp -p "$(REPO_DIR)"/parent/.claude/settings.json "$(DEST)"/.claude/settings.json
+	@cp -p "$(REPO_DIR)"/parent/.claude/hooks/bash-guard.sh "$(DEST)"/.claude/hooks/bash-guard.sh
+	@chmod +x "$(DEST)"/.claude/hooks/bash-guard.sh
 	@for skill in cleared-context-start elder-base-context final-tick-continuity \
 	              uniswap-arb-camping uniswap-market-overview \
 	              uniswap-sell-immediate uniswap-sell-scheduled; do \
@@ -84,6 +88,8 @@ install:
 	    mkdir -p $(DEST)/elder-$$n/.claude; \
 	    mkdir -p $(DEST)/elder-$$n/state/plugin-cache; \
 	    mkdir -p $(DEST)/elder-$$n/state/outbox; \
+	    rm -f $(DEST)/elder-$$n/.claude/settings.json \
+	          $(DEST)/elder-$$n/.claude/settings.local.json; \
 	    if [ ! -e $(DEST)/elder-$$n/.claude/.credentials.json ]; then \
 	        ln -sf $(HOME)/.claude/.credentials.json \
 	               $(DEST)/elder-$$n/.claude/.credentials.json; \
@@ -93,6 +99,10 @@ install:
 	        $(REPO_DIR)/template/run.sh.template \
 	        > $(DEST)/elder-$$n/run.sh; \
 	    chmod +x $(DEST)/elder-$$n/run.sh; \
+	    sed -e 's#{{ELDER_NUMBER}}#'"$$n"'#g' \
+	        -e 's#{{CLAN_WORLD_REPO}}#$(CLAN_WORLD_REPO)#g' \
+	        $(REPO_DIR)/template/.mcp.json.template \
+	        > $(DEST)/elder-$$n/.mcp.json; \
 	    if [ ! -f $(DEST)/elder-$$n/.claude/CLAUDE.md ]; then \
 	        cp -p $(REPO_DIR)/personalities/elder-$$n.md \
 	              $(DEST)/elder-$$n/.claude/CLAUDE.md; \

--- a/runtime/elders/README.md
+++ b/runtime/elders/README.md
@@ -14,6 +14,7 @@ Source tree for the 4-Elder ClanWorld cluster. Deploy to any machine:
 Materializes `$DEST/` with:
 - Shared parent config (`AGENTS.md`, `.claude/skills/`, `settings.json`)
 - Per-elder dirs (`elder-1/` through `elder-4/`) with `run.sh` and credentials symlink
+- Per-elder MCP config (`elder-N/.mcp.json`) for structured Elder tool calls
 - systemd unit files (`~/.config/systemd/user/ttyd-elder-{1..4}.service`)
 
 Idempotent: re-running safe; never clobbers `.env`, `agent-directive.secret.md`, or `state/`.
@@ -27,6 +28,14 @@ Each elder needs one-time OAuth setup (interactive browser dance):
     make -C $HOME/clan-world elders-up # now all 4 start cleanly
 
 See ADR 0013 for OAuth-MAX constraint — never use `ANTHROPIC_API_KEY`.
+
+## Runtime tool access
+
+Elders should use the `elder` MCP server for structured calls when available.
+The Bash fallback is intentionally tiny: exact `date` plus approved `elder`
+subcommands. Order JSON for the CLI fallback must be written with Claude
+`Write`/`Edit` under `/tmp/elder-N/`, then submitted with
+`elder clan submit-orders /tmp/elder-N/orders.json`.
 
 ## Shell shortcuts
 

--- a/runtime/elders/parent/.claude/hooks/bash-guard.sh
+++ b/runtime/elders/parent/.claude/hooks/bash-guard.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+deny() {
+  printf 'ClanWorld Elder Bash guard blocked this command: %s\n' "$1" >&2
+  printf 'Allowed Bash surface: exact date, or approved elder subcommands. Use Read/Write/Edit for files under /tmp/elder-$ELDER_N/.\n' >&2
+  exit 2
+}
+
+input="$(cat)"
+tool_name="$(jq -r '.tool_name // empty' <<<"$input" 2>/dev/null || true)"
+command_text="$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null || true)"
+
+if [[ "$tool_name" != "Bash" ]]; then
+  exit 0
+fi
+
+if [[ -z "$command_text" ]]; then
+  deny "missing Bash command in hook input"
+fi
+
+if [[ "$command_text" == *$'\n'* || "$command_text" == *$'\r'* ]]; then
+  deny "multi-line Bash is not allowed"
+fi
+
+for forbidden in '&&' '||' ';;' ';' '|' '>' '<' '`' '$(' '$[' '${' '*' '?' '[' ']' '~'; do
+  if [[ "$command_text" == *"$forbidden"* ]]; then
+    deny "shell syntax '$forbidden' is not allowed"
+  fi
+done
+
+argv_json="$(
+  python3 - "$command_text" <<'PY'
+import json
+import shlex
+import sys
+
+try:
+    print(json.dumps(shlex.split(sys.argv[1])))
+except ValueError as exc:
+    print(json.dumps({"error": str(exc)}))
+    sys.exit(1)
+PY
+)" || deny "could not parse command arguments"
+
+if jq -e 'type == "object" and has("error")' <<<"$argv_json" >/dev/null; then
+  deny "could not parse command arguments"
+fi
+
+argc="$(jq 'length' <<<"$argv_json")"
+cmd="$(jq -r '.[0] // empty' <<<"$argv_json")"
+
+is_int() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+is_safe_atom() {
+  [[ "$1" =~ ^[A-Za-z0-9._:/,@+=-]+$ ]]
+}
+
+is_tmp_order_path() {
+  local path="$1"
+  local elder_n="${ELDER_N:-${ELDER_NUMBER:-}}"
+  [[ -n "$elder_n" ]] || return 1
+  [[ "$path" =~ ^/tmp/elder-${elder_n}/[A-Za-z0-9._/-]+\.json$ ]] || return 1
+  [[ "$path" != *"/../"* && "$path" != *"/.." && "$path" != *".."* ]]
+}
+
+arg() {
+  jq -r ".[$1] // empty" <<<"$argv_json"
+}
+
+case "$cmd" in
+  date)
+    [[ "$argc" -eq 1 ]] || deny "date does not accept arguments in Elder sessions"
+    exit 0
+    ;;
+  elder)
+    ;;
+  *)
+    deny "only elder and date are allowed"
+    ;;
+esac
+
+ns="$(arg 1)"
+sub="$(arg 2)"
+
+case "$ns" in
+  --help|-h|--version|-v)
+    [[ "$argc" -eq 2 ]] || deny "invalid elder top-level option"
+    exit 0
+    ;;
+  world)
+    [[ "$sub" == "snapshot" ]] || deny "only elder world snapshot is allowed"
+    [[ "$argc" -eq 3 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder world snapshot arguments"
+    ;;
+  clan)
+    case "$sub" in
+      view)
+        [[ "$argc" -eq 4 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder clan view arguments"
+        third="$(arg 3)"
+        if [[ "$third" != "--help" && "$third" != "-h" ]]; then
+          is_int "$third" || deny "clan id must be numeric"
+          [[ -z "${ELDER_N:-}" || "$third" == "$ELDER_N" ]] || deny "Elders may only view their own clan via Bash"
+        fi
+        ;;
+      submit-orders)
+        [[ "$argc" -eq 4 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder clan submit-orders arguments"
+        third="$(arg 3)"
+        if [[ "$third" != "--help" && "$third" != "-h" ]]; then
+          is_tmp_order_path "$third" || deny "orders file must be /tmp/elder-$ELDER_N/*.json"
+        fi
+        ;;
+      --help|-h)
+        [[ "$argc" -eq 3 ]] || deny "invalid elder clan help arguments"
+        ;;
+      *)
+        deny "unsupported elder clan subcommand"
+        ;;
+    esac
+    ;;
+  memory)
+    case "$sub" in
+      recall)
+        [[ "$argc" -eq 4 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder memory recall arguments"
+        third="$(arg 3)"
+        [[ "$third" =~ ^--help|-h$ ]] || is_safe_atom "$third" || deny "memory key contains unsafe characters"
+        ;;
+      save)
+        [[ "$argc" -ge 5 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder memory save arguments"
+        third="$(arg 3)"
+        [[ "$third" =~ ^--help|-h$ ]] || is_safe_atom "$third" || deny "memory key contains unsafe characters"
+        ;;
+      --help|-h)
+        [[ "$argc" -eq 3 ]] || deny "invalid elder memory help arguments"
+        ;;
+      *)
+        deny "unsupported elder memory subcommand"
+        ;;
+    esac
+    ;;
+  peer)
+    case "$sub" in
+      inbox)
+        [[ "$argc" -eq 3 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder peer inbox arguments"
+        ;;
+      whisper)
+        [[ "$argc" -ge 5 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder peer whisper arguments"
+        third="$(arg 3)"
+        [[ "$third" =~ ^--help|-h$ ]] || is_int "$third" || deny "peer whisper recipient must be numeric"
+        ;;
+      --help|-h)
+        [[ "$argc" -eq 3 ]] || deny "invalid elder peer help arguments"
+        ;;
+      *)
+        deny "unsupported elder peer subcommand"
+        ;;
+    esac
+    ;;
+  bulletin)
+    case "$sub" in
+      post)
+        [[ "$argc" -ge 4 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder bulletin post arguments"
+        ;;
+      --help|-h)
+        [[ "$argc" -eq 3 ]] || deny "invalid elder bulletin help arguments"
+        ;;
+      *)
+        deny "unsupported elder bulletin subcommand"
+        ;;
+    esac
+    ;;
+  ack-clear|rules)
+    [[ "$argc" -eq 2 || ( "$argc" -eq 3 && "$(arg 2)" =~ ^--help|-h$ ) ]] || deny "invalid elder $ns arguments"
+    ;;
+  *)
+    deny "unsupported elder command"
+    ;;
+esac
+
+exit 0

--- a/runtime/elders/parent/.claude/hooks/bash-guard.sh
+++ b/runtime/elders/parent/.claude/hooks/bash-guard.sh
@@ -29,6 +29,10 @@ for forbidden in '&&' '||' ';;' ';' '|' '>' '<' '`' '$(' '$[' '${' '*' '?' '[' '
   fi
 done
 
+if [[ "$command_text" =~ \$[A-Za-z_0-9] ]]; then
+  deny "shell variable expansion is not allowed"
+fi
+
 argv_json="$(
   python3 - "$command_text" <<'PY'
 import json
@@ -97,7 +101,7 @@ case "$ns" in
   clan)
     case "$sub" in
       view)
-        [[ "$argc" -eq 4 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder clan view arguments"
+        [[ "$argc" -eq 4 ]] || deny "invalid elder clan view arguments"
         third="$(arg 3)"
         if [[ "$third" != "--help" && "$third" != "-h" ]]; then
           is_int "$third" || deny "clan id must be numeric"
@@ -105,7 +109,7 @@ case "$ns" in
         fi
         ;;
       submit-orders)
-        [[ "$argc" -eq 4 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder clan submit-orders arguments"
+        [[ "$argc" -eq 4 ]] || deny "invalid elder clan submit-orders arguments"
         third="$(arg 3)"
         if [[ "$third" != "--help" && "$third" != "-h" ]]; then
           is_tmp_order_path "$third" || deny "orders file must be /tmp/elder-$ELDER_N/*.json"
@@ -122,7 +126,7 @@ case "$ns" in
   memory)
     case "$sub" in
       recall)
-        [[ "$argc" -eq 4 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder memory recall arguments"
+        [[ "$argc" -eq 4 ]] || deny "invalid elder memory recall arguments"
         third="$(arg 3)"
         [[ "$third" =~ ^--help|-h$ ]] || is_safe_atom "$third" || deny "memory key contains unsafe characters"
         ;;
@@ -160,7 +164,7 @@ case "$ns" in
   bulletin)
     case "$sub" in
       post)
-        [[ "$argc" -ge 4 || ( "$argc" -eq 4 && "$(arg 3)" =~ ^--help|-h$ ) ]] || deny "invalid elder bulletin post arguments"
+        [[ "$argc" -ge 4 ]] || deny "invalid elder bulletin post arguments"
         ;;
       --help|-h)
         [[ "$argc" -eq 3 ]] || deny "invalid elder bulletin help arguments"

--- a/runtime/elders/parent/.claude/settings.json
+++ b/runtime/elders/parent/.claude/settings.json
@@ -1,22 +1,55 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "model": "claude-sonnet-4-6",
   "env": {
     "TZ": "America/New_York"
   },
-  "skipAutoPermissionPrompt": true,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_CONFIG_DIR/hooks/bash-guard.sh\""
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
-    "defaultMode": "deny",
+    "defaultMode": "dontAsk",
     "allow": [
+      "mcp__elder__*",
       "Bash(elder *)",
       "Bash(date)",
-      "Read",
-      "Write",
-      "Edit"
+      "Read(/home/claude/clan-world/.claude/skills/**)",
+      "Read(/tmp/elder-*/**)",
+      "Write(/tmp/elder-*/**)",
+      "Edit(/tmp/elder-*/**)"
     ],
     "deny": [
+      "Read(/home/claude/clan-world/.claude/.credentials.json)",
+      "Read(/home/claude/clan-world/.claude/.claude.json)",
+      "Read(/home/claude/clan-world/.claude/history.jsonl)",
+      "Read(/home/claude/clan-world/elder-*/.env)",
+      "Read(/home/claude/clan-world/elder-*/agent-directive.secret.md)",
+      "Read(/home/claude/clan-world/elder-*/.claude/**)",
+      "Bash(cat *)",
+      "Bash(tee *)",
+      "Bash(echo *)",
+      "Bash(ls *)",
+      "Bash(mkdir *)",
+      "Bash(python*)",
+      "Bash(node *)",
+      "Bash(curl *)",
+      "Bash(wget *)",
+      "Bash(git *)",
+      "Bash(systemctl *)",
+      "Bash(sudo *)",
       "WebFetch",
       "WebSearch"
     ]
-  }
+  },
+  "model": "claude-sonnet-4-6",
+  "skipAutoPermissionPrompt": true
 }

--- a/runtime/elders/template/.mcp.json.template
+++ b/runtime/elders/template/.mcp.json.template
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "elder": {
+      "command": "{{CLAN_WORLD_REPO}}/packages/agents/bin/elder-mcp",
+      "env": {
+        "ELDER_N": "{{ELDER_NUMBER}}",
+        "TZ": "America/New_York"
+      }
+    }
+  }
+}

--- a/runtime/elders/template/run.sh.template
+++ b/runtime/elders/template/run.sh.template
@@ -9,6 +9,7 @@ set -euo pipefail
 ELDER_NUMBER={{ELDER_NUMBER}}
 AGENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RUNTIME_DIR="$(cd "$AGENT_DIR/.." && pwd)"
+export CLAN_WORLD_REPO="${CLAN_WORLD_REPO:-$HOME/code/clan-world/clan-world-game}"
 
 # === Core config — shared Claude config dir for all Elders ===
 # NEVER use ANTHROPIC_API_KEY, NEVER use --bare (forces API key).
@@ -24,7 +25,7 @@ export IS_DEMO=1
 if [ -f "${CLAN_WORLD_REPO:-$HOME/code/clan-world}/.env.local" ]; then
   set -a
   # shellcheck disable=SC1091
-  source "${CLAN_WORLD_REPO:-$HOME/code/clan-world}/.env.local"
+  source "$CLAN_WORLD_REPO/.env.local"
   set +a
 fi
 if [ -f "$AGENT_DIR/.env" ]; then
@@ -38,7 +39,7 @@ fi
 # Run once during agent setup if not already present:
 mkdir -p "$CLAUDE_CONFIG_DIR"
 if [ ! -e "$CLAUDE_CONFIG_DIR/.credentials.json" ]; then
-  cp -p ~/.claude/.credentials.json "$CLAUDE_CONFIG_DIR/.credentials.json" || true
+  ln -sf ~/.claude/.credentials.json "$CLAUDE_CONFIG_DIR/.credentials.json" || true
 fi
 
 # === Plugin isolation (Telegram unused for Elders, but isolation matters) ===
@@ -74,7 +75,4 @@ echo "[$AGENT_NAME] Starting... model=$ANTHROPIC_MODEL $(date '+%Y-%m-%d %H:%M:%
 
 # Elders don't need the Telegram plugin (no inbound Telegram), so omit --channels.
 # The runner injects situation blocks via tmux send-keys directly to this REPL.
-exec claude \
-  --config-dir "$CLAUDE_CONFIG_DIR" \
-  --append-system-prompt "You are a Clan World Elder. Have access to `date` and `elder` bash commands. You are running on Elder $." \
-  "$@"
+exec claude "$@"


### PR DESCRIPTION
## Summary
- mirror local Elder runtime settings into `runtime/elders` and install a fail-closed Bash guard
- add `elder bulletin post` for public bulletin messages
- add `elder-mcp` stdio tools, including direct JSON `submit_orders` and `post_bulletin`

## Validation
- `pnpm --filter @clan-world/agents test`
- `pnpm --filter @clan-world/agents typecheck`
- hook smoke tests for allowed date/order/bulletin and denied cat/cross-clan view
- MCP stdio initialize/tools-list smoke

## Notes
No issue number was provided, so this PR does not include a `Closes #N` line.