### PR TITLE
feat(dev-ui): decode read results via viem (#282)

### DIFF
--- a/apps/dev-ui/src/App.tsx
+++ b/apps/dev-ui/src/App.tsx
@@ -9,7 +9,14 @@ import {
   useWaitForTransactionReceipt,
 } from 'wagmi';
 import { baseSepolia } from 'wagmi/chains';
-import { encodeFunctionData, type Abi, type Address, type AbiFunction, isAddress } from 'viem';
+import {
+  encodeFunctionData,
+  decodeFunctionResult,
+  type Abi,
+  type Address,
+  type AbiFunction,
+  isAddress,
+} from 'viem';
 
 // ABIs are imported from @clan-world/contracts as JSON modules. Source of truth lives at
 // packages/contracts/abi/*.json and is regenerated from forge artifacts by `pnpm codegen`.
@@ -163,7 +170,35 @@ function FunctionCard({ fn, diamond }: { fn: FnAbi; diamond: Address }) {
         method: 'eth_call',
         params: [{ to: diamond, data }, 'latest'],
       });
-      setReadResult(typeof res === 'string' ? res : JSON.stringify(res));
+      const rawHex = typeof res === 'string' ? res : JSON.stringify(res);
+      // Decode via viem so users see addresses / numbers / structs rather than zero-padded hex.
+      // BigInt values aren't JSON-stringifiable by default, so coerce them with a replacer.
+      try {
+        const decoded = decodeFunctionResult({
+          abi: COMBINED_ABI,
+          functionName: fn.name,
+          data: rawHex as `0x${string}`,
+        });
+        const isScalar =
+          decoded === null ||
+          (typeof decoded !== 'object' && typeof decoded !== 'bigint');
+        if (isScalar) {
+          setReadResult(String(decoded));
+        } else if (typeof decoded === 'bigint') {
+          setReadResult(decoded.toString());
+        } else {
+          setReadResult(
+            JSON.stringify(
+              decoded,
+              (_k, v) => (typeof v === 'bigint' ? v.toString() : v),
+              2,
+            ),
+          );
+        }
+      } catch (decodeErr: unknown) {
+        const dmsg = decodeErr instanceof Error ? decodeErr.message : String(decodeErr);
+        setReadResult(`${rawHex}\n\n(decode failed: ${dmsg})`);
+      }
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       setReadError(msg);


### PR DESCRIPTION
Closes #282.

## Summary

`apps/dev-ui/src/App.tsx` was rendering raw `eth_call` hex (e.g. `0x000…14392f…`) as the read result. This PR pipes the response through viem's `decodeFunctionResult` so the user sees the actual decoded value.

## Behavior

- **Scalars** (address, uint as bigint, bool, string, bytes): printed as their plain string form. BigInts get `.toString()` so we don't crash on `JSON.stringify`.
- **Arrays / structs**: pretty-printed JSON with a BigInt-safe replacer (`typeof v === 'bigint' ? v.toString() : v`).
- **Decode failures** (wrong contract, ABI mismatch): falls back to the raw hex with a `(decode failed: <reason>)` hint appended — preserves the previous debugging surface.

## Files

- `apps/dev-ui/src/App.tsx` — adds `decodeFunctionResult` import, wraps `onRead`'s result rendering with try/catch + BigInt replacer.

## Verification

- `pnpm --filter @clan-world/dev-ui typecheck` — clean
- `pnpm --filter @clan-world/dev-ui lint` — clean
- `pnpm --filter @clan-world/dev-ui build` — clean (only pre-existing dynamic-import warnings)

## Test plan

- [ ] Call `owner()` on the default diamond — expect decoded address (not zero-padded hex)
- [ ] Call `facets()` — expect pretty-printed JSON of facet structs
- [ ] Call a uint-returning view (e.g. season counter) — expect the integer as a string
- [ ] Point at an EOA / wrong contract, call a view — expect raw hex + "decode failed" hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)