### PR TITLE
feat(web): snapshot localStorage cache + grace period on "no chain data"

### DIFF
--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
+import { useCachedSnapshot } from './hooks/useCachedSnapshot';
 import { Application, Assets, BlurFilter, ColorMatrixFilter, Container, Graphics, Rectangle, Sprite, Text } from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
 import { useAgentLogs, type AgentLog } from './useAgentLogs';
@@ -1322,7 +1323,15 @@ export function WorldMap() {
   const [selectedClanId, setSelectedClanId] = useState<string | null>(null);
 
   const logs = useAgentLogs();
-  const snapshot = useQuery(api.getSnapshot.getSnapshot);
+  const liveSnapshot = useQuery(api.getSnapshot.getSnapshot);
+  // Cache the snapshot in localStorage so iOS Safari (and other browsers that
+  // pause background tabs) can render the last-known world state instantly on
+  // PWA return — instead of flashing the "no chain data yet" placeholder
+  // while Convex's websocket reconnects.
+  const snapshot = useCachedSnapshot(liveSnapshot);
+  // Grace period before showing the "no chain data yet" placeholder — see the
+  // useEffect a few hooks below for the 5s debounce.
+  const [showNoChainDataPlaceholder, setShowNoChainDataPlaceholder] = useState(false);
   const rawChainEvents = useQuery(api.events.getRecentChainEvents) as ChainEvent[] | undefined;
 
   // Derived live tick counter — the worldSnapshot.tick field is currently
@@ -1371,6 +1380,23 @@ export function WorldMap() {
     if (typeof rawTick === 'number' && Number.isFinite(rawTick)) {
       tickClockRef.current = { tick: rawTick, seenAtMs: Date.now() };
     }
+  }, [snapshot]);
+
+  // 5-second grace period before showing the "no chain data yet" placeholder.
+  // If chain data is present, hide immediately. If it's empty, wait 5s before
+  // flipping the placeholder on — so fast Convex reconnects (e.g. iOS Safari
+  // PWA returns) never reveal the bare-terrain overlay. Combined with the
+  // localStorage cache in useCachedSnapshot above, most reconnects render the
+  // last-known state immediately and never trip this timer at all.
+  useEffect(() => {
+    if (DEMO_MODE) return;
+    const hasClans = !!snapshot?.clans && snapshot.clans.length > 0;
+    if (hasClans) {
+      setShowNoChainDataPlaceholder(false);
+      return;
+    }
+    const timer = window.setTimeout(() => setShowNoChainDataPlaceholder(true), 5000);
+    return () => window.clearTimeout(timer);
   }, [snapshot]);
 
   // Snapshot-diff: derive bandit resolution outcome the moment the chain transitions
