### PR TITLE
feat(dev-ui): confirm() guard on destructive operations (#281)

### DIFF
--- a/apps/dev-ui/src/App.tsx
+++ b/apps/dev-ui/src/App.tsx
@@ -108,12 +108,19 @@ function ConnectButton() {
 // with the owner wallet could otherwise mis-click into an irreversible facet change.
 // Source: GH #281 (super-swarm finding from PR #272). Keep this list close to the
 // write handler so it stays visible during diamond changes.
+//
+// `/^init.*/` (broader than the literal `initialize`) covers ABI surfaces like
+// `initTreasury(...)` — one-shot setup functions that are as destructive as
+// `initialize` if re-fired. `seedPools` is the other current one-shot setup write.
+// Confirmed against packages/contracts/abi/IClanWorld.json on 2026-05-14 after a
+// codex tier-2 finding flagged both as unguarded.
 const DANGEROUS_FN_NAMES: ReadonlySet<string> = new Set([
   'diamondCut',
   'transferOwnership',
-  'initialize',
+  'seedPools',
 ]);
 const DANGEROUS_FN_PATTERNS: readonly RegExp[] = [
+  /^init.*/,
   /^set.*Address$/,
   /^upgrade.*/,
 ];

--- a/apps/dev-ui/src/App.tsx
+++ b/apps/dev-ui/src/App.tsx
@@ -102,6 +102,26 @@ function ConnectButton() {
   );
 }
 
+// Hardcoded danger-list for destructive diamond operations. Clicking "send tx (write)"
+// on any of these surfaces a native confirm() dialog before firing the wallet popup —
+// the dev-ui's `DEFAULT_DIAMOND` pre-populates the address input, so an admin connected
+// with the owner wallet could otherwise mis-click into an irreversible facet change.
+// Source: GH #281 (super-swarm finding from PR #272). Keep this list close to the
+// write handler so it stays visible during diamond changes.
+const DANGEROUS_FN_NAMES: ReadonlySet<string> = new Set([
+  'diamondCut',
+  'transferOwnership',
+  'initialize',
+]);
+const DANGEROUS_FN_PATTERNS: readonly RegExp[] = [
+  /^set.*Address$/,
+  /^upgrade.*/,
+];
+function isDangerousFn(name: string): boolean {
+  if (DANGEROUS_FN_NAMES.has(name)) return true;
+  return DANGEROUS_FN_PATTERNS.some((re) => re.test(name));
+}
+
 function defaultInputForType(t: string): string {
   if (t === 'address') return '';
   if (t === 'bool') return 'false';
@@ -173,7 +193,21 @@ function FunctionCard({ fn, diamond }: { fn: FnAbi; diamond: Address }) {
   const onWrite = () => {
     try {
       setReadError(null);
+      // Parse inputs FIRST so an invalid address/etc. surfaces as a normal error
+      // instead of being suppressed by the confirm() dialog.
       const args = fn.inputs.map((i, idx) => parseInputValue(i.type, inputs[idx]));
+      // Destructive-op guardrail: native confirm() before firing the wallet popup.
+      // See DANGEROUS_FN_NAMES / DANGEROUS_FN_PATTERNS above. GH #281.
+      if (isDangerousFn(fn.name)) {
+        const msg =
+          `This is a destructive operation that will modify the diamond.\n\n` +
+          `Function: ${fn.name}\n` +
+          `Diamond: ${diamond}\n\n` +
+          `Are you sure?`;
+        if (!window.confirm(msg)) {
+          return;
+        }
+      }
       writeContract.writeContract({
         address: diamond,
         abi: COMBINED_ABI,


### PR DESCRIPTION
## Summary

Hardcoded danger-list in `apps/dev-ui/src/App.tsx` `onWrite` handler. Clicking "send tx (write)" on a destructive function name now triggers a native `confirm()` dialog with the function name + diamond address before firing the wallet popup. Cancel aborts the submission entirely.

Danger-list (exact-match):
- `diamondCut`
- `transferOwnership`
- `initialize`

Danger-list (regex):
- `/^set.*Address$/`
- `/^upgrade.*/`

Non-danger writes (e.g. `setFoo(uint256)` unrelated to addresses, read methods) are unaffected.

## Implementation notes

- `DANGEROUS_FN_NAMES` (Set) + `DANGEROUS_FN_PATTERNS` (RegExp[]) live at module-level immediately above the `FunctionCard` component, beside the only consumer.
- Inputs are parsed BEFORE the confirm() prompt so an invalid address surfaces as a normal error rather than being suppressed by the dialog.
- Uses `window.confirm()` (native) per the issue spec — no new deps, no React state.

## Test plan

- [x] `pnpm typecheck` (dev-ui) — clean
- [x] `pnpm lint` (dev-ui) — clean
- [x] `pnpm build` (dev-ui) — clean (warnings unchanged from `origin/dev`)
- [ ] Manual UAT: click write on `diamondCut` → confirm dialog shows function name + diamond address; cancel aborts; OK proceeds.
- [ ] Manual UAT: click write on a non-danger function → no dialog, normal flow.

Closes #281.

Co-authored-by: Liam C <1342367+mcorrig4@users.noreply.github.com>