### PR TITLE
fix(android): right-align cockpit collapse/expand button

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/CockpitScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/CockpitScreen.kt
@@ -122,8 +122,8 @@ fun CockpitScreen(
           activeClanId = activeClanId,
           onToggle = { collapsed = !collapsed },
           modifier = Modifier
-            .align(Alignment.BottomCenter)
-            .padding(bottom = 12.dp),
+            .align(Alignment.BottomEnd)
+            .padding(end = 12.dp, bottom = 12.dp),
         )
       }
 


### PR DESCRIPTION
Closes #233

## Summary
Move the cockpit collapse/expand button from centered to right-aligned in `CockpitScreen.kt`. The toggle's parent Box alignment changed from `Alignment.BottomCenter` to `Alignment.BottomEnd`, with `end = 12.dp` padding added (mirrors the existing `bottom = 12.dp` for breathing room from the map's right edge). The `PageIndicatorOverlay` keeps its existing centered position — only the collapse/expand pill moves.

The `CollapseToggle` composable itself is unchanged; only the parent's alignment of it within the map-overlay Box flipped.

## Test plan
- [x] `:app:assembleDebug` ✓ (BUILD SUCCESSFUL in 37s)
- [ ] Both collapsed + expanded states visually correct on device / in preview