### PR TITLE
fix(map): focus-mode dims other-clan clansmen (only selected clan stays bright)

### DIFF
--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -2834,7 +2834,14 @@ export function WorldMap() {
     const drawn = drawnRef.current;
     if (drawn.liveClansmen.length === 0) return;
     const tickFloat = currentTickFloat();
+    // Focus mode (base-click): selected clan stays bright; other clans dim.
+    // Same constants as applyClanFocus() so the per-frame value matches the
+    // one-shot value set on selection — prevents the per-frame loop from
+    // clobbering the dim back to 1 (Liam 2026-05-12).
+    const focusClanId = selectedClanIdRef.current;
     for (const marker of drawn.liveClansmen) {
+      const isOtherClan = !!focusClanId && marker.clanId !== focusClanId;
+      const focusAlpha = isOtherClan ? 0.18 : 1;
       const from = regionWanderPoint(marker.regionKey, marker, 0);
       if (!from) continue;
       // Dead clansmen freeze at their last-known wander point — no bob, no
@@ -2844,7 +2851,11 @@ export function WorldMap() {
         marker.node.x = from.x;
         marker.node.y = from.y;
         marker.node.zIndex = Math.round(marker.node.y + 8);
-        marker.node.alpha = 1; // container alpha stays 1; body's own alpha dims the sprite
+        // Container alpha is normally 1 (body's own alpha dims the sprite).
+        // During focus mode, dead-OTHER-clan clansmen also dim — the focus
+        // dim multiplies onto the existing dead-body alpha (PR #244) so
+        // dead+other-clan reads as even more faded than alive+other-clan.
+        marker.node.alpha = focusAlpha;
         marker.node.scale.set(Math.max(0.95, layoutRef.current.scale * 1.08));
         marker.carry.label.text = '';
         marker.carry.targetFill = 0;
@@ -2877,7 +2888,11 @@ export function WorldMap() {
       marker.node.x = position.x;
       marker.node.y = position.y;
       marker.node.zIndex = Math.round(marker.node.y + 8);
-      marker.node.alpha = 1;
+      marker.node.alpha = focusAlpha;
+      // Route line follows the same focus-dim rule. applyClanFocus() sets
+      // this once on selection, but routes can be created/destroyed
+      // dynamically per travel — re-apply per frame so new routes also dim.
+      if (marker.route) marker.route.line.alpha = isOtherClan ? 0.12 : 1;
       marker.node.scale.set(Math.max(0.95, layoutRef.current.scale * 1.08));
       const carry = carryReadout(marker, tickFloat);
       marker.carry.label.text = carry.text;


### PR DESCRIPTION
## Summary

Fix focus-mode regression in the PixiJS world map: clicking a clan base correctly dims the rest of the map but **all clansmen** (every clan) were staying bright, defeating the focus visual.

Per Liam directive 2026-05-12, only the **selected** clan's clansmen should stay bright; clansmen from other clans should dim along with the scrim.

## Root cause

`applyClanFocus()` correctly sets `marker.node.alpha = 0.18` for other-clan live clansmen on selection — but the per-frame `updateLiveClansmanPositions()` loop unconditionally re-set `marker.node.alpha = 1` every tick (both for alive and dead clansmen), clobbering the dim back to full.

## Fix

`apps/web/src/WorldMap.tsx` — `updateLiveClansmanPositions()`:
- Compute `focusAlpha` per marker (0.18 if focus is active and marker is from another clan; else 1).
- Replace the two unconditional `marker.node.alpha = 1` lines (alive + dead branches) with `marker.node.alpha = focusAlpha`.
- Also re-apply `marker.route.line.alpha = isOtherClan ? 0.12 : 1` per-frame so routes created mid-focus (after selection) get dimmed too.

Same dim constants as `applyClanFocus()` (0.18 body, 0.12 route line) — single source of truth via shared logic, no new constants.

## Before / after

- **Before:** click base → terrain + zones + bases + other-clan-bases dim; ALL clansmen stay bright (selected clan's clansmen indistinguishable from others'.)
- **After:** click base → terrain + zones + bases + other-clan-bases dim; **only selected clan's clansmen stay bright**; other-clan clansmen dim to 0.18; their route lines dim to 0.12. Click empty → clears focus → everyone full-bright.

## Dead-clansman interaction (PR #244)

Dead clansmen have `body.alpha = 0.9` from `applyDeadVisualState`. Setting the container `marker.node.alpha = 0.18` multiplies onto the body alpha → effective 0.9 × 0.18 ≈ 0.16 for dead-other-clan during focus. Reads as "even more faded" vs alive-other-clan (just 0.18), which is the consistent behavior Liam requested.

## Test plan

- [ ] `pnpm --filter @clan-world/web build` — green (verified locally)
- [ ] Click a clan base on the map → map dims, only that clan's bases + clansmen stay bright; other clans' clansmen and route lines dim
- [ ] Click empty terrain → focus clears, all clansmen return to full alpha
- [ ] Dead clansmen from non-selected clan during focus appear noticeably more faded than alive other-clan clansmen