### PR TITLE
feat(web): useCachedSnapshot last-known-good guard (#283)

### DIFF
--- a/apps/web/src/hooks/snapshotCacheConstants.ts
+++ b/apps/web/src/hooks/snapshotCacheConstants.ts
@@ -49,6 +49,26 @@ export const PAYLOAD_VERSION = 1;
 export const MAX_CACHE_AGE_MS = 60 * 60 * 1000; // 1 hour
 
 /**
+ * "Last known good" freshness window for the `useCachedSnapshot` guard.
+ *
+ * When the live websocket re-emits an empty snapshot (e.g. `{ clans: [] }`)
+ * during a reconnect or post-reset indexing window, we want to KEEP the
+ * previous cached state instead of letting that transient empty payload
+ * overwrite a perfectly good cache and flip the UI into "no clans" mode.
+ *
+ * But we also can't resurrect a cached snapshot indefinitely — a full-game
+ * reset legitimately empties the realm and we have to honor that. 5 minutes
+ * is the design call from PR #272 super-swarm: long enough to mask any
+ * normal reconnect / indexing gap, short enough that a real post-reset
+ * empty state surfaces within a single coffee break.
+ *
+ * Strictly less than `MAX_CACHE_AGE_MS` by construction — once the cache
+ * has aged past the freshness window we yield to live (even when live is
+ * empty); past the max age we drop the cache entirely on next read.
+ */
+export const FRESHNESS_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
  * Cached-snapshot envelope. Generic over the snapshot type so consumers can
  * narrow `data` to their own typed shape without this module depending on
  * Convex / app types.

--- a/apps/web/src/hooks/useCachedSnapshot.ts
+++ b/apps/web/src/hooks/useCachedSnapshot.ts
@@ -3,6 +3,7 @@ import {
   CACHE_KEY,
   PAYLOAD_VERSION,
   MAX_CACHE_AGE_MS,
+  FRESHNESS_THRESHOLD_MS,
   type CachedSnapshot,
 } from './snapshotCacheConstants';
 
@@ -22,6 +23,18 @@ import {
  * Cache key + payload version + max age live in `./snapshotCacheConstants`
  * because `MapGhostLayer.tsx` reads the same cache before PixiJS warms up
  * and the two MUST stay in lockstep on schema migrations.
+ *
+ * "Last known good" guard (issue #283 / PR #272 super-swarm):
+ * During a websocket reconnect or post-reset indexing window the live
+ * payload can briefly be `{ clans: [] }` even though the previously-cached
+ * payload had clans. Writing that transient empty payload through would
+ * (a) immediately flip the UI into "no clans" placeholder mode and
+ * (b) destroy the very cache that masks the NEXT reconnect gap. So when
+ * live has zero clans, cached has clans, and the cached payload is younger
+ * than `FRESHNESS_THRESHOLD_MS`, we keep the cached state and skip the
+ * write. Once the cache ages past the freshness window we yield to the
+ * live empty state — a real post-reset realm should not be resurrected
+ * indefinitely.
  */
 
 // Throttle localStorage writes — Convex emits a fresh snapshot every heartbeat
@@ -29,8 +42,40 @@ import {
 // can block the main thread on mobile Safari.
 const WRITE_THROTTLE_MS = 30 * 1000; // 30 seconds
 
+/**
+ * Duck-type check for "this snapshot has a clans array with at least one
+ * entry." Kept loose on purpose — the hook is generic over the snapshot
+ * shape, and the `.clans` property is the only field we need to reason
+ * about for the last-known-good guard. Anything without a clans array
+ * falls through to the normal write path (the guard simply doesn't fire).
+ */
+function snapshotHasClans(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const clans = (value as { clans?: unknown }).clans;
+  return Array.isArray(clans) && clans.length > 0;
+}
+
+/**
+ * Inverse of `snapshotHasClans` for "the snapshot definitively has zero
+ * clans" — i.e. the `.clans` property exists and is an empty array.
+ * Crucially this returns false for snapshots that don't carry `.clans`
+ * at all, so a snapshot shape without that field never trips the guard.
+ */
+function snapshotHasEmptyClans(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const clans = (value as { clans?: unknown }).clans;
+  return Array.isArray(clans) && clans.length === 0;
+}
+
+type CachedEntry<T> = { data: T; ts: number };
+
 export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
-  const [cached, setCached] = useState<T | undefined>(() => {
+  // Track the cached payload's original timestamp alongside the data so the
+  // last-known-good guard can reason about cache age without a separate
+  // localStorage re-read. The companion ref mirrors the latest committed
+  // value so the live-update useEffect can read it without taking a
+  // dependency on `cachedEntry` (which would cause re-render loops).
+  const [cachedEntry, setCachedEntry] = useState<CachedEntry<T> | undefined>(() => {
     try {
       const raw = localStorage.getItem(CACHE_KEY);
       if (!raw) return undefined;
@@ -38,18 +83,39 @@ export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
       if (!parsed || typeof parsed.ts !== 'number') return undefined;
       if (parsed.v !== PAYLOAD_VERSION) return undefined;
       if (Date.now() - parsed.ts > MAX_CACHE_AGE_MS) return undefined;
-      return parsed.data;
+      return { data: parsed.data, ts: parsed.ts };
     } catch {
       return undefined;
     }
   });
+  const cachedEntryRef = useRef<CachedEntry<T> | undefined>(cachedEntry);
 
-  // Track last write timestamp across renders without triggering re-renders.
+  // Track last localStorage write timestamp across renders without
+  // triggering re-renders. Separate from cachedEntry.ts because the
+  // throttle is about write frequency, not cache age.
   const lastWriteTsRef = useRef<number>(0);
 
   useEffect(() => {
     if (live === undefined) return;
     const now = Date.now();
+
+    // Last-known-good guard. If live is an empty-clans payload, cached has
+    // clans, AND the cached payload is still inside the freshness window,
+    // treat the live empty as a transient reconnect artifact. We skip BOTH
+    // the localStorage write and the setState call — the existing cache
+    // stays exactly as-is (same data, same ts), so the freshness window
+    // continues to run from the original write, not from "now".
+    const currentCached = cachedEntryRef.current;
+    const lastKnownGoodGuardActive = (
+      snapshotHasEmptyClans(live)
+      && currentCached !== undefined
+      && snapshotHasClans(currentCached.data)
+      && now - currentCached.ts < FRESHNESS_THRESHOLD_MS
+    );
+    if (lastKnownGoodGuardActive) {
+      return;
+    }
+
     if (now - lastWriteTsRef.current >= WRITE_THROTTLE_MS) {
       // Update timestamp BEFORE attempting the write so failed writes
       // (private-mode / quota) are also throttled, not retried every tick.
@@ -61,8 +127,30 @@ export function useCachedSnapshot<T>(live: T | undefined): T | undefined {
         // quota or private-mode — ignore
       }
     }
-    setCached(live);
+    const nextEntry: CachedEntry<T> = { data: live, ts: now };
+    cachedEntryRef.current = nextEntry;
+    setCachedEntry(nextEntry);
   }, [live]);
 
-  return live ?? cached;
+  // Return semantics:
+  //  - If live is undefined (typical reconnect gap), serve the cached data
+  //    so the UI renders instantly instead of flashing the "no chain data"
+  //    placeholder.
+  //  - If live is defined AND the last-known-good guard would fire for it,
+  //    ALSO serve the cached data — surfacing a transient `{ clans: [] }`
+  //    to the consumer would flip the WorldMap's `hasClans` derivation to
+  //    false and trip the 5-second placeholder timer (defeats the guard).
+  //    The guard re-evaluates from the live useEffect on every tick, so as
+  //    soon as live recovers (non-empty clans) we return live again.
+  //  - Otherwise return live verbatim.
+  if (live === undefined) return cachedEntry?.data;
+  if (
+    cachedEntry !== undefined
+    && snapshotHasEmptyClans(live)
+    && snapshotHasClans(cachedEntry.data)
+    && Date.now() - cachedEntry.ts < FRESHNESS_THRESHOLD_MS
+  ) {
+    return cachedEntry.data;
+  }
+  return live;
 }


### PR DESCRIPTION
Closes #283.

## Summary

Adds a "last known good" guard to `useCachedSnapshot` so a transient `live = { clans: [] }` payload (websocket reconnect or post-reset indexing window) does not overwrite a perfectly good cache and flip the WorldMap UI into the "no clans" placeholder state.

## Behavior

- `live` has clans (any non-empty) → always writes through (live wins). Unchanged from before.
- `live` has zero clans AND cached has clans:
  - cached is **fresh** (age < 5 min): keep cached, skip the localStorage write, also surface cached to the consumer so `WorldMap`'s `hasClans` derivation stays true.
  - cached is **stale** (age ≥ 5 min): yield to live empty state — write through.
- `live === undefined` (reconnect gap): unchanged — serve cached.

The freshness window `FRESHNESS_THRESHOLD_MS = 5 * 60 * 1000` lives in `snapshotCacheConstants.ts` so it's discoverable next to `MAX_CACHE_AGE_MS` (1h) and `PAYLOAD_VERSION` for any future tuning.

## Implementation notes

- The hook stays generic over `T`. The clans check is duck-typed (`snapshotHasClans`/`snapshotHasEmptyClans`) so any future caller whose snapshot shape doesn't carry `.clans` simply never trips the guard — falls through to the original write path with no surprises.
- `cachedEntry` state now carries `{data, ts}` instead of just `data` so the guard can reason about cache age without re-reading localStorage.
- A `cachedEntryRef` mirrors the latest value so the live-update `useEffect` can read it without depending on `cachedEntry` (which would cause re-render loops on every accepted write).
- The guard is checked at BOTH sites: inside the `useEffect` (to skip the localStorage write + state update) AND at the return-value site (to surface the cached data to consumers). The return-site check is critical — without it the hook would still hand the transient empty payload to `WorldMap`, defeating the guard at the UI level.

## Test plan

- [ ] Open WorldMap on a deployed Convex backend with real clans → cache populates.
- [ ] Disconnect/reconnect Convex websocket (background tab on iOS Safari, or `convex stop` mid-session) → live briefly emits `{ clans: [] }` → UI stays on the cached clans (no placeholder flash).
- [ ] Same as above but wait 6+ minutes before reconnect → on reconnect the empty live state takes over (placeholder appears after the existing 5s grace timer).
- [ ] After a `pnpm convex run reset:full` followed by reconnect: live always non-empty → cache updates immediately, no resurrection of stale post-reset clans.
- [x] `pnpm --filter @clan-world/web typecheck` (clean)
- [x] `pnpm --filter @clan-world/web build` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)