### PR TITLE
fix(cockpit + map): show dead clansmen as DEAD, rotated + darkened

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/tabs/ClansmanTab.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/tabs/ClansmanTab.kt
@@ -20,11 +20,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import world.clan.app.BuildConfig
@@ -72,16 +74,27 @@ fun ClansmanTab(elder: Elder, modifier: Modifier = Modifier) {
 @Composable
 private fun ClansmanRowItem(c: StubData.ClansmanRow, accent: Color) {
   val starving = c.hunger > 0.7f
-  val borderColor = if (starving) CockpitTokens.TextC.Danger else CockpitTokens.Border.ParchmentEdge
+  // Dead state mirrors web ClansmanTab.tsx: row darkens, mission text turns
+  // danger-red and reads "DEAD" instead of the action verb, ETA/CD collapses
+  // to an em dash, and hunger bar stops showing starvation (the clansman is
+  // beyond hunger). Border still flags danger so the row catches the eye.
+  val borderColor = when {
+    c.isDead -> CockpitTokens.TextC.Danger
+    starving -> CockpitTokens.TextC.Danger
+    else     -> CockpitTokens.Border.ParchmentEdge
+  }
+  val rowBackground = if (c.isDead) Color.Black.copy(alpha = 0.18f) else Color.White.copy(alpha = 0.22f)
+  val rowAlpha = if (c.isDead) 0.55f else 1f
 
   Row(
     modifier = Modifier
       .fillMaxWidth()
       .height(IntrinsicSize.Min)
       .clip(RoundedCornerShape(CockpitTokens.Radius.sm))
-      .background(Color.White.copy(alpha = 0.22f))
+      .background(rowBackground)
       .border(1.dp, borderColor, RoundedCornerShape(CockpitTokens.Radius.sm))
-      .padding(horizontal = 8.dp, vertical = 6.dp),
+      .padding(horizontal = 8.dp, vertical = 6.dp)
+      .alpha(rowAlpha),
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(8.dp),
   ) {
@@ -94,6 +107,7 @@ private fun ClansmanRowItem(c: StubData.ClansmanRow, accent: Color) {
         fontSize = 12.sp,
         fontWeight = FontWeight.Bold,
         color = accent,
+        textDecoration = if (c.isDead) TextDecoration.LineThrough else TextDecoration.None,
       ),
     )
 
@@ -104,8 +118,9 @@ private fun ClansmanRowItem(c: StubData.ClansmanRow, accent: Color) {
         style = TextStyle(
           fontFamily = CockpitFonts.Inter,
           fontSize = 11.sp,
-          fontWeight = FontWeight.SemiBold,
-          color = CockpitTokens.TextC.OnParchment,
+          fontWeight = if (c.isDead) FontWeight.Bold else FontWeight.SemiBold,
+          color = if (c.isDead) CockpitTokens.TextC.Danger else CockpitTokens.TextC.OnParchment,
+          letterSpacing = if (c.isDead) 1.2.sp else 0.sp,
         ),
       )
       Text(
@@ -118,8 +133,9 @@ private fun ClansmanRowItem(c: StubData.ClansmanRow, accent: Color) {
       )
     }
 
-    // ETA / Cooldown / Ready
+    // ETA / Cooldown / Ready / Dead
     val (statusText, statusColor) = when {
+      c.isDead                   -> "—" to CockpitTokens.TextC.OnParchmentDim
       c.eta != null && c.eta > 0 -> "${c.eta}t" to CockpitTokens.TextC.OnParchmentDim
       c.cooldown > 0             -> "cd ${c.cooldown}t" to CockpitTokens.TextC.Muted
       else                       -> "ready" to READY_GREEN
@@ -135,8 +151,8 @@ private fun ClansmanRowItem(c: StubData.ClansmanRow, accent: Color) {
       ),
     )
 
-    // Hunger bar
-    HungerBar(hunger = c.hunger, starving = starving)
+    // Hunger bar — dead clansmen don't get a starvation flag (they're beyond hunger).
+    HungerBar(hunger = c.hunger, starving = starving && !c.isDead)
   }
 }
 

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/StubData.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/StubData.kt
@@ -48,6 +48,7 @@ object StubData {
     val eta: Int?,        // ticks until mission ends; null = idle
     val cooldown: Int,    // ticks of cooldown remaining; 0 = ready
     val hunger: Float,    // 0..1
+    val isDead: Boolean = false, // true = chain reports ClansmanState.DEAD; row renders darkened
   )
 
   fun clansmen(clanId: Int): List<ClansmanRow> = listOf(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/convex/ConvexShapes.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/convex/ConvexShapes.kt
@@ -64,6 +64,13 @@ data class ClansmanWire(
   val eta: Double? = null,
   val cooldown: Double = 0.0,
   val hunger: Double = 0.0,
+  /**
+   * True when the chain reports `ClansmanState.DEAD` (enum=3). The cockpit
+   * renders "DEAD" instead of the mission verb so a wiped clan reads as
+   * fallen rather than "Idle / ready". Default false for back-compat with
+   * older query payloads that didn't ship this field.
+   */
+  val isDead: Boolean = false,
 )
 
 // ---- 0G memory -------------------------------------------------------

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/convex/Mappers.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/data/convex/Mappers.kt
@@ -69,6 +69,7 @@ fun ClansmanWire.toDomain(): StubData.ClansmanRow = StubData.ClansmanRow(
   eta = eta?.toInt(),
   cooldown = cooldown.toInt(),
   hunger = hunger.toFloat(),
+  isDead = isDead,
 )
 
 // ---- 0G memory -------------------------------------------------------

--- a/apps/server/convex/clansmen.ts
+++ b/apps/server/convex/clansmen.ts
@@ -1,18 +1,22 @@
 import { query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constants";
+import { ClansmanState } from "@clan-world/shared/generated/enums";
 
 /**
  * Per-clansman roster for ClansmanTab. Reads the latest `clanView` row, maps
  * the raw chain `ClansmanFullView[]` into a UI-friendly row shape, and
- * synthesizes the four fields the tab renders:
- *   - mission   : action verb (or "Idle")
+ * synthesizes the fields the tab renders:
+ *   - mission   : action verb ("Idle" when waiting, "DEAD" when fallen)
  *   - location  : human region label (start-region while traveling)
- *   - eta       : ticks until mission settles, or null when idle
+ *   - eta       : ticks until mission settles, or null when idle/dead
  *   - cooldown  : ticks of cooldown remaining after mission ends, 0 = ready
  *   - hunger    : 0..1 — derived from clan-level isStarving flag
  *                  (per-clansman hunger isn't on chain; we use clan starvation
  *                   ramp so the visual warning still surfaces correctly)
+ *   - isDead    : true when the chain `ClansmanState` is DEAD (3). Takes
+ *                  precedence over any active mission — the cockpit renders
+ *                  "DEAD" instead of "Idle" so wiped clans don't read as alive.
  *
  * Returns `[]` when there is no `clanView` row yet (cold demo / no indexer).
  * The frontend treats `[]` as "fall back to STUB_CLANSMEN" so the cockpit
@@ -113,6 +117,12 @@ export interface ClansmanRow {
   eta: number | null;
   cooldown: number;
   hunger: number;
+  /**
+   * True when the chain reports this clansman as ClansmanState.DEAD (enum=3).
+   * The tab uses this to override the mission/eta/cooldown display so a wiped
+   * clan reads as DEAD instead of "Idle / ready".
+   */
+  isDead: boolean;
 }
 
 export const getClanClansmen = query({
@@ -143,7 +153,14 @@ export const getClanClansmen = query({
       const clansmanId = numberLike(fieldAt(clansman, "clansmanId"));
       if (clansmanId <= 0) continue;
 
-      const missionActive = boolLike(fieldAt(mission, "active"));
+      // Dead-state check: ClansmanState.DEAD = 3 on chain. When a clansman is
+      // dead, we still render the row so the roster reflects the wipe — but
+      // we surface "DEAD" instead of mission/idle and zero out eta/cooldown
+      // so the row doesn't read as "ready in 0t" (alive-looking).
+      const clansmanStateRaw = numberLike(fieldAt(clansman, "state"), -1);
+      const isDead = clansmanStateRaw === ClansmanState.DEAD;
+
+      const missionActive = !isDead && boolLike(fieldAt(mission, "active"));
       const action = missionActive ? numberLike(fieldAt(mission, "action")) : 0;
 
       const currentRegion = numberLike(
@@ -200,11 +217,15 @@ export const getClanClansmen = query({
 
       out.push({
         id: `C${clansmanId}`,
-        mission: missionActive ? actionLabel(action) : "Idle",
+        mission: isDead ? "DEAD" : missionActive ? actionLabel(action) : "Idle",
         location: regionLabel(displayRegion),
-        eta,
-        cooldown,
+        // Dead clansmen never have an active mission OR a cooldown to wait on —
+        // both fields are forced to a "no countdown" state so the row reads as
+        // permanently fallen rather than "cooldown 3t / ready next tick".
+        eta: isDead ? null : eta,
+        cooldown: isDead ? 0 : cooldown,
         hunger,
+        isDead,
       });
     }
     return out;

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -112,7 +112,18 @@ type LiveClansmanMarker = {
   carryFish: number;
   offsetIndex: number;
   color: number;
+  /**
+   * True when the chain reports ClansmanState.DEAD (enum=3). Dead clansmen
+   * stay visible at their last region (no hide), but the body sprite rotates
+   * 90° (lying down) and darkens via tint so the world map state matches the
+   * cockpit "DEAD" badge instead of continuing to render an idle/standing pose.
+   */
+  isDead: boolean;
   node: Container;
+  /** Direct ref to the body sprite (or Graphics fallback) so we can rotate / tint it without rotating the carry indicator + status badge. */
+  body: Sprite | Graphics | null;
+  /** Halo Graphics drawn for active-mission markers. Hidden when isDead. */
+  halo: Graphics | null;
   carry: CarryIndicator;
   statusBg: Graphics;
   statusText: Text;
@@ -2174,7 +2185,7 @@ export function WorldMap() {
   function extractLiveClansmen(liveClans: readonly SnapshotClan[] | undefined) {
     if (!liveClans || liveClans.length === 0) return [];
     const byClan = new Map(liveClansToVisualClans(liveClans).map((clan) => [clan.id, clan]));
-    const markers: Array<Omit<LiveClansmanMarker, 'node' | 'carry' | 'statusBg' | 'statusText' | 'offsetIndex'>> = [];
+    const markers: Array<Omit<LiveClansmanMarker, 'node' | 'body' | 'halo' | 'carry' | 'statusBg' | 'statusText' | 'offsetIndex'>> = [];
     for (const clan of liveClans) {
       const visual = byClan.get(clan.id);
       if (!visual || !Array.isArray(clan.clansmen)) continue;
@@ -2184,16 +2195,22 @@ export function WorldMap() {
         const mission = fieldAt(row, 'activeMission') ?? fieldAt(derived, 'activeMission');
         const clansmanId = numberLike(fieldAt(clansman, 'clansmanId'));
         if (clansmanId <= 0) continue;
+        // ClansmanState.DEAD = 3 (mirrors enum in IClanWorld.sol + shared/generated/enums.ts).
+        // Dead clansmen render at their last-known region (lying down + darkened),
+        // and we suppress any "active mission" hint so the sprite doesn't animate.
+        const clansmanStateRaw = numberLike(fieldAt(clansman, 'state'), -1);
+        const isDead = clansmanStateRaw === 3;
         const currentRegion = numberLike(
           fieldAt(derived, 'effectiveRegion') ?? fieldAt(clansman, 'currentRegion') ?? clan.baseRegion,
           clan.baseRegion ?? 0,
         );
-        const missionActive = Boolean(fieldAt(mission, 'active'));
+        const missionActive = !isDead && Boolean(fieldAt(mission, 'active'));
         const action = missionActive ? numberLike(fieldAt(mission, 'action')) : 0;
         const startRegion = missionActive ? numberLike(fieldAt(mission, 'startRegion'), currentRegion) : currentRegion;
         const targetRegion = missionActive ? numberLike(fieldAt(mission, 'targetRegion'), currentRegion) : currentRegion;
         const regionKey = REGION_KEY_BY_CHAIN_ID[missionActive ? startRegion : currentRegion] ?? visual.homeRegion;
-        const targetRegionKey = REGION_KEY_BY_CHAIN_ID[targetRegion];
+        // Dead clansmen never have a target region — the route line should not draw.
+        const targetRegionKey = isDead ? undefined : REGION_KEY_BY_CHAIN_ID[targetRegion];
         const startTick = numberLike(fieldAt(mission, 'startTick') ?? fieldAt(mission, 'submittedAtTick'));
         const arrivalTick = numberLike(fieldAt(mission, 'arrivalTick'), startTick);
         const actionStartTick = numberLike(fieldAt(mission, 'actionStartTick'), arrivalTick);
@@ -2215,6 +2232,7 @@ export function WorldMap() {
           carryWheat: resourceUnits(fieldAt(clansman, 'carryWheat')),
           carryFish: resourceUnits(fieldAt(clansman, 'carryFish')),
           color: visual.color,
+          isDead,
         });
       }
     }
@@ -2227,7 +2245,7 @@ export function WorldMap() {
     });
   }
 
-  function makeLiveClansmanMarker(color: number, clanId: string, missionActive: boolean) {
+  function makeLiveClansmanMarker(color: number, clanId: string, missionActive: boolean, isDead: boolean) {
     const container = new Container();
     const statusBg = new Graphics();
     const statusText = new Text({
@@ -2241,28 +2259,36 @@ export function WorldMap() {
       },
     });
     statusText.anchor.set(0.5, 0.5);
+    let body: Sprite | Graphics | null = null;
     const tex = clansmanTextureCache[clanId];
     if (tex) {
       const sprite = new Sprite(tex);
-      sprite.anchor.set(0.5, 0.82);
+      // Dead clansmen rotate 90° (lying down) — anchor at sprite center so the
+      // rotation pivots on the body, not the feet. Live clansmen keep the
+      // feet-anchor (0.5, 0.82) so they stand on their map dot.
+      sprite.anchor.set(0.5, isDead ? 0.5 : 0.82);
       const targetH = missionActive ? 42 : 34;
       const ratio = targetH / sprite.texture.height;
       sprite.height = targetH;
       sprite.width = sprite.texture.width * ratio;
       container.addChild(sprite);
+      body = sprite;
     } else {
       const fallback = new Graphics();
       fallback.circle(0, 0, missionActive ? 7 : 6);
       fallback.fill({ color, alpha: 1 });
       fallback.stroke({ color: 0xffffff, width: 1.5, alpha: 0.85 });
       container.addChild(fallback);
+      body = fallback;
     }
-    if (missionActive) {
-      const halo = new Graphics();
+    let halo: Graphics | null = null;
+    if (missionActive && !isDead) {
+      halo = new Graphics();
       halo.circle(0, 0, 16);
       halo.stroke({ color: 0xffe6a0, width: 2, alpha: 0.95 });
       container.addChildAt(halo, 0);
     }
+    applyDeadVisualState(body, isDead);
     const carry = makeCarryIndicator();
     carry.container.y = -24;
     container.addChild(carry.container);
@@ -2275,7 +2301,32 @@ export function WorldMap() {
         setSelectedClanId(null);
       }
     });
-    return { container, carry, statusBg, statusText };
+    return { container, body, halo, carry, statusBg, statusText };
+  }
+
+  /**
+   * Apply (or remove) the "dead" pose on a clansman body — rotation 90° and
+   * a darkening tint. Pulled out so it can run both at marker-creation time
+   * and whenever an alive→dead transition fires inside the sync loop.
+   *
+   * Why tint=0x808080: PixiJS multiplies the tint against the source pixels,
+   * so a flat mid-grey collapses the dynamic range and reads as "shadowed"
+   * without losing the silhouette. Graphics fallbacks accept the same tint
+   * channel since PIXI v8.
+   */
+  function applyDeadVisualState(body: Sprite | Graphics | null, isDead: boolean) {
+    if (!body) return;
+    if (isDead) {
+      body.rotation = Math.PI / 2; // 90°, sprite lies on its side
+      // Cast to any: Graphics has `tint` in pixi v8 too but the type only
+      // surfaces it on Sprite; we know the runtime supports it.
+      (body as Sprite).tint = 0x808080;
+      body.alpha = 0.9;
+    } else {
+      body.rotation = 0;
+      (body as Sprite).tint = 0xffffff;
+      body.alpha = 1;
+    }
   }
 
   function syncLiveClansmanVisuals(isAssetLoadCancelled: () => boolean) {
@@ -2299,22 +2350,40 @@ export function WorldMap() {
     for (const marker of markers) {
       const existing = existingByKey.get(marker.key);
       if (existing) {
+        const wasDead = existing.isDead;
         Object.assign(existing, marker, {
           node: existing.node,
+          body: existing.body,
+          halo: existing.halo,
           carry: existing.carry,
           statusBg: existing.statusBg,
           statusText: existing.statusText,
           route: existing.route,
         });
+        // Alive→dead (or vice versa) transition: re-pose the body sprite
+        // in place without rebuilding the node. Also stash any active route
+        // so it stops being redrawn — a corpse doesn't travel.
+        if (wasDead !== marker.isDead) {
+          applyDeadVisualState(existing.body, marker.isDead);
+          if (marker.isDead && existing.halo) {
+            existing.halo.visible = false;
+          }
+          if (marker.isDead && existing.route) {
+            existing.route.line.parent?.removeChild(existing.route.line);
+            existing.route.line.destroy();
+            existing.route = undefined;
+          }
+        }
         continue;
       }
-      const { container, carry, statusBg, statusText } = makeLiveClansmanMarker(
+      const { container, body, halo, carry, statusBg, statusText } = makeLiveClansmanMarker(
         marker.color,
         marker.clanId,
         marker.missionActive,
+        marker.isDead,
       );
       layers.worldDynamic.addChild(container);
-      drawn.liveClansmen.push({ ...marker, node: container, carry, statusBg, statusText });
+      drawn.liveClansmen.push({ ...marker, node: container, body, halo, carry, statusBg, statusText });
     }
     liveClansmanVisualKeyRef.current = rosterKey;
     updateLiveClansmanPositions();
@@ -2604,6 +2673,24 @@ export function WorldMap() {
     for (const marker of drawn.liveClansmen) {
       const from = regionWanderPoint(marker.regionKey, marker, 0);
       if (!from) continue;
+      // Dead clansmen freeze at their last-known wander point — no bob, no
+      // route line, no carry/status overlay. The body sprite is already
+      // rotated 90° + darkened via applyDeadVisualState at create time.
+      if (marker.isDead) {
+        marker.node.x = from.x;
+        marker.node.y = from.y;
+        marker.node.zIndex = Math.round(marker.node.y + 8);
+        marker.node.alpha = 1; // container alpha stays 1; body's own alpha dims the sprite
+        marker.node.scale.set(Math.max(0.95, layoutRef.current.scale * 1.08));
+        marker.carry.label.text = '';
+        marker.carry.targetFill = 0;
+        marker.carry.displayedFill = 0;
+        redrawCarryIndicator(marker.carry);
+        marker.statusText.text = '';
+        marker.statusText.alpha = 0;
+        marker.statusBg.clear();
+        continue;
+      }
       const isTraveling = marker.missionActive && marker.targetRegionKey && marker.targetRegionKey !== marker.regionKey;
       let position: Point2 = from;
       if (isTraveling && marker.targetRegionKey) {

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -9,7 +9,7 @@ import { EventTicker } from './EventTicker';
 import { api } from '../../server/convex/_generated/api';
 import worldMapBg from './assets/world-map.png';
 import { DEMO_MODE } from './config/env';
-import { BanditState } from '@clan-world/shared/generated/enums';
+import { BanditState, ClansmanState } from '@clan-world/shared/generated/enums';
 import { createWinterSnow, type WinterSnowHandle } from './effects/winterSnow';
 
 // World dimensions used by pixi-viewport for pan/clamp/center math.
@@ -2195,11 +2195,11 @@ export function WorldMap() {
         const mission = fieldAt(row, 'activeMission') ?? fieldAt(derived, 'activeMission');
         const clansmanId = numberLike(fieldAt(clansman, 'clansmanId'));
         if (clansmanId <= 0) continue;
-        // ClansmanState.DEAD = 3 (mirrors enum in IClanWorld.sol + shared/generated/enums.ts).
+        // ClansmanState.DEAD (chain enum mirrored in shared/generated/enums.ts).
         // Dead clansmen render at their last-known region (lying down + darkened),
         // and we suppress any "active mission" hint so the sprite doesn't animate.
         const clansmanStateRaw = numberLike(fieldAt(clansman, 'state'), -1);
-        const isDead = clansmanStateRaw === 3;
+        const isDead = clansmanStateRaw === ClansmanState.DEAD;
         const currentRegion = numberLike(
           fieldAt(derived, 'effectiveRegion') ?? fieldAt(clansman, 'currentRegion') ?? clan.baseRegion,
           clan.baseRegion ?? 0,
@@ -2305,28 +2305,58 @@ export function WorldMap() {
   }
 
   /**
-   * Apply (or remove) the "dead" pose on a clansman body — rotation 90° and
-   * a darkening tint. Pulled out so it can run both at marker-creation time
-   * and whenever an alive→dead transition fires inside the sync loop.
+   * Apply the "dead" pose on a clansman body — rotation 90°, darkening tint,
+   * and a centered anchor so the 90° rotation pivots on the body center
+   * rather than the feet. Pulled out so it can run both at marker-creation
+   * time and whenever an alive→dead transition fires inside the sync loop.
    *
    * Why tint=0x808080: PixiJS multiplies the tint against the source pixels,
    * so a flat mid-grey collapses the dynamic range and reads as "shadowed"
    * without losing the silhouette. Graphics fallbacks accept the same tint
    * channel since PIXI v8.
+   *
+   * For the inverse transition (dead→alive), use applyAliveVisualState — it
+   * restores the feet-anchor (0.5, 0.82) and clears tint/rotation/alpha.
    */
   function applyDeadVisualState(body: Sprite | Graphics | null, isDead: boolean) {
     if (!body) return;
     if (isDead) {
+      // Anchor BEFORE rotation so the 90° flip pivots around the body
+      // center, not the feet. Graphics fallback (circle drawn at origin)
+      // has no .anchor — guard with `'anchor' in body`.
+      if ('anchor' in body) {
+        (body as Sprite).anchor.set(0.5, 0.5);
+      }
       body.rotation = Math.PI / 2; // 90°, sprite lies on its side
       // Cast to any: Graphics has `tint` in pixi v8 too but the type only
       // surfaces it on Sprite; we know the runtime supports it.
       (body as Sprite).tint = 0x808080;
       body.alpha = 0.9;
     } else {
-      body.rotation = 0;
-      (body as Sprite).tint = 0xffffff;
-      body.alpha = 1;
+      // Backwards-compat path: callers that pass isDead=false still get the
+      // alive pose, but applyAliveVisualState is the preferred entry point
+      // because it makes the symmetry explicit at call-sites.
+      applyAliveVisualState(body);
     }
+  }
+
+  /**
+   * Apply the "alive" pose on a clansman body — feet-anchor (0.5, 0.82) so
+   * the sprite stands on its map dot, rotation 0, full opacity, default
+   * tint. This is the symmetric counterpart to applyDeadVisualState and is
+   * what the sync-loop calls on a dead→alive (revive) transition.
+   *
+   * Note: the caller is responsible for restoring `halo.visible = true` on
+   * the marker container — halo lives at marker level, not on `body`.
+   */
+  function applyAliveVisualState(body: Sprite | Graphics | null) {
+    if (!body) return;
+    if ('anchor' in body) {
+      (body as Sprite).anchor.set(0.5, 0.82);
+    }
+    body.rotation = 0;
+    (body as Sprite).tint = 0xffffff;
+    body.alpha = 1;
   }
 
   function syncLiveClansmanVisuals(isAssetLoadCancelled: () => boolean) {
@@ -2360,18 +2390,30 @@ export function WorldMap() {
           statusText: existing.statusText,
           route: existing.route,
         });
-        // Alive→dead (or vice versa) transition: re-pose the body sprite
-        // in place without rebuilding the node. Also stash any active route
-        // so it stops being redrawn — a corpse doesn't travel.
+        // Alive→dead (or dead→alive) transition: re-pose the body sprite
+        // in place without rebuilding the node. The split between
+        // applyDeadVisualState and applyAliveVisualState makes the symmetry
+        // explicit — both branches MUST set anchor (centered for the dead
+        // 90° rotation, feet for the standing pose) and tint/alpha/rotation,
+        // otherwise an alive→dead→alive cycle leaks state.
         if (wasDead !== marker.isDead) {
-          applyDeadVisualState(existing.body, marker.isDead);
-          if (marker.isDead && existing.halo) {
-            existing.halo.visible = false;
-          }
-          if (marker.isDead && existing.route) {
-            existing.route.line.parent?.removeChild(existing.route.line);
-            existing.route.line.destroy();
-            existing.route = undefined;
+          if (marker.isDead) {
+            applyDeadVisualState(existing.body, true);
+            if (existing.halo) existing.halo.visible = false;
+            if (existing.route) {
+              // A corpse doesn't travel — drop the route line. We keep
+              // existing.route undefined so updateLiveClansmanPositions()
+              // won't try to re-draw it.
+              existing.route.line.parent?.removeChild(existing.route.line);
+              existing.route.line.destroy();
+              existing.route = undefined;
+            }
+          } else {
+            applyAliveVisualState(existing.body);
+            // Halo lives at marker level, not on body — restore here on
+            // revive. Whether it should be visible right now depends on
+            // missionActive, which `marker` already reflects.
+            if (existing.halo) existing.halo.visible = marker.missionActive;
           }
         }
         continue;

--- a/apps/web/src/components/cockpit/tabs/ClansmanTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/ClansmanTab.tsx
@@ -18,6 +18,13 @@ interface ClansmanRow {
   cooldown: number;
   /** Hunger fraction 0-1; >0.7 = visual starvation warning. */
   hunger: number;
+  /**
+   * True when the chain reports this clansman as ClansmanState.DEAD. The row
+   * darkens, shows "DEAD" in place of mission, and suppresses the ETA/cooldown
+   * countdown so a wiped clan doesn't look like it's about to act again.
+   * Optional for back-compat with stub data + older query payloads.
+   */
+  isDead?: boolean;
 }
 
 // Stub fallback. Used whenever the live Convex query is still loading
@@ -76,23 +83,33 @@ export function ClansmanTab({ elder, testIdPrefix }: Props) {
       >
         {rows.map((c) => {
           const starving = c.hunger > 0.7;
+          // Dead state takes precedence over starvation styling: the whole row
+          // dims so a wiped clan reads at-a-glance as fallen. Border switches
+          // to the danger color (same red used for starvation) but the row
+          // alpha drops to ~55%, giving the "tombstone" affordance.
+          const isDead = c.isDead === true;
+          const borderColor = isDead
+            ? tokens.text.danger
+            : starving
+              ? tokens.text.danger
+              : tokens.border.parchmentEdge;
           return (
             <div
               key={c.id}
               data-testid={`${testIdPrefix}-clansman-${c.id}`}
+              data-dead={isDead ? 'true' : 'false'}
               style={{
                 display: 'grid',
                 gridTemplateColumns: '28px 1fr 60px 36px',
                 gap: tokens.space.sm,
                 alignItems: 'center',
                 padding: '6px 8px',
-                background: 'rgba(255,255,255,0.22)',
-                border: `1px solid ${
-                  starving ? tokens.text.danger : tokens.border.parchmentEdge
-                }`,
+                background: isDead ? 'rgba(0,0,0,0.18)' : 'rgba(255,255,255,0.22)',
+                border: `1px solid ${borderColor}`,
                 borderRadius: tokens.radius.sm,
                 fontFamily: tokens.font.mono,
                 fontSize: '11px',
+                opacity: isDead ? 0.55 : 1,
               }}
             >
               <span
@@ -100,6 +117,7 @@ export function ClansmanTab({ elder, testIdPrefix }: Props) {
                   fontWeight: 700,
                   color: elder.accent,
                   fontSize: '12px',
+                  textDecoration: isDead ? 'line-through' : 'none',
                 }}
               >
                 {c.id}
@@ -107,8 +125,9 @@ export function ClansmanTab({ elder, testIdPrefix }: Props) {
               <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
                 <span
                   style={{
-                    fontWeight: 600,
-                    color: tokens.text.onParchment,
+                    fontWeight: isDead ? 700 : 600,
+                    color: isDead ? tokens.text.danger : tokens.text.onParchment,
+                    letterSpacing: isDead ? '0.12em' : undefined,
                   }}
                 >
                   {c.mission}
@@ -129,7 +148,12 @@ export function ClansmanTab({ elder, testIdPrefix }: Props) {
                   textAlign: 'right',
                 }}
               >
-                {c.eta !== null ? (
+                {isDead ? (
+                  // Dead clansmen have no mission to ETA and no cooldown to
+                  // burn down — show an em dash so the column stays visually
+                  // aligned but doesn't suggest impending action.
+                  <span aria-label="dead — no countdown">—</span>
+                ) : c.eta !== null ? (
                   <span>ETA {c.eta}t</span>
                 ) : c.cooldown > 0 ? (
                   <span>CD {c.cooldown}t</span>
@@ -137,7 +161,7 @@ export function ClansmanTab({ elder, testIdPrefix }: Props) {
                   <span style={{ color: '#3a7a3a' }}>ready</span>
                 )}
               </div>
-              <HungerBar hunger={c.hunger} starving={starving} />
+              <HungerBar hunger={c.hunger} starving={starving && !isDead} />
             </div>
           );
         })}


### PR DESCRIPTION
## Summary

When all 4 clans died during today's demo, the cockpit kept showing clansmen as **Idle / ready** and the world map kept rendering their sprites in a standing/upright pose. The UI completely masked the wipe.

This PR makes dead clansmen visibly dead in three surfaces:

### 1. Cockpit (web) — `apps/web/src/components/cockpit/tabs/ClansmanTab.tsx`
- New `isDead?: boolean` field on `ClansmanRow`.
- When dead: mission label becomes **DEAD** (red, letter-spaced, the ID gets struck through), the ETA/cooldown column collapses to an em dash, the row drops to ~55% opacity with a darker background and danger border, and the hunger bar stops flagging starvation (a corpse is beyond hunger).
- `data-dead="true|false"` attribute added for E2E hooks.

### 2. Cockpit (android) — `apps/clan-world-mobile/.../ClansmanTab.kt`
- Same affordances ported to Compose: dimmed background + alpha, red DEAD label with line-through on the ID, em-dash status column, no starvation flag.
- `ClansmanWire` + `StubData.ClansmanRow` gain an `isDead` field (default `false` for back-compat with older payloads).

### 3. World map (Pixi) — `apps/web/src/WorldMap.tsx`
- `LiveClansmanMarker` gains `isDead`, plus direct refs to `body` (the sprite) and `halo` (active-mission ring).
- New `applyDeadVisualState(body, isDead)` helper applies `rotation = π/2` (90° lying down) and `tint = 0x808080` (mid-grey multiply, collapses dynamic range without losing silhouette). Anchor swaps from feet (0.5, 0.82) → center (0.5, 0.5) so the rotation pivots on the body, not on a vanished foot.
- Sync loop detects alive→dead transitions and re-poses the body in place (no node rebuild). Halo hides and any in-flight travel route gets torn down — corpses don't walk.
- Position loop short-circuits for dead markers: no bob animation, no carry indicator, no status text, no route line. Frozen at last-known wander point.
- Dead state is sourced from chain `ClansmanFullView.clansman.clansman.state == ClansmanState.DEAD` (enum=3, mirrors `IClanWorld.sol`).

### 4. Convex query — `apps/server/convex/clansmen.ts`
- `getClanClansmen` now reads `clansman.state` and exposes `isDead` on the returned `ClansmanRow`.
- Dead branch takes precedence over active-mission branch: mission is `DEAD`, eta is `null`, cooldown is `0`. Hunger is still derived (useful for post-mortem analytics).
- Imports `ClansmanState` from `@clan-world/shared/generated/enums` (matches the existing `BanditState` import pattern in `getSnapshot.ts`).

## Files changed

```
apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/tabs/ClansmanTab.kt
apps/clan-world-mobile/app/src/main/java/world/clan/app/data/StubData.kt
apps/clan-world-mobile/app/src/main/java/world/clan/app/data/convex/ConvexShapes.kt
apps/clan-world-mobile/app/src/main/java/world/clan/app/data/convex/Mappers.kt
apps/server/convex/clansmen.ts
apps/web/src/WorldMap.tsx
apps/web/src/components/cockpit/tabs/ClansmanTab.tsx
```

## Test plan

- [x] `pnpm --filter web build` — green (vite production build, 7s)
- [x] `pnpm --filter @clan-world/server typecheck` — green
- [x] `pnpm --filter @clan-world/server test` — 34 tests pass (no regression in `indexer`, `gold`, `vault`, `heartbeat` suites)
- [x] `./gradlew :app:assembleDebug` (with the env vars per README) — green, debug APK builds in 50s
- [ ] **UAT: kill all 4 clans on devnet and confirm**:
  - [ ] Web cockpit ClansmanTab shows "DEAD" rows (red, struck through, em-dash status, ~55% opacity)
  - [ ] World map sprites lie on their side at last-known region, darkened, no travel halo, no carry indicator
  - [ ] Android cockpit shows the same DEAD treatment

## Notes

- Stub data + fixture-based tests are unaffected (`isDead` defaults to `false`).
- `data-dead` test hook on the row enables a Playwright assertion: `expect(row).toHaveAttribute('data-dead', 'true')` once you have a chain seed that flips clansman state to 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)