### PR TITLE
fix(web): TopHud — season % adjacent to bar, event chip rightmost

### DIFF
--- a/apps/web/src/TopHud.tsx
+++ b/apps/web/src/TopHud.tsx
@@ -238,6 +238,20 @@ export function TopHud({ liveTick }: { liveTick: number }) {
 
       {/* Right: status chips */}
       <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0 }}>
+        {/* Season progress percentage — sits adjacent to the bar so the
+            season-progress group (bar + %) reads as a single unit. Event
+            chips (winter / bandit) follow as separate right-aligned elements. */}
+        <div
+          style={{
+            color: `${PARCHMENT}55`,
+            fontSize: 11,
+            fontFamily: 'monospace',
+            letterSpacing: '0.04em',
+          }}
+        >
+          {Math.round(seasonProgress * 100)}%
+        </div>
+
         {/* Winter active */}
         {winterActive && (
           <div
@@ -289,18 +303,6 @@ export function TopHud({ liveTick }: { liveTick: number }) {
             ⚔ RAID IN {banditTicksUntil}
           </div>
         )}
-
-        {/* Compact tick legend */}
-        <div
-          style={{
-            color: `${PARCHMENT}55`,
-            fontSize: 11,
-            fontFamily: 'monospace',
-            letterSpacing: '0.04em',
-          }}
-        >
-          {Math.round(seasonProgress * 100)}%
-        </div>
       </div>
 
       <style>{`


### PR DESCRIPTION
## Summary

The TopHud row was rendering the Winter/Bandit event chip **between** the season progress bar and its percentage, leaving the percentage feeling orphaned on the far right.

### Before
```
tick 222    SEASON 1  [───progress bar───]   ❄ WINTER   62%
```

### After
```
tick 222    SEASON 1  [───progress bar───]   62%   ❄ WINTER
```

The season-progress group (bar + %) now reads as a single unit; the event chip is a separate right-aligned element. Reference: Liam screenshot 2026-05-12.

## Implementation

Inside the right-side flex container in `apps/web/src/TopHud.tsx`, moved the `{Math.round(seasonProgress * 100)}%` span from the LAST position to the FIRST position. No spacing/gap values changed — ordering-only swap. Both unconditional (no chip) and chip-present states (`winterActive`, `winterWarning`, `banditActive`) keep the % adjacent to the bar.

## Test plan

- [x] `pnpm --filter @clan-world/web build` green (vite 6.01s)
- [x] Empty state (no event chips): bar → % renders correctly
- [x] WINTER chip state: bar → % → ❄ WINTER
- [x] Bandit RAID IN chip state: bar → % → ⚔ RAID IN N

Single-file diff (`apps/web/src/TopHud.tsx`, +14/-12).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>