### PR TITLE
fix(web): PR #272 super-swarm prerelease blockers

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -55,6 +55,16 @@ VITE_CLAN_WORLD_USE_STUB_LLM=true
 # Convex/chain state.
 VITE_CLANWORLD_DEMO_MODE=false
 
+# Diamond address realm-discriminator for client-side caches. Mirrors the
+# server-side `CLAN_WORLD_CONTRACT_ADDRESS` above and SHOULD be set to the
+# SAME value. Used to scope `localStorage` snapshot caches per realm so that
+# the full-game-reset runbook (docs/runbooks/full-game-reset.md) — which
+# redeploys the diamond while reusing the same Convex URL — doesn't leak the
+# old realm's cached state into the new realm for up to 1 hour after reset.
+# Vercel: set this per-environment (preview/prod) so each deployment scopes
+# its localStorage to its own realm.
+VITE_CLAN_WORLD_CONTRACT_ADDRESS=
+
 # ============================================================
 # Runner daemon (packages/runner) — Cycle A + Cycle B per Elder
 # ============================================================

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -9,6 +9,15 @@
 # Convex backend URL
 VITE_CONVEX_URL=
 
+# Diamond address realm-discriminator for client-side caches. Mirrors the
+# server-side `CLAN_WORLD_CONTRACT_ADDRESS` and SHOULD be set to the SAME
+# value. Used to scope `localStorage` snapshot caches per realm so that the
+# full-game-reset runbook (docs/runbooks/full-game-reset.md) — which
+# redeploys the diamond while reusing the same Convex URL — doesn't leak the
+# old realm's cached state into the new realm for up to 1 hour after reset.
+# Vercel: set per-environment (preview/prod).
+VITE_CLAN_WORLD_CONTRACT_ADDRESS=
+
 # Demo/dev mode is opt-in.
 # true = show mock clans, bandits, walls, canned travel (dev UX preserved)
 # false/unset = render real Convex/chain state; empty world stays empty

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -36,9 +36,11 @@ const WORLD_HEIGHT = MAP_HEIGHT;
 
 // Debug overlay: render REGIONS[*].polygon as a colored fill + stroke so the
 // hand-tuned region polygons are visible against the new map background. Lets
-// us iterate the polygon coords visually with the map in view. Flip OFF for
-// release; ON during region authoring / map redesigns.
-const SHOW_REGION_POLYGONS = true;
+// us iterate the polygon coords visually with the map in view. Gated to
+// `pnpm dev` only via `import.meta.env.DEV` so production builds never ship
+// the debug fills + raw (x,y) vertex labels, while keeping the tooling on
+// for future region authoring / map redesigns.
+const SHOW_REGION_POLYGONS = import.meta.env.DEV;
 
 // Winter map-overlay fade timings. The base map (`world-map.png`) stays fully
 // opaque at all times; we modulate the alpha of a second Sprite

--- a/apps/web/src/components/MapGhostLayer.tsx
+++ b/apps/web/src/components/MapGhostLayer.tsx
@@ -9,6 +9,11 @@ import {
   FALLBACK_HOME_REGION_BY_INDEX,
   baseVisualScale as _baseVisualScale,
 } from './mapGeometry';
+import {
+  CACHE_KEY as SNAPSHOT_CACHE_KEY,
+  PAYLOAD_VERSION as SNAPSHOT_PAYLOAD_VERSION,
+  MAX_CACHE_AGE_MS as SNAPSHOT_MAX_AGE_MS,
+} from '../hooks/snapshotCacheConstants';
 
 /**
  * MapGhostLayer — static HTML+CSS "ghost" of the world map rendered ABOVE the
@@ -45,12 +50,10 @@ import {
  */
 
 const VIEWPORT_STORAGE_KEY = 'cw-viewport-v1';
-// Matches the same key derivation used by useCachedSnapshot.ts so the ghost
-// reads the exact same payload that the canvas will hydrate from.
-const ENV_SCOPE = (import.meta.env.VITE_CONVEX_URL as string | undefined) ?? 'no-backend';
-const SNAPSHOT_CACHE_KEY = `cw-snapshot-v1:${ENV_SCOPE}`;
-const SNAPSHOT_PAYLOAD_VERSION = 1;
-const SNAPSHOT_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour (matches useCachedSnapshot)
+// Snapshot cache key / payload version / max age are imported from the shared
+// `hooks/snapshotCacheConstants` module so the ghost reads the EXACT same
+// payload that `useCachedSnapshot` writes. Previously these were duplicated
+// here — a schema-migration footgun if PAYLOAD_VERSION ever drifted.
 
 // Fade duration matches PixiJS's first-frame budget on mobile. Long enough
 // that the eye reads the swap as a cross-fade, short enough not to feel

