### PR TITLE
feat(diamond): setMaxBanditTier admin setter

### DIFF
--- a/packages/contracts/script/DiamondSelectors.sol
+++ b/packages/contracts/script/DiamondSelectors.sol
@@ -24,13 +24,15 @@ library DiamondSelectors {
     }
 
     function heartbeatConfigSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](6);
+        selectors = new bytes4[](8);
         selectors[0] = HeartbeatConfigFacet.heartbeatIntervalSeconds.selector;
         selectors[1] = HeartbeatConfigFacet.setHeartbeatIntervalSeconds.selector;
         selectors[2] = HeartbeatConfigFacet.clansmanCooldownSeconds.selector;
         selectors[3] = HeartbeatConfigFacet.setClansmanCooldownSeconds.selector;
         selectors[4] = HeartbeatConfigFacet.banditSpawnTriggered.selector;
         selectors[5] = HeartbeatConfigFacet.triggerBanditSpawn.selector;
+        selectors[6] = HeartbeatConfigFacet.maxBanditTier.selector;
+        selectors[7] = HeartbeatConfigFacet.setMaxBanditTier.selector;
     }
 
     function worldPauseSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/packages/contracts/src/diamond/facets/HeartbeatConfigFacet.sol
+++ b/packages/contracts/src/diamond/facets/HeartbeatConfigFacet.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.34;
 
 import {ClanWorldConstants} from "../../IClanWorld.sol";
+import {LibBanditSpawning} from "../lib/LibBanditSpawning.sol";
 import {LibDiamond} from "../lib/LibDiamond.sol";
 import {LibStorage} from "../lib/LibStorage.sol";
 import {LibWorldClock} from "../lib/LibWorldClock.sol";
