### PR TITLE
feat(web): preload map BG + decoding=async (closes #271, #298)

### DIFF
--- a/apps/web/src/components/MapGhostLayer.tsx
+++ b/apps/web/src/components/MapGhostLayer.tsx
@@ -354,7 +354,15 @@ export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
         <img
           src={worldMapBg}
           alt=""
-          decoding="sync"
+          // decoding="async" pairs with the <link rel="preload" as="image">
+          // injected by the `inject-map-bg-preload` Vite plugin (see
+          // apps/web/vite.config.ts). The preload tag in index.html starts
+          // the fetch+decode during HTML parse — before React mounts — so by
+          // the time this <img> renders the decoded bitmap is usually already
+          // available, avoiding the blank-ghost flash codex flagged in
+          // PR #270. `async` is then the safe choice: it never blocks the
+          // surrounding paint on cold first-ever load (closes #271, #298).
+          decoding="async"
           draggable={false}
           style={{
             position: 'absolute',

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
@@ -20,12 +20,70 @@ const DEFAULT_PORT = (() => {
   }
 })();
 
+/**
+ * Inject `<link rel="preload" as="image">` for the map-BG asset into index.html.
+ *
+ * Why: MapGhostLayer.tsx renders the world-map.png background ASAP and ideally
+ * with `decoding="async"` so the first React paint doesn't block on bitmap
+ * decode. For that to be safe on cold cache (no HTTP entry), the browser needs
+ * to start fetching+decoding the PNG as early as possible. A `<link rel=preload>`
+ * in the HTML head gives the browser the URL during HTML parse — before any
+ * JS executes — so the fetch races with React bootstrap instead of waiting for
+ * mount. See issues #271, #298.
+ *
+ * Vite hashes the asset at build time (`world-map.<hash>.png`), so the link
+ * href can't be static. This `transformIndexHtml` hook computes the right href
+ * for both dev (unhashed) and build (hashed) modes:
+ *   - In build: `ctx.bundle` is populated → scan for the emitted asset whose
+ *     filename matches `world-map-*.png` (or `world-map.png` if hash disabled)
+ *     and use its bundle key as the href.
+ *   - In dev: `ctx.bundle` is undefined → use the source path so the dev
+ *     server's middleware resolves it via the import graph.
+ *
+ * `order: 'pre'` ensures the link is injected before Vite's own asset
+ * transforms run on index.html.
+ */
+function mapBgPreloadPlugin(): Plugin {
+  return {
+    name: 'inject-map-bg-preload',
+    transformIndexHtml: {
+      order: 'pre',
+      handler(html, ctx) {
+        let href: string | null = null;
+        if (ctx.bundle) {
+          // Build: find the emitted hashed asset. Match `world-map` followed
+          // by EITHER `.png` (no hash) or `-<hash>.png` (Vite's default
+          // emitFileName scheme: name-hash.ext). Restrict to the assets dir
+          // and forbid additional name segments after `world-map` — otherwise
+          // sibling assets like `world-map-winter-*.png` would also match.
+          // The hash itself is base64url-ish ([A-Za-z0-9_-]+) but never
+          // contains a hyphen at the start (Vite uses underscores in the
+          // middle of the hash); requiring a single `-` then non-hyphen chars
+          // then `.png` is enough to disambiguate from `world-map-winter-*`.
+          const key = Object.keys(ctx.bundle).find((p) =>
+            /(^|\/)assets\/world-map(?:-[A-Za-z0-9_]+)?\.png$/.test(p),
+          );
+          if (key) {
+            href = `/${key}`;
+          }
+        } else {
+          // Dev: Vite serves the source asset directly via /src/assets/...
+          href = '/src/assets/world-map.png';
+        }
+        if (!href) return html;
+        const preloadTag = `    <link rel="preload" as="image" href="${href}" />`;
+        return html.replace('</head>', `${preloadTag}\n  </head>`);
+      },
+    },
+  };
+}
+
 // envDir: load .env.local from the monorepo root, not the web app folder.
 // .env.local lives at <repo-root>/.env.local and is shared with server/agents.
 // Without this, VITE_* values are undefined at build time and the prod bundle
 // has no Convex URL or demo-mode configuration baked in.
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), mapBgPreloadPlugin()],
   envDir: path.resolve(__dirname, '../..'),
   server: {
     port: DEFAULT_PORT,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -32,16 +32,24 @@ const DEFAULT_PORT = (() => {
  * mount. See issues #271, #298.
  *
  * Vite hashes the asset at build time (`world-map.<hash>.png`), so the link
- * href can't be static. This `transformIndexHtml` hook computes the right href
- * for both dev (unhashed) and build (hashed) modes:
- *   - In build: `ctx.bundle` is populated → scan for the emitted asset whose
- *     filename matches `world-map-*.png` (or `world-map.png` if hash disabled)
- *     and use its bundle key as the href.
+ * href can't be static. We compute the right href for both modes:
+ *   - In build: `ctx.bundle` is populated → find the emitted asset by its
+ *     ORIGINAL name (`output.name === 'world-map.png'`) rather than regex over
+ *     the hashed key. This is hash-shape independent (a Vite hash containing
+ *     hyphens won't break the lookup, per gemini-flash review on PR #303) and
+ *     cleanly excludes sibling assets like `world-map-winter.png` without
+ *     needing a fragile character-class.
  *   - In dev: `ctx.bundle` is undefined → use the source path so the dev
  *     server's middleware resolves it via the import graph.
  *
- * `order: 'pre'` ensures the link is injected before Vite's own asset
- * transforms run on index.html.
+ * We return Vite tag descriptors (`{ tag, attrs, injectTo: 'head' }`) rather
+ * than doing a string `replace` on `</head>`. The descriptor path is what
+ * Vite's own preload helper uses, so injection is insensitive to surrounding
+ * whitespace, case (`</HEAD>`), or other transforms reshaping the HTML —
+ * closing the "string-replace fragility" LOW from codex review on PR #303.
+ *
+ * `order: 'pre'` keeps the tag toward the top of `<head>`, before other
+ * Vite-injected script/style links.
  */
 function mapBgPreloadPlugin(): Plugin {
   return {
@@ -49,30 +57,36 @@ function mapBgPreloadPlugin(): Plugin {
     transformIndexHtml: {
       order: 'pre',
       handler(html, ctx) {
+        // Honor a custom `base` if/when one is configured (e.g. deploying
+        // under a subpath). Defaults to '/' which is the current setup.
+        const base = ctx.server?.config.base ?? '/';
         let href: string | null = null;
         if (ctx.bundle) {
-          // Build: find the emitted hashed asset. Match `world-map` followed
-          // by EITHER `.png` (no hash) or `-<hash>.png` (Vite's default
-          // emitFileName scheme: name-hash.ext). Restrict to the assets dir
-          // and forbid additional name segments after `world-map` — otherwise
-          // sibling assets like `world-map-winter-*.png` would also match.
-          // The hash itself is base64url-ish ([A-Za-z0-9_-]+) but never
-          // contains a hyphen at the start (Vite uses underscores in the
-          // middle of the hash); requiring a single `-` then non-hyphen chars
-          // then `.png` is enough to disambiguate from `world-map-winter-*`.
-          const key = Object.keys(ctx.bundle).find((p) =>
-            /(^|\/)assets\/world-map(?!-winter)(?:-[A-Za-z0-9_-]+)?\.png$/.test(p),
-          );
-          if (key) {
-            href = `/${key}`;
+          // Build: locate by original source filename. Vite/Rollup populates
+          // `output.name` with the pre-hash basename for asset outputs, so
+          // this is hash-shape independent. Restrict to type==='asset' so we
+          // don't accidentally match a chunk that happens to be named the same.
+          for (const [key, output] of Object.entries(ctx.bundle)) {
+            if (output.type === 'asset' && output.name === 'world-map.png') {
+              href = `${base}${key}`.replace(/\/{2,}/g, '/');
+              break;
+            }
           }
         } else {
           // Dev: Vite serves the source asset directly via /src/assets/...
-          href = '/src/assets/world-map.png';
+          href = `${base}src/assets/world-map.png`.replace(/\/{2,}/g, '/');
         }
         if (!href) return html;
-        const preloadTag = `    <link rel="preload" as="image" href="${href}" />`;
-        return html.replace('</head>', `${preloadTag}\n  </head>`);
+        return {
+          html,
+          tags: [
+            {
+              tag: 'link',
+              attrs: { rel: 'preload', as: 'image', href },
+              injectTo: 'head',
+            },
+          ],
+        };
       },
     },
   };

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -61,7 +61,7 @@ function mapBgPreloadPlugin(): Plugin {
           // middle of the hash); requiring a single `-` then non-hyphen chars
           // then `.png` is enough to disambiguate from `world-map-winter-*`.
           const key = Object.keys(ctx.bundle).find((p) =>
-            /(^|\/)assets\/world-map(?:-[A-Za-z0-9_]+)?\.png$/.test(p),
+            /(^|\/)assets\/world-map(?!-winter)(?:-[A-Za-z0-9_-]+)?\.png$/.test(p),
           );
           if (key) {
             href = `/${key}`;


### PR DESCRIPTION
## Summary

Closes the deferred trade-off from PR #270 / issue #271 (decoding=sync vs async) and unblocks the cold-cache first-paint win tracked in #298.

- Custom Vite `transformIndexHtml` plugin (`inject-map-bg-preload`) computes the hashed map-BG asset URL at build time and injects `<link rel="preload" as="image" href="...">` into `index.html`. In dev mode it points at `/src/assets/world-map.png`; in build mode at `/assets/world-map-<hash>.png`. Regex `world-map(?:-[A-Za-z0-9_]+)?\.png` excludes sibling `world-map-winter-*.png`.
- `MapGhostLayer.tsx` map-BG `<img>` flipped from `decoding="sync"` → `decoding="async"`. The preload front-runs HTML parse, so the bitmap is usually decoded by the time React mounts — no blank-ghost flash, no main-thread block on first paint.

Closes #271. Closes #298.

## Verification

- `pnpm --filter @clan-world/web build` succeeds.
- `dist/index.html` contains `<link rel="preload" as="image" href="/assets/world-map-BftcqVBy.png" />`.
- The href matches a real file in `dist/assets/`.
- Existing canvas-warmth Playwright spec still uses `data-testid="map-ghost-layer"` — no test selectors changed.

## Test plan

- [ ] iOS Safari PWA cold-load (returning visit): ghost paints without one-frame blank flash.
- [ ] iOS Safari PWA cold-load (first-ever visit, no HTTP cache): first paint commits immediately; map BG fills in within ~100ms.
- [ ] DevTools Network panel on cold load: `world-map-*.png` priority = "Highest" (preload).
- [ ] Local 3-tier swarm (codex + claude-subagent + gemini-flash) clean.

Co-authored-by: Liam C <1342367+mcorrig4@users.noreply.github.com>

Generated with [Claude Code](https://claude.com/claude-code)