--- a/apps/web/src/hooks/snapshotCacheConstants.ts
+++ b/apps/web/src/hooks/snapshotCacheConstants.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared cache key + payload-version + max-age constants for the WorldMap
+ * snapshot localStorage cache. Imported by BOTH `useCachedSnapshot.ts` (the
+ * hook that writes the cache) and `components/MapGhostLayer.tsx` (the static
+ * ghost that reads it before PixiJS warms up).
+ *
+ * Why a shared module: these constants were previously duplicated across the
+ * two files. If `PAYLOAD_VERSION` were bumped in the hook for a schema
+ * migration but not in the ghost, the ghost would read stale data as if it
+ * matched the new shape — silent corruption with no runtime error. Extracting
+ * to one source of truth eliminates that drift hazard.
+ *
+ * Pure constants. NO imports from React, Pixi, Convex, or anything else —
+ * keeps the module trivially tree-shakeable and safe to import from any layer.
+ */
+
+// Scope the cache key per backend so dev and prod (served from the same
+// localhost origin during development) never share a localStorage slot.
+const ENV_SCOPE = (import.meta.env.VITE_CONVEX_URL as string | undefined) ?? 'no-backend';
+
+// Realm-scope the cache key by the diamond address too. The repo's
+// full-game-reset runbook (docs/runbooks/full-game-reset.md) explicitly
+// supports redeploying the diamond and re-pointing Convex at the new realm;
+// without this discriminator a returning user would see the OLD realm's
+// cached state for up to MAX_CACHE_AGE_MS (1 hour) while the new realm
+// hydrates. Mirrors the server-side `CLAN_WORLD_CONTRACT_ADDRESS` env var.
+const DIAMOND_SCOPE =
+  (import.meta.env.VITE_CLAN_WORLD_CONTRACT_ADDRESS as string | undefined) ?? 'no-diamond';
+
+/**
+ * localStorage key under which the cached snapshot payload lives. Bumped via
+ * `PAYLOAD_VERSION`, not via key rename — old entries are dropped on read
+ * when the version doesn't match.
+ */
+export const CACHE_KEY = `cw-snapshot-v1:${ENV_SCOPE}:${DIAMOND_SCOPE}`;
+
+/**
+ * Increment when the cached payload SHAPE changes (Convex schema migration,
+ * field rename, etc.). Entries with a different `v` are silently dropped on
+ * read instead of causing a runtime crash or surfacing corrupt state.
+ */
+export const PAYLOAD_VERSION = 1;
+
+/**
+ * Drop cache older than this — avoids surfacing wildly stale state if a user
+ * returns to the PWA after a long absence. 1 hour balances "instant hydration
+ * for typical mobile-tab-pause scenarios" against "don't show day-old state".
+ */
+export const MAX_CACHE_AGE_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Cached-snapshot envelope. Generic over the snapshot type so consumers can
+ * narrow `data` to their own typed shape without this module depending on
+ * Convex / app types.
+ */
+export type CachedSnapshot<T> = { v: number; ts: number; data: T };

--- a/apps/web/src/hooks/useCachedSnapshot.ts
+++ b/apps/web/src/hooks/useCachedSnapshot.ts
@@ -1,4 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
+import {
+  CACHE_KEY,
+  PAYLOAD_VERSION,
+  MAX_CACHE_AGE_MS,
+  type CachedSnapshot,
+} from './snapshotCacheConstants';
 
 /**
  * Snapshot cache for the WorldMap's Convex `getSnapshot` query.
@@ -12,21 +18,11 @@ import { useEffect, useRef, useState } from 'react';
  *
  * Generic over the snapshot type so we don't pull the Convex API type into
  * this hook — keeps it framework-agnostic and easy to unit-test.
+ *
+ * Cache key + payload version + max age live in `./snapshotCacheConstants`
+ * because `MapGhostLayer.tsx` reads the same cache before PixiJS warms up
+ * and the two MUST stay in lockstep on schema migrations.
  */
-
-// Scope the cache key per environment so dev and prod (served from the same
-// localhost origin during development) never share a localStorage slot.
-const ENV_SCOPE = (import.meta.env.VITE_CONVEX_URL as string | undefined) ?? 'no-backend';
-// Bump this on snapshot shape changes (Convex schema migrations).
-const CACHE_KEY = `cw-snapshot-v1:${ENV_SCOPE}`;
-// Drop cache older than this — avoids surfacing wildly stale state.
-const MAX_CACHE_AGE_MS = 60 * 60 * 1000; // 1 hour
-
-// Version discriminant — increment when the cached payload shape changes so
-// stale entries from previous versions are silently dropped on read instead of
-// causing runtime errors or surfacing corrupt state.
-const PAYLOAD_VERSION = 1;
-type Cached<T> = { v: number; ts: number; data: T };
 
 // Throttle localStorage writes — Convex emits a fresh snapshot every heartbeat
 // tick so without throttling we'd JSON.stringify + setItem on every tick, which
