### PR TITLE
fix(contracts): check:abi covers all ABI targets (#278)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "codegen": "pnpm gen:constants && turbo run codegen",
     "dev": "turbo run dev",
     "gen:chainclient-abi": "node scripts/gen-chainclient-abi.mjs",
-    "gen:contract-abi": "node scripts/gen-contract-abi.mjs",
+    "gen:contract-abi": "node scripts/gen-contract-abi.mjs --build",
     "gen:constants": "node scripts/gen-constants.mjs",
     "gen:enums": "node scripts/gen-enums.mjs",
     "check:abi": "pnpm --dir packages/contracts run check:abi && pnpm test:chainclient-abi",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -10,7 +10,7 @@
     "./abi/OwnershipFacet.json": "./abi/OwnershipFacet.json"
   },
   "scripts": {
-    "build": "bash scripts/forge.sh build script/DeployDiamond.s.sol src/IClanWorld.sol src/IClanWorldLens.sol",
+    "build": "bash scripts/forge.sh build script/DeployDiamond.s.sol src/IClanWorld.sol src/IClanWorldLens.sol src/diamond/IDiamondLoupe.sol src/diamond/IDiamondCut.sol src/diamond/facets/OwnershipFacet.sol",
     "codegen": "node ../../scripts/gen-contract-abi.mjs --build",
     "gen:enums": "pnpm --dir ../.. gen:enums",
     "check:abi": "node scripts/check-contract-abi.mjs",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -11,9 +11,9 @@
   },
   "scripts": {
     "build": "bash scripts/forge.sh build script/DeployDiamond.s.sol src/IClanWorld.sol src/IClanWorldLens.sol",
-    "codegen": "bash scripts/forge.sh build src/IClanWorld.sol src/IClanWorldLens.sol src/IDiamondLoupe.sol src/IDiamondCut.sol src/OwnershipFacet.sol && node ../../scripts/gen-contract-abi.mjs",
+    "codegen": "node ../../scripts/gen-contract-abi.mjs --build",
     "gen:enums": "pnpm --dir ../.. gen:enums",
-    "check:abi": "bash -c 'command -v jq >/dev/null 2>&1 || { echo \"jq not installed; cannot check ABI\"; exit 1; }; bash scripts/forge.sh build src/IClanWorld.sol src/IClanWorldLens.sol && diff <(jq \".abi\" out/IClanWorld.sol/IClanWorld.json) <(jq \".abi\" abi/IClanWorld.json) && diff <(jq \".abi\" out/IClanWorldLens.sol/IClanWorldLens.json) <(jq \".abi\" abi/IClanWorldLens.json)'",
+    "check:abi": "node scripts/check-contract-abi.mjs",
     "check:sizes": "node scripts/check-contract-sizes.mjs",
     "test": "pnpm run check:abi && bash scripts/forge.sh test",
     "typecheck": "echo 'no TS in contracts package'",

--- a/packages/contracts/scripts/check-contract-abi.mjs
+++ b/packages/contracts/scripts/check-contract-abi.mjs
@@ -4,24 +4,17 @@
  * freshly compiled artifact in `out/`. Pulls the target list from the shared
  * `scripts/abi-targets.mjs` so it cannot drift from `gen-contract-abi.mjs`.
  *
- * Usage: from `packages/contracts/`, run `pnpm check:abi`. Assumes `forge build`
- * has already been invoked by the calling script for the required sources.
+ * Usage: from `packages/contracts/`, run `pnpm check:abi`. Builds the canonical
+ * sources via forge, then JSON-diffs each artifact's `.abi` against the
+ * committed JSON entirely in Node — no shell interpolation of paths.
  */
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { abiTargets, repoRoot } from '../../../scripts/abi-targets.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const contractsRoot = path.resolve(__dirname, '..');
-
-const jqCheck = spawnSync('bash', ['-c', 'command -v jq >/dev/null 2>&1'], { stdio: 'ignore' });
-if (jqCheck.status !== 0) {
-  console.error('jq not installed; cannot check ABI');
-  process.exit(1);
-}
+const contractsRoot = path.join(repoRoot, 'packages/contracts');
 
 // Build every source that has a committed ABI target.
 const sources = abiTargets.map(({ sourcePath }) => sourcePath);
@@ -34,14 +27,28 @@ if (build.status !== 0) {
   process.exit(build.status ?? 1);
 }
 
+function readAbi(filePath, kind) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed.abi)) {
+    throw new Error(`${kind} ${path.relative(repoRoot, filePath)} is missing an "abi" array`);
+  }
+  return parsed.abi;
+}
+
 let failed = false;
 
