### PR TITLE
feat(contracts): diamond upgrade script + executed deploy on Base Sepolia (HeartbeatFacet + bandit-tier cap)

### DIFF
--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -31,6 +31,7 @@ import type * as kickstart from "../kickstart.js";
 import type * as memory from "../memory.js";
 import type * as mock from "../mock.js";
 import type * as ops from "../ops.js";
+import type * as resetLock from "../resetLock.js";
 import type * as vault from "../vault.js";
 
 /**
@@ -60,6 +61,7 @@ declare const fullApi: ApiFromModules<{
   memory: typeof memory;
   mock: typeof mock;
   ops: typeof ops;
+  resetLock: typeof resetLock;
   vault: typeof vault;
 }>;
 export declare const api: FilterApi<

--- a/packages/contracts/script/UpgradeHeartbeatBanditCap.s.sol
+++ b/packages/contracts/script/UpgradeHeartbeatBanditCap.s.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+import {Script, console} from "forge-std/Script.sol";
+import {DiamondSelectors} from "./DiamondSelectors.sol";
+import {IDiamondCut} from "../src/diamond/IDiamondCut.sol";
+import {HeartbeatConfigFacet} from "../src/diamond/facets/HeartbeatConfigFacet.sol";
+import {HeartbeatFacet} from "../src/diamond/facets/HeartbeatFacet.sol";
+
+/// @notice Deploys new HeartbeatFacet + HeartbeatConfigFacet (both linked
+///         to the new LibBanditSpawning bytecode with the maxBanditTier
+///         clamp), then diamondCuts the live diamond to REPLACE the
+///         currently-routed Heartbeat selectors and ADD the two new
+///         HeartbeatConfigFacet selectors (`maxBanditTier()` /
+///         `setMaxBanditTier(uint8)`).
+///
+/// @dev Required env:
+///   - DEPLOYER_PRIVATE_KEY     — diamond owner key
+///   - CLAN_WORLD_DIAMOND_ADDRESS (preferred) or CLAN_WORLD_CONTRACT_ADDRESS — the target diamond
+///
+/// On-chain pre-state (Base Sepolia, captured 2026-05-11):
+///   - heartbeat() (0x3defb962)                  → 0xfA742EEF25e6a16506f7bCc40e3710EC5A4B41eE (REPLACE)
+///   - heartbeatIntervalSeconds (0x648d6c85)     → 0xdE3Ed840BF083BC288Baa01b80989cfD392C1047 (REPLACE)
+///   - setHeartbeatIntervalSeconds (0xa3783d06)  → 0xdE3Ed840BF083BC288Baa01b80989cfD392C1047 (REPLACE)
+///   - clansmanCooldownSeconds (0xf91ffcc0)      → 0xdE3Ed840BF083BC288Baa01b80989cfD392C1047 (REPLACE)
+///   - setClansmanCooldownSeconds (0x9fcadb74)   → 0xdE3Ed840BF083BC288Baa01b80989cfD392C1047 (REPLACE)
+///   - banditSpawnTriggered (0x17fca79b)         → 0xdE3Ed840BF083BC288Baa01b80989cfD392C1047 (REPLACE)
+///   - triggerBanditSpawn (0x1f79b9b0)           → 0xdE3Ed840BF083BC288Baa01b80989cfD392C1047 (REPLACE)
+///   - maxBanditTier (0x16fd8fc6)                → address(0)                                  (ADD)
+///   - setMaxBanditTier (0x90fab46c)             → address(0)                                  (ADD)
+contract UpgradeHeartbeatBanditCap is Script {
+    function run() external returns (HeartbeatFacet newHeartbeat, HeartbeatConfigFacet newHeartbeatConfig) {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        // Support either env var name (CLAN_WORLD_DIAMOND_ADDRESS or CLAN_WORLD_CONTRACT_ADDRESS).
+        address diamond = _diamondAddress();
+
+        // Split the 8-entry heartbeatConfigSelectors() array into:
+        //   - first 6 → REPLACE (already routed to old HeartbeatConfigFacet)
+        //   - last 2  → ADD     (new in this upgrade: maxBanditTier + setMaxBanditTier)
+        bytes4[] memory allConfig = DiamondSelectors.heartbeatConfigSelectors();
+        require(allConfig.length == 8, "heartbeatConfigSelectors len drift");
+
+        bytes4[] memory replaceConfig = new bytes4[](6);
+        for (uint256 i = 0; i < 6; i++) {
+            replaceConfig[i] = allConfig[i];
+        }
+
+        bytes4[] memory addConfig = new bytes4[](2);
+        addConfig[0] = allConfig[6]; // maxBanditTier()
+        addConfig[1] = allConfig[7]; // setMaxBanditTier(uint8)
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        newHeartbeat = new HeartbeatFacet();
+        newHeartbeatConfig = new HeartbeatConfigFacet();
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](3);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(newHeartbeat),
+            action: IDiamondCut.FacetCutAction.Replace,
+            functionSelectors: DiamondSelectors.heartbeatSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(newHeartbeatConfig),
+            action: IDiamondCut.FacetCutAction.Replace,
+            functionSelectors: replaceConfig
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: address(newHeartbeatConfig),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: addConfig
+        });
+        IDiamondCut(diamond).diamondCut(cut, address(0), "");
+
+        vm.stopBroadcast();
+
+        console.log("DIAMOND:                       ", diamond);
+        console.log("NEW_HEARTBEAT_FACET_ADDRESS:   ", address(newHeartbeat));
+        console.log("NEW_HEARTBEAT_CONFIG_FACET:    ", address(newHeartbeatConfig));
+    }
+
+    function _diamondAddress() private view returns (address) {
+        // Prefer CLAN_WORLD_DIAMOND_ADDRESS (per ops runbook); fall back to
+        // CLAN_WORLD_CONTRACT_ADDRESS (the .env.local in this repo).
+        try vm.envAddress("CLAN_WORLD_DIAMOND_ADDRESS") returns (address d) {
+            return d;
+        } catch {
+            return vm.envAddress("CLAN_WORLD_CONTRACT_ADDRESS");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `script/UpgradeHeartbeatBanditCap.s.sol` and **executed it on Base Sepolia** — diamond `0xb49df83821bb4ECcD25b3bb856De71dc944Cb7F1` now routes to fresh `HeartbeatFacet` + `HeartbeatConfigFacet` carrying the new `LibBanditSpawning` bytecode (with the `maxBanditTier` clamp + the 2 new selectors `maxBanditTier()` / `setMaxBanditTier(uint8)`).

Before this cut, the on-chain diamond still ran the **pre-cap** bytecode even though PR-level dev had the cap code merged. Spawned bandits were uncapped.

## What the script does

1. Deploys new `HeartbeatFacet` (links new `LibBanditSpawning`, transitive via `LibHeartbeat`).
2. Deploys new `HeartbeatConfigFacet` (links new `LibBanditSpawning` directly).
3. Diamond-cuts the live diamond:
   - **Replace** `heartbeat()` (0x3defb962) → new `HeartbeatFacet`
   - **Replace** the 6 existing HeartbeatConfig selectors → new `HeartbeatConfigFacet`
   - **Add** the 2 new HeartbeatConfig selectors (`maxBanditTier()` 0x16fd8fc6, `setMaxBanditTier(uint8)` 0x90fab46c) → new `HeartbeatConfigFacet`

## Pre-broadcast checks

- `forge build` — clean (warnings only, no new errors)
- `forge test --match-contract StorageLayoutGuard` — 2 passed, 0 failed
- `forge script ... --rpc-url $RPC_URL_PRIMARY` (dry-run) — SIMULATION COMPLETE, no selector collision
- Verified diamond owner == `$DEPLOYER_ADDRESS` (`0x02C4d76d0Ce17c6a81cD44C810167D79d99267c7`)
- Verified pre-state: 6 HeartbeatConfig selectors routed to OLD `0xdE3Ed840BF083BC288Baa01b80989cfD392C1047`; 2 new selectors returned `address(0)`; `heartbeat()` routed to OLD `0xfA742EEF25e6a16506f7bCc40e3710EC5A4B41eE`

## Broadcast (Base Sepolia, chain 84532)

The script also auto-deploys 9 supporting external libraries that link into the facets. All txs landed (status 0x1).

| # | What | Tx Hash |
|---|------|---------|
| 0 | `LibBanditCleanup` deploy | `0x9f40e8a802b0bfce59d511e16417955a117d7b0afccc5705fcef7329939f4b33` |
| 1 | `LibBanditCombat` deploy  | `0x3503d589ad6d834fc3d88d2dcc1730f227cff96da9e6ec6f1ad78c392540fd94` |
| 2 | `LibBanditLifecycle` deploy | `0x48723721ba0b98bf4df233e2d70d4bedeb52c85791efaa47b1eee33bd0e6a552` |
| 3 | `LibBanditPassive` deploy | `0x75e3d342f816a3e2ed2c48693ec5997585c531120044204cb8ec8bb514b3006a` |
| 4 | `LibBanditSpawning` deploy | `0x627cf0c372ee817644845dba53df3600c85b11b7005f00487ce362febfd94c16` |
| 5 | `LibBanditTargets` deploy | `0x14e65f9ce9c138bc75a4bf383243eaaac68d9fa775f0d4766cb7f2b6f83f6533` |
| 6 | `LibOrderDefenders` deploy | `0xad14b2b7688e05aad4e5edece90b11b88b84d6f145dfeec07025e0d4b52d3dd5` |
| 7 | `LibOrderMarket` deploy | `0xab7f8452a06e696d63c7350380506a7a934a4134ab4deafcb7864728abed6446` |
| 8 | `LibOrderUpgrades` deploy | `0x9502aea7ff8b165c5a49bfbfdf1ebd6bc1e35c608a35c7891d91ab4ef24f65b6` |
| 9 | **`HeartbeatFacet` deploy** | `0xf17b068cb4045022716fb02155a3500fbbb6a97f44af5af3639d4a4b110307b3` |
| 10 | **`HeartbeatConfigFacet` deploy** | `0xd1fcfe04e77c3bf53d98299ec46419d7ca61b72e79216a6a540a8813e5f1f4ca` |
| 11 | **`diamondCut(3 entries)`** | `0xc80255d568e8bd0de292392e65c5f8bef7046c6ca61540794ea74e4c08694da3` |

### New facet addresses

- `HeartbeatFacet`       → `0xd208C87EBaDB6FE888a248908fCba112c8C1561E`
- `HeartbeatConfigFacet` → `0xa1C57eF8667B1b6645D7C5ba01c4D350F6Aa4521`

### Before → After facet routing

| Selector | Function | Before | After |
|----------|----------|--------|-------|
| `0x3defb962` | `heartbeat()` | `0xfA74...41eE` | `0xd208...561E` |
| `0x648d6c85` | `heartbeatIntervalSeconds()` | `0xdE3E...1047` | `0xa1C5...4521` |
| `0xa3783d06` | `setHeartbeatIntervalSeconds(uint64)` | `0xdE3E...1047` | `0xa1C5...4521` |
| `0xf91ffcc0` | `clansmanCooldownSeconds()` | `0xdE3E...1047` | `0xa1C5...4521` |
| `0x9fcadb74` | `setClansmanCooldownSeconds(uint64)` | `0xdE3E...1047` | `0xa1C5...4521` |
| `0x17fca79b` | `banditSpawnTriggered()` | `0xdE3E...1047` | `0xa1C5...4521` |
| `0x1f79b9b0` | `triggerBanditSpawn()` | `0xdE3E...1047` | `0xa1C5...4521` |
| `0x16fd8fc6` | `maxBanditTier()` | `address(0)` | `0xa1C5...4521` |
| `0x90fab46c` | `setMaxBanditTier(uint8)` | `address(0)` | `0xa1C5...4521` |

### Post-broadcast `cast call` verifications

```
$ cast call $DIAMOND "facetAddress(bytes4)(address)" 0x90fab46c
0xa1C57eF8667B1b6645D7C5ba01c4D350F6Aa4521   # setMaxBanditTier routed to new facet

$ cast call $DIAMOND "maxBanditTier()(uint8)"
5                                            # default — storage 0 falls through to BANDIT_TIER_COUNT=5

$ cast call $DIAMOND "setMaxBanditTier(uint8)" 3 --from $DEPLOYER_ADDRESS
0x                                           # owner-side simulation succeeds (no broadcast)

$ cast call $DIAMOND "setMaxBanditTier(uint8)" 3 --from 0x000...dEaD
Error: execution reverted, data: "0x337aa4d0..."  # non-owner correctly rejected
```

## Notes

- First broadcast attempt hit Infura's "replacement transaction underpriced" error on the 2nd tx — partial submission, no state change. Retried with `--slow --priority-gas-price 1000000` and it landed cleanly end-to-end (all 12 txs).
- Default `maxBanditTier()` returns `5` (storage `0` falls through to `BANDIT_TIER_COUNT=5`). The setter is wired and callable but NOT auto-engaged — per Liam directive, leaving it to be invoked manually when the demo cap is desired (e.g. `cast send $DIAMOND "setMaxBanditTier(uint8)" 3 --rpc-url ... --private-key ...`).
- Storage layout guard tests pass — no AppStorage regressions from the `uint8 maxBanditTier` append.

## Test plan

- [x] `forge build` clean
- [x] `forge test --match-contract StorageLayoutGuard` (2/2 passed)
- [x] `forge script` dry-run simulation succeeds
- [x] Broadcast completed on Base Sepolia (chain 84532)
- [x] New facet bytecode present (47861 chars HeartbeatFacet, 3635 chars HeartbeatConfigFacet)
- [x] All 9 selectors route to new facets
- [x] `maxBanditTier()` getter reads `5` (default)
- [x] Owner can call `setMaxBanditTier(3)` (simulated)
- [x] Non-owner cannot call `setMaxBanditTier` (reverts as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)