@@ -9,9 +10,11 @@ import {LibWorldClock} from "../lib/LibWorldClock.sol";
 contract HeartbeatConfigFacet {
     uint64 private constant MAX_HEARTBEAT_INTERVAL_SECONDS = 1 hours;
     uint64 private constant MAX_CLANSMAN_COOLDOWN_SECONDS = 1 hours;
+    uint8 private constant MAX_BANDIT_TIER_CEILING = 5;
 
     event HeartbeatIntervalUpdated(uint64 oldIntervalSeconds, uint64 newIntervalSeconds, uint64 nextHeartbeatAtTs);
     event ClansmanCooldownUpdated(uint64 oldCooldownSeconds, uint64 newCooldownSeconds);
+    event MaxBanditTierUpdated(uint8 oldMax, uint8 newMax);
     event BanditSpawnTriggered(uint64 currentTick);
 
     function heartbeatIntervalSeconds() external view returns (uint64) {
@@ -53,6 +56,21 @@ contract HeartbeatConfigFacet {
         s.clansmanCooldownSeconds = cooldownSeconds;
 
         emit ClansmanCooldownUpdated(oldCooldownSeconds, cooldownSeconds);
+    }
+
+    function maxBanditTier() external view returns (uint8) {
+        return LibBanditSpawning.maxBanditTier(LibStorage.appStorage());
+    }
+
+    function setMaxBanditTier(uint8 newMax) external {
+        LibDiamond.enforceIsContractOwner();
+        require(newMax >= 1 && newMax <= MAX_BANDIT_TIER_CEILING, "ClanWorld: invalid max bandit tier");
+
+        LibStorage.AppStorage storage s = LibStorage.appStorage();
+        uint8 oldMax = LibBanditSpawning.maxBanditTier(s);
+        s.maxBanditTier = newMax;
+
+        emit MaxBanditTierUpdated(oldMax, newMax);
     }
 
     function banditSpawnTriggered() external view returns (bool) {

--- a/packages/contracts/src/diamond/lib/LibBanditSpawning.sol
+++ b/packages/contracts/src/diamond/lib/LibBanditSpawning.sol
@@ -57,6 +57,10 @@ library LibBanditSpawning {
         uint8 selectedRegion = selectBanditSpawnRegion(tickSeed, candidateWeights);
         if (selectedRegion != ClanWorldConstants.REGION_NOOP) {
             uint8 tier = banditSpawnTier(tickSeed, selectedRegion);
+            uint8 cap = maxBanditTier(s);
+            if (tier > cap) {
+                tier = cap;
+            }
             spawnBandit(s, selectedRegion, tier, getBanditAttackPower(tier));
         }
 
@@ -194,6 +198,14 @@ library LibBanditSpawning {
         uint256 nonce = uint256(keccak256(abi.encodePacked("bandit_spawn_tier", region)));
         uint256 roll = RNG.rngBounded(tickSeed, RNG.DOMAIN_BANDIT_SPAWN, nonce, BANDIT_TIER_COUNT);
         return uint8(roll + 1);
+    }
+
+    function maxBanditTier(LibStorage.AppStorage storage s) internal view returns (uint8) {
+        uint8 configured = s.maxBanditTier;
+        if (configured == 0) {
+            return BANDIT_TIER_COUNT;
+        }
+        return configured;
     }
 
     function isBanditAllowedRegion(uint8 region) public pure returns (bool) {

--- a/packages/contracts/src/diamond/lib/LibStorage.sol
+++ b/packages/contracts/src/diamond/lib/LibStorage.sol
@@ -111,6 +111,7 @@ library LibStorage {
         uint64 heartbeatIntervalSeconds;
         uint64 clansmanCooldownSeconds;
         bool forceBanditSpawnNextHeartbeat;
+        uint8 maxBanditTier;
     }
 
     error ReentrantCall();

--- a/packages/contracts/test/diamond/DiamondSkeleton.t.sol
+++ b/packages/contracts/test/diamond/DiamondSkeleton.t.sol
@@ -86,6 +86,8 @@ interface IHeartbeatAdmin {
     function setClansmanCooldownSeconds(uint64 cooldownSeconds) external;
     function banditSpawnTriggered() external view returns (bool);
     function triggerBanditSpawn() external;
+    function maxBanditTier() external view returns (uint8);
+    function setMaxBanditTier(uint8 newMax) external;
 }
 
 interface IOwnershipFacet {
@@ -767,6 +769,68 @@ contract DiamondSkeletonTest is Test {
         WorldState memory worldState = IClanWorld(address(diamond)).getWorldState();
         assertFalse(heartbeatAdmin.banditSpawnTriggered());
         assertEq(worldState.activeBanditId, 1);
+    }
+
+    function testDiamondMaxBanditTierCanBeConfiguredByOwner() public {
+        HeartbeatFacet heartbeatFacet = new HeartbeatFacet();
+        HeartbeatConfigFacet heartbeatConfigFacet = new HeartbeatConfigFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_heartbeatCut(address(heartbeatFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_heartbeatConfigCut(address(heartbeatConfigFacet)), address(0), "");
+
+        IHeartbeatAdmin heartbeatAdmin = IHeartbeatAdmin(address(diamond));
+
+        assertEq(heartbeatAdmin.maxBanditTier(), 5);
+
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondNotOwner.selector, address(0xBEEF)));
+        heartbeatAdmin.setMaxBanditTier(3);
+
+        heartbeatAdmin.setMaxBanditTier(3);
+        assertEq(heartbeatAdmin.maxBanditTier(), 3);
+
+        vm.expectRevert(bytes("ClanWorld: invalid max bandit tier"));
+        heartbeatAdmin.setMaxBanditTier(0);
+
+        vm.expectRevert(bytes("ClanWorld: invalid max bandit tier"));
+        heartbeatAdmin.setMaxBanditTier(6);
+
+        heartbeatAdmin.setMaxBanditTier(1);
+        assertEq(heartbeatAdmin.maxBanditTier(), 1);
+        heartbeatAdmin.setMaxBanditTier(5);
+        assertEq(heartbeatAdmin.maxBanditTier(), 5);
+    }
+
+    function testDiamondMaxBanditTierCapsForcedSpawnTier() public {
+        HeartbeatFacet heartbeatFacet = new HeartbeatFacet();
+        HeartbeatConfigFacet heartbeatConfigFacet = new HeartbeatConfigFacet();
+        ClanLifecycleFacet lifecycleFacet = new ClanLifecycleFacet();
+        ClanWorldDiamondInit init = new ClanWorldDiamondInit();
+
+        IDiamondCut(address(diamond))
+            .diamondCut(_rawViewsCut(), address(init), abi.encodeCall(ClanWorldDiamondInit.init, ()));
+        IDiamondCut(address(diamond)).diamondCut(_heartbeatCut(address(heartbeatFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_heartbeatConfigCut(address(heartbeatConfigFacet)), address(0), "");
+        IDiamondCut(address(diamond)).diamondCut(_lifecycleCut(address(lifecycleFacet)), address(0), "");
+
+        address elder = address(0xCAFE);
+        IClanWorld(address(diamond)).mintClan(elder);
+
+        IHeartbeatAdmin heartbeatAdmin = IHeartbeatAdmin(address(diamond));
+        heartbeatAdmin.setMaxBanditTier(1);
+        heartbeatAdmin.triggerBanditSpawn();
+
+        vm.warp(block.timestamp + ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS);
+        IClanWorld(address(diamond)).heartbeat();
+
+        uint32 activeBanditId = IClanWorld(address(diamond)).getWorldState().activeBanditId;
+        assertEq(activeBanditId, 1);
+        BanditTroop memory bandit = IClanWorld(address(diamond)).getBandit(activeBanditId);
+        assertEq(bandit.tier, 1);
+        assertEq(bandit.strength, 30);
     }
 
     function testDiamondHeartbeatAdvancesSpawnedBanditToCampedLikeCore() public {
@@ -1580,7 +1644,7 @@ contract DiamondSkeletonTest is Test {
     }
 
     function _expectedProductionSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](71);
+        selectors = new bytes4[](73);
         uint256 offset;
         selectors[offset++] = IDiamondCut.diamondCut.selector;
         offset = _copySelectors(selectors, offset, DiamondSelectors.loupeSelectors());


### PR DESCRIPTION
## Summary

Add a `setMaxBanditTier(uint8)` admin setter on the ClanWorld diamond. Mirrors the existing `setHeartbeatIntervalSeconds(uint64)` pattern.

Default behavior is unchanged: storage zero falls through to `BANDIT_TIER_COUNT = 5`. Calling the setter with a value `1 ≤ n ≤ 5` clamps freshly-spawned bandits to tier ≤ n.

## Motivation (Liam 2026-05-11)

In tonight's demo bring-up, all 4 clans died at ~tick 90 because the first bandit spawn was tier 5 / power 95. Fresh clans with 4 untrained clansmen can't survive that, and the elders had no time to react. This setter lets the owner pre-cap the demo to a survivable tier (e.g. 3) for next demos while leaving production behavior untouched.

## Implementation

- `LibStorage.sol`: append `uint8 maxBanditTier` to `AppStorage` (diamond storage append-only rule)
- `HeartbeatConfigFacet.sol`: `setMaxBanditTier(uint8)` (owner-only) + `getMaxBanditTier()` + `MaxBanditTierUpdated(uint8 oldMax, uint8 newMax)` event
- `LibBanditSpawning.sol`: spawn-side cap `tier = min(computed, max)` when `max != 0`
- `DiamondSelectors.sol`: register new selectors on diamond cut
- `DiamondSkeleton.t.sol`: 2 new tests — owner-can-set + spawn-cap-applies

## Tests

- `forge build` — green
- `forge test --match-test "MaxBanditTier" -vv` — 2/2 pass
- `forge test --match-contract "DiamondSkeleton" -vv` — 39/39 pass
- `forge test --match-contract "StorageLayoutGuard" -vv` — 2/2 pass

## Pre-existing test failures (NOT introduced by this PR)

`test/BanditAttackResolution.t.sol` has 2 failing tests on `origin/dev` HEAD `36f8e7f` (verified before any changes):
- `test_defeatedBanditLootBurnsDropRemainderAndCarryOverflow` — gold-share assertion `37333... != 36000...`
- `test_defeatedBanditLootSplitsEquallyAcrossContributingClansmen` — gold-share assertion `32571... != 32000...`

Both fail with identical numbers on this branch. They predate this work.

## Implemented by

Codex 5.5 via orchestrator dispatch per Liam directive. Codex log: `~/claudes-world/tmp/codex-set-max-bandit-tier-output.md`.