### PR TITLE
feat(web): WebGL context-loss auto-recovery (closes #304)

### DIFF
--- a/apps/web/src/components/cockpit/shared/WorldMapBoundary.tsx
+++ b/apps/web/src/components/cockpit/shared/WorldMapBoundary.tsx
@@ -1,9 +1,71 @@
-import { Component, type ReactNode } from 'react';
+import { Component, Fragment, type ReactNode } from 'react';
 import { tokens } from '../../../styles/cockpit-tokens';
+
+/**
+ * Maximum number of auto-retry attempts within RETRY_WINDOW_MS before we stop
+ * trying and require the user to tap the manual reload button. Tuned to
+ * absorb transient mobile-Safari GPU resets (typically 1-2 in quick succession
+ * after a memory-pressure event) without spinning forever on a truly broken
+ * GPU.
+ */
+const MAX_AUTO_RETRIES = 3;
+
+/**
+ * Rolling window for the retry budget. After 60s of stability we forget old
+ * retry timestamps so a fresh burst doesn't get penalised by ancient history.
+ */
+const RETRY_WINDOW_MS = 60_000;
+
+/**
+ * Delay before the first auto-retry kicks in. Gives the browser a beat to
+ * actually finish reclaiming + restoring the GL context before we mount a
+ * fresh canvas on top of it. Empirically anything under ~500ms tends to
+ * immediately re-lose the new context on iOS Safari after a memory event.
+ */
+const RETRY_DELAY_MS = 1000;
+
+/**
+ * Detect whether the captured error is something we want to auto-retry.
+ * Only WebGL-flavored failures qualify — generic errors (Convex unreachable,
+ * asset load failure, programmer bugs) need user attention and would just
+ * spin forever in a retry loop. Match is intentionally generous: covers the
+ * exact string thrown from WorldMap.tsx as well as anything PixiJS or the
+ * browser surfaces that mentions WebGL / GL / context loss.
+ */
+function isWebglError(message: string | undefined): boolean {
+  if (!message) return false;
+  const m = message.toLowerCase();
+  return (
+    m.includes('webgl context lost') ||
+    m.includes('webgl context') ||
+    m.includes('webglcontextlost') ||
+    m.includes('context lost') ||
+    m.includes('gl context')
+  );
+}
 
 interface State {
   hasError: boolean;
   errorMessage?: string;
+  /**
+   * Bumped each time we auto-retry. Used as a React `key` on the children so
+   * the WorldMap subtree fully unmounts + remounts (fresh Pixi `Application`,
+   * fresh canvas, fresh GL context) instead of trying to reuse a destroyed
+   * context.
+   */
+  retryKey: number;
+  /**
+   * Timestamps (ms since epoch) of recent auto-retry attempts, used to enforce
+   * MAX_AUTO_RETRIES within RETRY_WINDOW_MS. Entries older than the window
+   * are pruned before each new attempt.
+   */
+  retryTimestamps: number[];
+  /**
+   * True while a setTimeout-scheduled retry is pending. Used to render the
+   * "Recovering…" state instead of the manual "Tap to reload" button while
+   * auto-recovery is in flight.
+   */
+  retryPending: boolean;
 }
 
 /**
@@ -12,19 +74,47 @@ interface State {
  * standalone judge route loads without a backend. In that case we want the
  * 4 mini-cockpits to keep rendering — only the map cell should degrade.
  *
- * Phase B will replace this with a richer "no chain data yet" placeholder
- * once the demo-mode toggle and seeded mock dataset land.
+ * Also handles WebGL context-loss recovery: on mobile Safari the GL context
+ * can be reclaimed under memory pressure or tab backgrounding. When that
+ * happens WorldMap throws a "WebGL context lost" error and lands here. For
+ * those errors we auto-retry by bumping a remount key on the children — up
+ * to MAX_AUTO_RETRIES within RETRY_WINDOW_MS — instead of forcing a full
+ * page reload. Other error classes still require user action via the
+ * "Tap to reload" button.
  */
 export class WorldMapBoundary extends Component<
   { children: ReactNode },
   State
 > {
-  override state: State = { hasError: false };
+  override state: State = {
+    hasError: false,
+    retryKey: 0,
+    retryTimestamps: [],
+    retryPending: false,
+  };
 
-  static getDerivedStateFromError(error: unknown): State {
+  /**
+   * Tracks the pending auto-retry timer so componentWillUnmount can cancel
+   * it. Using a ref-style instance field rather than state because writing
+   * it doesn't need to trigger a re-render.
+   */
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * True between mount and unmount. Guards the setTimeout callback so we
+   * don't setState on a torn-down component (React 18 strict-mode double-
+   * mount safety + general defence against unmount-during-retry).
+   */
+  private mounted = false;
+
+  static getDerivedStateFromError(error: unknown): Partial<State> {
     const errorMessage =
       error instanceof Error ? error.message : String(error ?? 'unknown');
     return { hasError: true, errorMessage };
+  }
+
+  override componentDidMount() {
+    this.mounted = true;
   }
 
   override componentDidCatch(error: unknown, info: unknown) {
@@ -32,10 +122,72 @@ export class WorldMapBoundary extends Component<
     // and surfaces in error-tracking integrations. Includes React component
     // stack so we can see WHERE in the WorldMap tree the throw came from.
     console.error('[cockpit] WorldMap failed to mount:', error, info);
+
+    // Auto-recovery for WebGL context loss: schedule a retry by bumping the
+    // remount key. We do this from componentDidCatch (not getDerivedStateFromError)
+    // because getDerivedStateFromError is supposed to be pure — side-effects
+    // like setTimeout belong here.
+    const message =
+      error instanceof Error ? error.message : String(error ?? '');
+    if (isWebglError(message)) {
+      this.scheduleAutoRetry();
+    }
+  }
+
+  override componentWillUnmount() {
+    this.mounted = false;
+    if (this.retryTimer !== null) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+  }
+
+  /**
+   * If the retry budget allows, schedule a remount of the children after
+   * RETRY_DELAY_MS. Caller has already confirmed the error is WebGL-flavored.
+   * Prunes stale timestamps outside RETRY_WINDOW_MS before counting, so a
+   * user who hits the limit once and then runs cleanly for 60s gets a fresh
+   * budget on the next incident.
+   */
+  private scheduleAutoRetry() {
+    const now = Date.now();
+    const recent = this.state.retryTimestamps.filter(
+      t => now - t < RETRY_WINDOW_MS,
+    );
+    if (recent.length >= MAX_AUTO_RETRIES) {
+      // Budget exhausted — let the manual "Tap to reload" UI take over.
+      // Clear retryPending so the button (not the spinner) renders.
+      if (this.state.retryPending) {
+        this.setState({ retryPending: false });
+      }
+      return;
+    }
+
+    // Guard against double-scheduling (defensive — React 18 strict mode can
+    // double-invoke componentDidCatch in dev). If a timer is already pending,
+    // let it run.
+    if (this.retryTimer !== null) return;
+
+    this.setState({ retryPending: true });
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      if (!this.mounted) return;
+      this.setState(prev => ({
+        hasError: false,
+        errorMessage: undefined,
+        retryKey: prev.retryKey + 1,
+        retryTimestamps: [
+          ...prev.retryTimestamps.filter(t => Date.now() - t < RETRY_WINDOW_MS),
+          Date.now(),
+        ],
+        retryPending: false,
+      }));
+    }, RETRY_DELAY_MS);
   }
 
   override render() {
     if (this.state.hasError) {
+      const isWebgl = isWebglError(this.state.errorMessage);
       return (
         <div
           data-testid="cockpit-worldmap-fallback"
@@ -66,7 +218,9 @@ export class WorldMapBoundary extends Component<
             >
               ◈
             </div>
-            <div style={{ textTransform: 'uppercase' }}>World Map Offline</div>
+            <div style={{ textTransform: 'uppercase' }}>
+              {this.state.retryPending ? 'Recovering Map…' : 'World Map Offline'}
+            </div>
             <div
               style={{
                 fontFamily: tokens.font.mono,
@@ -76,11 +230,13 @@ export class WorldMapBoundary extends Component<
                 letterSpacing: '0.05em',
               }}
             >
-              {this.state.errorMessage
-                ? `error: ${this.state.errorMessage}`
-                : 'Standalone view — backend not reachable'}
+              {this.state.retryPending
+                ? 'Reclaiming WebGL context'
+                : this.state.errorMessage
+                  ? `error: ${this.state.errorMessage}`
+                  : 'Standalone view — backend not reachable'}
             </div>
-            {this.state.errorMessage?.includes('WebGL context lost') && (
+            {isWebgl && !this.state.retryPending && (
               <button
                 type="button"
                 onClick={() => window.location.reload()}
@@ -105,6 +261,15 @@ export class WorldMapBoundary extends Component<
         </div>
       );
     }
-    return this.props.children;
+    // `key` on a Fragment forces a full unmount+remount of the WorldMap
+    // subtree after each auto-recovery so PixiJS gets a fresh canvas + fresh
+    // GL context instead of trying to revive a destroyed one. Fragment (not
+    // a div) is deliberate: the parent containers in MobileCockpitLayout,
+    // Cockpit page, and the standalone /worldmap-only route all rely on
+    // WorldMap's own root div being a direct flex/grid child — an extra
+    // wrapper div would break flex sizing in App.tsx. `key` is stable across
+    // non-error renders (retryKey only changes via scheduleAutoRetry) so
+    // normal re-renders don't blow away the map for no reason.
+    return <Fragment key={this.state.retryKey}>{this.props.children}</Fragment>;
   }
 }


### PR DESCRIPTION
## Summary

Closes #304.

`WorldMapBoundary` now auto-retries WebGL-flavored errors by bumping a `key` on a `Fragment` wrapper around its children — fully remounting the WorldMap subtree (and giving PixiJS a fresh canvas + GL context) instead of forcing `window.location.reload()`.

- Up to 3 auto-retries within a rolling 60s window. Exhausted budget falls through to the existing "Tap to reload" manual control.
- Non-WebGL errors (Convex unreachable, asset load fail, programmer bug) skip auto-retry and require user action, same as before.
- Pending-retry state renders "Recovering Map… / Reclaiming WebGL context" in place of the manual button so the user sees something is happening during the 1s recovery delay.
- `Fragment` (not a wrapper `<div>`) preserves WorldMap's existing flex/grid sizing contract in App.tsx, MobileCockpitLayout, and Cockpit page.

`WorldMap.tsx` is unchanged. Its existing `webglcontextlost` listener still throws via the `webglLost` state path; we just catch + heal more gracefully now.

## Test plan

- [x] `pnpm --filter @clan-world/web typecheck` — clean
- [x] `pnpm --filter @clan-world/web build` — clean (6.23s, no new warnings)
- [ ] Manual: trigger WebGL context loss via DevTools `WEBGL_lose_context.loseContext()`, confirm auto-recovery + max-3-in-60s cap
- [ ] Manual: throw non-WebGL error in WorldMap, confirm no auto-retry (existing fallback shows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)