### PR TITLE
fix(web): env-scope cw-viewport-v1 storage key (#300)

### DIFF
--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { useCachedSnapshot } from './hooks/useCachedSnapshot';
+import { VIEWPORT_STORAGE_KEY } from './hooks/snapshotCacheConstants';
 import { Application, Assets, BlurFilter, ColorMatrixFilter, Container, Graphics, Rectangle, Sprite, Text } from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
 import { useAgentLogs, type AgentLog } from './useAgentLogs';
@@ -1725,12 +1726,13 @@ export function WorldMap() {
         // Persist + restore pan/zoom so iOS Safari tab eviction (or HMR full
         // reload during dev) doesn't lose the user's current view. Keyed in
         // sessionStorage so it's tab-scoped — closing the tab resets to fit.
-        const VIEWPORT_STORAGE_KEY = 'cw-viewport-v1';
+        // `VIEWPORT_STORAGE_KEY` is env+diamond scoped (see issue #300) so
+        // switching backends or realms doesn't surface stale viewport state.
         try {
           const raw = sessionStorage.getItem(VIEWPORT_STORAGE_KEY);
           if (raw) {
             const saved = JSON.parse(raw) as { cx: number; cy: number; scale: number };
-            // Bounds-clamp: a poisoned `cw-viewport-v1` entry (e.g. cx=99999,
+            // Bounds-clamp: a poisoned viewport entry (e.g. cx=99999,
             // cy=99999 from a since-shrunk world or storage corruption) would
             // restore the viewport to an off-world center and the user would
             // see a mostly-blank canvas. Reject out-of-range coords entirely

--- a/apps/web/src/components/MapGhostLayer.tsx
+++ b/apps/web/src/components/MapGhostLayer.tsx
@@ -13,6 +13,7 @@ import {
   CACHE_KEY as SNAPSHOT_CACHE_KEY,
   PAYLOAD_VERSION as SNAPSHOT_PAYLOAD_VERSION,
   MAX_CACHE_AGE_MS as SNAPSHOT_MAX_AGE_MS,
+  VIEWPORT_STORAGE_KEY,
 } from '../hooks/snapshotCacheConstants';
 import { isValidSnapshotShape } from '../hooks/useCachedSnapshot';
 
@@ -33,7 +34,8 @@ import { isValidSnapshotShape } from '../hooks/useCachedSnapshot';
  * the map should be. This component fills that gap with plain <img> tags
  * (map background + clan base sprites) positioned using the same viewport
  * (cx, cy, scale) state that pixi-viewport already persists to
- * sessionStorage as `cw-viewport-v1`.
+ * sessionStorage under the shared env+diamond-scoped `VIEWPORT_STORAGE_KEY`
+ * (see `hooks/snapshotCacheConstants` and issue #300).
  *
  * The ghost is purely additive — it never touches the PixiJS pipeline and
  * does not depend on Pixi being present. When `pixiReady` flips true the
@@ -50,11 +52,12 @@ import { isValidSnapshotShape } from '../hooks/useCachedSnapshot';
  * pixi-viewport's projection.
  */
 
-const VIEWPORT_STORAGE_KEY = 'cw-viewport-v1';
-// Snapshot cache key / payload version / max age are imported from the shared
-// `hooks/snapshotCacheConstants` module so the ghost reads the EXACT same
-// payload that `useCachedSnapshot` writes. Previously these were duplicated
-// here — a schema-migration footgun if PAYLOAD_VERSION ever drifted.
+// Snapshot cache key / payload version / max age AND the viewport storage key
+// are imported from the shared `hooks/snapshotCacheConstants` module so the
+// ghost reads the EXACT same payload + viewport state that `useCachedSnapshot`
+// and `WorldMap.tsx` write. Previously these were duplicated here — a
+// schema-migration footgun if PAYLOAD_VERSION ever drifted, and a per-realm
+// state-leak hazard once the viewport key got env+diamond scoped (issue #300).
 
 // Fade duration matches PixiJS's first-frame budget on mobile. Long enough
 // that the eye reads the swap as a cross-fade, short enough not to feel

--- a/apps/web/src/hooks/snapshotCacheConstants.ts
+++ b/apps/web/src/hooks/snapshotCacheConstants.ts
@@ -1,14 +1,19 @@
 /**
  * Shared cache key + payload-version + max-age constants for the WorldMap
- * snapshot localStorage cache. Imported by BOTH `useCachedSnapshot.ts` (the
- * hook that writes the cache) and `components/MapGhostLayer.tsx` (the static
- * ghost that reads it before PixiJS warms up).
+ * snapshot localStorage cache, plus the env+diamond-scoped viewport storage
+ * key used by both `WorldMap.tsx` (writer) and `components/MapGhostLayer.tsx`
+ * (reader). Imported by BOTH `useCachedSnapshot.ts` (the hook that writes
+ * the snapshot cache) and `components/MapGhostLayer.tsx` (the static ghost
+ * that reads it before PixiJS warms up).
  *
  * Why a shared module: these constants were previously duplicated across the
  * two files. If `PAYLOAD_VERSION` were bumped in the hook for a schema
  * migration but not in the ghost, the ghost would read stale data as if it
  * matched the new shape — silent corruption with no runtime error. Extracting
- * to one source of truth eliminates that drift hazard.
+ * to one source of truth eliminates that drift hazard. The same reasoning
+ * applies to `VIEWPORT_STORAGE_KEY`: WorldMap.tsx writes it, MapGhostLayer.tsx
+ * reads it, and they must agree on the exact scoped key to avoid the ghost
+ * rendering a different viewport than the canvas.
  *
  * Pure constants. NO imports from React, Pixi, Convex, or anything else —
  * keeps the module trivially tree-shakeable and safe to import from any layer.
@@ -33,6 +38,25 @@ const DIAMOND_SCOPE =
  * when the version doesn't match.
  */
 export const CACHE_KEY = `cw-snapshot-v1:${ENV_SCOPE}:${DIAMOND_SCOPE}`;
+
+/**
+ * sessionStorage key under which the WorldMap pan/zoom viewport state lives.
+ * Env+diamond scoped so switching backends in the same tab (or rolling out a
+ * new realm via the full-game-reset runbook) doesn't surface stale viewport
+ * state from the previous realm. Mirrors `CACHE_KEY`'s scoping pattern — see
+ * issue #300 / PR #275 for the diamond-scope rationale.
+ *
+ * Note: this lives in sessionStorage (tab-scoped, cleared on tab close) while
+ * `CACHE_KEY` lives in localStorage (origin-scoped, persists across tabs).
+ * The two scope discriminators are still applied identically so the keys
+ * stay logically consistent.
+ *
+ * One-time cost on the deploy that introduces this scoping: any user with an
+ * existing `cw-viewport-v1` sessionStorage entry will get a cache miss on
+ * first load (key changes) and fall back to fit-cover default. Same one-time
+ * cold-cache cost as PR #275's diamond-scope addition to `CACHE_KEY`.
+ */
+export const VIEWPORT_STORAGE_KEY = `cw-viewport-v1:${ENV_SCOPE}:${DIAMOND_SCOPE}`;
 
 /**
  * Increment when the cached payload SHAPE changes (Convex schema migration,


### PR DESCRIPTION
Closes #300.

## Summary

Refactor `VIEWPORT_STORAGE_KEY` in `WorldMap.tsx` (and the matching reader in `MapGhostLayer.tsx`) from the single-global `'cw-viewport-v1'` to the env+diamond-scoped pattern already used by `CACHE_KEY` in `hooks/snapshotCacheConstants.ts`:

```ts
export const VIEWPORT_STORAGE_KEY = `cw-viewport-v1:${ENV_SCOPE}:${DIAMOND_SCOPE}`;
```

The constant lives alongside `CACHE_KEY` in `snapshotCacheConstants.ts` (same file already coordinates the snapshot cache key between writer/reader). Both consumers import from there.

Source: PR #270 super-swarm (opus 4.7 LOW) — switching environments in the same tab, or rolling out a layout change that breaks old viewport state, currently has no clean opt-out path. This makes the key opt out automatically per-realm, matching the snapshot cache.

## Changes

- `apps/web/src/hooks/snapshotCacheConstants.ts` — export new `VIEWPORT_STORAGE_KEY` (env+diamond scoped), extend module docstring to cover both keys.
- `apps/web/src/WorldMap.tsx` — import the shared constant, drop the local literal.
- `apps/web/src/components/MapGhostLayer.tsx` — import the shared constant, drop the local literal.

## One-time cost

Existing viewport state in sessionStorage will be lost on first deploy after this lands — key changes, lookup misses, the viewport falls back to fit-cover default. Same expected behavior as PR #275's diamond-scope addition to `CACHE_KEY`. Acceptable per issue #300.

## Test plan

- [x] `pnpm typecheck` passes (apps/web)
- [x] `pnpm build` passes (apps/web)
- [ ] Smoke: load the PWA, pan/zoom, refresh, viewport restores
- [ ] Smoke: switch backends (or simulate via VITE_CONVEX_URL change), confirm viewport falls back to fit-cover instead of restoring stale state from the prior realm