### PR TITLE
fix(android): move page indicator dots into panel + fill bottom unsafe area

### DIFF
--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/CockpitScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/CockpitScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsTopHeight
@@ -92,9 +93,11 @@ fun CockpitScreen(
       // Spacer for row 2 (controls strip)
       Box(modifier = Modifier.fillMaxWidth().height(HeaderRow2Height))
 
-      // Map region — fills its weighted height; dots + toggle overlay the
-      // bottom edge so there's no gap before the panel. Map's bottom
-      // corners are rounded (mirrors the device's natural top-corner curve).
+      // Map region — fills its weighted height; collapse toggle overlays
+      // the bottom edge. Page indicator dots have been moved into the
+      // panel below so they scroll/animate with the pager, not the map.
+      // Map's bottom corners are rounded (mirrors the device's natural
+      // top-corner curve).
       Box(
         modifier = Modifier
           .fillMaxWidth()
@@ -108,15 +111,6 @@ fun CockpitScreen(
       ) {
         MapWebView(modifier = Modifier.fillMaxSize())
 
-        PageIndicatorOverlay(
-          pageCount = ELDERS.size,
-          currentPage = (activeClanId - 1).coerceIn(0, ELDERS.size - 1),
-          onDotClick = { activeClanId = it + 1 },
-          modifier = Modifier
-            .align(Alignment.BottomCenter)
-            .padding(bottom = 56.dp),
-        )
-
         CollapseToggle(
           collapsed = collapsed,
           activeClanId = activeClanId,
@@ -127,15 +121,34 @@ fun CockpitScreen(
         )
       }
 
-      ClanPanelPager(
+      // Panel region — wraps the pager in a Box so the page indicator
+      // dots can anchor to the panel's bottom edge instead of floating
+      // over the map. The dots also pick up nav-bar safe padding so
+      // they sit above the gesture handle while the panel background
+      // continues to fill behind it.
+      Box(
         modifier = Modifier
           .fillMaxWidth()
           .weight(pagerWeight),
-        activeClanId = activeClanId,
-        onActiveClanChange = { activeClanId = it },
-        contentAlpha = pagerAlpha,
-        onOwnerControl = onOwnerControl,
-      )
+      ) {
+        ClanPanelPager(
+          modifier = Modifier.fillMaxSize(),
+          activeClanId = activeClanId,
+          onActiveClanChange = { activeClanId = it },
+          contentAlpha = pagerAlpha,
+          onOwnerControl = onOwnerControl,
+        )
+
+        PageIndicatorOverlay(
+          pageCount = ELDERS.size,
+          currentPage = (activeClanId - 1).coerceIn(0, ELDERS.size - 1),
+          onDotClick = { activeClanId = it + 1 },
+          modifier = Modifier
+            .align(Alignment.BottomCenter)
+            .navigationBarsPadding()
+            .padding(bottom = 8.dp),
+        )
+      }
     }
 
     // (2) Bulletin flyout — drawn over the body. Its top shadow extends

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/PageIndicatorOverlay.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/PageIndicatorOverlay.kt
@@ -20,9 +20,14 @@ import world.clan.app.data.elderById
 import world.clan.app.ui.theme.CockpitTokens
 
 /**
- * Page-indicator dots — overlay drawn on top of the map's bottom edge.
- * Each dot tints to the corresponding clan's accent when active. Tapping
- * a dot moves the pager.
+ * Page-indicator dots — overlay anchored to the bottom of the clan panel
+ * pager (NOT the map). Each dot tints to the corresponding clan's accent
+ * when active. Tapping a dot moves the pager.
+ *
+ * Caller is responsible for adding `Modifier.navigationBarsPadding()` so
+ * the dots sit above the gesture handle / nav bar — the panel background
+ * itself fills behind the unsafe bottom inset, but interactive controls
+ * must not be obscured.
  */
 @Composable
 fun PageIndicatorOverlay(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/OwnerComingSoonScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/OwnerComingSoonScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -43,7 +45,14 @@ fun OwnerComingSoonScreen(
     modifier = Modifier
       .fillMaxSize()
       .background(CockpitTokens.Bg.Iron)
-      .windowInsetsPadding(WindowInsets.systemBars),
+      // Top status-bar inset only — content fills behind the bottom
+      // nav bar / gesture handle. No interactive controls live at the
+      // bottom of this screen, so no per-element nav-bar padding.
+      .windowInsetsPadding(
+        WindowInsets.systemBars.only(
+          WindowInsetsSides.Top + WindowInsetsSides.Horizontal,
+        ),
+      ),
   ) {
     // 2dp top accent line (matches MiniCockpit panel chrome)
     Box(

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/OwnerSignInScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/OwnerSignInScreen.kt
@@ -17,7 +17,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -89,7 +93,14 @@ fun OwnerSignInScreen(
           ),
         ),
       )
-      .windowInsetsPadding(WindowInsets.systemBars),
+      // Keep top status-bar inset; fill behind the bottom nav bar /
+      // gesture handle. Interactive elements below add their own
+      // `navigationBarsPadding()` so they aren't obscured.
+      .windowInsetsPadding(
+        WindowInsets.systemBars.only(
+          WindowInsetsSides.Top + WindowInsetsSides.Horizontal,
+        ),
+      ),
   ) {
     BackChevron(onBack = onBack, modifier = Modifier.padding(start = 8.dp, top = 8.dp))
 
@@ -137,6 +148,7 @@ fun OwnerSignInScreen(
       hostState = snackbar,
       modifier = Modifier
         .align(Alignment.BottomCenter)
+        .navigationBarsPadding()
         .padding(16.dp),
     )
   }

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt
@@ -16,8 +16,12 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -350,6 +354,14 @@ fun ClanWorldApp(
   ) {
     Scaffold(
       containerColor = Color.Transparent,
+      // Top: keep the status-bar safe inset on content. Bottom: let
+      // content + bottom bar fill behind the nav bar / gesture handle.
+      // Interactive elements (tab icons, page-indicator dots) apply
+      // `navigationBarsPadding()` themselves so they remain above the
+      // gesture handle.
+      contentWindowInsets = WindowInsets.statusBars.only(
+        WindowInsetsSides.Top + WindowInsetsSides.Horizontal,
+      ),
       bottomBar = {
         AnimatedVisibility(
           visible = showTabBar,

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Tabbar.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Tabbar.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -69,10 +70,13 @@ fun ClanWorldTabBar(
 
   val selectedIndex = RootTab.values().indexOf(selected)
 
+  // Outer Box: background gradient + top hairline fill the full unsafe
+  // bottom area (extends behind the gesture handle). Inner content adds
+  // `navigationBarsPadding()` so the tab icons + halo sit ABOVE the
+  // gesture handle while the obsidian still paints to screen bottom.
   Box(
     modifier
       .fillMaxWidth()
-      .height(84.dp)
       .background(
         Brush.verticalGradient(
           0f to Color.Transparent,
@@ -93,6 +97,8 @@ fun ClanWorldTabBar(
     BoxWithConstraints(
       modifier = Modifier
         .fillMaxWidth()
+        .navigationBarsPadding()
+        .height(84.dp)
         .padding(start = 18.dp, top = 10.dp, end = 18.dp, bottom = 20.dp),
     ) {
       val tabCount = RootTab.values().size

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ConnectScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/ConnectScreen.kt
@@ -6,13 +6,16 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -115,7 +118,11 @@ private fun ConnectScreen(
     Column(
       modifier = Modifier
         .fillMaxSize()
-        .padding(WindowInsets.statusBars.asPaddingValues())
+        .padding(
+          WindowInsets.systemBars
+            .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
+            .asPaddingValues(),
+        )
         .padding(horizontal = 36.dp, vertical = 64.dp),
       horizontalAlignment = Alignment.CenterHorizontally,
       verticalArrangement = Arrangement.SpaceBetween,
@@ -169,7 +176,9 @@ private fun ConnectScreen(
       Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(18.dp),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+          .fillMaxWidth()
+          .navigationBarsPadding(),
       ) {
         EmberCta(
           text = when {

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/screens/SteeringConsoleScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -215,6 +216,7 @@ private fun SteeringConsole(
     Column(
       modifier = Modifier
         .fillMaxSize()
+        .navigationBarsPadding()
         .padding(horizontal = 22.dp),
     ) {
       OrnamentRule(label = "ÆLDER WHISPERS")


### PR DESCRIPTION
## Summary

Two visual fixes for the Android Compose app, from Liam 2026-05-12.

### Change 1: page indicator dots moved out of map overlay

`PageIndicatorOverlay` was previously drawn as a z-overlay on the map's bottom edge (with `.padding(bottom = 56.dp)` over the `MapWebView`'s Box). It has been moved into a wrapper Box around `ClanPanelPager` and anchored to `Alignment.BottomCenter` of the panel region.

- Dots now scroll/animate with the panel context, not float over the map.
- When `collapsed = true` the pager region collapses to ~0 height, so the dots collapse with it — natural pairing with the new collapse-pill behavior from PR #234.
- Horizontal centering preserved.

### Change 2: edge-to-edge — fill bottom unsafe area, preserve top safe area

`MainActivity.kt` already called `enableEdgeToEdge()`. The Material3 `Scaffold` in `ClanWorldApp.kt` had no explicit `contentWindowInsets`, so it used the default (`WindowInsets.systemBars`), which padded BOTH top and bottom — content stopped above the gesture handle.

New behavior:
- `Scaffold.contentWindowInsets = WindowInsets.statusBars.only(Top + Horizontal)` — content keeps the top status-bar inset, fills behind the bottom nav bar / gesture handle.
- `ClanWorldTabBar`: background gradient + top hairline fill the full unsafe bottom area; inner `BoxWithConstraints` (icons + halo) gets `navigationBarsPadding()` so the interactive content sits above the gesture handle.
- `PageIndicatorOverlay` placement (cockpit) gets `navigationBarsPadding()` so the dots aren't hidden by the gesture handle, while the panel background continues to fill behind it.
- `OwnerSignInScreen` + `OwnerComingSoonScreen` switched from `windowInsetsPadding(WindowInsets.systemBars)` to `.only(Top + Horizontal)`. Snackbar in OwnerSignIn picks up `navigationBarsPadding()` directly.

### Files changed

- `apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/CockpitScreen.kt` — wrap pager in Box, move dots to BottomCenter of panel, add `navigationBarsPadding()`.
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/PageIndicatorOverlay.kt` — KDoc updated, caller now owns nav-bar padding.
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/ClanWorldApp.kt` — `Scaffold.contentWindowInsets = statusBars.only(Top + Horizontal)`.
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/ui/components/Tabbar.kt` — outer Box drops fixed `.height(84.dp)`, inner content gets `navigationBarsPadding()` + `.height(84.dp)` so background extends to screen edge while icons stay above gesture handle.
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/OwnerSignInScreen.kt` — top-only inset; snackbar picks up nav-bar padding.
- `apps/clan-world-mobile/app/src/main/java/world/clan/app/owner/OwnerComingSoonScreen.kt` — top-only inset.

## Build

```
ANDROID_HOME=/opt/android-sdk \
  CLAN_WORLD_MAP_URL=https://app.clan-world.com \
  CLAN_WORLD_TERMINAL_BASE_URL=https://cockpit.clan-world.com \
  CLAN_WORLD_VERSION_NAME=2.5.2 \
  CLAN_WORLD_VERSION_CODE=2005002 \
  ./gradlew :app:assembleDebug
```

→ `BUILD SUCCESSFUL` (clean compile, no warnings introduced).

## ⚠ Needs visual UAT on device

No emulator/device available in this dispatch loop. Please verify on a physical device with a gesture-handle nav bar (e.g. Pixel 7+):

- [ ] **Home (Hearth)**: tab bar background fills behind the gesture handle; tab icons + labels sit clearly above it.
- [ ] **Hall / Bazaar / Codex**: same tab-bar behavior; obsidian background fills the bottom unsafe area.
- [ ] **Cockpit (panel expanded)**: page indicator dots now sit in the bottom of the panel (NOT over the map). Dots are centered horizontally. Dots clear the gesture handle (above it).
- [ ] **Cockpit (panel collapsed)**: dots collapse with the panel (acceptable / expected — feedback if undesired).
- [ ] **Cockpit (top)**: CLAN/WORLD header still respects the status bar safe area at top.
- [ ] **Cockpit (background fill)**: void background extends to the screen bottom edge; gesture handle area is filled visually, not white/system-color.
- [ ] **Owner Sign-In / Coming Soon**: background gradient fills to bottom; snackbar (sign-in) appears above the gesture handle.

### Known follow-ups (not in this PR)

- Cockpit panel tabs (Terminal/Vault/Clansman/ZeroG/Comms) are scrollable. With the new dot position over the bottom of the panel, the bottom ~32–48dp of content sits behind the dots. If this is visually disruptive, follow-up should add bottom content padding inside each tab (e.g. `Spacer(Modifier.height(40.dp))` at end of each scroll column). Not addressed here because the directive was scoped to "move the dots" not "reflow the panel content."

🤖 Generated with [Claude Code](https://claude.com/claude-code)