### PR TITLE
feat(web): static HTML ghost layer (eliminate PixiJS warmup flash)

### DIFF
--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -7,6 +7,7 @@ import { useAgentLogs, type AgentLog } from './useAgentLogs';
 import { WorldNoticePanel } from './WorldNoticePanel';
 import { TopHud } from './TopHud';
 import { EventTicker } from './EventTicker';
+import { MapGhostLayer } from './components/MapGhostLayer';
 import { api } from '../../server/convex/_generated/api';
 import worldMapBg from './assets/world-map.png';
 import worldMapWinterBg from './assets/world-map-winter.png';
@@ -1645,8 +1646,15 @@ export function WorldMap() {
         if (!mounted || !isMountedRef.current || !canvasWrapRef.current) return;
         canvasWrapRef.current.appendChild(app.canvas);
         pixiCanvas = app.canvas;
-        // CSS: stretch to wrapper
+        // CSS: stretch to wrapper. We pin the canvas as `position: absolute;
+        // inset: 0` with an explicit z-index ABOVE the MapGhostLayer (which
+        // sits at z-index 0 in the same container). Without explicit
+        // positioning + z-index the absolutely-positioned ghost would paint
+        // on top of the static-positioned canvas, defeating the swap.
         app.canvas.style.display = 'block';
+        app.canvas.style.position = 'absolute';
+        app.canvas.style.inset = '0';
+        app.canvas.style.zIndex = '1';
         app.canvas.style.width = '100%';
         app.canvas.style.height = '100%';
         // Round-6 pinch fix: pixi-viewport handles multi-touch internally, so
@@ -4054,8 +4062,9 @@ export function WorldMap() {
       // One Text per polygon vertex, showing its (x,y) polygon coords. Added to
       // terrainBackground AFTER the Graphics so labels render on top of the fill.
       const vertexLabels: Text[] = [];
-      if (SHOW_REGION_POLYGONS) {
-        for (const [px, py] of REGIONS[i].polygon) {
+      const regionDef = REGIONS[i];
+      if (SHOW_REGION_POLYGONS && regionDef) {
+        for (const [px, py] of regionDef.polygon) {
           const t = new Text({
             text: `(${px},${py})`,
             style: {
@@ -5349,7 +5358,15 @@ export function WorldMap() {
           width: '100%',
           height: '100%',
         }}
-      />
+      >
+        {/* Static HTML "ghost" of the map — visible briefly while PixiJS
+            warms up WebGL (~500ms-1s on cold mobile Safari). Renders the
+            cached map background + clan bases using the same viewport
+            (cx, cy, scale) state pixi-viewport already persists. Fades
+            out once `pixiReady` flips true.
+            See: apps/web/src/components/MapGhostLayer.tsx. */}
+        <MapGhostLayer pixiReady={pixiReady} />
+      </div>
 
       {/* Top HUD bar — tick clock, season progress, status chips */}
       <TopHud liveTick={liveTick} />

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1646,11 +1646,11 @@ export function WorldMap() {
         if (!mounted || !isMountedRef.current || !canvasWrapRef.current) return;
         canvasWrapRef.current.appendChild(app.canvas);
         pixiCanvas = app.canvas;
-        // CSS: stretch to wrapper. We pin the canvas as `position: absolute;
-        // inset: 0` with an explicit z-index ABOVE the MapGhostLayer (which
-        // sits at z-index 0 in the same container). Without explicit
-        // positioning + z-index the absolutely-positioned ghost would paint
-        // on top of the static-positioned canvas, defeating the swap.
+        // CSS: stretch to wrapper. The ghost (MapGhostLayer) sits at z-index 2
+        // so it covers the canvas during warmup; the canvas sits at z-index 1
+        // BELOW the ghost. Once `pixiReady` fires the ghost fades out and
+        // unmounts, leaving only the canvas. pointer-events:none on the ghost
+        // ensures taps reach the canvas even before the fade completes.
         app.canvas.style.display = 'block';
         app.canvas.style.position = 'absolute';
         app.canvas.style.inset = '0';

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -8,6 +8,7 @@ import { WorldNoticePanel } from './WorldNoticePanel';
 import { TopHud } from './TopHud';
 import { EventTicker } from './EventTicker';
 import { MapGhostLayer } from './components/MapGhostLayer';
+import { MAP_WIDTH, MAP_HEIGHT, LIVE_CLAN_REGION_BY_ID } from './components/mapGeometry';
 import { api } from '../../server/convex/_generated/api';
 import worldMapBg from './assets/world-map.png';
 import worldMapWinterBg from './assets/world-map-winter.png';
@@ -29,8 +30,7 @@ import {
 // World dimensions used by pixi-viewport for pan/clamp/center math.
 // Matches the actual hand-curated bg PNG (apps/web/src/assets/world-map.png)
 // at native resolution. The viewport scales/pans this world inside the screen.
-const MAP_WIDTH = 1086;
-const MAP_HEIGHT = 1448;
+// Re-exported from mapGeometry below (pure-data shared module).
 const WORLD_WIDTH = MAP_WIDTH;
 const WORLD_HEIGHT = MAP_HEIGHT;
 
@@ -319,14 +319,7 @@ const MOCK_CLANS: ClanDef[] = [
   { id: 'clan-storm', spriteSheetId: 'clan-storm', name: 'Storm Riders', homeRegion: 'east-farms', color: 0x44aacc, sigil: '/sigils/storm-riders-sigil.png', portrait: '/portraits/mira-portrait.png',   archetype: 'Trader',     basePng: '/bases/tide-wardens.png',  clansmanPng: '/clansmen/clan-storm.png' },
 ];
 
-const LIVE_CLAN_REGION_BY_ID: Record<number, string> = {
-  1: 'forest',
-  2: 'mountains',
-  4: 'west-farms',
-  5: 'east-farms',
-  6: 'west-docks',
-  7: 'east-docks',
-};
+// LIVE_CLAN_REGION_BY_ID is imported from ./components/mapGeometry — shared with MapGhostLayer.
 
 function clansmanPngForClanId(clanId: string): string | null {
   return MOCK_CLANS.find((clan) => clan.id === clanId)?.clansmanPng ?? null;

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -5357,6 +5357,9 @@ export function WorldMap() {
           inset: 0,
           width: '100%',
           height: '100%',
+          // Scope the ghost/canvas z-index stacking to this container so it
+          // cannot compete with grand-sibling overlays (HUD, scoreboard, etc).
+          isolation: 'isolate',
         }}
       >
         {/* Static HTML "ghost" of the map — visible briefly while PixiJS

--- a/apps/web/src/components/MapGhostLayer.tsx
+++ b/apps/web/src/components/MapGhostLayer.tsx
@@ -1,9 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import worldMapBg from '../assets/world-map.png';
+import {
+  MAP_WIDTH,
+  MAP_HEIGHT,
+  REGION_CENTERS_BY_KEY,
+  LIVE_CLAN_REGION_BY_ID,
+  BASE_PNG_BY_VISUAL_INDEX,
+  FALLBACK_HOME_REGION_BY_INDEX,
+  baseVisualScale as _baseVisualScale,
+} from './mapGeometry';
 
 /**
- * MapGhostLayer — static HTML+CSS "ghost" of the world map rendered UNDER the
- * PixiJS canvas while WebGL is warming up.
+ * MapGhostLayer — static HTML+CSS "ghost" of the world map rendered ABOVE the
+ * PixiJS canvas while WebGL is warming up, then fading out once pixiReady fires.
  *
  * Why: on iOS Safari (and other browsers that aggressively pause background
  * tabs), returning to the PWA goes through this sequence:
@@ -35,8 +44,6 @@ import worldMapBg from '../assets/world-map.png';
  * pixi-viewport's projection.
  */
 
-const MAP_WIDTH = 1086;
-const MAP_HEIGHT = 1448;
 const VIEWPORT_STORAGE_KEY = 'cw-viewport-v1';
 // Matches the same key derivation used by useCachedSnapshot.ts so the ghost
 // reads the exact same payload that the canvas will hydrate from.
@@ -50,58 +57,10 @@ const SNAPSHOT_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour (matches useCachedSnapshot
 // laggy. Keep in sync with the inline style transition below.
 const FADE_OUT_MS = 200;
 
-// Region centers in NORMALIZED world coords (REF_W/REF_H = MAP_WIDTH/MAP_HEIGHT).
-// Mirrors REGIONS[*].{nx, ny} in WorldMap.tsx. We keep a duplicate here so the
-// ghost can render without importing the much larger WorldMap module (and the
-// PixiJS bundle it pulls in) — that would defeat the "render before canvas"
-// goal. If the canonical REGIONS array moves, update this map alongside.
-const REGION_CENTERS_BY_KEY: Record<string, { nx: number; ny: number }> = {
-  'forest':       { nx: 280 / MAP_WIDTH, ny: 245 / MAP_HEIGHT },
-  'mountains':    { nx: 854 / MAP_WIDTH, ny: 245 / MAP_HEIGHT },
-  'unicorn-town': { nx: 482 / MAP_WIDTH, ny: 500 / MAP_HEIGHT },
-  'west-farms':   { nx: 280 / MAP_WIDTH, ny: 760 / MAP_HEIGHT },
-  'east-farms':   { nx: 834 / MAP_WIDTH, ny: 760 / MAP_HEIGHT },
-  'west-docks':   { nx: 293 / MAP_WIDTH, ny: 1115 / MAP_HEIGHT },
-  'east-docks':   { nx: 874 / MAP_WIDTH, ny: 1115 / MAP_HEIGHT },
-  'deep-sea':     { nx: 540 / MAP_WIDTH, ny: 1095 / MAP_HEIGHT },
-};
-
-// On-chain baseRegion id → region key. Mirrors LIVE_CLAN_REGION_BY_ID in
-// WorldMap.tsx. Same rationale as REGION_CENTERS_BY_KEY: we don't want to
-// import the WorldMap module from here.
-const LIVE_CLAN_REGION_BY_ID: Record<number, string> = {
-  1: 'forest',
-  2: 'mountains',
-  4: 'west-farms',
-  5: 'east-farms',
-  6: 'west-docks',
-  7: 'east-docks',
-};
-
-// Mirrors MOCK_CLANS / LIVE_CLAN_META in WorldMap.tsx — visual asset slot
-// indexed by the snapshot's clan order. Live mode assigns the first N
-// LIVE_CLAN_META entries to the first N on-chain clans, falling back to
-// MOCK_CLANS for any extras. We replicate the same logic here so the
-// rendered base sprite matches what PixiJS will draw post-warmup. Keys are
-// kept in array order to match `live.map((clan, index) => ...)`.
-const BASE_PNG_BY_VISUAL_INDEX: readonly string[] = [
-  '/bases/cobalt-keep.png',     // Iron Guard
-  '/bases/bone-standard.png',   // Ember Hand
-  '/bases/gilded-hold.png',     // Dawn Watch
-  '/bases/tide-wardens.png',    // Storm Riders
-  '/bases/cobalt-keep.png',     // Deployer Keep (uses iron's frame)
-];
-
-// Fallback home region by visual index — matches MOCK_CLANS' homeRegion when
-// the snapshot doesn't carry a baseRegion (defensive only; live snapshots
-// generally do).
-const FALLBACK_HOME_REGION_BY_INDEX: readonly string[] = [
-  'forest',
-  'mountains',
-  'west-farms',
-  'east-farms',
-  'forest',
-];
+// REGION_CENTERS_BY_KEY, LIVE_CLAN_REGION_BY_ID, BASE_PNG_BY_VISUAL_INDEX,
+// FALLBACK_HOME_REGION_BY_INDEX are imported from ./mapGeometry — the shared
+// pure-data module used by both the ghost and WorldMap.tsx. No PixiJS imports
+// allowed in that module (see its header comment).
 
 type GhostClan = {
   id: string;
@@ -184,6 +143,12 @@ type ViewportState = { cx: number; cy: number; scale: number };
  * malformed, fall back to fit-cover centered on the world — same default
  * pixi-viewport applies on cold init. We pass screen dimensions in so the
  * fallback scale matches what the canvas will compute.
+ *
+ * The saved scale is only accepted when it lies inside the same
+ * [initialFitScale, initialFitScale * 4] band that WorldMap.tsx enforces at
+ * L1742-1743. Outside that band pixi-viewport falls back to cold-init
+ * fit-cover, so the ghost must also fall back or they'd paint at different
+ * zoom levels and produce the exact snap this component is meant to prevent.
  */
 function readViewportState(screenW: number, screenH: number): ViewportState {
   const fitScale = Math.max(screenW / MAP_WIDTH, screenH / MAP_HEIGHT);
@@ -200,7 +165,8 @@ function readViewportState(screenW: number, screenH: number): ViewportState {
       typeof saved.cx === 'number' && Number.isFinite(saved.cx) &&
       typeof saved.cy === 'number' && Number.isFinite(saved.cy) &&
       typeof saved.scale === 'number' && Number.isFinite(saved.scale) &&
-      saved.scale > 0
+      saved.scale >= fitScale &&
+      saved.scale <= fitScale * 4
     ) {
       return { cx: saved.cx, cy: saved.cy, scale: saved.scale };
     }
@@ -317,9 +283,8 @@ export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
   // baseVisualScale mirrors the stepwise function in WorldMap.tsx (NOT a
   // linear formula): levels 1-2 → 0.675, 3-4 → 0.81, 5 → 0.9. Keep in sync.
   const baseSizeFor = (level: number): number => {
-    const lvl = Math.max(1, Math.min(5, Math.floor(level)));
-    const visualScale = lvl <= 2 ? 0.675 : lvl <= 4 ? 0.81 : 0.9;
-    return 101 * visualScale;
+    const lvl = clamp(Math.floor(level), 1, 5);
+    return 101 * _baseVisualScale(lvl);
   };
 
   return (

--- a/apps/web/src/components/MapGhostLayer.tsx
+++ b/apps/web/src/components/MapGhostLayer.tsx
@@ -234,12 +234,18 @@ export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
   // inset: 0 inside the same canvasWrapRef container, so its bounding-box
   // equals the canvas's bounding-box.
   const rootRef = useRef<HTMLDivElement>(null);
-  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+  // Init synchronously from window.innerWidth/Height so the first paint uses
+  // real screen dimensions instead of 0x0 (ResizeObserver fires post-paint).
+  const [dims, setDims] = useState<{ w: number; h: number }>(() => ({
+    w: typeof window !== 'undefined' ? (window.innerWidth || 1) : 1,
+    h: typeof window !== 'undefined' ? (window.innerHeight || 1) : 1,
+  }));
 
   useEffect(() => {
     const el = rootRef.current;
     if (!el) return;
-    // Initial measure
+    // Refine to the actual container dimensions once mounted (may differ from
+    // window dims if the map occupies a sub-region of the viewport).
     setDims({ w: el.clientWidth || 1, h: el.clientHeight || 1 });
     if (typeof ResizeObserver === 'undefined') return;
     const ro = new ResizeObserver(() => {
@@ -265,14 +271,16 @@ export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
       setFullyHidden(false);
       return;
     }
-    const t = window.setTimeout(() => setFullyHidden(true), FADE_OUT_MS);
+    // Add 50ms headroom above the CSS transition duration so the browser
+    // compositor always delivers the final opacity=0 frame before we unmount.
+    const t = window.setTimeout(() => setFullyHidden(true), FADE_OUT_MS + 50);
     return () => window.clearTimeout(t);
   }, [pixiReady]);
 
   if (fullyHidden) return null;
 
-  const screenW = dims?.w ?? 0;
-  const screenH = dims?.h ?? 0;
+  const screenW = dims.w;
+  const screenH = dims.h;
 
   // Compute viewport (cx, cy, scale) once per mount + when screen dims
   // settle. We don't subscribe to viewport changes during the ghost's
@@ -319,22 +327,18 @@ export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
       style={{
         position: 'absolute',
         inset: 0,
-        // Under the PixiJS canvas. WorldMap's Pixi init code pins the
-        // canvas at position: absolute; inset: 0; z-index: 1 (see
-        // app.canvas.style.* assignments around the appendChild call) —
-        // so this layer (z-index 0) stays beneath the canvas in the same
-        // stacking context. Without the explicit z-index on both, the
-        // absolutely-positioned ghost would paint OVER the
-        // statically-positioned canvas, defeating the swap.
-        zIndex: 0,
+        // ABOVE the PixiJS canvas. WorldMap pins the canvas at z-index: 1;
+        // we sit at z-index: 2 so the ghost is visible on every frame from
+        // mount until `pixiReady` triggers the fade-out. pointer-events: none
+        // (already set below) ensures the ghost never intercepts taps.
+        zIndex: 2,
         overflow: 'hidden',
         pointerEvents: 'none',
         background: '#1a2a1a', // matches PixiJS init background color
-        // Fade out + remove from layout once the canvas takes over.
+        // Fade out once the canvas takes over; unmount after transition
+        // (handled by the fullyHidden → return null above).
         opacity: pixiReady ? 0 : 1,
         transition: `opacity ${FADE_OUT_MS}ms ease-out`,
-        // Hide from a11y tree + remove from compositor work after fade.
-        visibility: pixiReady && fullyHidden ? 'hidden' : 'visible',
       }}
     >
       {/* World-space wrapper — applies the same projection pixi-viewport
@@ -359,7 +363,7 @@ export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
         <img
           src={worldMapBg}
           alt=""
-          decoding="async"
+          decoding="sync"
           draggable={false}
           style={{
             position: 'absolute',
@@ -367,10 +371,9 @@ export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
             left: 0,
             width: MAP_WIDTH,
             height: MAP_HEIGHT,
-            // Don't let img scaling interpolate weirdly while the canvas
-            // takes over — pixel-art-like crisp scaling matches the PixiJS
-            // Sprite which uses Nearest by default for the map.
-            imageRendering: 'auto',
+            // pixelated matches PixiJS's Nearest-filter rendering so there
+            // is no visual change when the canvas takes over.
+            imageRendering: 'pixelated',
             userSelect: 'none',
             // Prevent iOS Safari's long-press image menu from popping if
             // the ghost happens to be visible during the user's tap.

--- a/apps/web/src/components/MapGhostLayer.tsx
+++ b/apps/web/src/components/MapGhostLayer.tsx
@@ -1,0 +1,417 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import worldMapBg from '../assets/world-map.png';
+
+/**
+ * MapGhostLayer — static HTML+CSS "ghost" of the world map rendered UNDER the
+ * PixiJS canvas while WebGL is warming up.
+ *
+ * Why: on iOS Safari (and other browsers that aggressively pause background
+ * tabs), returning to the PWA goes through this sequence:
+ *
+ *   1. React mounts. (instant)
+ *   2. `useCachedSnapshot` hydrates from localStorage. (instant — PR #269)
+ *   3. PixiJS Application.init() — creates WebGL context, uploads textures,
+ *      builds the scene graph. ~500ms-1s on cold mobile Safari.
+ *   4. `pixiReady` flips true and the canvas paints its first frame.
+ *
+ * Between step 2 and step 4 the user sees a blank #1a2a1a background where
+ * the map should be. This component fills that gap with plain <img> tags
+ * (map background + clan base sprites) positioned using the same viewport
+ * (cx, cy, scale) state that pixi-viewport already persists to
+ * sessionStorage as `cw-viewport-v1`.
+ *
+ * The ghost is purely additive — it never touches the PixiJS pipeline and
+ * does not depend on Pixi being present. When `pixiReady` flips true the
+ * ghost fades out via CSS opacity + visibility and unmounts after the
+ * transition completes.
+ *
+ * Coordinate math (matches pixi-viewport's moveCenter + setZoom):
+ *
+ *   transform-origin: 0 0;
+ *   transform: translate(Sw/2, Sh/2) scale(s) translate(-cx, -cy);
+ *
+ * applied to children positioned at world coords (wx, wy) maps each child
+ * to screen coord (Sw/2 + (wx-cx)*s, Sh/2 + (wy-cy)*s) — identical to
+ * pixi-viewport's projection.
+ */
+
+const MAP_WIDTH = 1086;
+const MAP_HEIGHT = 1448;
+const VIEWPORT_STORAGE_KEY = 'cw-viewport-v1';
+// Matches the same key derivation used by useCachedSnapshot.ts so the ghost
+// reads the exact same payload that the canvas will hydrate from.
+const ENV_SCOPE = (import.meta.env.VITE_CONVEX_URL as string | undefined) ?? 'no-backend';
+const SNAPSHOT_CACHE_KEY = `cw-snapshot-v1:${ENV_SCOPE}`;
+const SNAPSHOT_PAYLOAD_VERSION = 1;
+const SNAPSHOT_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour (matches useCachedSnapshot)
+
+// Fade duration matches PixiJS's first-frame budget on mobile. Long enough
+// that the eye reads the swap as a cross-fade, short enough not to feel
+// laggy. Keep in sync with the inline style transition below.
+const FADE_OUT_MS = 200;
+
+// Region centers in NORMALIZED world coords (REF_W/REF_H = MAP_WIDTH/MAP_HEIGHT).
+// Mirrors REGIONS[*].{nx, ny} in WorldMap.tsx. We keep a duplicate here so the
+// ghost can render without importing the much larger WorldMap module (and the
+// PixiJS bundle it pulls in) — that would defeat the "render before canvas"
+// goal. If the canonical REGIONS array moves, update this map alongside.
+const REGION_CENTERS_BY_KEY: Record<string, { nx: number; ny: number }> = {
+  'forest':       { nx: 280 / MAP_WIDTH, ny: 245 / MAP_HEIGHT },
+  'mountains':    { nx: 854 / MAP_WIDTH, ny: 245 / MAP_HEIGHT },
+  'unicorn-town': { nx: 482 / MAP_WIDTH, ny: 500 / MAP_HEIGHT },
+  'west-farms':   { nx: 280 / MAP_WIDTH, ny: 760 / MAP_HEIGHT },
+  'east-farms':   { nx: 834 / MAP_WIDTH, ny: 760 / MAP_HEIGHT },
+  'west-docks':   { nx: 293 / MAP_WIDTH, ny: 1115 / MAP_HEIGHT },
+  'east-docks':   { nx: 874 / MAP_WIDTH, ny: 1115 / MAP_HEIGHT },
+  'deep-sea':     { nx: 540 / MAP_WIDTH, ny: 1095 / MAP_HEIGHT },
+};
+
+// On-chain baseRegion id → region key. Mirrors LIVE_CLAN_REGION_BY_ID in
+// WorldMap.tsx. Same rationale as REGION_CENTERS_BY_KEY: we don't want to
+// import the WorldMap module from here.
+const LIVE_CLAN_REGION_BY_ID: Record<number, string> = {
+  1: 'forest',
+  2: 'mountains',
+  4: 'west-farms',
+  5: 'east-farms',
+  6: 'west-docks',
+  7: 'east-docks',
+};
+
+// Mirrors MOCK_CLANS / LIVE_CLAN_META in WorldMap.tsx — visual asset slot
+// indexed by the snapshot's clan order. Live mode assigns the first N
+// LIVE_CLAN_META entries to the first N on-chain clans, falling back to
+// MOCK_CLANS for any extras. We replicate the same logic here so the
+// rendered base sprite matches what PixiJS will draw post-warmup. Keys are
+// kept in array order to match `live.map((clan, index) => ...)`.
+const BASE_PNG_BY_VISUAL_INDEX: readonly string[] = [
+  '/bases/cobalt-keep.png',     // Iron Guard
+  '/bases/bone-standard.png',   // Ember Hand
+  '/bases/gilded-hold.png',     // Dawn Watch
+  '/bases/tide-wardens.png',    // Storm Riders
+  '/bases/cobalt-keep.png',     // Deployer Keep (uses iron's frame)
+];
+
+// Fallback home region by visual index — matches MOCK_CLANS' homeRegion when
+// the snapshot doesn't carry a baseRegion (defensive only; live snapshots
+// generally do).
+const FALLBACK_HOME_REGION_BY_INDEX: readonly string[] = [
+  'forest',
+  'mountains',
+  'west-farms',
+  'east-farms',
+  'forest',
+];
+
+type GhostClan = {
+  id: string;
+  homeRegionKey: string;
+  basePng: string;
+  level: number;
+};
+
+type CachedSnapshotPayload = {
+  v: number;
+  ts: number;
+  data: {
+    clans?: Array<{
+      id?: string;
+      baseRegion?: number;
+      baseLevel?: number;
+      monumentLevel?: number;
+    }>;
+  };
+};
+
+/**
+ * Read the same cached snapshot localStorage entry that useCachedSnapshot
+ * writes — we need it synchronously at first render to avoid a flash between
+ * mount and the first useEffect tick. Mirrors that hook's validation logic
+ * exactly so a payload deemed invalid there is also ignored here.
+ */
+function readCachedClans(): GhostClan[] {
+  try {
+    const raw = localStorage.getItem(SNAPSHOT_CACHE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as CachedSnapshotPayload;
+    if (!parsed || typeof parsed.ts !== 'number') return [];
+    if (parsed.v !== SNAPSHOT_PAYLOAD_VERSION) return [];
+    if (Date.now() - parsed.ts > SNAPSHOT_MAX_AGE_MS) return [];
+    const clans = parsed.data?.clans;
+    if (!Array.isArray(clans) || clans.length === 0) return [];
+    const out: GhostClan[] = [];
+    for (let i = 0; i < clans.length; i++) {
+      const c = clans[i];
+      if (!c || typeof c.id !== 'string') continue;
+      const regionId = typeof c.baseRegion === 'number' ? c.baseRegion : 0;
+      const homeRegionKey =
+        LIVE_CLAN_REGION_BY_ID[regionId]
+        ?? FALLBACK_HOME_REGION_BY_INDEX[i]
+        ?? FALLBACK_HOME_REGION_BY_INDEX[0]!;
+      const basePng =
+        BASE_PNG_BY_VISUAL_INDEX[i]
+        ?? BASE_PNG_BY_VISUAL_INDEX[i % BASE_PNG_BY_VISUAL_INDEX.length]
+        ?? BASE_PNG_BY_VISUAL_INDEX[0]!;
+      const level = clamp(c.baseLevel ?? c.monumentLevel ?? 1, 1, 5);
+      out.push({ id: c.id, homeRegionKey, basePng, level });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  if (!Number.isFinite(n)) return lo;
+  return Math.max(lo, Math.min(hi, n));
+}
+
+/**
+ * Append the level suffix to a base PNG path, mirroring `levelBasePng` in
+ * WorldMap.tsx so the ghost sprite uses the same upgraded variant the canvas
+ * will render. Levels are clamped to the 1-5 range that the asset library
+ * actually ships.
+ */
+function levelBasePng(basePng: string, level: number): string {
+  const clamped = clamp(level, 1, 5);
+  return basePng.replace(/(?:-lv[1-5])?\.png$/, `-lv${clamped}.png`);
+}
+
+type ViewportState = { cx: number; cy: number; scale: number };
+
+/**
+ * Read the persisted (cx, cy, scale) the user last sat at. If absent or
+ * malformed, fall back to fit-cover centered on the world — same default
+ * pixi-viewport applies on cold init. We pass screen dimensions in so the
+ * fallback scale matches what the canvas will compute.
+ */
+function readViewportState(screenW: number, screenH: number): ViewportState {
+  const fitScale = Math.max(screenW / MAP_WIDTH, screenH / MAP_HEIGHT);
+  const fallback: ViewportState = {
+    cx: MAP_WIDTH / 2,
+    cy: MAP_HEIGHT / 2,
+    scale: fitScale,
+  };
+  try {
+    const raw = sessionStorage.getItem(VIEWPORT_STORAGE_KEY);
+    if (!raw) return fallback;
+    const saved = JSON.parse(raw) as Partial<ViewportState>;
+    if (
+      typeof saved.cx === 'number' && Number.isFinite(saved.cx) &&
+      typeof saved.cy === 'number' && Number.isFinite(saved.cy) &&
+      typeof saved.scale === 'number' && Number.isFinite(saved.scale) &&
+      saved.scale > 0
+    ) {
+      return { cx: saved.cx, cy: saved.cy, scale: saved.scale };
+    }
+  } catch {
+    // ignore — fall through to fit-cover
+  }
+  return fallback;
+}
+
+interface MapGhostLayerProps {
+  /**
+   * The same `pixiReady` boolean that WorldMap flips true once PixiJS has
+   * finished init + first relayout. When true, the ghost fades out and
+   * unmounts after the transition completes.
+   */
+  pixiReady: boolean;
+}
+
+export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
+  // Read cached clans ONCE per mount. We don't subscribe to live snapshot
+  // updates because (a) the canvas will take over within a frame or two
+  // anyway and (b) re-renders on every Convex tick would defeat the
+  // "static / cheap" goal of this layer. If the user is on a cold mount
+  // with empty cache, this returns [] and we render the map background
+  // only (the 5s grace-period placeholder from PR #269 handles that case).
+  const cachedClans = useMemo(() => readCachedClans(), []);
+
+  // Match the wrapper's pixel dimensions so the projection math uses real
+  // screen coords (the same dims pixi-viewport's screenWidth/Height see).
+  // We use the parent container as the reference — the ghost is positioned
+  // inset: 0 inside the same canvasWrapRef container, so its bounding-box
+  // equals the canvas's bounding-box.
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    // Initial measure
+    setDims({ w: el.clientWidth || 1, h: el.clientHeight || 1 });
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => {
+      // clientWidth/Height return CSS pixels — which is exactly the
+      // coordinate space pixi-viewport's screenWidth/screenHeight use
+      // (autoDensity:true makes Pixi treat resolution internally).
+      setDims({ w: el.clientWidth || 1, h: el.clientHeight || 1 });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // After pixiReady flips true, hold the ghost mounted just long enough
+  // for the CSS opacity transition to complete, then unmount entirely so
+  // we don't pay any layout cost for an invisible layer. Mirrors the
+  // FADE_OUT_MS constant above.
+  const [fullyHidden, setFullyHidden] = useState(false);
+  useEffect(() => {
+    if (!pixiReady) {
+      // Re-entry / hot-reload safety: if pixiReady ever flips back to false
+      // (e.g. WebGL context loss recovery in a future iteration), make sure
+      // the ghost is visible again.
+      setFullyHidden(false);
+      return;
+    }
+    const t = window.setTimeout(() => setFullyHidden(true), FADE_OUT_MS);
+    return () => window.clearTimeout(t);
+  }, [pixiReady]);
+
+  if (fullyHidden) return null;
+
+  const screenW = dims?.w ?? 0;
+  const screenH = dims?.h ?? 0;
+
+  // Compute viewport (cx, cy, scale) once per mount + when screen dims
+  // settle. We don't subscribe to viewport changes during the ghost's
+  // lifetime — it's only on-screen for ~500ms and the user can't pan a
+  // canvas that hasn't rendered yet.
+  const viewport = useMemo(
+    () => readViewportState(screenW || 1, screenH || 1),
+    [screenW, screenH],
+  );
+
+  // CSS transform that mirrors pixi-viewport's moveCenter(cx,cy) + setZoom(s).
+  // transform-origin defaults to 50% 50% — we explicitly set 0 0 below so
+  // the math collapses to (translate Sw/2,Sh/2) (scale s) (translate -cx,-cy).
+  const transform =
+    `translate(${screenW / 2}px, ${screenH / 2}px) ` +
+    `scale(${viewport.scale}) ` +
+    `translate(${-viewport.cx}px, ${-viewport.cy}px)`;
+
+  // Match Pixi's base size formula:
+  //   baseSize = Math.max(67, 101 * cappedSizeScale) * baseVisualScale(level)
+  // where cappedSizeScale = min(scaleX, scaleY, 1.4) and scaleX/Y =
+  // screen/world. The ghost is rendered in WORLD-pixel coords (the transform
+  // above does the scaling), so we want the WORLD-pixel size of the sprite,
+  // which is what Pixi sets entry.sprite.width/height to before the viewport
+  // scales it for display. So we compute the same baseSize here but in
+  // world-pixel units — independent of screenW/screenH. The only screen-size
+  // dependency is the `cappedSizeScale` cap (1.4) — but since relayout runs
+  // at WORLD_WIDTH x WORLD_HEIGHT (see relayout call in WorldMap.tsx around
+  // L2172), scaleX = scaleY = 1 and cappedSizeScale = 1. So baseSize here is
+  // simply max(67, 101) * levelScale = 101 * levelScale — same as canvas.
+  //
+  // baseVisualScale mirrors the stepwise function in WorldMap.tsx (NOT a
+  // linear formula): levels 1-2 → 0.675, 3-4 → 0.81, 5 → 0.9. Keep in sync.
+  const baseSizeFor = (level: number): number => {
+    const lvl = Math.max(1, Math.min(5, Math.floor(level)));
+    const visualScale = lvl <= 2 ? 0.675 : lvl <= 4 ? 0.81 : 0.9;
+    return 101 * visualScale;
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        // Under the PixiJS canvas. WorldMap's Pixi init code pins the
+        // canvas at position: absolute; inset: 0; z-index: 1 (see
+        // app.canvas.style.* assignments around the appendChild call) —
+        // so this layer (z-index 0) stays beneath the canvas in the same
+        // stacking context. Without the explicit z-index on both, the
+        // absolutely-positioned ghost would paint OVER the
+        // statically-positioned canvas, defeating the swap.
+        zIndex: 0,
+        overflow: 'hidden',
+        pointerEvents: 'none',
+        background: '#1a2a1a', // matches PixiJS init background color
+        // Fade out + remove from layout once the canvas takes over.
+        opacity: pixiReady ? 0 : 1,
+        transition: `opacity ${FADE_OUT_MS}ms ease-out`,
+        // Hide from a11y tree + remove from compositor work after fade.
+        visibility: pixiReady && fullyHidden ? 'hidden' : 'visible',
+      }}
+    >
+      {/* World-space wrapper — applies the same projection pixi-viewport
+          uses. Anything positioned at (wx, wy) in WORLD coords lands at the
+          right pixel on screen. transform-origin: 0 0 makes the math
+          collapse to (translate Sw/2,Sh/2)(scale s)(translate -cx,-cy). */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: MAP_WIDTH,
+          height: MAP_HEIGHT,
+          transformOrigin: '0 0',
+          transform,
+          // Hint to the browser to compositor-promote this subtree so the
+          // background image upload happens off the main thread. Without
+          // this, large bitmaps can synchronously decode on first paint.
+          willChange: 'transform',
+        }}
+      >
+        <img
+          src={worldMapBg}
+          alt=""
+          decoding="async"
+          draggable={false}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: MAP_WIDTH,
+            height: MAP_HEIGHT,
+            // Don't let img scaling interpolate weirdly while the canvas
+            // takes over — pixel-art-like crisp scaling matches the PixiJS
+            // Sprite which uses Nearest by default for the map.
+            imageRendering: 'auto',
+            userSelect: 'none',
+            // Prevent iOS Safari's long-press image menu from popping if
+            // the ghost happens to be visible during the user's tap.
+            WebkitTouchCallout: 'none',
+          }}
+        />
+
+        {/* Clan base sprites — only when we have a non-empty cached
+            snapshot. First-ever-visit (no cache) just shows the map bg,
+            then the grace-period placeholder from PR #269 appears after
+            5s if chain data still hasn't arrived. */}
+        {cachedClans.map((clan) => {
+          const region = REGION_CENTERS_BY_KEY[clan.homeRegionKey];
+          if (!region) return null;
+          const cx = region.nx * MAP_WIDTH;
+          const cy = region.ny * MAP_HEIGHT;
+          const size = baseSizeFor(clan.level);
+          const baseY = cy + size * 0.15; // matches entry.baseY in WorldMap relayout
+          const src = levelBasePng(clan.basePng, clan.level);
+          return (
+            <img
+              key={clan.id}
+              src={src}
+              alt=""
+              decoding="async"
+              draggable={false}
+              style={{
+                position: 'absolute',
+                // anchor.set(0.5, 1) in Pixi = bottom-center. We translate
+                // from top-left so subtract half-width + full-height.
+                left: cx - size / 2,
+                top: baseY - size,
+                width: size,
+                height: size,
+                userSelect: 'none',
+                WebkitTouchCallout: 'none',
+              }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/MapGhostLayer.tsx
+++ b/apps/web/src/components/MapGhostLayer.tsx
@@ -277,8 +277,6 @@ export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
     return () => window.clearTimeout(t);
   }, [pixiReady]);
 
-  if (fullyHidden) return null;
-
   const screenW = dims.w;
   const screenH = dims.h;
 
@@ -286,10 +284,14 @@ export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
   // settle. We don't subscribe to viewport changes during the ghost's
   // lifetime — it's only on-screen for ~500ms and the user can't pan a
   // canvas that hasn't rendered yet.
+  // NOTE: must stay above the `if (fullyHidden) return null` guard so
+  // the hook call count is constant across renders (Rules of Hooks).
   const viewport = useMemo(
     () => readViewportState(screenW || 1, screenH || 1),
     [screenW, screenH],
   );
+
+  if (fullyHidden) return null;
 
   // CSS transform that mirrors pixi-viewport's moveCenter(cx,cy) + setZoom(s).
   // transform-origin defaults to 50% 50% — we explicitly set 0 0 below so

--- a/apps/web/src/components/mapGeometry.ts
+++ b/apps/web/src/components/mapGeometry.ts
@@ -1,0 +1,80 @@
+/**
+ * mapGeometry — pure-data / pure-function constants shared between
+ * WorldMap.tsx (PixiJS canvas) and MapGhostLayer.tsx (static HTML ghost).
+ *
+ * IMPORTANT: this module must remain PixiJS-free. It must never import from
+ * `pixi.js`, `@pixi/*`, `pixi-viewport`, or any file that transitively pulls
+ * in those packages. The whole point is that MapGhostLayer can import these
+ * constants without dragging the PixiJS bundle into its own chunk.
+ */
+
+// ---------------------------------------------------------------------------
+// World dimensions
+// ---------------------------------------------------------------------------
+
+export const MAP_WIDTH = 1086;
+export const MAP_HEIGHT = 1448;
+
+// ---------------------------------------------------------------------------
+// Region centers (normalised world coords)
+// Mirrors REGIONS[*].{nx, ny} in WorldMap.tsx.
+// ---------------------------------------------------------------------------
+
+export const REGION_CENTERS_BY_KEY: Readonly<Record<string, { nx: number; ny: number }>> = {
+  'forest':       { nx: 280 / MAP_WIDTH, ny: 245 / MAP_HEIGHT },
+  'mountains':    { nx: 854 / MAP_WIDTH, ny: 245 / MAP_HEIGHT },
+  'unicorn-town': { nx: 482 / MAP_WIDTH, ny: 500 / MAP_HEIGHT },
+  'west-farms':   { nx: 280 / MAP_WIDTH, ny: 760 / MAP_HEIGHT },
+  'east-farms':   { nx: 834 / MAP_WIDTH, ny: 760 / MAP_HEIGHT },
+  'west-docks':   { nx: 293 / MAP_WIDTH, ny: 1115 / MAP_HEIGHT },
+  'east-docks':   { nx: 874 / MAP_WIDTH, ny: 1115 / MAP_HEIGHT },
+  'deep-sea':     { nx: 540 / MAP_WIDTH, ny: 1095 / MAP_HEIGHT },
+};
+
+// ---------------------------------------------------------------------------
+// On-chain baseRegion id → region key
+// Mirrors LIVE_CLAN_REGION_BY_ID in WorldMap.tsx.
+// ---------------------------------------------------------------------------
+
+export const LIVE_CLAN_REGION_BY_ID: Readonly<Record<number, string>> = {
+  1: 'forest',
+  2: 'mountains',
+  4: 'west-farms',
+  5: 'east-farms',
+  6: 'west-docks',
+  7: 'east-docks',
+};
+
+// ---------------------------------------------------------------------------
+// Base PNG paths by visual index
+// Mirrors MOCK_CLANS / LIVE_CLAN_META in WorldMap.tsx.
+// ---------------------------------------------------------------------------
+
+export const BASE_PNG_BY_VISUAL_INDEX: readonly string[] = [
+  '/bases/cobalt-keep.png',     // Iron Guard
+  '/bases/bone-standard.png',   // Ember Hand
+  '/bases/gilded-hold.png',     // Dawn Watch
+  '/bases/tide-wardens.png',    // Storm Riders
+  '/bases/cobalt-keep.png',     // Deployer Keep (uses iron's frame)
+];
+
+// Fallback home region by visual index — matches MOCK_CLANS' homeRegion when
+// the snapshot doesn't carry a baseRegion (defensive only; live snapshots
+// generally do).
+export const FALLBACK_HOME_REGION_BY_INDEX: readonly string[] = [
+  'forest',
+  'mountains',
+  'west-farms',
+  'east-farms',
+  'forest',
+];
+
+// ---------------------------------------------------------------------------
+// Visual scale step function
+// Mirrors the stepwise formula in WorldMap.tsx (NOT a linear function).
+// Levels 1-2 → 0.675, 3-4 → 0.81, 5 → 0.9. Keep in sync.
+// ---------------------------------------------------------------------------
+
+export function baseVisualScale(level: number): number {
+  return level <= 2 ? 0.675 : level <= 4 ? 0.81 : 0.9;
+}


### PR DESCRIPTION
## Summary

Mounts a static HTML+CSS \"ghost\" of the map UNDER the PixiJS canvas on cold load. Renders the cached map BG + clan bases as plain `<img>` tags using the snapshot + viewport state already persisted by PR #269. Fades out (200ms) once PixiJS dispatches its existing `pixiReady` signal.

**Net effect on iOS Safari PWA return:** zero-millisecond perceived first paint instead of the ~500ms–1s WebGL warmup gap that PR #269 could not address (it fixed the data flash; this fixes the canvas flash).

## Approach

Implements **Option D** from the recent design audit. Two parallel DA reviews (codex + gemini-pro) both ranked D 1st out of 4 candidate approaches.

- New: `apps/web/src/components/MapGhostLayer.tsx`
- Modified: `apps/web/src/WorldMap.tsx`
  - Imports + renders `<MapGhostLayer pixiReady={pixiReady} />` inside the existing `canvasWrapRef` div.
  - Pins the Pixi canvas as `position: absolute; inset: 0; z-index: 1` so the absolutely-positioned ghost (z-index 0) sits beneath it in the same stacking context. Without explicit z-index on both children, the absolutely-positioned ghost would paint OVER the static-positioned canvas, defeating the swap.
  - Trivial pre-existing typecheck fix: `REGIONS[i].polygon` possibly-undefined guard at line 4058 (was failing `pnpm typecheck` + `pnpm build` on `dev` HEAD; needed green to verify this PR).

### Coordinate math

CSS transform mirrors `pixi-viewport.moveCenter(cx, cy)` + `setZoom(scale)`:

```css
transform-origin: 0 0;
transform: translate(Sw/2, Sh/2) scale(s) translate(-cx, -cy);
```

applied to a wrapper containing children in WORLD-pixel coords. Maps each child at `(wx, wy)` to screen `(Sw/2 + (wx-cx)*s, Sh/2 + (wy-cy)*s)` — identical to pixi-viewport's projection.

### Reads the same state the canvas reads

- `cw-snapshot-v1:${VITE_CONVEX_URL}` from localStorage (same key derivation as `useCachedSnapshot.ts`, same validation: v=1, ts within 1h, `clans[]` non-empty).
- `cw-viewport-v1` from sessionStorage. Falls back to fit-cover (matches Pixi's cold-init default) if absent.

### Static, additive, non-invasive

- Does NOT touch the PixiJS rendering pipeline.
- Does NOT re-subscribe to Convex (no per-tick re-renders).
- Does NOT modify `useCachedSnapshot.ts` or the grace-period logic.
- Reads cached clans ONCE per mount; the ghost is only on screen for ~500ms.

## Blind spots from DA — addressed

- **DPI** (gemini-pro): cached `(cx, cy, scale)` are in CSS-pixel space because pixi-viewport's API works in stage coords (not device). The HTML layer is also in CSS-pixel space. No conversion needed.
- **Asset path** (codex): map background imported as a Vite asset (`import worldMapBg from '../assets/world-map.png'`) → hashed URL → HTTP-cached with content hash. NOT moved to `public/`.
- **Coordinate sync** (both): the ghost uses the same `(cx, cy, scale)` triple that pixi-viewport persisted, so when Pixi takes over there's no visual snap. Fit-cover fallback matches Pixi's cold-init `initialFitScale`.
- **Stepwise base-size formula** (caught during impl): `baseVisualScale` in `WorldMap.tsx` is stepwise (1-2 → 0.675, 3-4 → 0.81, 5 → 0.9), not linear. Mirrored exactly in `MapGhostLayer.tsx`.

## Trade-offs / deferred

- **No `<link rel=\"preload\">` for the map background.** Vite hashes the asset URL so a static preload tag in `index.html` needs a build-time plugin (`vite-plugin-preload`) or a `transformIndexHtml` hook. Deferred — relying on browser HTTP cache is the cheapest path for v1. Filed as follow-up.
- **REGIONS / clan metadata duplicated** in `MapGhostLayer.tsx`. The alternative — importing from `WorldMap.tsx` — would pull in the PixiJS bundle through `WorldMap`'s top-level imports, defeating the \"render before canvas-bundle parses\" goal. The duplicates are flagged inline with \"keep in sync\" notes.

## Verification

- `pnpm install` — clean.
- `pnpm --filter @clan-world/web typecheck` — passes (was failing pre-existing TS2532 on `dev`, fixed inline).
- `pnpm --filter @clan-world/web build` — passes, no new chunks, no new bundle warnings.

## Test plan

- [ ] Hard refresh on `/`: ghost visible briefly (~hundreds of ms on a cold WebGL init), then fades as PixiJS takes over with no visual snap.
- [ ] Zoom in, refresh: ghost renders at the saved zoom (not fit-cover) so the swap to canvas is positionally invariant.
- [ ] iOS Safari PWA: background the tab for 30+ seconds, return — perceived first paint should be instantaneous (cached BG + bases visible) instead of black + delayed WebGL init.
- [ ] First-ever visit (clear storage): ghost shows only the map background (no bases). The PR #269 grace-period placeholder appears after 5s as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)