### PR TITLE
feat(web): winter snowfall particle overlay

### DIFF
--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -10,6 +10,7 @@ import { api } from '../../server/convex/_generated/api';
 import worldMapBg from './assets/world-map.png';
 import { DEMO_MODE } from './config/env';
 import { BanditState } from '@clan-world/shared/generated/enums';
+import { createWinterSnow, type WinterSnowHandle } from './effects/winterSnow';
 
 // World dimensions used by pixi-viewport for pan/clamp/center math.
 // Matches the actual hand-curated bg PNG (apps/web/src/assets/world-map.png)
@@ -1128,6 +1129,11 @@ export function WorldMap() {
   const burstTickerCbRef = useRef<(() => void) | null>(null);
   const seenBurstLogIdsRef = useRef<Set<string>>(new Set());
 
+  // Winter snowfall overlay (screen-space particle layer above viewport, below
+  // React DOM UI). Created post-init; activated/deactivated via setActive in a
+  // separate effect that watches `snapshot.winterActive`.
+  const winterSnowRef = useRef<WinterSnowHandle | null>(null);
+
   // Bandit attack animation (docs/planning/bandit-animation-impl-plan.md).
   // Snapshot-diff tracking: derive last resolution outcome on every snapshot tick.
   // Known cold-start gap: if the page reloads during the T4 resolution window,
@@ -1808,6 +1814,24 @@ export function WorldMap() {
         burstTickerCbRef.current = burstCb;
         app.ticker.add(burstCb);
 
+        // Winter snowfall overlay. Lives directly on app.stage (NOT inside the
+        // pixi-viewport) so particles stay in screen space — falling from the
+        // top of the visible canvas regardless of how the user has panned/zoomed
+        // the world. Stage children: [viewport, snow.container]. React DOM
+        // (TopHud / EventTicker / status badges) renders above the canvas in
+        // the DOM, so it sits above the snow naturally. Honors
+        // `prefers-reduced-motion`: when set, we skip creating the system at
+        // all so we never spend ticker cycles on motion the user opted out of.
+        const reducedMotion =
+          typeof window !== 'undefined' &&
+          typeof window.matchMedia === 'function' &&
+          window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (!reducedMotion) {
+          const snow = createWinterSnow(app, { particleCount: 100 });
+          app.stage.addChild(snow.container);
+          winterSnowRef.current = snow;
+        }
+
         // 4. Initial layout (PR #41) — projects normalized coords + positions flag anchors.
         // relayout now operates in WORLD space (MAP_WIDTH x MAP_HEIGHT) since the
         // viewport handles screen-fit transformation. Children inside the viewport
@@ -1834,6 +1858,13 @@ export function WorldMap() {
       if (a && combatTickerCbRef.current) a.ticker.remove(combatTickerCbRef.current);
       if (a && banditAnimTickerCbRef.current) a.ticker.remove(banditAnimTickerCbRef.current);
       if (a && burstTickerCbRef.current) a.ticker.remove(burstTickerCbRef.current);
+      // Winter snow owns its own ticker callback + texture lifecycle; .destroy()
+      // unregisters from the app ticker and disposes the shared snowflake
+      // texture so Pixi destroy() (below) doesn't leave a GPU texture leak.
+      if (winterSnowRef.current) {
+        winterSnowRef.current.destroy();
+        winterSnowRef.current = null;
+      }
       if (pixiCanvas && canvasClickHandler) pixiCanvas.removeEventListener('click', canvasClickHandler);
       finishCombatVignette(true);
       selectedRef.current?.ring.destroy();
@@ -3944,6 +3975,19 @@ export function WorldMap() {
     redrawBandit();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [liveTick, pixiReady, liveBandit]);
+
+  // Winter snowfall: subscribe to `worldSnapshot.winterActive` and drive the
+  // particle overlay's active state. The underlying snapshot type doesn't yet
+  // expose the season fields (matches the cast TopHud does — same getSnapshot
+  // query, same broader-schema-pending caveat), so we read via `any`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const winterActive = (snapshot as any)?.winterActive === true;
+  useEffect(() => {
+    if (!pixiReady) return;
+    const snow = winterSnowRef.current;
+    if (!snow) return; // reduced-motion path — handle was never created
+    snow.setActive(winterActive);
+  }, [pixiReady, winterActive]);
 
   // Snapshot clan changes: re-layout so monument heights track live treasury.
   useEffect(() => {

--- a/apps/web/src/effects/winterSnow.ts
+++ b/apps/web/src/effects/winterSnow.ts
@@ -1,0 +1,258 @@
+import { Application, Container, Graphics, Sprite, Texture } from 'pixi.js';
+
+/**
+ * Winter snowfall particle overlay.
+ *
+ * Hand-rolled (no `@pixi/particle-emitter` dependency) — we pre-allocate a
+ * pool of `Sprite` instances sharing one generated white-circle texture and
+ * recycle them as they exit the bottom of the viewport. The emitter renders
+ * in screen space (added as a direct child of `app.stage`, not the
+ * pixi-viewport) so particles stay visually consistent regardless of
+ * pan / zoom.
+ *
+ * Lifecycle:
+ *   - `createWinterSnow(app, opts)` builds the pool + texture, registers a
+ *     ticker callback, attaches a screen-space Container above the viewport,
+ *     and returns a `WinterSnowHandle`.
+ *   - Call `handle.setActive(true | false)` when `worldSnapshot.winterActive`
+ *     flips. The container fades over ~1s on deactivate; ticker stops once
+ *     fade completes.
+ *   - Call `handle.destroy()` on Pixi teardown to remove the ticker callback
+ *     and dispose the container/texture.
+ *
+ * Performance:
+ *   - One generated 4×4 white-disc texture, shared by all sprites.
+ *   - ~100 sprites at default density on a typical desktop viewport.
+ *   - Per-frame work is purely position math (`x += vx`, sine-of-time drift) —
+ *     no allocations, no Graphics redraws.
+ *
+ * Layer order:
+ *   - Stage children: [viewport, snowContainer] — snow renders above the
+ *     world (terrain, regions, bubbles) but below the React DOM UI overlay
+ *     (TopHud, EventTicker, status badges), which is Liam's design intent.
+ */
+
+export interface WinterSnowOptions {
+  /** Approximate particle count. The pool is pre-allocated to this size. */
+  particleCount?: number;
+  /** Vertical fall speed range in px/sec (min, max). */
+  fallSpeedRange?: [number, number];
+  /** Horizontal drift amplitude in px. Sway = sin(time + seed) * amplitude. */
+  driftAmplitude?: number;
+  /** Particle radius range in px (min, max). Larger = closer flakes. */
+  radiusRange?: [number, number];
+  /** Base alpha range (min, max). */
+  alphaRange?: [number, number];
+  /** Fade-out duration in ms when deactivating. */
+  fadeOutMs?: number;
+}
+
+interface SnowParticle {
+  sprite: Sprite;
+  /** Phase seed for sine drift — keeps each flake out of lockstep. */
+  seed: number;
+  /** Vertical velocity in px/sec. */
+  vy: number;
+  /** Base x (drift is added on top of this). */
+  baseX: number;
+  /** Drift amplitude assigned per-particle so flakes don't sway identically. */
+  amp: number;
+  /** Per-particle drift frequency multiplier. */
+  freq: number;
+  /** Base alpha for this particle (so they're not all uniform). */
+  baseAlpha: number;
+}
+
+export interface WinterSnowHandle {
+  container: Container;
+  /** Enable / disable snowfall. Idempotent. Fades over `fadeOutMs` on disable. */
+  setActive: (active: boolean) => void;
+  destroy: () => void;
+}
+
+const DEFAULTS = {
+  particleCount: 100,
+  fallSpeedRange: [40, 90] as [number, number],
+  driftAmplitude: 18,
+  radiusRange: [1.0, 2.4] as [number, number],
+  alphaRange: [0.45, 0.95] as [number, number],
+  fadeOutMs: 1000,
+};
+
+/** Pick a uniform random number in [min, max]. */
+function rand(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+/**
+ * Build a small white-disc texture once via `Graphics` → `generateTexture`,
+ * shared by every particle Sprite. Pixi 8 `Graphics` uses the `circle()` +
+ * `fill()` fluent API; resolution=2 keeps the disc crisp on hi-dpi.
+ */
+function buildSnowflakeTexture(app: Application): Texture {
+  const g = new Graphics();
+  // 4px radius gives us headroom for the upper end of `radiusRange` — sprites
+  // are scaled down per-particle, so oversampling here yields crisper output
+  // than scaling up a tiny texture.
+  g.circle(0, 0, 4).fill({ color: 0xffffff, alpha: 1 });
+  const tex = app.renderer.generateTexture({ target: g, resolution: 2 });
+  g.destroy();
+  return tex;
+}
+
+/**
+ * Reset one particle to the top of the viewport with a fresh randomised x,
+ * speed, and drift profile. Called both on initial pool fill and when a
+ * particle exits the bottom of the screen (recycling — no GC churn).
+ */
+function spawnParticle(
+  p: SnowParticle,
+  screenW: number,
+  screenH: number,
+  opts: Required<WinterSnowOptions>,
+  initial: boolean,
+): void {
+  p.baseX = rand(-20, screenW + 20);
+  // On first spawn, distribute particles randomly across the screen so the
+  // effect doesn't have a "waterfall building up" flash on activate. On
+  // recycling, start just above the top edge.
+  const y = initial ? rand(-screenH * 0.2, screenH) : rand(-30, -5);
+  p.sprite.x = p.baseX;
+  p.sprite.y = y;
+  p.vy = rand(opts.fallSpeedRange[0], opts.fallSpeedRange[1]);
+  const r = rand(opts.radiusRange[0], opts.radiusRange[1]);
+  // Texture native radius is 4 (see buildSnowflakeTexture); scale to target.
+  p.sprite.scale.set(r / 4);
+  p.baseAlpha = rand(opts.alphaRange[0], opts.alphaRange[1]);
+  p.sprite.alpha = p.baseAlpha;
+  p.seed = Math.random() * Math.PI * 2;
+  p.amp = rand(opts.driftAmplitude * 0.4, opts.driftAmplitude);
+  // Slow flakes drift slower; fast ones can sway faster. Map vy → freq.
+  p.freq = rand(0.6, 1.6);
+}
+
+export function createWinterSnow(
+  app: Application,
+  options: WinterSnowOptions = {},
+): WinterSnowHandle {
+  const opts: Required<WinterSnowOptions> = { ...DEFAULTS, ...options };
+
+  const container = new Container();
+  // `eventMode = 'none'` ensures snow never intercepts pointer events meant
+  // for clan bases / regions underneath.
+  container.eventMode = 'none';
+  container.visible = false;
+  container.alpha = 0;
+
+  const texture = buildSnowflakeTexture(app);
+  const particles: SnowParticle[] = [];
+
+  let screenW = app.renderer.screen.width;
+  let screenH = app.renderer.screen.height;
+
+  for (let i = 0; i < opts.particleCount; i++) {
+    const sprite = new Sprite(texture);
+    sprite.anchor.set(0.5);
+    container.addChild(sprite);
+    const p: SnowParticle = {
+      sprite,
+      seed: 0,
+      vy: 0,
+      baseX: 0,
+      amp: 0,
+      freq: 1,
+      baseAlpha: 1,
+    };
+    spawnParticle(p, screenW, screenH, opts, true);
+    particles.push(p);
+  }
+
+  /**
+   * Activation state machine: `idle` (hidden, ticker not running) →
+   * `active` (visible, full alpha, ticker animating) → `fading` (visible,
+   * alpha ramping to 0, ticker still animating) → `idle`. Re-activating
+   * mid-fade cancels the fade and ramps back up.
+   */
+  type Phase = 'idle' | 'active' | 'fading';
+  let phase: Phase = 'idle';
+  let fadeStartMs = 0;
+  let tickerRegistered = false;
+  let startMs = performance.now();
+
+  const tick = (): void => {
+    const now = performance.now();
+    const dtMs = app.ticker.deltaMS;
+    const dtSec = dtMs / 1000;
+
+    // Track latest screen dims — cheap, supports resize without an explicit
+    // re-init pass. Used to recycle particles + clamp baseX on respawn.
+    screenW = app.renderer.screen.width;
+    screenH = app.renderer.screen.height;
+
+    // Alpha envelope for fade-out / fade-in.
+    if (phase === 'fading') {
+      const fadeT = (now - fadeStartMs) / opts.fadeOutMs;
+      if (fadeT >= 1) {
+        container.alpha = 0;
+        container.visible = false;
+        phase = 'idle';
+        // Leave ticker registered — registering/unregistering Pixi tickers
+        // every season swap is more expensive than letting the callback
+        // early-return while idle.
+        return;
+      }
+      container.alpha = 1 - fadeT;
+    } else if (phase === 'active') {
+      // Fade IN over ~400ms on activate for a softer onset.
+      const fadeInMs = 400;
+      const t = Math.min(1, (now - startMs) / fadeInMs);
+      container.alpha = t;
+    } else {
+      // idle — skip per-particle work entirely.
+      return;
+    }
+
+    // Per-particle: gravity-driven fall + sine drift, recycle on bottom exit.
+    const tSec = (now - startMs) / 1000;
+    for (const p of particles) {
+      p.sprite.y += p.vy * dtSec;
+      p.sprite.x = p.baseX + Math.sin(tSec * p.freq + p.seed) * p.amp;
+      // Recycle past bottom — small slack so the recycle frame isn't visible.
+      if (p.sprite.y > screenH + 10) {
+        spawnParticle(p, screenW, screenH, opts, false);
+      }
+    }
+  };
+
+  app.ticker.add(tick);
+  tickerRegistered = true;
+
+  const setActive = (active: boolean): void => {
+    if (active) {
+      if (phase === 'active') return;
+      phase = 'active';
+      container.visible = true;
+      // Reset startMs so fade-in begins fresh. (If reactivating mid-fade-out,
+      // this also restarts the alpha envelope from 0.)
+      startMs = performance.now();
+      container.alpha = 0;
+    } else {
+      if (phase === 'idle') return;
+      // Already fading — keep current fade in flight, don't restart.
+      if (phase === 'fading') return;
+      phase = 'fading';
+      fadeStartMs = performance.now();
+    }
+  };
+
+  const destroy = (): void => {
+    if (tickerRegistered) {
+      app.ticker.remove(tick);
+      tickerRegistered = false;
+    }
+    container.destroy({ children: true });
+    texture.destroy(true);
+  };
+
+  return { container, setActive, destroy };
+}

--- a/apps/web/src/effects/winterSnow.ts
+++ b/apps/web/src/effects/winterSnow.ts
@@ -171,27 +171,51 @@ export function createWinterSnow(
    * Activation state machine: `idle` (hidden, ticker not running) →
    * `active` (visible, full alpha, ticker animating) → `fading` (visible,
    * alpha ramping to 0, ticker still animating) → `idle`. Re-activating
-   * mid-fade cancels the fade and ramps back up.
+   * mid-fade cancels the fade and ramps back up from the current alpha
+   * (no blink), and the drift clock is preserved across cycles so flake
+   * sine phase doesn't snap.
    */
   type Phase = 'idle' | 'active' | 'fading';
   let phase: Phase = 'idle';
-  let fadeStartMs = 0;
+  // Drift clock — monotonic across the lifetime of this handle. Never reset
+  // after construction; resetting it would discontinuously snap every flake's
+  // horizontal sine drift on every activate/deactivate (visible jump).
+  const startMs = performance.now();
+  // Envelope clocks — separate from `startMs` so fade timing can resume from
+  // any current alpha without disturbing the drift phase. The fade-in/out
+  // envelopes are parameterised so that `alpha(fadeStartMs) === fadeStartAlpha`
+  // and `alpha(fadeStartMs + duration*(1 - startAlpha)) === target`, i.e. the
+  // remaining-duration math accounts for the alpha we're already at.
+  const FADE_IN_MS = 400;
+  let fadeInStartMs = 0;
+  let fadeInStartAlpha = 0;
+  let fadeOutStartMs = 0;
+  let fadeOutStartAlpha = 0;
   let tickerRegistered = false;
-  let startMs = performance.now();
 
   const tick = (): void => {
     const now = performance.now();
     const dtMs = app.ticker.deltaMS;
     const dtSec = dtMs / 1000;
 
+    // Idle short-circuit — skip dims read + envelope math + particle loop.
+    if (phase === 'idle') {
+      return;
+    }
+
     // Track latest screen dims — cheap, supports resize without an explicit
     // re-init pass. Used to recycle particles + clamp baseX on respawn.
     screenW = app.renderer.screen.width;
     screenH = app.renderer.screen.height;
 
-    // Alpha envelope for fade-out / fade-in.
+    // Alpha envelope for fade-out / fade-in. Both envelopes are computed from
+    // the alpha value at the start of the fade — so a fade-in that begins at
+    // alpha=0.6 only needs 40% of FADE_IN_MS to reach 1.0, and a fade-out from
+    // alpha=0.3 only needs 30% of fadeOutMs to reach 0. This makes mid-fade
+    // direction reversals seamless (no blink).
     if (phase === 'fading') {
-      const fadeT = (now - fadeStartMs) / opts.fadeOutMs;
+      const remainingMs = opts.fadeOutMs * fadeOutStartAlpha;
+      const fadeT = remainingMs > 0 ? (now - fadeOutStartMs) / remainingMs : 1;
       if (fadeT >= 1) {
         container.alpha = 0;
         container.visible = false;
@@ -201,18 +225,17 @@ export function createWinterSnow(
         // early-return while idle.
         return;
       }
-      container.alpha = 1 - fadeT;
-    } else if (phase === 'active') {
-      // Fade IN over ~400ms on activate for a softer onset.
-      const fadeInMs = 400;
-      const t = Math.min(1, (now - startMs) / fadeInMs);
-      container.alpha = t;
+      container.alpha = fadeOutStartAlpha * (1 - fadeT);
     } else {
-      // idle — skip per-particle work entirely.
-      return;
+      // phase === 'active' — fade IN from current alpha to 1.0.
+      const remainingMs = FADE_IN_MS * (1 - fadeInStartAlpha);
+      const fadeT = remainingMs > 0 ? Math.min(1, (now - fadeInStartMs) / remainingMs) : 1;
+      container.alpha = fadeInStartAlpha + (1 - fadeInStartAlpha) * fadeT;
     }
 
     // Per-particle: gravity-driven fall + sine drift, recycle on bottom exit.
+    // tSec uses the monotonic `startMs` so sine phase is continuous across
+    // any number of activate/deactivate cycles (no horizontal jump).
     const tSec = (now - startMs) / 1000;
     for (const p of particles) {
       p.sprite.y += p.vy * dtSec;
@@ -230,18 +253,24 @@ export function createWinterSnow(
   const setActive = (active: boolean): void => {
     if (active) {
       if (phase === 'active') return;
+      // Preserve the current alpha as the fade-in start — if we were mid
+      // fade-out at e.g. alpha=0.5, the fade-in resumes from 0.5 (no blink).
+      // If we were idle (alpha=0), this is the normal cold-start case.
+      fadeInStartAlpha = container.alpha;
+      fadeInStartMs = performance.now();
       phase = 'active';
       container.visible = true;
-      // Reset startMs so fade-in begins fresh. (If reactivating mid-fade-out,
-      // this also restarts the alpha envelope from 0.)
-      startMs = performance.now();
-      container.alpha = 0;
+      // NOTE: `startMs` (drift clock) is intentionally NOT touched here —
+      // resetting it would snap every particle's sine phase, causing all 100
+      // flakes to horizontally jump on every reactivate.
     } else {
       if (phase === 'idle') return;
-      // Already fading — keep current fade in flight, don't restart.
-      if (phase === 'fading') return;
+      // Mid fade-in or already fading — start a fresh fade-out from the
+      // current alpha. This is symmetric with the fade-in resume above and
+      // also prevents a blink if a season flip happens during fade-in.
+      fadeOutStartAlpha = container.alpha;
+      fadeOutStartMs = performance.now();
       phase = 'fading';
-      fadeStartMs = performance.now();
     }
   };
 


### PR DESCRIPTION
## Summary

Add a PixiJS snowfall particle overlay that activates when `worldSnapshot.winterActive` is true. ~100 pooled sprites fall from the top of the viewport with gentle sine-driven horizontal drift, fade in over ~400ms on winter onset, and fade out over ~1s when the season changes.

Reported by Liam after demo session 2026-05-11.

## Design

- **Source of truth:** `worldSnapshot.winterActive` (same field `TopHud.tsx` already reads from the `getSnapshot` query — currently surfaced via `any` cast pending the broader snapshot type).
- **Layer:** added directly to `app.stage` as a sibling of the `pixi-viewport`, so particles render in screen space — they fall straight down regardless of pan/zoom, sit above all in-world content (terrain, regions, sigils, bubbles), and naturally sit below the React DOM UI (TopHud, EventTicker, status badges).
- **Hand-rolled** (no new dep) — pre-allocated pool of `Sprite` instances sharing one generated 4×4 white-disc texture (`renderer.generateTexture({ target: Graphics.circle().fill() })` at `resolution: 2` for hi-dpi crispness). Per-frame work is pure position math; recycle when `y > screenH + 10` — no GC churn.
- **Drift:** `x = baseX + sin(t·freq + seed) · amp` with per-particle `seed`/`freq`/`amp` so flakes don't sway in lockstep.
- **Density:** 100 particles at default. Tunable via `createWinterSnow(app, { particleCount })`. Erred toward subtle — large rates feel like a blizzard on the small viewport.
- **Lifecycle:**
  - Created once after Pixi init, alongside the existing ticker callbacks.
  - `setActive(true)` on winter start → container becomes visible, alpha ramps 0→1 over ~400ms.
  - `setActive(false)` on winter end → alpha ramps 1→0 over ~1000ms, then `idle` (ticker callback early-returns).
  - `destroy()` in cleanup unregisters the ticker callback and disposes the shared texture so Pixi `app.destroy()` doesn't leak GPU memory.
- **`prefers-reduced-motion`:** detected at init via `window.matchMedia`; when set, the snow system is never created — no ticker overhead.

## Files changed

- `apps/web/src/effects/winterSnow.ts` (new) — self-contained particle system + `WinterSnowHandle` interface.
- `apps/web/src/WorldMap.tsx` — import, ref, create-on-init, cleanup, and a `useEffect` that mirrors `winterActive` into `snow.setActive()`.

## Build

- `pnpm exec vite build` → green (10s, no new warnings).
- Pre-existing `tsc -b` errors in `apps/server/convex/*` and a handful of other files are unchanged by this PR — none in the modified files.

## UAT required (visual)

Particle systems can't be meaningfully unit-tested, so this needs a visual pass.

- [ ] When `winterActive=false`, no snow is rendered.
- [ ] When `winterActive` flips to true, snow fades in over ~0.5s and falls smoothly with subtle drift.
- [ ] When `winterActive` flips back to false, snow fades out over ~1s.
- [ ] Snow sits ABOVE terrain/clans but BELOW React-DOM HUD (TopHud, EventTicker, ❄ WINTER badge).
- [ ] Pan/zoom does not warp the snow (still falls straight down).
- [ ] No frame drops on a typical desktop viewport at the default density of 100 particles.
- [ ] With `prefers-reduced-motion: reduce` set in OS/browser, no snow renders even during winter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)