### PR TITLE
fix(web): MapGhostLayer uses visualViewport, not innerHeight (#280)

### DIFF
--- a/apps/web/src/components/MapGhostLayer.tsx
+++ b/apps/web/src/components/MapGhostLayer.tsx
@@ -203,12 +203,20 @@ export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
   // inset: 0 inside the same canvasWrapRef container, so its bounding-box
   // equals the canvas's bounding-box.
   const rootRef = useRef<HTMLDivElement>(null);
-  // Init synchronously from window.innerWidth/Height so the first paint uses
-  // real screen dimensions instead of 0x0 (ResizeObserver fires post-paint).
-  const [dims, setDims] = useState<{ w: number; h: number }>(() => ({
-    w: typeof window !== 'undefined' ? (window.innerWidth || 1) : 1,
-    h: typeof window !== 'undefined' ? (window.innerHeight || 1) : 1,
-  }));
+  // Init synchronously from visualViewport (falling back to innerWidth/Height)
+  // so the first paint uses real screen dimensions instead of 0x0
+  // (ResizeObserver fires post-paint). On iOS Safari window.innerHeight
+  // returns the largest viewport (URL bar hidden); visualViewport.height
+  // gives the actual visible viewport, excluding URL bar and on-screen
+  // keyboard. Safari 13+ supports visualViewport; we fall back gracefully.
+  const [dims, setDims] = useState<{ w: number; h: number }>(() => {
+    if (typeof window === 'undefined') return { w: 1, h: 1 };
+    const vv = window.visualViewport;
+    return {
+      w: (vv?.width ?? window.innerWidth) || 1,
+      h: (vv?.height ?? window.innerHeight) || 1,
+    };
+  });
 
   useEffect(() => {
     const el = rootRef.current;


### PR DESCRIPTION
## Summary

Closes #280.

Fixes the same iOS Safari viewport bug class as the `100vh` issue PR #274 fixed — but for the JS `window.innerHeight` read site in `MapGhostLayer.tsx`.

On iOS Safari, `window.innerHeight` returns the largest viewport (URL bar hidden), not the actual visible area. `visualViewport.height` (Safari 13+) returns the real visible viewport, excluding URL bar / on-screen keyboard.

## Change

`apps/web/src/components/MapGhostLayer.tsx` first-paint dim init:

```ts
// before
w: typeof window !== 'undefined' ? (window.innerWidth || 1) : 1,
h: typeof window !== 'undefined' ? (window.innerHeight || 1) : 1,

// after
const vv = window.visualViewport;
w: (vv?.width ?? window.innerWidth) || 1,
h: (vv?.height ?? window.innerHeight) || 1,
```

`visualViewport` is optional-chained so SSR / non-Safari-13+ environments fall back to `innerWidth/Height` gracefully. ResizeObserver continues to refine post-mount as before (unchanged).

## Test plan

- [ ] CI green
- [ ] iOS Safari first-paint ghost layer aligns with actual visible viewport (URL bar visible) rather than extending below it
- [ ] Desktop / non-iOS-Safari behavior unchanged (visualViewport == innerWidth/Height in those env)