### PR TITLE
v2.8.1 — wave-2: preload + WebGL recovery + env-scope + init regex

### DIFF
--- a/apps/dev-ui/src/App.tsx
+++ b/apps/dev-ui/src/App.tsx
@@ -166,18 +166,28 @@ function ConnectButton() {
 // Source: GH #281 (super-swarm finding from PR #272). Keep this list close to the
 // write handler so it stays visible during diamond changes.
 //
-// `/^init.*/` (broader than the literal `initialize`) covers ABI surfaces like
+// `/^init([A-Z]|$)/` (tightened from broader `/^init.*/`) covers ABI surfaces like
 // `initTreasury(...)` — one-shot setup functions that are as destructive as
 // `initialize` if re-fired. `seedPools` is the other current one-shot setup write.
 // Confirmed against packages/contracts/abi/IClanWorld.json on 2026-05-14 after a
-// codex tier-2 finding flagged both as unguarded.
+// codex tier-2 finding flagged both as unguarded. The CamelCase-or-end anchor avoids
+// over-matching view getters like `initialized`, `initialState`, `initData` while
+// still catching future destructive `init<X>` functions. Source: GH #299.
+//
+// `initialize` is exact-matched in DANGEROUS_FN_NAMES below because the regex
+// (correctly) only matches `init` + CamelCase boundary or end-of-string — a literal
+// `initialize` has a lowercase `i` after `init` and would slip through the regex.
+// No `initialize` function exists in the current diamond ABI surface, but the exact
+// name is preserved as defense-in-depth for any future facet upgrade. Caught by the
+// PR #301 swarm (gemini-flash HIGH, codex MED).
 const DANGEROUS_FN_NAMES: ReadonlySet<string> = new Set([
   'diamondCut',
   'transferOwnership',
   'seedPools',
+  'initialize',
 ]);
 const DANGEROUS_FN_PATTERNS: readonly RegExp[] = [
-  /^init.*/,
+  /^init([A-Z]|$)/,
   /^set.*Address$/,
   /^upgrade.*/,
 ];

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { useCachedSnapshot } from './hooks/useCachedSnapshot';
+import { VIEWPORT_STORAGE_KEY } from './hooks/snapshotCacheConstants';
 import { Application, Assets, BlurFilter, ColorMatrixFilter, Container, Graphics, Rectangle, Sprite, Text } from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
 import { useAgentLogs, type AgentLog } from './useAgentLogs';
@@ -1725,12 +1726,13 @@ export function WorldMap() {
         // Persist + restore pan/zoom so iOS Safari tab eviction (or HMR full
         // reload during dev) doesn't lose the user's current view. Keyed in
         // sessionStorage so it's tab-scoped — closing the tab resets to fit.
-        const VIEWPORT_STORAGE_KEY = 'cw-viewport-v1';
+        // `VIEWPORT_STORAGE_KEY` is env+diamond scoped (see issue #300) so
+        // switching backends or realms doesn't surface stale viewport state.
         try {
           const raw = sessionStorage.getItem(VIEWPORT_STORAGE_KEY);
           if (raw) {
             const saved = JSON.parse(raw) as { cx: number; cy: number; scale: number };
-            // Bounds-clamp: a poisoned `cw-viewport-v1` entry (e.g. cx=99999,
+            // Bounds-clamp: a poisoned viewport entry (e.g. cx=99999,
             // cy=99999 from a since-shrunk world or storage corruption) would
             // restore the viewport to an off-world center and the user would
             // see a mostly-blank canvas. Reject out-of-range coords entirely

--- a/apps/web/src/components/MapGhostLayer.tsx
+++ b/apps/web/src/components/MapGhostLayer.tsx
@@ -13,6 +13,7 @@ import {
   CACHE_KEY as SNAPSHOT_CACHE_KEY,
   PAYLOAD_VERSION as SNAPSHOT_PAYLOAD_VERSION,
   MAX_CACHE_AGE_MS as SNAPSHOT_MAX_AGE_MS,
+  VIEWPORT_STORAGE_KEY,
 } from '../hooks/snapshotCacheConstants';
 import { isValidSnapshotShape } from '../hooks/useCachedSnapshot';
 
@@ -33,7 +34,8 @@ import { isValidSnapshotShape } from '../hooks/useCachedSnapshot';
  * the map should be. This component fills that gap with plain <img> tags
  * (map background + clan base sprites) positioned using the same viewport
  * (cx, cy, scale) state that pixi-viewport already persists to
- * sessionStorage as `cw-viewport-v1`.
+ * sessionStorage under the shared env+diamond-scoped `VIEWPORT_STORAGE_KEY`
+ * (see `hooks/snapshotCacheConstants` and issue #300).
  *
  * The ghost is purely additive — it never touches the PixiJS pipeline and
  * does not depend on Pixi being present. When `pixiReady` flips true the
@@ -50,11 +52,12 @@ import { isValidSnapshotShape } from '../hooks/useCachedSnapshot';
  * pixi-viewport's projection.
  */
 
-const VIEWPORT_STORAGE_KEY = 'cw-viewport-v1';
-// Snapshot cache key / payload version / max age are imported from the shared
-// `hooks/snapshotCacheConstants` module so the ghost reads the EXACT same
-// payload that `useCachedSnapshot` writes. Previously these were duplicated
-// here — a schema-migration footgun if PAYLOAD_VERSION ever drifted.
+// Snapshot cache key / payload version / max age AND the viewport storage key
+// are imported from the shared `hooks/snapshotCacheConstants` module so the
+// ghost reads the EXACT same payload + viewport state that `useCachedSnapshot`
+// and `WorldMap.tsx` write. Previously these were duplicated here — a
+// schema-migration footgun if PAYLOAD_VERSION ever drifted, and a per-realm
+// state-leak hazard once the viewport key got env+diamond scoped (issue #300).
 
 // Fade duration matches PixiJS's first-frame budget on mobile. Long enough
 // that the eye reads the swap as a cross-fade, short enough not to feel

--- a/apps/web/src/components/MapGhostLayer.tsx
+++ b/apps/web/src/components/MapGhostLayer.tsx
@@ -357,7 +357,15 @@ export function MapGhostLayer({ pixiReady }: MapGhostLayerProps) {
         <img
           src={worldMapBg}
           alt=""
-          decoding="sync"
+          // decoding="async" pairs with the <link rel="preload" as="image">
+          // injected by the `inject-map-bg-preload` Vite plugin (see
+          // apps/web/vite.config.ts). The preload tag in index.html starts
+          // the fetch+decode during HTML parse — before React mounts — so by
+          // the time this <img> renders the decoded bitmap is usually already
+          // available, avoiding the blank-ghost flash codex flagged in
+          // PR #270. `async` is then the safe choice: it never blocks the
+          // surrounding paint on cold first-ever load (closes #271, #298).
+          decoding="async"
           draggable={false}
           style={{
             position: 'absolute',

--- a/apps/web/src/components/cockpit/shared/WorldMapBoundary.tsx
+++ b/apps/web/src/components/cockpit/shared/WorldMapBoundary.tsx
@@ -1,9 +1,71 @@
-import { Component, type ReactNode } from 'react';
+import { Component, Fragment, type ReactNode } from 'react';
 import { tokens } from '../../../styles/cockpit-tokens';
+
+/**
+ * Maximum number of auto-retry attempts within RETRY_WINDOW_MS before we stop
+ * trying and require the user to tap the manual reload button. Tuned to
+ * absorb transient mobile-Safari GPU resets (typically 1-2 in quick succession
+ * after a memory-pressure event) without spinning forever on a truly broken
+ * GPU.
+ */
+const MAX_AUTO_RETRIES = 3;
+
+/**
+ * Rolling window for the retry budget. After 60s of stability we forget old
+ * retry timestamps so a fresh burst doesn't get penalised by ancient history.
+ */
+const RETRY_WINDOW_MS = 60_000;
+
+/**
+ * Delay before the first auto-retry kicks in. Gives the browser a beat to
+ * actually finish reclaiming + restoring the GL context before we mount a
+ * fresh canvas on top of it. Empirically anything under ~500ms tends to
+ * immediately re-lose the new context on iOS Safari after a memory event.
+ */
+const RETRY_DELAY_MS = 1000;
+
+/**
+ * Detect whether the captured error is something we want to auto-retry.
+ * Only WebGL-flavored failures qualify — generic errors (Convex unreachable,
+ * asset load failure, programmer bugs) need user attention and would just
+ * spin forever in a retry loop. Match is intentionally generous: covers the
+ * exact string thrown from WorldMap.tsx as well as anything PixiJS or the
+ * browser surfaces that mentions WebGL / GL / context loss.
+ */
+function isWebglError(message: string | undefined): boolean {
+  if (!message) return false;
+  const m = message.toLowerCase();
+  return (
+    m.includes('webgl context lost') ||
+    m.includes('webgl context') ||
+    m.includes('webglcontextlost') ||
+    m.includes('context lost') ||
+    m.includes('gl context')
+  );
+}
 
 interface State {
   hasError: boolean;
   errorMessage?: string;
+  /**
+   * Bumped each time we auto-retry. Used as a React `key` on the children so
+   * the WorldMap subtree fully unmounts + remounts (fresh Pixi `Application`,
+   * fresh canvas, fresh GL context) instead of trying to reuse a destroyed
+   * context.
+   */
+  retryKey: number;
+  /**
+   * Timestamps (ms since epoch) of recent auto-retry attempts, used to enforce
+   * MAX_AUTO_RETRIES within RETRY_WINDOW_MS. Entries older than the window
+   * are pruned before each new attempt.
+   */
+  retryTimestamps: number[];
+  /**
+   * True while a setTimeout-scheduled retry is pending. Used to render the
+   * "Recovering…" state instead of the manual "Tap to reload" button while
+   * auto-recovery is in flight.
+   */
+  retryPending: boolean;
 }
 
 /**
@@ -12,19 +74,47 @@ interface State {
  * standalone judge route loads without a backend. In that case we want the
  * 4 mini-cockpits to keep rendering — only the map cell should degrade.
  *
- * Phase B will replace this with a richer "no chain data yet" placeholder
- * once the demo-mode toggle and seeded mock dataset land.
+ * Also handles WebGL context-loss recovery: on mobile Safari the GL context
+ * can be reclaimed under memory pressure or tab backgrounding. When that
+ * happens WorldMap throws a "WebGL context lost" error and lands here. For
+ * those errors we auto-retry by bumping a remount key on the children — up
+ * to MAX_AUTO_RETRIES within RETRY_WINDOW_MS — instead of forcing a full
+ * page reload. Other error classes still require user action via the
+ * "Tap to reload" button.
  */
 export class WorldMapBoundary extends Component<
   { children: ReactNode },
   State
 > {
-  override state: State = { hasError: false };
+  override state: State = {
+    hasError: false,
+    retryKey: 0,
+    retryTimestamps: [],
+    retryPending: false,
+  };
 
-  static getDerivedStateFromError(error: unknown): State {
+  /**
+   * Tracks the pending auto-retry timer so componentWillUnmount can cancel
+   * it. Using a ref-style instance field rather than state because writing
+   * it doesn't need to trigger a re-render.
+   */
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * True between mount and unmount. Guards the setTimeout callback so we
+   * don't setState on a torn-down component (React 18 strict-mode double-
+   * mount safety + general defence against unmount-during-retry).
+   */
+  private mounted = false;
+
+  static getDerivedStateFromError(error: unknown): Partial<State> {
     const errorMessage =
       error instanceof Error ? error.message : String(error ?? 'unknown');
     return { hasError: true, errorMessage };
+  }
+
+  override componentDidMount() {
+    this.mounted = true;
   }
 
   override componentDidCatch(error: unknown, info: unknown) {
@@ -32,10 +122,72 @@ export class WorldMapBoundary extends Component<
     // and surfaces in error-tracking integrations. Includes React component
     // stack so we can see WHERE in the WorldMap tree the throw came from.
     console.error('[cockpit] WorldMap failed to mount:', error, info);
+
+    // Auto-recovery for WebGL context loss: schedule a retry by bumping the
+    // remount key. We do this from componentDidCatch (not getDerivedStateFromError)
+    // because getDerivedStateFromError is supposed to be pure — side-effects
+    // like setTimeout belong here.
+    const message =
+      error instanceof Error ? error.message : String(error ?? '');
+    if (isWebglError(message)) {
+      this.scheduleAutoRetry();
+    }
+  }
+
+  override componentWillUnmount() {
+    this.mounted = false;
+    if (this.retryTimer !== null) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+  }
+
+  /**
+   * If the retry budget allows, schedule a remount of the children after
+   * RETRY_DELAY_MS. Caller has already confirmed the error is WebGL-flavored.
+   * Prunes stale timestamps outside RETRY_WINDOW_MS before counting, so a
+   * user who hits the limit once and then runs cleanly for 60s gets a fresh
+   * budget on the next incident.
+   */
+  private scheduleAutoRetry() {
+    const now = Date.now();
+    const recent = this.state.retryTimestamps.filter(
+      t => now - t < RETRY_WINDOW_MS,
+    );
+    if (recent.length >= MAX_AUTO_RETRIES) {
+      // Budget exhausted — let the manual "Tap to reload" UI take over.
+      // Clear retryPending so the button (not the spinner) renders.
+      if (this.state.retryPending) {
+        this.setState({ retryPending: false });
+      }
+      return;
+    }
+
+    // Guard against double-scheduling (defensive — React 18 strict mode can
+    // double-invoke componentDidCatch in dev). If a timer is already pending,
+    // let it run.
+    if (this.retryTimer !== null) return;
+
+    this.setState({ retryPending: true });
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      if (!this.mounted) return;
+      this.setState(prev => ({
+        hasError: false,
+        errorMessage: undefined,
+        retryKey: prev.retryKey + 1,
+        retryTimestamps: [
+          ...prev.retryTimestamps.filter(t => Date.now() - t < RETRY_WINDOW_MS),
+          Date.now(),
+        ],
+        retryPending: false,
+      }));
+    }, RETRY_DELAY_MS);
   }
 
   override render() {
     if (this.state.hasError) {
+      const isWebgl = isWebglError(this.state.errorMessage);
       return (
         <div
           data-testid="cockpit-worldmap-fallback"
@@ -66,7 +218,9 @@ export class WorldMapBoundary extends Component<
             >
               ◈
             </div>
-            <div style={{ textTransform: 'uppercase' }}>World Map Offline</div>
+            <div style={{ textTransform: 'uppercase' }}>
+              {this.state.retryPending ? 'Recovering Map…' : 'World Map Offline'}
+            </div>
             <div
               style={{
                 fontFamily: tokens.font.mono,
@@ -76,11 +230,13 @@ export class WorldMapBoundary extends Component<
                 letterSpacing: '0.05em',
               }}
             >
-              {this.state.errorMessage
-                ? `error: ${this.state.errorMessage}`
-                : 'Standalone view — backend not reachable'}
+              {this.state.retryPending
+                ? 'Reclaiming WebGL context'
+                : this.state.errorMessage
+                  ? `error: ${this.state.errorMessage}`
+                  : 'Standalone view — backend not reachable'}
             </div>
-            {this.state.errorMessage?.includes('WebGL context lost') && (
+            {isWebgl && !this.state.retryPending && (
               <button
                 type="button"
                 onClick={() => window.location.reload()}
@@ -105,6 +261,15 @@ export class WorldMapBoundary extends Component<
         </div>
       );
     }
-    return this.props.children;
+    // `key` on a Fragment forces a full unmount+remount of the WorldMap
+    // subtree after each auto-recovery so PixiJS gets a fresh canvas + fresh
+    // GL context instead of trying to revive a destroyed one. Fragment (not
+    // a div) is deliberate: the parent containers in MobileCockpitLayout,
+    // Cockpit page, and the standalone /worldmap-only route all rely on
+    // WorldMap's own root div being a direct flex/grid child — an extra
+    // wrapper div would break flex sizing in App.tsx. `key` is stable across
+    // non-error renders (retryKey only changes via scheduleAutoRetry) so
+    // normal re-renders don't blow away the map for no reason.
+    return <Fragment key={this.state.retryKey}>{this.props.children}</Fragment>;
   }
 }

--- a/apps/web/src/hooks/snapshotCacheConstants.ts
+++ b/apps/web/src/hooks/snapshotCacheConstants.ts
@@ -1,14 +1,19 @@
 /**
  * Shared cache key + payload-version + max-age constants for the WorldMap
- * snapshot localStorage cache. Imported by BOTH `useCachedSnapshot.ts` (the
- * hook that writes the cache) and `components/MapGhostLayer.tsx` (the static
- * ghost that reads it before PixiJS warms up).
+ * snapshot localStorage cache, plus the env+diamond-scoped viewport storage
+ * key used by both `WorldMap.tsx` (writer) and `components/MapGhostLayer.tsx`
+ * (reader). Imported by BOTH `useCachedSnapshot.ts` (the hook that writes
+ * the snapshot cache) and `components/MapGhostLayer.tsx` (the static ghost
+ * that reads it before PixiJS warms up).
  *
  * Why a shared module: these constants were previously duplicated across the
  * two files. If `PAYLOAD_VERSION` were bumped in the hook for a schema
  * migration but not in the ghost, the ghost would read stale data as if it
  * matched the new shape — silent corruption with no runtime error. Extracting
- * to one source of truth eliminates that drift hazard.
+ * to one source of truth eliminates that drift hazard. The same reasoning
+ * applies to `VIEWPORT_STORAGE_KEY`: WorldMap.tsx writes it, MapGhostLayer.tsx
+ * reads it, and they must agree on the exact scoped key to avoid the ghost
+ * rendering a different viewport than the canvas.
  *
  * Pure constants. NO imports from React, Pixi, Convex, or anything else —
  * keeps the module trivially tree-shakeable and safe to import from any layer.
@@ -33,6 +38,25 @@ const DIAMOND_SCOPE =
  * when the version doesn't match.
  */
 export const CACHE_KEY = `cw-snapshot-v1:${ENV_SCOPE}:${DIAMOND_SCOPE}`;
+
+/**
+ * sessionStorage key under which the WorldMap pan/zoom viewport state lives.
+ * Env+diamond scoped so switching backends in the same tab (or rolling out a
+ * new realm via the full-game-reset runbook) doesn't surface stale viewport
+ * state from the previous realm. Mirrors `CACHE_KEY`'s scoping pattern — see
+ * issue #300 / PR #275 for the diamond-scope rationale.
+ *
+ * Note: this lives in sessionStorage (tab-scoped, cleared on tab close) while
+ * `CACHE_KEY` lives in localStorage (origin-scoped, persists across tabs).
+ * The two scope discriminators are still applied identically so the keys
+ * stay logically consistent.
+ *
+ * One-time cost on the deploy that introduces this scoping: any user with an
+ * existing `cw-viewport-v1` sessionStorage entry will get a cache miss on
+ * first load (key changes) and fall back to fit-cover default. Same one-time
+ * cold-cache cost as PR #275's diamond-scope addition to `CACHE_KEY`.
+ */
+export const VIEWPORT_STORAGE_KEY = `cw-viewport-v1:${ENV_SCOPE}:${DIAMOND_SCOPE}`;
 
 /**
  * Increment when the cached payload SHAPE changes (Convex schema migration,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
@@ -20,12 +20,84 @@ const DEFAULT_PORT = (() => {
   }
 })();
 
+/**
+ * Inject `<link rel="preload" as="image">` for the map-BG asset into index.html.
+ *
+ * Why: MapGhostLayer.tsx renders the world-map.png background ASAP and ideally
+ * with `decoding="async"` so the first React paint doesn't block on bitmap
+ * decode. For that to be safe on cold cache (no HTTP entry), the browser needs
+ * to start fetching+decoding the PNG as early as possible. A `<link rel=preload>`
+ * in the HTML head gives the browser the URL during HTML parse — before any
+ * JS executes — so the fetch races with React bootstrap instead of waiting for
+ * mount. See issues #271, #298.
+ *
+ * Vite hashes the asset at build time (`world-map.<hash>.png`), so the link
+ * href can't be static. We compute the right href for both modes:
+ *   - In build: `ctx.bundle` is populated → find the emitted asset by its
+ *     ORIGINAL name (`output.name === 'world-map.png'`) rather than regex over
+ *     the hashed key. This is hash-shape independent (a Vite hash containing
+ *     hyphens won't break the lookup, per gemini-flash review on PR #303) and
+ *     cleanly excludes sibling assets like `world-map-winter.png` without
+ *     needing a fragile character-class.
+ *   - In dev: `ctx.bundle` is undefined → use the source path so the dev
+ *     server's middleware resolves it via the import graph.
+ *
+ * We return Vite tag descriptors (`{ tag, attrs, injectTo: 'head' }`) rather
+ * than doing a string `replace` on `</head>`. The descriptor path is what
+ * Vite's own preload helper uses, so injection is insensitive to surrounding
+ * whitespace, case (`</HEAD>`), or other transforms reshaping the HTML —
+ * closing the "string-replace fragility" LOW from codex review on PR #303.
+ *
+ * `order: 'pre'` keeps the tag toward the top of `<head>`, before other
+ * Vite-injected script/style links.
+ */
+function mapBgPreloadPlugin(): Plugin {
+  return {
+    name: 'inject-map-bg-preload',
+    transformIndexHtml: {
+      order: 'pre',
+      handler(html, ctx) {
+        // Honor a custom `base` if/when one is configured (e.g. deploying
+        // under a subpath). Defaults to '/' which is the current setup.
+        const base = ctx.server?.config.base ?? '/';
+        let href: string | null = null;
+        if (ctx.bundle) {
+          // Build: locate by original source filename. Vite/Rollup populates
+          // `output.name` with the pre-hash basename for asset outputs, so
+          // this is hash-shape independent. Restrict to type==='asset' so we
+          // don't accidentally match a chunk that happens to be named the same.
+          for (const [key, output] of Object.entries(ctx.bundle)) {
+            if (output.type === 'asset' && output.name === 'world-map.png') {
+              href = `${base}${key}`.replace(/\/{2,}/g, '/');
+              break;
+            }
+          }
+        } else {
+          // Dev: Vite serves the source asset directly via /src/assets/...
+          href = `${base}src/assets/world-map.png`.replace(/\/{2,}/g, '/');
+        }
+        if (!href) return html;
+        return {
+          html,
+          tags: [
+            {
+              tag: 'link',
+              attrs: { rel: 'preload', as: 'image', href },
+              injectTo: 'head',
+            },
+          ],
+        };
+      },
+    },
+  };
+}
+
 // envDir: load .env.local from the monorepo root, not the web app folder.
 // .env.local lives at <repo-root>/.env.local and is shared with server/agents.
 // Without this, VITE_* values are undefined at build time and the prod bundle
 // has no Convex URL or demo-mode configuration baked in.
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), mapBgPreloadPlugin()],
   envDir: path.resolve(__dirname, '../..'),
   server: {
     port: DEFAULT_PORT,


### PR DESCRIPTION
## Summary

Post-v2.8.0 follow-up sweep: 4 PRs landing wave-2 + wave-3 deliverables from the overnight cycle.

## What's in this release

- **#299** (#301 `a9bd068`) — Tighten danger-list regex from `/^init.*/` → `/^init([A-Z]|$)/` to stop over-matching `initialized`-style view getters. Belt-and-suspenders: added `initialize` to literal `DANGEROUS_FN_NAMES` set (codex r2 catch).
- **#300** (#302 `9126865`) — Env-scope `cw-viewport-v1` storage key (now `cw-viewport-v1:${VITE_CONVEX_URL}:${VITE_CLAN_WORLD_CONTRACT_ADDRESS}`) for consistency with the snapshot cache pattern from #275. One-time viewport sessionStorage cache miss on first deploy expected.
- **#271, #298** (#303 `1fdcce9`) — `<link rel="preload" as="image">` injected via custom Vite `transformIndexHtml` plugin for the hashed map BG asset; `MapGhostLayer` flipped to `decoding="async"` for non-blocking first paint. Closes deferred trade-off from PR #270.
- **#304** (#305 `5870d97`) — WebGL context-loss auto-recovery in `WorldMapBoundary`. Up to 3 retries within rolling 60s window via `<Fragment key={retryKey}>` remount. Non-WebGL errors still require manual reload.

## Review process

Each PR ran the local 3-tier swarm with fix rounds until clean:
- #303 r2: codex caught Vite asset regex rejecting hashes with `-`; fixed with `[A-Za-z0-9_-]+` + negative lookahead for `world-map-winter` sibling.
- #301 r2: codex caught new regex no longer matching bare `initialize`; added to literal name set.

Cloud reviewers (Copilot + Gemini Code Assist) will fire after PR open.

## Test plan

- [ ] Vercel preview build emits `<link rel="preload" as="image">` for the hashed map asset
- [ ] iOS PWA cold-load: map BG paints without the brief white flash
- [ ] Dev-ui: `initialize` triggers the confirm() dialog if invoked
- [ ] Force WebGL context loss via Chromium devtools "Lose Context" → auto-recovery happens without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)