### PR TITLE
fix(android): faucet ATA self-owned dedup + Builder fluent API

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/gold/GoldSolanaClient.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/gold/GoldSolanaClient.kt
@@ -99,26 +99,7 @@ class GoldSolanaClient(
   }
 
   suspend fun buildFaucetClaim(ownerBase58: String, memo: String): ByteArray {
-    val owner = ownerBase58.toPubkey()
-    val ownerAta = associatedTokenAddress(owner, mint)
-    val mintAuthority = pda("mint-authority")
-    return buildTransaction(
-      listOf(
-        createAssociatedTokenAccountIdempotent(owner, owner, mint, ownerAta),
-        TransactionInstruction(
-          faucetProgram,
-          listOf(
-            AccountMeta(owner, isSigner = true, isWritable = true),
-            AccountMeta(mint, isSigner = false, isWritable = true),
-            AccountMeta(ownerAta, isSigner = false, isWritable = true),
-            AccountMeta(mintAuthority, isSigner = false, isWritable = false),
-            AccountMeta(TOKEN_PROGRAM_ID, isSigner = false, isWritable = false),
-          ),
-          anchorDiscriminator("global:claim"),
-        ),
-        memo(owner, memo),
-      ),
-    )
+    return buildTransaction(faucetClaimInstructions(ownerBase58.toPubkey(), memo))
   }
 
   suspend fun buildBurn(
@@ -127,7 +108,38 @@ class GoldSolanaClient(
     memo: String,
     skipTax: Long = 0L,
   ): ByteArray {
-    val owner = ownerBase58.toPubkey()
+    return buildTransaction(burnInstructions(ownerBase58.toPubkey(), amount, memo, skipTax))
+  }
+
+  internal suspend fun faucetClaimInstructions(
+    owner: SolanaPublicKey,
+    memo: String,
+  ): List<TransactionInstruction> {
+    val ownerAta = associatedTokenAddress(owner, mint)
+    val mintAuthority = pda("mint-authority")
+    return listOf(
+      createAssociatedTokenAccountIdempotent(owner, owner, mint, ownerAta),
+      TransactionInstruction(
+        faucetProgram,
+        listOf(
+          AccountMeta(owner, isSigner = true, isWritable = true),
+          AccountMeta(mint, isSigner = false, isWritable = true),
+          AccountMeta(ownerAta, isSigner = false, isWritable = true),
+          AccountMeta(mintAuthority, isSigner = false, isWritable = false),
+          AccountMeta(TOKEN_PROGRAM_ID, isSigner = false, isWritable = false),
+        ),
+        anchorDiscriminator("global:claim"),
+      ),
+      memo(owner, memo),
+    )
+  }
+
+  internal suspend fun burnInstructions(
+    owner: SolanaPublicKey,
+    amount: Long,
+    memo: String,
+    skipTax: Long = 0L,
+  ): List<TransactionInstruction> {
     val ownerAta = associatedTokenAddress(owner, mint)
     val instructions = mutableListOf<TransactionInstruction>()
     instructions += burnChecked(ownerAta, mint, owner, amount)
@@ -137,15 +149,16 @@ class GoldSolanaClient(
       instructions += transferChecked(ownerAta, mint, treasuryAta, owner, skipTax)
     }
     instructions += memo(owner, memo)
-    return buildTransaction(instructions)
+    return instructions
   }
 
   private suspend fun buildTransaction(
     instructions: List<TransactionInstruction>,
   ): ByteArray {
     val blockhash = latestBlockhash()
+    val canonical = unionAccountFlags(instructions)
     val builder = Message.Builder().setRecentBlockhash(blockhash)
-    instructions.forEach { builder.addInstruction(it) }
+    canonical.forEach { builder.addInstruction(it) }
     return Transaction(builder.build()).serialize()
   }
 
@@ -178,20 +191,61 @@ class GoldSolanaClient(
     owner: SolanaPublicKey,
     mint: SolanaPublicKey,
     ata: SolanaPublicKey,
-  ): TransactionInstruction {
-    val ownerIsSelf = owner.bytes.contentEquals(payer.bytes)
-    return TransactionInstruction(
-      ASSOCIATED_TOKEN_PROGRAM_ID,
-      listOf(
-        AccountMeta(payer, isSigner = true, isWritable = true),
-        AccountMeta(ata, isSigner = false, isWritable = true),
-        AccountMeta(owner, isSigner = ownerIsSelf, isWritable = ownerIsSelf),
-        AccountMeta(mint, isSigner = false, isWritable = false),
-        AccountMeta(SYSTEM_PROGRAM_ID, isSigner = false, isWritable = false),
-        AccountMeta(TOKEN_PROGRAM_ID, isSigner = false, isWritable = false),
-      ),
-      byteArrayOf(1),
-    )
+  ): TransactionInstruction = TransactionInstruction(
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+    listOf(
+      AccountMeta(payer, isSigner = true, isWritable = true),
+      AccountMeta(ata, isSigner = false, isWritable = true),
+      AccountMeta(owner, isSigner = false, isWritable = false),
+      AccountMeta(mint, isSigner = false, isWritable = false),
+      AccountMeta(SYSTEM_PROGRAM_ID, isSigner = false, isWritable = false),
+      AccountMeta(TOKEN_PROGRAM_ID, isSigner = false, isWritable = false),
+    ),
+    byteArrayOf(1),
+  )
+
+  /**
+   * Pre-pass for #240 follow-up:
+   * `com.solanamobile:web3-solana-jvm:0.3.0-beta4`'s `Message.Builder.build()`
+   * buckets `AccountMeta`s by `(isSigner, isWritable)` GLOBALLY across all
+   * instructions (writable-signer / readonly-signer / writable-non-signer /
+   * readonly-non-signer). The compiled `accounts` list dedups pubkeys, but the
+   * header counters (`signatureCount`, `readOnlyAccounts`, `readOnlyNonSigners`)
+   * use the RAW bucket sizes pre-dedup. So a pubkey that appears in 2+
+   * instructions with DIFFERENT flag tuples produces a malformed header /
+   * accounts mismatch, and the on-chain sanitizer rejects the transaction
+   * with "Transaction failed to sanitize accounts offsets correctly".
+   *
+   * Real-world hit: `buildFaucetClaim` adds the owner as writable-signer
+   * (via ATA-create's payer slot + claim's payer slot) AND as readonly-signer
+   * (via `memo()`'s owner slot). Same problem in `buildBurn(skipTax > 0)`.
+   *
+   * Canonical Solana SDKs (Rust `solana-sdk` `Message::new`, JS `@solana/web3.js`)
+   * union flags per pubkey before compiling. The JVM SDK does not, so we
+   * compensate here by normalizing every occurrence of a pubkey to the
+   * OR-union of its flag tuples.
+   */
+  internal fun unionAccountFlags(
+    instructions: List<TransactionInstruction>,
+  ): List<TransactionInstruction> {
+    val union = mutableMapOf<List<Byte>, Pair<Boolean, Boolean>>()
+    instructions.forEach { ix ->
+      ix.accounts.forEach { meta ->
+        val key = meta.publicKey.bytes.toList()
+        val prev = union[key] ?: (false to false)
+        union[key] = (prev.first || meta.isSigner) to (prev.second || meta.isWritable)
+      }
+    }
+    return instructions.map { ix ->
+      TransactionInstruction(
+        ix.programId,
+        ix.accounts.map { meta ->
+          val (isS, isW) = union[meta.publicKey.bytes.toList()]!!
+          AccountMeta(meta.publicKey, isSigner = isS, isWritable = isW)
+        },
+        ix.data,
+      )
+    }
   }
 
   private fun burnChecked(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/gold/GoldSolanaClient.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/gold/GoldSolanaClient.kt
@@ -103,8 +103,7 @@ class GoldSolanaClient(
     val ownerAta = associatedTokenAddress(owner, mint)
     val mintAuthority = pda("mint-authority")
     return buildTransaction(
-      payer = owner,
-      instructions = listOf(
+      listOf(
         createAssociatedTokenAccountIdempotent(owner, owner, mint, ownerAta),
         TransactionInstruction(
           faucetProgram,
@@ -138,18 +137,16 @@ class GoldSolanaClient(
       instructions += transferChecked(ownerAta, mint, treasuryAta, owner, skipTax)
     }
     instructions += memo(owner, memo)
-    return buildTransaction(owner, instructions)
+    return buildTransaction(instructions)
   }
 
   private suspend fun buildTransaction(
-    payer: SolanaPublicKey,
     instructions: List<TransactionInstruction>,
   ): ByteArray {
     val blockhash = latestBlockhash()
-    val message = Message.Builder(instructions.toMutableList(), payer)
-      .setRecentBlockhash(blockhash)
-      .build()
-    return Transaction(message).serialize()
+    val builder = Message.Builder().setRecentBlockhash(blockhash)
+    instructions.forEach { builder.addInstruction(it) }
+    return Transaction(builder.build()).serialize()
   }
 
   private suspend fun latestBlockhash(): String = withContext(Dispatchers.IO) {
@@ -176,23 +173,26 @@ class GoldSolanaClient(
   private suspend fun pda(seed: String): SolanaPublicKey =
     ProgramDerivedAddress.find(listOf(seed.toByteArray()), faucetProgram).getOrThrow()
 
-  private fun createAssociatedTokenAccountIdempotent(
+  internal fun createAssociatedTokenAccountIdempotent(
     payer: SolanaPublicKey,
     owner: SolanaPublicKey,
     mint: SolanaPublicKey,
     ata: SolanaPublicKey,
-  ) = TransactionInstruction(
-    ASSOCIATED_TOKEN_PROGRAM_ID,
-    listOf(
-      AccountMeta(payer, isSigner = true, isWritable = true),
-      AccountMeta(ata, isSigner = false, isWritable = true),
-      AccountMeta(owner, isSigner = false, isWritable = false),
-      AccountMeta(mint, isSigner = false, isWritable = false),
-      AccountMeta(SYSTEM_PROGRAM_ID, isSigner = false, isWritable = false),
-      AccountMeta(TOKEN_PROGRAM_ID, isSigner = false, isWritable = false),
-    ),
-    byteArrayOf(1),
-  )
+  ): TransactionInstruction {
+    val ownerIsSelf = owner.bytes.contentEquals(payer.bytes)
+    return TransactionInstruction(
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+      listOf(
+        AccountMeta(payer, isSigner = true, isWritable = true),
+        AccountMeta(ata, isSigner = false, isWritable = true),
+        AccountMeta(owner, isSigner = ownerIsSelf, isWritable = ownerIsSelf),
+        AccountMeta(mint, isSigner = false, isWritable = false),
+        AccountMeta(SYSTEM_PROGRAM_ID, isSigner = false, isWritable = false),
+        AccountMeta(TOKEN_PROGRAM_ID, isSigner = false, isWritable = false),
+      ),
+      byteArrayOf(1),
+    )
+  }
 
   private fun burnChecked(
     source: SolanaPublicKey,

--- a/apps/clan-world-mobile/app/src/test/java/world/clan/app/data/gold/GoldSolanaClientTest.kt
+++ b/apps/clan-world-mobile/app/src/test/java/world/clan/app/data/gold/GoldSolanaClientTest.kt
@@ -1,25 +1,56 @@
 package world.clan.app.data.gold
 
 import com.solana.publickey.SolanaPublicKey
+import com.solana.transaction.LegacyMessage
 import com.solana.transaction.Message
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Regression test for issue #240: when the ATA-create-idempotent instruction
- * was emitted with `payer == owner` but conflicting AccountMeta flags
- * (writable signer vs. readonly non-signer), web3-solana's
- * [Message.Builder.build] bucket-added the owner pubkey to BOTH the
- * writable-signers set AND the readonly-non-signers set. The compiled
- * message then carried the same pubkey twice in `accounts`, which
- * Solana's pre-flight sanitizer rejects with
+ * Regression tests for issue #240.
+ *
+ * # The bug
+ *
+ * `com.solanamobile:web3-solana-jvm:0.3.0-beta4` `Message.Builder.build()`
+ * buckets `AccountMeta`s by `(isSigner, isWritable)` GLOBALLY across all
+ * instructions. The compiled `accounts` list dedups pubkeys via
+ * `LinkedHashSet`, but the header counters
+ * (`signatureCount`, `readOnlyAccounts`, `readOnlyNonSigners`) use the RAW
+ * bucket sizes pre-dedup. So a pubkey that appears in 2+ instructions with
+ * different flag tuples produces a malformed header/accounts mismatch and
+ * the on-chain sanitizer rejects the transaction with
  * "Transaction failed to sanitize accounts offsets correctly".
  *
- * The fix promotes the owner slot's flags to match the payer slot when
- * `payer == owner`, so both slots route to the same bucket and the
- * underlying LinkedHashSet collapses them to a single entry in `accounts`.
+ * Real-world hit (faucet path): `memo()` emits `owner(true, false)`
+ * (readonly-signer) while ATA-create's payer slot + claim's payer slot
+ * emit `owner(true, true)` (writable-signer). Same pubkey lands in two
+ * buckets. Same shape in `buildBurn(skipTax > 0)`.
+ *
+ * # The fix
+ *
+ * `GoldSolanaClient.buildTransaction` runs every instruction list through
+ * `unionAccountFlags` BEFORE handing it to `Message.Builder`. The pre-pass
+ * computes the OR-union of `(isSigner, isWritable)` for every pubkey and
+ * normalizes all occurrences. Compiled message now has every pubkey in
+ * exactly ONE bucket, and the header counters match the accounts list.
+ *
+ * # What these tests assert
+ *
+ * The canonical invariant: the compiled `LegacyMessage` has
+ *
+ *   `accounts.size == signatureCount + writableNonSigners + readOnlyNonSigners`
+ *
+ * where `writableNonSigners` is derived as
+ * `accounts.size - signatureCount - readOnlyNonSigners`. If the union
+ * pre-pass is reverted, `writableNonSigners` can go negative — that's the
+ * exact header/accounts mismatch the on-chain sanitizer trips on.
+ *
+ * We also assert: any pubkey that is `isWritable=true` in ANY input
+ * instruction MUST end up in a writable bucket in the compiled message.
+ * (Owner is writable in ATA-create + claim, so it must be a writable
+ * signer — NOT readonly-signer.)
  */
 class GoldSolanaClientTest {
 
@@ -29,6 +60,9 @@ class GoldSolanaClientTest {
   private val differentPayer = SolanaPublicKey(ByteArray(32) { (it + 96).toByte() })
   private val blockhash = SolanaPublicKey(ByteArray(32) { (it + 128).toByte() })
 
+  // Real devnet-shaped base58 strings so the eager toPubkey() in the
+  // constructor decodes 32 bytes — system-program pubkey is the canonical
+  // safe placeholder.
   private val client = GoldSolanaClient(
     rpcUrl = "http://localhost",
     mintBase58 = "11111111111111111111111111111111",
@@ -37,42 +71,27 @@ class GoldSolanaClientTest {
     decimals = 6,
   )
 
+  // ─── ATA-create instruction unit ──────────────────────────────────────────
+
   @Test
-  fun selfFundedAtaCreatePutsOwnerInAccountsExactlyOnce() {
+  fun selfFundedAtaCreateOwnerEndsUpWritableSignerInCompiledMessage() = runBlocking {
+    // Replicates round-1 PR #241 narrow-path test, but asserts the meaningful
+    // invariant — header-counter consistency — instead of tautologies.
     val ix = client.createAssociatedTokenAccountIdempotent(
       payer = owner,
       owner = owner,
       mint = mint,
       ata = ata,
     )
-    val message = Message.Builder()
-      .setRecentBlockhash(blockhash)
-      .addInstruction(ix)
-      .build()
 
-    val ownerOccurrences = message.accounts.count { it.bytes.contentEquals(owner.bytes) }
-    assertEquals(
-      "Owner pubkey must appear exactly once in compiled message accounts " +
-        "(double-occurrence is what triggers the sanitize-offsets RPC error)",
-      1,
-      ownerOccurrences,
-    )
+    val message = buildLegacyMessage(client.unionAccountFlags(listOf(ix)))
 
-    val distinctKeys = message.accounts.map { it.bytes.toList() }.distinct()
-    assertEquals(
-      "Compiled message must not contain duplicate account keys",
-      message.accounts.size,
-      distinctKeys.size,
-    )
-
-    val payerSlot = ix.accounts[0]
-    val ownerSlot = ix.accounts[2]
-    assertTrue("Self-funded payer slot stays a writable signer", payerSlot.isSigner && payerSlot.isWritable)
-    assertTrue("Self-funded owner duplicate slot is also writable signer", ownerSlot.isSigner && ownerSlot.isWritable)
+    assertHeaderAccountsConsistent(message)
+    assertOwnerInWritableSignerBucket(message, owner)
   }
 
   @Test
-  fun separatePayerKeepsOwnerReadonly() {
+  fun separatePayerKeepsOwnerReadonlyNonSigner() = runBlocking {
     val ix = client.createAssociatedTokenAccountIdempotent(
       payer = differentPayer,
       owner = owner,
@@ -80,24 +99,186 @@ class GoldSolanaClientTest {
       ata = ata,
     )
 
-    val payerSlot = ix.accounts[0]
-    val ownerSlot = ix.accounts[2]
+    val message = buildLegacyMessage(client.unionAccountFlags(listOf(ix)))
 
-    assertTrue("Payer is writable signer", payerSlot.isSigner && payerSlot.isWritable)
+    assertHeaderAccountsConsistent(message)
+    // payer is the only signer; owner is readonly non-signer.
+    val payerIndex = message.accounts.indexOfFirst { it.bytes.contentEquals(differentPayer.bytes) }
+    val ownerIndex = message.accounts.indexOfFirst { it.bytes.contentEquals(owner.bytes) }
+    val signers = message.signatureCount.toInt()
+    val readonlyNonSigners = message.readOnlyNonSigners.toInt()
+    assertTrue("payer should be in signer prefix", payerIndex in 0 until signers)
     assertTrue(
-      "Owner slot is readonly non-signer when distinct from payer",
-      !ownerSlot.isSigner && !ownerSlot.isWritable,
+      "owner should land in readonly-non-signer suffix",
+      ownerIndex in (message.accounts.size - readonlyNonSigners) until message.accounts.size,
     )
-    assertNotEquals(payerSlot.publicKey.bytes.toList(), ownerSlot.publicKey.bytes.toList())
+  }
 
-    val message = Message.Builder()
-      .setRecentBlockhash(blockhash)
-      .addInstruction(ix)
-      .build()
+  // ─── Full buildFaucetClaim instruction list (Tier 1 + Tier 2 critical) ───
 
-    val payerOccurrences = message.accounts.count { it.bytes.contentEquals(differentPayer.bytes) }
-    val ownerOccurrences = message.accounts.count { it.bytes.contentEquals(owner.bytes) }
-    assertEquals(1, payerOccurrences)
-    assertEquals(1, ownerOccurrences)
+  @Test
+  fun faucetClaimFullInstructionListHasConsistentHeader() = runBlocking {
+    // This is the empirical reproduction the round-1 swarm identified:
+    // the full instruction list — ATA-create + claim + memo — must compile
+    // to a Message whose header counters partition `accounts` cleanly.
+    val instructions = client.faucetClaimInstructions(owner, "faucet:test")
+    val canonical = client.unionAccountFlags(instructions)
+    val message = buildLegacyMessage(canonical)
+
+    assertHeaderAccountsConsistent(message)
+    // No duplicate pubkeys in the compiled accounts list.
+    assertEquals(
+      "Compiled message must not have duplicate pubkeys",
+      message.accounts.size,
+      message.accounts.map { it.bytes.toList() }.distinct().size,
+    )
+    // Owner needs to sign AND be writable (ATA-create payer slot + claim
+    // payer slot both require it), so it MUST land in the writable-signer
+    // bucket — NOT readonly-signer.
+    assertOwnerInWritableSignerBucket(message, owner)
+  }
+
+  @Test
+  fun faucetClaimUnionsOwnerFlagsAcrossMemoAndPayerSlots() = runBlocking {
+    val raw = client.faucetClaimInstructions(owner, "faucet:test")
+    // Sanity-check the input shape: memo() emits owner as readonly-signer
+    // while ATA-create + claim emit owner as writable-signer. This is the
+    // bucket-split that triggers the bug.
+    val memoIx = raw.last()
+    val memoOwnerMeta = memoIx.accounts.single { it.publicKey.bytes.contentEquals(owner.bytes) }
+    assertTrue("memo() emits owner as readonly-signer (input shape)", memoOwnerMeta.isSigner && !memoOwnerMeta.isWritable)
+
+    // After union, every owner meta should be writable-signer.
+    val canonical = client.unionAccountFlags(raw)
+    canonical.forEach { ix ->
+      ix.accounts.filter { it.publicKey.bytes.contentEquals(owner.bytes) }.forEach { meta ->
+        assertTrue(
+          "Owner meta after union must be writable signer (instruction ${canonical.indexOf(ix)})",
+          meta.isSigner && meta.isWritable,
+        )
+      }
+    }
+  }
+
+  // ─── Full buildBurn(skipTax > 0) instruction list ────────────────────────
+
+  @Test
+  fun burnWithSkipTaxHasConsistentHeader() = runBlocking {
+    // Burn-with-skip-tax exercises the same multi-bucket shape:
+    // burnChecked emits owner(true,false), the inner ATA-create for
+    // treasuryAta emits payer=owner(true,true), transferChecked emits
+    // owner(true,false), and memo emits owner(true,false).
+    val instructions = client.burnInstructions(owner, amount = 100L, memo = "burn:test", skipTax = 5L)
+    val canonical = client.unionAccountFlags(instructions)
+    val message = buildLegacyMessage(canonical)
+
+    assertHeaderAccountsConsistent(message)
+    assertOwnerInWritableSignerBucket(message, owner)
+  }
+
+  @Test
+  fun burnWithoutSkipTaxStillProducesConsistentHeader() = runBlocking {
+    // No-skip-tax burn: owner only appears as readonly-signer (no writable
+    // need). Verify the union pre-pass is a no-op here and that the header
+    // is still consistent.
+    val instructions = client.burnInstructions(owner, amount = 100L, memo = "burn:test", skipTax = 0L)
+    val canonical = client.unionAccountFlags(instructions)
+    val message = buildLegacyMessage(canonical)
+
+    assertHeaderAccountsConsistent(message)
+    // Owner should be readonly-signer here (no writable need).
+    val signers = message.signatureCount.toInt()
+    val readonlyAccounts = message.readOnlyAccounts.toInt()
+    val ownerIndex = message.accounts.indexOfFirst { it.bytes.contentEquals(owner.bytes) }
+    val firstReadonlySigner = signers - readonlyAccounts
+    assertTrue(
+      "Owner in burn-no-skip-tax should land in readonly-signer slice " +
+        "[$firstReadonlySigner, $signers) — actual index $ownerIndex",
+      ownerIndex in firstReadonlySigner until signers,
+    )
+  }
+
+  // ─── unionAccountFlags unit semantics ────────────────────────────────────
+
+  @Test
+  fun unionAccountFlagsIsIdempotentOnAlreadyCanonicalInput() = runBlocking {
+    val canonical = client.unionAccountFlags(client.faucetClaimInstructions(owner, "memo"))
+    val twice = client.unionAccountFlags(canonical)
+    assertEquals(canonical.size, twice.size)
+    canonical.zip(twice).forEach { (a, b) ->
+      assertEquals(a.accounts.size, b.accounts.size)
+      a.accounts.zip(b.accounts).forEach { (am, bm) ->
+        assertEquals(am.publicKey.bytes.toList(), bm.publicKey.bytes.toList())
+        assertEquals(am.isSigner, bm.isSigner)
+        assertEquals(am.isWritable, bm.isWritable)
+      }
+    }
+  }
+
+  // ─── helpers ─────────────────────────────────────────────────────────────
+
+  private fun buildLegacyMessage(
+    instructions: List<com.solana.transaction.TransactionInstruction>,
+  ): LegacyMessage {
+    val builder = Message.Builder().setRecentBlockhash(blockhash)
+    instructions.forEach { builder.addInstruction(it) }
+    val message = builder.build()
+    require(message is LegacyMessage) { "Expected LegacyMessage, got ${message::class}" }
+    return message
+  }
+
+  /**
+   * The canonical Solana message invariant:
+   * `accounts.size == signatureCount + writableNonSigners + readOnlyNonSigners`
+   * where `writableNonSigners = accounts.size - signatureCount - readOnlyNonSigners`.
+   *
+   * Equivalently: `writableNonSigners >= 0` AND `readOnlyAccounts <= signatureCount`.
+   *
+   * Before the union pre-pass, a pubkey landing in two buckets could push
+   * the raw bucket-sum past the deduped `accounts.size`, making
+   * `writableNonSigners` negative — that's the exact mismatch that yields
+   * "Transaction failed to sanitize accounts offsets correctly" at the RPC.
+   */
+  private fun assertHeaderAccountsConsistent(m: LegacyMessage) {
+    val signers = m.signatureCount.toInt()
+    val readonlySigners = m.readOnlyAccounts.toInt()
+    val readonlyNonSigners = m.readOnlyNonSigners.toInt()
+    val total = m.accounts.size
+
+    assertTrue(
+      "readOnlyAccounts ($readonlySigners) must be <= signatureCount ($signers)",
+      readonlySigners <= signers,
+    )
+    assertTrue(
+      "signatureCount + readOnlyNonSigners ($signers + $readonlyNonSigners = " +
+        "${signers + readonlyNonSigners}) must be <= accounts.size ($total). " +
+        "If this fails, a pubkey landed in 2 buckets and the on-chain sanitizer will reject.",
+      signers + readonlyNonSigners <= total,
+    )
+    // No duplicate pubkeys in the compiled accounts list.
+    assertEquals(
+      "Compiled message must not have duplicate pubkeys in accounts list",
+      total,
+      m.accounts.map { it.bytes.toList() }.distinct().size,
+    )
+  }
+
+  /**
+   * The compiled `accounts` list is ordered: writable-signers,
+   * readonly-signers, writable-non-signers, readonly-non-signers.
+   * "Owner in writable-signer bucket" means index in [0, signatureCount - readOnlyAccounts).
+   */
+  private fun assertOwnerInWritableSignerBucket(m: LegacyMessage, ownerKey: SolanaPublicKey) {
+    val signers = m.signatureCount.toInt()
+    val readonlySigners = m.readOnlyAccounts.toInt()
+    val writableSigners = signers - readonlySigners
+    val ownerIndex = m.accounts.indexOfFirst { it.bytes.contentEquals(ownerKey.bytes) }
+    assertTrue("owner must appear in compiled accounts", ownerIndex >= 0)
+    assertTrue(
+      "Owner index ($ownerIndex) must be in writable-signer slice [0, $writableSigners). " +
+        "writableSigners=$writableSigners, signatureCount=$signers, readOnlyAccounts=$readonlySigners. " +
+        "If owner lands outside this slice, the multi-bucket bug is back.",
+      ownerIndex in 0 until writableSigners,
+    )
   }
 }

--- a/apps/clan-world-mobile/app/src/test/java/world/clan/app/data/gold/GoldSolanaClientTest.kt
+++ b/apps/clan-world-mobile/app/src/test/java/world/clan/app/data/gold/GoldSolanaClientTest.kt
@@ -1,0 +1,103 @@
+package world.clan.app.data.gold
+
+import com.solana.publickey.SolanaPublicKey
+import com.solana.transaction.Message
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression test for issue #240: when the ATA-create-idempotent instruction
+ * was emitted with `payer == owner` but conflicting AccountMeta flags
+ * (writable signer vs. readonly non-signer), web3-solana's
+ * [Message.Builder.build] bucket-added the owner pubkey to BOTH the
+ * writable-signers set AND the readonly-non-signers set. The compiled
+ * message then carried the same pubkey twice in `accounts`, which
+ * Solana's pre-flight sanitizer rejects with
+ * "Transaction failed to sanitize accounts offsets correctly".
+ *
+ * The fix promotes the owner slot's flags to match the payer slot when
+ * `payer == owner`, so both slots route to the same bucket and the
+ * underlying LinkedHashSet collapses them to a single entry in `accounts`.
+ */
+class GoldSolanaClientTest {
+
+  private val owner = SolanaPublicKey(ByteArray(32) { (it + 1).toByte() })
+  private val ata = SolanaPublicKey(ByteArray(32) { (it + 32).toByte() })
+  private val mint = SolanaPublicKey(ByteArray(32) { (it + 64).toByte() })
+  private val differentPayer = SolanaPublicKey(ByteArray(32) { (it + 96).toByte() })
+  private val blockhash = SolanaPublicKey(ByteArray(32) { (it + 128).toByte() })
+
+  private val client = GoldSolanaClient(
+    rpcUrl = "http://localhost",
+    mintBase58 = "11111111111111111111111111111111",
+    faucetProgramBase58 = "11111111111111111111111111111111",
+    treasuryOwnerBase58 = "11111111111111111111111111111111",
+    decimals = 6,
+  )
+
+  @Test
+  fun selfFundedAtaCreatePutsOwnerInAccountsExactlyOnce() {
+    val ix = client.createAssociatedTokenAccountIdempotent(
+      payer = owner,
+      owner = owner,
+      mint = mint,
+      ata = ata,
+    )
+    val message = Message.Builder()
+      .setRecentBlockhash(blockhash)
+      .addInstruction(ix)
+      .build()
+
+    val ownerOccurrences = message.accounts.count { it.bytes.contentEquals(owner.bytes) }
+    assertEquals(
+      "Owner pubkey must appear exactly once in compiled message accounts " +
+        "(double-occurrence is what triggers the sanitize-offsets RPC error)",
+      1,
+      ownerOccurrences,
+    )
+
+    val distinctKeys = message.accounts.map { it.bytes.toList() }.distinct()
+    assertEquals(
+      "Compiled message must not contain duplicate account keys",
+      message.accounts.size,
+      distinctKeys.size,
+    )
+
+    val payerSlot = ix.accounts[0]
+    val ownerSlot = ix.accounts[2]
+    assertTrue("Self-funded payer slot stays a writable signer", payerSlot.isSigner && payerSlot.isWritable)
+    assertTrue("Self-funded owner duplicate slot is also writable signer", ownerSlot.isSigner && ownerSlot.isWritable)
+  }
+
+  @Test
+  fun separatePayerKeepsOwnerReadonly() {
+    val ix = client.createAssociatedTokenAccountIdempotent(
+      payer = differentPayer,
+      owner = owner,
+      mint = mint,
+      ata = ata,
+    )
+
+    val payerSlot = ix.accounts[0]
+    val ownerSlot = ix.accounts[2]
+
+    assertTrue("Payer is writable signer", payerSlot.isSigner && payerSlot.isWritable)
+    assertTrue(
+      "Owner slot is readonly non-signer when distinct from payer",
+      !ownerSlot.isSigner && !ownerSlot.isWritable,
+    )
+    assertNotEquals(payerSlot.publicKey.bytes.toList(), ownerSlot.publicKey.bytes.toList())
+
+    val message = Message.Builder()
+      .setRecentBlockhash(blockhash)
+      .addInstruction(ix)
+      .build()
+
+    val payerOccurrences = message.accounts.count { it.bytes.contentEquals(differentPayer.bytes) }
+    val ownerOccurrences = message.accounts.count { it.bytes.contentEquals(owner.bytes) }
+    assertEquals(1, payerOccurrences)
+    assertEquals(1, ownerOccurrences)
+  }
+}


### PR DESCRIPTION
Closes #240

## Summary

Two bugs in `GoldSolanaClient.kt` combined to produce "Transaction failed to sanitize accounts offsets correctly" when minting 100k GOLD from the Android faucet:

1. **ATA-create AccountMeta flag mismatch (primary).** For self-funded ATAs (`payer == owner`, e.g. faucet claim) the same pubkey was emitted in slot 0 as `(isSigner=true, isWritable=true)` and slot 2 as `(isSigner=false, isWritable=false)`. `web3-solana:0.3.0-beta4`'s `Message.Builder.build()` bucket-adds each `AccountMeta` to one of four `LinkedHashSet`s (writable-signers / readonly-signers / writable-non-signers / readonly-non-signers) without flag-unioning, so the owner pubkey landed in TWO buckets and appeared twice in `message.accounts`. Solana's pre-flight sanitizer rejects duplicates. Fix: when `payer == owner`, promote the owner-slot flags so both slots route to the same bucket and collapse to one entry.

2. **`Message.Builder` constructor positional misalignment (secondary).** `Message.Builder(instructions.toMutableList(), payer)` placed `payer` into the `blockhash` slot — `setRecentBlockhash` immediately overwrote it, so functionally harmless in this SDK (Builder has only `instructions` + `blockhash` fields; fee payer is implicit from the first writable signer), but confusing intent. Fix: use the no-arg constructor + fluent `setRecentBlockhash` + `addInstruction`.

Note: the brief sketched `addFeePayer(payer)`; the actual SDK has no such method (verified by inspecting `Message$Builder` bytecode in `web3-solana-jvm:0.3.0-beta4`). The fee payer is inferred from the first writable signer in the instruction list, which for both flows here is `owner`. The unused `payer` parameter on `buildTransaction` was therefore dropped.

## Test plan

- [x] `:app:assembleDebug` — BUILD SUCCESSFUL
- [x] `:app:testDebugUnitTest` — all tests pass, including 2 new regression tests in `GoldSolanaClientTest`:
  - `selfFundedAtaCreatePutsOwnerInAccountsExactlyOnce` — verified to FAIL when fix is reverted, PASS with fix applied
  - `separatePayerKeepsOwnerReadonly` — guards the non-self-owned (treasury skip-tax) path stays readonly
- [ ] Manual: mint 100k GOLD from Android app on devnet succeeds without sanitize error
- [ ] Manual: existing skip-tax burn flow (`treasuryOwner != owner`) still works (no regression)