### PR TITLE
fix(web): iOS Safari viewport + PWA safe-area for cockpit collapse toggle

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -21,7 +21,7 @@ class CockpitErrorBoundary extends Component<{ children: ReactNode }, { hasError
           style={{
             background: '#0a0a0a',
             width: '100vw',
-            height: '100vh',
+            height: '100dvh',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -129,7 +129,7 @@ function MainApp() {
       style={{
         background: '#0a0a0a',
         width: '100vw',
-        height: '100vh',
+        height: '100dvh',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -18,10 +18,10 @@ class CockpitErrorBoundary extends Component<{ children: ReactNode }, { hasError
     if (this.state.hasError) {
       return (
         <main
+          className="cw-fullheight"
           style={{
             background: '#0a0a0a',
             width: '100vw',
-            height: '100dvh',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -126,10 +126,10 @@ export function App() {
 function MainApp() {
   return (
     <main
+      className="cw-fullheight"
       style={{
         background: '#0a0a0a',
         width: '100vw',
-        height: '100dvh',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',

--- a/apps/web/src/components/cockpit/MobileCockpitLayout.tsx
+++ b/apps/web/src/components/cockpit/MobileCockpitLayout.tsx
@@ -265,7 +265,7 @@ function CollapseToggle({ collapsed, onToggle, accent }: CollapseToggleProps) {
       aria-expanded={!collapsed}
       style={{
         position: 'absolute',
-        bottom: 'calc(8px + env(safe-area-inset-bottom))',
+        bottom: '8px',
         left: '50%',
         transform: 'translateX(-50%)',
         height: '28px',

--- a/apps/web/src/components/cockpit/MobileCockpitLayout.tsx
+++ b/apps/web/src/components/cockpit/MobileCockpitLayout.tsx
@@ -265,7 +265,7 @@ function CollapseToggle({ collapsed, onToggle, accent }: CollapseToggleProps) {
       aria-expanded={!collapsed}
       style={{
         position: 'absolute',
-        bottom: '8px',
+        bottom: 'calc(8px + env(safe-area-inset-bottom))',
         left: '50%',
         transform: 'translateX(-50%)',
         height: '28px',

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -74,7 +74,7 @@ if (!convexUrl && !isStandalonePath) {
     <main
       style={{
         background: '#0d1a0d',
-        minHeight: '100vh',
+        minHeight: '100dvh',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ConvexProvider, ConvexReactClient } from 'convex/react';
 import { App } from './App';
+import './styles/viewport.css';
 
 // Telegram Mini App fullscreen: hide the platform top chrome (the bar that
 // shows the app title + V down-arrow). Available in Telegram Mini App API
@@ -72,9 +73,9 @@ if (!convexUrl && !isStandalonePath) {
   console.error('VITE_CONVEX_URL is not set — rendering degraded fallback');
   root.render(
     <main
+      className="cw-fullheight-min"
       style={{
         background: '#0d1a0d',
-        minHeight: '100dvh',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',

--- a/apps/web/src/pages/Cockpit.tsx
+++ b/apps/web/src/pages/Cockpit.tsx
@@ -41,7 +41,8 @@ export function Cockpit() {
       style={{
         background: tokens.bg.void,
         width: '100vw',
-        height: '100vh',
+        height: '100dvh',
+        paddingBottom: 'env(safe-area-inset-bottom)',
         overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',

--- a/apps/web/src/pages/Cockpit.tsx
+++ b/apps/web/src/pages/Cockpit.tsx
@@ -42,7 +42,7 @@ export function Cockpit() {
       style={{
         background: tokens.bg.void,
         width: '100vw',
-        paddingBottom: 'env(safe-area-inset-bottom)',
+        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
         boxSizing: 'border-box',
         overflow: 'hidden',
         display: 'flex',

--- a/apps/web/src/pages/Cockpit.tsx
+++ b/apps/web/src/pages/Cockpit.tsx
@@ -38,11 +38,12 @@ export function Cockpit() {
   return (
     <main
       data-testid="cockpit-root"
+      className="cw-fullheight"
       style={{
         background: tokens.bg.void,
         width: '100vw',
-        height: '100dvh',
         paddingBottom: 'env(safe-area-inset-bottom)',
+        boxSizing: 'border-box',
         overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',

--- a/apps/web/src/pages/OwnerEditor.tsx
+++ b/apps/web/src/pages/OwnerEditor.tsx
@@ -230,7 +230,7 @@ export function OwnerEditor() {
   return (
     <main
       style={{
-        minHeight: '100vh',
+        minHeight: '100dvh',
         background: '#15120e',
         color: '#f2ead8',
         fontFamily: '"Inter", system-ui, sans-serif',

--- a/apps/web/src/pages/OwnerEditor.tsx
+++ b/apps/web/src/pages/OwnerEditor.tsx
@@ -229,8 +229,8 @@ export function OwnerEditor() {
 
   return (
     <main
+      className="cw-fullheight-min"
       style={{
-        minHeight: '100dvh',
         background: '#15120e',
         color: '#f2ead8',
         fontFamily: '"Inter", system-ui, sans-serif',

--- a/apps/web/src/styles/viewport.css
+++ b/apps/web/src/styles/viewport.css
@@ -1,0 +1,18 @@
+/**
+ * Viewport height utility classes with dvh fallback.
+ *
+ * `100dvh` is supported from iOS Safari 15.4 and Chrome 108.
+ * Older browsers silently drop the property leaving the element with
+ * 0 height. These classes cascade the fallback first so browsers that
+ * understand `100dvh` override the `100vh` declaration.
+ */
+
+.cw-fullheight {
+  height: 100vh;   /* fallback: iOS Safari ≤15.3, Chrome ≤107 */
+  height: 100dvh;  /* iOS 15.4+, Chrome 108+ */
+}
+
+.cw-fullheight-min {
+  min-height: 100vh;   /* fallback: iOS Safari ≤15.3, Chrome ≤107 */
+  min-height: 100dvh;  /* iOS 15.4+, Chrome 108+ */
+}


### PR DESCRIPTION
## Summary

Two compounding bugs made the cockpit's collapse toggle uncatchable on iOS — content extending behind the Safari bottom toolbar in normal Safari, and tapping inside the home-indicator gesture zone in PWA mode.

## Root cause (both at once)

1. **`height: 100vh` on iOS Safari.** Returns the LARGEST possible viewport (URL bar hidden), so when the URL bar is visible the content overflows behind the bottom toolbar where Safari intercepts taps. Fix: `100dvh` (dynamic viewport height; iOS 15.4+). Precedent: `apps/web/src/pages/agent/AgentControlPage.tsx` already used `100dvh` correctly.
2. **`viewport-fit=cover` + `apple-mobile-web-app-status-bar-style=black-translucent` + no safe-area padding.** In PWA mode there's no Safari toolbar, but the home-indicator gesture area at the bottom is still "unsafe" — iOS intercepts touches there as system swipe-up gestures, blocking onClick. The `CollapseToggle` sits at `bottom: 8px` of its parent, which lands inside the gesture zone when collapsed.

## Fixes (belt-and-suspenders)

1. `100vh` -> `100dvh` in 4 files: `Cockpit.tsx`, `App.tsx` (x2), `main.tsx`, `OwnerEditor.tsx`.
2. `paddingBottom: env(safe-area-inset-bottom)` on cockpit-root `<main>`.
3. `CollapseToggle` `bottom: calc(8px + env(safe-area-inset-bottom))` so the toggle is never inside the gesture zone, even if the parent's safe-area padding is overridden somewhere.

The meta tags (`viewport-fit=cover`, `apple-mobile-web-app-status-bar-style=black-translucent`) are intentionally unchanged — they drive the iOS PWA look.

## Files touched

- `apps/web/src/pages/Cockpit.tsx` (lines 44-45) — `100vh -> 100dvh` + `paddingBottom: env(safe-area-inset-bottom)`
- `apps/web/src/App.tsx` (lines 24, 132) — `100vh -> 100dvh` in error boundary + MainApp shell
- `apps/web/src/main.tsx` (line 77) — `minHeight: 100vh -> 100dvh`
- `apps/web/src/pages/OwnerEditor.tsx` (line 233) — `minHeight: 100vh -> 100dvh`
- `apps/web/src/components/cockpit/MobileCockpitLayout.tsx` (line 268) — `CollapseToggle` bottom uses `calc(8px + env(safe-area-inset-bottom))`

## Verification

- `pnpm --filter @clan-world/web typecheck` — passing
- `pnpm --filter @clan-world/web build` — passing (vite 5.4.11, 6.11s)
- No remaining `100vh` in `apps/web/src/`
- `WorldMap.tsx` canvas-sizing reads `wrap.clientHeight` (lines 1503, 1625, 2346) — these auto-pick up the new dvh-driven container height; no changes needed.

## Out of scope (flagged for follow-up)

- `apps/web/src/components/MapGhostLayer.tsx:207` uses `window.innerHeight` for ghost-layer sizing. On iOS Safari this returns the LARGEST viewport (same bug class). Per the brief I did not fix it here — flagging it.

## Test plan

- [ ] Liam: open ClanWorld in iOS Safari (non-PWA, URL bar visible). The collapse toggle should be tappable above the Safari bottom toolbar.
- [ ] Liam: install to home screen + open as PWA. The collapse toggle should sit above the home-indicator gesture zone.
- [ ] Liam: spot-check desktop Chrome / Firefox — no visible regression (desktop browsers honor `100dvh` like `100vh` since there's no dynamic toolbar).
- [ ] Liam: spot-check OwnerEditor + auth/landing routes for any obvious height regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)