@@ -38,7 +34,7 @@ export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
     try {
       const raw = localStorage.getItem(CACHE_KEY);
       if (!raw) return undefined;
-      const parsed = JSON.parse(raw) as Cached<T>;
+      const parsed = JSON.parse(raw) as CachedSnapshot<T>;
       if (!parsed || typeof parsed.ts !== 'number') return undefined;
       if (parsed.v !== PAYLOAD_VERSION) return undefined;
       if (Date.now() - parsed.ts > MAX_CACHE_AGE_MS) return undefined;
@@ -59,7 +55,7 @@ export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
       // (private-mode / quota) are also throttled, not retried every tick.
       lastWriteTsRef.current = now;
       try {
-        const payload: Cached<T> = { v: PAYLOAD_VERSION, ts: now, data: live };
+        const payload: CachedSnapshot<T> = { v: PAYLOAD_VERSION, ts: now, data: live };
         localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
       } catch {
         // quota or private-mode — ignore


### PR DESCRIPTION
## Summary

Two MUST FIX items from the PR #272 (dev->main release) super-swarm synthesis, plus one opportunistic SHOULD FIX. These need to land on `dev` before #272 can safely merge to `main`.

### M1 — `SHOW_REGION_POLYGONS` gated to dev only
**Super-swarm signal:** codex 5.5 HIGH, codex 5.4 LOW (cross-tier convergence).

Was hardcoded `true` → production users would see translucent region fills + raw `(x,y)` vertex coordinate labels rendered over the live map (the polygon-tuning dev tooling). The in-code comment already said to flip this off for release.

Changed:
```ts
const SHOW_REGION_POLYGONS = import.meta.env.DEV;
```

`pnpm dev` keeps the overlay; `vite build` tree-shakes the debug branches out of the prod bundle. Confirmed: `grep "import.meta.env.DEV"` in the built bundle returns 0 hits (Vite inlined it), and only the data-structure references to `regionPolygons` remain — the debug-render branches are gone.

### M2 — Snapshot cache realm-scoped
**Super-swarm signal:** codex 5.4 MED.

`docs/runbooks/full-game-reset.md` explicitly supports redeploying the diamond + re-pointing Convex at a new realm. Old cache key was only scoped by `VITE_CONVEX_URL`, so within the 1-hour window a returning user would see the OLD realm's state for up to ~5s while the new realm hydrates.

- New env var `VITE_CLAN_WORLD_CONTRACT_ADDRESS` documented in `.env.template` AND `apps/web/.env.example` (mirrors server-side `CLAN_WORLD_CONTRACT_ADDRESS`).
- Cache key now derives as `cw-snapshot-v1:${VITE_CONVEX_URL}:${VITE_CLAN_WORLD_CONTRACT_ADDRESS}` with safe fallbacks `no-backend` / `no-diamond` when either is unset.
- **Vercel action:** set `VITE_CLAN_WORLD_CONTRACT_ADDRESS` per-environment (preview/prod) to match the deployed diamond. If unset, the cache still works — it just falls back to `no-diamond` (no regression vs prior behavior, only loses the realm discriminator).

### S2 (opportunistic) — Shared snapshot cache constants
**Super-swarm signal:** opus 4.6 + opus 4.7 MED.

`useCachedSnapshot.ts` and `MapGhostLayer.tsx` both duplicated `CACHE_KEY` / `PAYLOAD_VERSION` / `MAX_CACHE_AGE_MS`. Schema-migration footgun: bump `PAYLOAD_VERSION` in the hook and forget the ghost, and the ghost reads stale data as if it matched the new shape — silent corruption.

Extracted to `apps/web/src/hooks/snapshotCacheConstants.ts`. Both files now import. Pure constants, zero non-vite-env imports.

## Files touched
- `apps/web/src/WorldMap.tsx` — gate `SHOW_REGION_POLYGONS` on `import.meta.env.DEV`
- `apps/web/src/hooks/snapshotCacheConstants.ts` — **new**, shared constants module
- `apps/web/src/hooks/useCachedSnapshot.ts` — import from shared module, drop duplicates
- `apps/web/src/components/MapGhostLayer.tsx` — import from shared module, drop duplicates
- `.env.template` — document `VITE_CLAN_WORLD_CONTRACT_ADDRESS` (Vite section)
- `apps/web/.env.example` — same

## Verification
- `pnpm install` — clean
- `pnpm --filter @clan-world/web typecheck` — clean (no errors)
- `pnpm --filter @clan-world/web build` — clean (built in ~6s, 2074 modules)
- Prod bundle check — cache key built with both scopes (`cw-snapshot-v1:${EB}:${PB}` with `no-backend` / `no-diamond` fallbacks present); `import.meta.env.DEV` references inlined out by Vite.

## Test plan
- [ ] Local 3-tier swarm review (Claude subagent + codex + gemini-flash) — orchestrator will dispatch via `/swarm-review`.
- [ ] In `pnpm dev`, region polygons still render with the dev overlay (no regression to dev UX).
- [ ] In `pnpm build && pnpm preview`, region polygons NOT rendered, no debug fills/labels visible.
- [ ] Confirm Vercel preview env can be configured with `VITE_CLAN_WORLD_CONTRACT_ADDRESS` set; cache key in DevTools localStorage reflects the diamond address.
- [ ] When `VITE_CLAN_WORLD_CONTRACT_ADDRESS` is unset, cache key falls back to `no-diamond` (verified via build output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)