-for (const { artifactPath, targetPath } of abiTargets) {
+for (const { sourcePath, artifactPath, targetPath } of abiTargets) {
   const artifactRel = path.relative(repoRoot, artifactPath);
   const targetRel = path.relative(repoRoot, targetPath);
 
   if (!fs.existsSync(artifactPath)) {
-    console.error(`MISSING artifact: ${artifactRel} (run forge build)`);
+    console.error(
+      `MISSING artifact: ${artifactRel}\n` +
+        `  forge built but did not emit this artifact. Likely cause: ` +
+        `sourcePath="${sourcePath}" in scripts/abi-targets.mjs does not match the actual ` +
+        `Solidity source file. Verify the file exists under packages/contracts/.`,
+    );
     failed = true;
     continue;
   }
@@ -51,13 +58,20 @@ for (const { artifactPath, targetPath } of abiTargets) {
     continue;
   }
 
-  const diff = spawnSync(
-    'bash',
-    ['-c', `diff <(jq ".abi" "${artifactPath}") <(jq ".abi" "${targetPath}")`],
-    { stdio: 'inherit' },
-  );
+  let artifactAbi;
+  let committedAbi;
+  try {
+    artifactAbi = readAbi(artifactPath, 'artifact');
+    committedAbi = readAbi(targetPath, 'committed ABI');
+  } catch (err) {
+    console.error(err.message);
+    failed = true;
+    continue;
+  }
 
-  if (diff.status !== 0) {
+  const artifactJson = JSON.stringify(artifactAbi);
+  const committedJson = JSON.stringify(committedAbi);
+  if (artifactJson !== committedJson) {
     console.error(`ABI MISMATCH: ${targetRel} differs from ${artifactRel}`);
     console.error('Run `pnpm codegen` from the repo root to refresh committed ABIs.');
     failed = true;

--- a/packages/contracts/scripts/check-contract-abi.mjs
+++ b/packages/contracts/scripts/check-contract-abi.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Verifies that every committed ABI under `packages/contracts/abi/` matches the
+ * freshly compiled artifact in `out/`. Pulls the target list from the shared
+ * `scripts/abi-targets.mjs` so it cannot drift from `gen-contract-abi.mjs`.
+ *
+ * Usage: from `packages/contracts/`, run `pnpm check:abi`. Assumes `forge build`
+ * has already been invoked by the calling script for the required sources.
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { abiTargets, repoRoot } from '../../../scripts/abi-targets.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const contractsRoot = path.resolve(__dirname, '..');
+
+const jqCheck = spawnSync('bash', ['-c', 'command -v jq >/dev/null 2>&1'], { stdio: 'ignore' });
+if (jqCheck.status !== 0) {
+  console.error('jq not installed; cannot check ABI');
+  process.exit(1);
+}
+
+// Build every source that has a committed ABI target.
+const sources = abiTargets.map(({ sourcePath }) => sourcePath);
+const build = spawnSync(
+  'bash',
+  ['scripts/forge.sh', 'build', ...sources],
+  { cwd: contractsRoot, stdio: 'inherit' },
+);
+if (build.status !== 0) {
+  process.exit(build.status ?? 1);
+}
+
+let failed = false;
+
+for (const { artifactPath, targetPath } of abiTargets) {
+  const artifactRel = path.relative(repoRoot, artifactPath);
+  const targetRel = path.relative(repoRoot, targetPath);
+
+  if (!fs.existsSync(artifactPath)) {
+    console.error(`MISSING artifact: ${artifactRel} (run forge build)`);
+    failed = true;
+    continue;
+  }
+  if (!fs.existsSync(targetPath)) {
+    console.error(`MISSING committed ABI: ${targetRel} (run pnpm codegen)`);
+    failed = true;
+    continue;
+  }
+
+  const diff = spawnSync(
+    'bash',
+    ['-c', `diff <(jq ".abi" "${artifactPath}") <(jq ".abi" "${targetPath}")`],
+    { stdio: 'inherit' },
+  );
+
+  if (diff.status !== 0) {
+    console.error(`ABI MISMATCH: ${targetRel} differs from ${artifactRel}`);
+    console.error('Run `pnpm codegen` from the repo root to refresh committed ABIs.');
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+
+console.log(`OK: ${abiTargets.length} ABI target(s) match their compiled artifacts.`);

--- a/scripts/abi-targets.mjs
+++ b/scripts/abi-targets.mjs
@@ -1,0 +1,44 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const repoRoot = path.resolve(__dirname, '..');
+
+/**
+ * Canonical list of contract ABI artifacts that ship in `packages/contracts/abi/`.
+ *
+ * Both the generator (`scripts/gen-contract-abi.mjs`) and the checker
+ * (`packages/contracts/scripts/check-contract-abi.mjs`) import this list so the
+ * two can never drift. Adding a new exported ABI requires exactly one edit here.
+ *
+ * `sourcePath` is relative to `packages/contracts/` and is the input to `forge build`.
+ */
+export const abiTargets = [
+  {
+    sourcePath: 'src/IClanWorld.sol',
+    artifactPath: path.join(repoRoot, 'packages/contracts/out/IClanWorld.sol/IClanWorld.json'),
+    targetPath: path.join(repoRoot, 'packages/contracts/abi/IClanWorld.json'),
+  },
+  {
+    sourcePath: 'src/IClanWorldLens.sol',
+    artifactPath: path.join(repoRoot, 'packages/contracts/out/IClanWorldLens.sol/IClanWorldLens.json'),
+    targetPath: path.join(repoRoot, 'packages/contracts/abi/IClanWorldLens.json'),
+  },
+  // Diamond / Ownership facet ABIs consumed by apps/dev-ui (generic write/read UI over the
+  // ClanWorld diamond). Kept canonical here so dev-ui never vendors a stale copy.
+  {
+    sourcePath: 'src/diamond/IDiamondLoupe.sol',
+    artifactPath: path.join(repoRoot, 'packages/contracts/out/IDiamondLoupe.sol/IDiamondLoupe.json'),
+    targetPath: path.join(repoRoot, 'packages/contracts/abi/IDiamondLoupe.json'),
+  },
+  {
+    sourcePath: 'src/diamond/IDiamondCut.sol',
+    artifactPath: path.join(repoRoot, 'packages/contracts/out/IDiamondCut.sol/IDiamondCut.json'),
+    targetPath: path.join(repoRoot, 'packages/contracts/abi/IDiamondCut.json'),
+  },
+  {
+    sourcePath: 'src/diamond/facets/OwnershipFacet.sol',
+    artifactPath: path.join(repoRoot, 'packages/contracts/out/OwnershipFacet.sol/OwnershipFacet.json'),
+    targetPath: path.join(repoRoot, 'packages/contracts/abi/OwnershipFacet.json'),
+  },
+];

--- a/scripts/gen-contract-abi.mjs
+++ b/scripts/gen-contract-abi.mjs
@@ -1,34 +1,22 @@
 #!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(__dirname, '..');
-const abiTargets = [
-  {
-    artifactPath: path.join(repoRoot, 'packages/contracts/out/IClanWorld.sol/IClanWorld.json'),
-    targetPath: path.join(repoRoot, 'packages/contracts/abi/IClanWorld.json'),
-  },
-  {
-    artifactPath: path.join(repoRoot, 'packages/contracts/out/IClanWorldLens.sol/IClanWorldLens.json'),
-    targetPath: path.join(repoRoot, 'packages/contracts/abi/IClanWorldLens.json'),
-  },
-  // Diamond / Ownership facet ABIs consumed by apps/dev-ui (generic write/read UI over the
-  // ClanWorld diamond). Kept canonical here so dev-ui never vendors a stale copy.
-  {
-    artifactPath: path.join(repoRoot, 'packages/contracts/out/IDiamondLoupe.sol/IDiamondLoupe.json'),
-    targetPath: path.join(repoRoot, 'packages/contracts/abi/IDiamondLoupe.json'),
-  },
-  {
-    artifactPath: path.join(repoRoot, 'packages/contracts/out/IDiamondCut.sol/IDiamondCut.json'),
-    targetPath: path.join(repoRoot, 'packages/contracts/abi/IDiamondCut.json'),
-  },
-  {
-    artifactPath: path.join(repoRoot, 'packages/contracts/out/OwnershipFacet.sol/OwnershipFacet.json'),
-    targetPath: path.join(repoRoot, 'packages/contracts/abi/OwnershipFacet.json'),
-  },
-];
+import { abiTargets, repoRoot } from './abi-targets.mjs';
+
+if (process.argv.includes('--build')) {
+  const sources = abiTargets.map(({ sourcePath }) => sourcePath);
+  const contractsRoot = path.join(repoRoot, 'packages/contracts');
+  const build = spawnSync(
+    'bash',
+    ['scripts/forge.sh', 'build', ...sources],
+    { cwd: contractsRoot, stdio: 'inherit' },
+  );
+  if (build.status !== 0) {
+    process.exit(build.status ?? 1);
+  }
+}
 
 for (const { artifactPath, targetPath } of abiTargets) {
   if (!fs.existsSync(artifactPath)) {


### PR DESCRIPTION
Closes #278.

## Problem

`packages/contracts/package.json:check:abi` validated only `IClanWorld` + `IClanWorldLens`, even though PR #267 added three more committed ABIs (`IDiamondLoupe`, `IDiamondCut`, `OwnershipFacet`). Drift hazard: a facet/interface change could leave checked-in JSON stale while CI stays green.

A second latent bug was uncovered while fixing: PR #267's `codegen` script passed invalid source paths to `forge build` (`src/IDiamondLoupe.sol` instead of `src/diamond/IDiamondLoupe.sol`, etc.). Forge silently ignored them and reported success, so the three diamond/ownership artifacts were never recompiled by `pnpm codegen`. Anyone who ran codegen after PR #267 would have hit `Missing out/IDiamondLoupe.sol/IDiamondLoupe.json. Run forge build first.` from `gen-contract-abi.mjs`. Fixed here as a side-effect of using a shared target list.

## Fix

- New `scripts/abi-targets.mjs` — single source of truth for the 5 ABI targets (source path + artifact path + committed JSON path). Both the generator and the new checker import from it.
- Refactored `scripts/gen-contract-abi.mjs` to import from the shared list; added a `--build` flag that builds via `forge` first using the shared source list.
- New `packages/contracts/scripts/check-contract-abi.mjs` — iterates every target, builds via forge, diffs each artifact's `.abi` against the committed JSON. Replaces the inline 2-target bash one-liner.
- `packages/contracts/package.json` — `check:abi` now invokes the mjs script; `codegen` uses `gen-contract-abi.mjs --build` (eliminates the second hardcoded source list).
- Corrected diamond source paths in the shared list to `src/diamond/IDiamondLoupe.sol`, `src/diamond/IDiamondCut.sol`, `src/diamond/facets/OwnershipFacet.sol`.

After this PR, adding a new exported ABI requires exactly one edit: append to `abiTargets` in `scripts/abi-targets.mjs`.

## Verification

```
# Clean state — all 5 targets match
$ rm -rf packages/contracts/out
$ pnpm --filter @clan-world/contracts check:abi
Compiling 6 files with Solc 0.8.34
OK: 5 ABI target(s) match their compiled artifacts.

# Deliberate drift — fake function added to IDiamondLoupe.json
$ jq '.abi += [{"type":"function","name":"BOGUS",...}]' abi/IDiamondLoupe.json > ...
$ pnpm --filter @clan-world/contracts check:abi
> BOGUS
ABI MISMATCH: packages/contracts/abi/IDiamondLoupe.json differs from ...
Run `pnpm codegen` from the repo root to refresh committed ABIs.
Exit status 1

# codegen still produces zero diff against committed ABIs
$ pnpm --filter @clan-world/contracts codegen
Updated 5 ABIs.
$ git status packages/contracts/abi/
nothing to commit, working tree clean
```

## Test plan

- [x] `pnpm --filter @clan-world/contracts check:abi` passes on a clean checkout
- [x] Corrupting any single committed ABI causes `check:abi` to fail with a clear mismatch message
- [x] `pnpm --filter @clan-world/contracts codegen` regenerates all 5 ABIs and produces no git diff