@@ -5327,9 +5353,11 @@ export function WorldMap() {
       })()}
 
       {/* "No chain data yet" placeholder — shown when DEMO_MODE is off and no
-          live snapshot clans are present. Centered overlay so it reads clearly
-          on the bare terrain map. */}
-      {!DEMO_MODE && (!snapshot?.clans || snapshot.clans.length === 0) && (
+          snapshot clans are present, *after* a 5-second grace period managed
+          by `showNoChainDataPlaceholder` (see the useEffect declared with the
+          snapshot hooks above). Centered overlay so it reads clearly on the
+          bare terrain map. */}
+      {!DEMO_MODE && showNoChainDataPlaceholder && (
         <div
           data-testid="no-chain-data-placeholder"
           style={{

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1329,6 +1329,10 @@ export function WorldMap() {
   // PWA return — instead of flashing the "no chain data yet" placeholder
   // while Convex's websocket reconnects.
   const snapshot = useCachedSnapshot(liveSnapshot);
+  // Stable boolean: true only when the snapshot contains at least one deployed
+  // clan. Used as the sole dep of the grace-period useEffect so we don't reset
+  // the 5s timer on every heartbeat tick (snapshot object changes every tick).
+  const hasClans = !!snapshot?.clans && snapshot.clans.length > 0;
   // Grace period before showing the "no chain data yet" placeholder — see the
   // useEffect a few hooks below for the 5s debounce.
   const [showNoChainDataPlaceholder, setShowNoChainDataPlaceholder] = useState(false);
@@ -1389,15 +1393,13 @@ export function WorldMap() {
   // localStorage cache in useCachedSnapshot above, most reconnects render the
   // last-known state immediately and never trip this timer at all.
   useEffect(() => {
-    if (DEMO_MODE) return;
-    const hasClans = !!snapshot?.clans && snapshot.clans.length > 0;
-    if (hasClans) {
+    if (DEMO_MODE || hasClans) {
       setShowNoChainDataPlaceholder(false);
       return;
     }
     const timer = window.setTimeout(() => setShowNoChainDataPlaceholder(true), 5000);
     return () => window.clearTimeout(timer);
-  }, [snapshot]);
+  }, [hasClans]);
 
   // Snapshot-diff: derive bandit resolution outcome the moment the chain transitions
   // out of Camped. See docs/planning/bandit-animation-impl-plan.md §"Snapshot diff

--- a/apps/web/src/hooks/useCachedSnapshot.ts
+++ b/apps/web/src/hooks/useCachedSnapshot.ts
@@ -14,12 +14,19 @@ import { useEffect, useState } from 'react';
  * this hook — keeps it framework-agnostic and easy to unit-test.
  */
 
+// Scope the cache key per environment so dev and prod (served from the same
+// localhost origin during development) never share a localStorage slot.
+const ENV_SCOPE = (import.meta.env.VITE_CONVEX_URL as string | undefined) ?? 'no-backend';
 // Bump this on snapshot shape changes (Convex schema migrations).
-const CACHE_KEY = 'cw-snapshot-v1';
+const CACHE_KEY = `cw-snapshot-v1:${ENV_SCOPE}`;
 // Drop cache older than this — avoids surfacing wildly stale state.
 const MAX_CACHE_AGE_MS = 60 * 60 * 1000; // 1 hour
 
-type Cached<T> = { ts: number; data: T };
+// Version discriminant — increment when the cached payload shape changes so
+// stale entries from previous versions are silently dropped on read instead of
+// causing runtime errors or surfacing corrupt state.
+const PAYLOAD_VERSION = 1;
+type Cached<T> = { v: number; ts: number; data: T };
 
 export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
   const [cached, setCached] = useState<T | undefined>(() => {
@@ -28,6 +35,7 @@ export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
       if (!raw) return undefined;
       const parsed = JSON.parse(raw) as Cached<T>;
       if (!parsed || typeof parsed.ts !== 'number') return undefined;
+      if (parsed.v !== PAYLOAD_VERSION) return undefined;
       if (Date.now() - parsed.ts > MAX_CACHE_AGE_MS) return undefined;
       return parsed.data;
     } catch {
@@ -38,7 +46,7 @@ export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
   useEffect(() => {
     if (live === undefined) return;
     try {
-      const payload: Cached<T> = { ts: Date.now(), data: live };
+      const payload: Cached<T> = { v: PAYLOAD_VERSION, ts: Date.now(), data: live };
       localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
     } catch {
       // quota or private-mode — ignore

--- a/apps/web/src/hooks/useCachedSnapshot.ts
+++ b/apps/web/src/hooks/useCachedSnapshot.ts
@@ -55,10 +55,12 @@ export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
     if (live === undefined) return;
     const now = Date.now();
     if (now - lastWriteTsRef.current >= WRITE_THROTTLE_MS) {
+      // Update timestamp BEFORE attempting the write so failed writes
+      // (private-mode / quota) are also throttled, not retried every tick.
+      lastWriteTsRef.current = now;
       try {
         const payload: Cached<T> = { v: PAYLOAD_VERSION, ts: now, data: live };
         localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
-        lastWriteTsRef.current = now;
       } catch {
         // quota or private-mode — ignore
       }

--- a/apps/web/src/hooks/useCachedSnapshot.ts
+++ b/apps/web/src/hooks/useCachedSnapshot.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 /**
  * Snapshot cache for the WorldMap's Convex `getSnapshot` query.
@@ -28,6 +28,11 @@ const MAX_CACHE_AGE_MS = 60 * 60 * 1000; // 1 hour
 const PAYLOAD_VERSION = 1;
 type Cached<T> = { v: number; ts: number; data: T };
 
+// Throttle localStorage writes — Convex emits a fresh snapshot every heartbeat
+// tick so without throttling we'd JSON.stringify + setItem on every tick, which
+// can block the main thread on mobile Safari.
+const WRITE_THROTTLE_MS = 30 * 1000; // 30 seconds
+
 export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
   const [cached, setCached] = useState<T | undefined>(() => {
     try {
@@ -43,13 +48,20 @@ export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
     }
   });
 
+  // Track last write timestamp across renders without triggering re-renders.
+  const lastWriteTsRef = useRef<number>(0);
+
   useEffect(() => {
     if (live === undefined) return;
-    try {
-      const payload: Cached<T> = { v: PAYLOAD_VERSION, ts: Date.now(), data: live };
-      localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
-    } catch {
-      // quota or private-mode — ignore
+    const now = Date.now();
+    if (now - lastWriteTsRef.current >= WRITE_THROTTLE_MS) {
+      try {
+        const payload: Cached<T> = { v: PAYLOAD_VERSION, ts: now, data: live };
+        localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
+        lastWriteTsRef.current = now;
+      } catch {
+        // quota or private-mode — ignore
+      }
     }
     setCached(live);
   }, [live]);

--- a/apps/web/src/hooks/useCachedSnapshot.ts
+++ b/apps/web/src/hooks/useCachedSnapshot.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Snapshot cache for the WorldMap's Convex `getSnapshot` query.
+ *
+ * Why: on iOS Safari (and any browser that aggressively pauses background
+ * tabs), returning to the PWA briefly leaves the Convex `useQuery` hook
+ * returning `undefined` while the websocket reconnects. That gap previously
+ * surfaced as a white "no chain data yet" flash. We instead show the
+ * previously-cached state instantly (read synchronously from localStorage
+ * during useState's initializer) until fresh data arrives.
+ *
+ * Generic over the snapshot type so we don't pull the Convex API type into
+ * this hook — keeps it framework-agnostic and easy to unit-test.
+ */
+
+// Bump this on snapshot shape changes (Convex schema migrations).
+const CACHE_KEY = 'cw-snapshot-v1';
+// Drop cache older than this — avoids surfacing wildly stale state.
+const MAX_CACHE_AGE_MS = 60 * 60 * 1000; // 1 hour
+
+type Cached<T> = { ts: number; data: T };
+
+export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
+  const [cached, setCached] = useState<T | undefined>(() => {
+    try {
+      const raw = localStorage.getItem(CACHE_KEY);
+      if (!raw) return undefined;
+      const parsed = JSON.parse(raw) as Cached<T>;
+      if (!parsed || typeof parsed.ts !== 'number') return undefined;
+      if (Date.now() - parsed.ts > MAX_CACHE_AGE_MS) return undefined;
+      return parsed.data;
+    } catch {
+      return undefined;
+    }
+  });
+
+  useEffect(() => {
+    if (live === undefined) return;
+    try {
+      const payload: Cached<T> = { ts: Date.now(), data: live };
+      localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
+    } catch {
+      // quota or private-mode — ignore
+    }
+    setCached(live);
+  }, [live]);
+
+  return live ?? cached;
+}


### PR DESCRIPTION
## Problem

iOS Safari (and any browser that aggressively pauses background tabs) leaves the Convex `useQuery(api.getSnapshot.getSnapshot)` hook returning `undefined` for a beat while the websocket reconnects when the user returns to the PWA. That gap surfaces as a white *"no chain data yet"* flash over a bare terrain map — feels broken even though it's just a sub-second reconnect.

## Fix (two parts)

### Part A — `apps/web/src/hooks/useCachedSnapshot.ts` (new)

Generic hook that:
- Synchronously reads the last-known snapshot from `localStorage` in `useState`'s initializer (so the first render already has data — no `undefined` flash).
- Writes back to `localStorage` on every non-`undefined` `live` value.
- Cache key: `cw-snapshot-v1` — **bump on Convex schema migrations**.
- Hard cap: `MAX_CACHE_AGE_MS = 1 hour` — anything older is dropped, so we never surface wildly stale state.
- Tolerates `JSON.parse` failures, missing key, quota errors, private-mode localStorage rejections — all silent fallthrough to `undefined`.
- Generic over `T` so we don't pull the Convex API type into the hook (keeps it framework-agnostic + easy to unit-test later).

### Part B — `apps/web/src/WorldMap.tsx`

```ts
const liveSnapshot = useQuery(api.getSnapshot.getSnapshot);
const snapshot = useCachedSnapshot(liveSnapshot);
```

Plus a 5-second grace period before the `data-testid="no-chain-data-placeholder"` overlay can render:

```ts
const [showNoChainDataPlaceholder, setShowNoChainDataPlaceholder] = useState(false);
useEffect(() => {
  if (DEMO_MODE) return;
  const hasClans = !!snapshot?.clans && snapshot.clans.length > 0;
  if (hasClans) { setShowNoChainDataPlaceholder(false); return; }
  const timer = window.setTimeout(() => setShowNoChainDataPlaceholder(true), 5000);
  return () => window.clearTimeout(timer);
}, [snapshot]);
```

JSX render condition swapped from `!snapshot?.clans || snapshot.clans.length === 0` to `showNoChainDataPlaceholder`. Inner JSX unchanged.

## Behavior summary

1. **First-ever load** (no cache, no live yet): nothing shown for ≤5s, then placeholder fades in.
2. **Returning PWA user** (cache hit, live still reconnecting): last-known world renders immediately; `live` arrives within ~1-2s; placeholder timer never fires.
3. **Long reconnect** (>5s, cache stale or missing): placeholder appears at 5s, hides instantly when `live` returns with clans.
4. **DEMO_MODE**: effect short-circuits, placeholder stays hidden as before.

## Cache invariants

- Key `cw-snapshot-v1` — bump on snapshot shape change.
- 1-hour hard cap on cache age (prevents "the world from yesterday" rendering).
- All localStorage access wrapped in try/catch — Safari private mode is a no-op, not a crash.

## Testing

- `pnpm --filter @clan-world/web typecheck` — passes.
- `pnpm --filter @clan-world/web build` — passes (5.9s, no new warnings).
- No unit-test convention in `apps/web` yet (only Playwright e2e), so per the implementation spec no test infra was introduced just for this hook. Hook is intentionally simple + self-contained — straightforward to add a vitest later when the test suite lands.

## Risk

Low. Two narrow additions:
- A new generic hook with no external deps beyond React.
- A single state + effect + render-condition swap on the placeholder overlay. The placeholder still renders the same JSX; only the *when* changed.

Worst-case regression is the placeholder taking 5s longer to appear in the no-chain-data steady state, which is desirable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)