### PR TITLE
ci: deploy to vercel only on v* tag push

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,79 @@
+name: Deploy to Vercel (tags only)
+
+# Production deploys for apps/web and apps/landing fire ONLY on a v* tag push.
+# Vercel's automatic git integration MUST be disconnected for both projects.
+# Requires repo secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID_WEB, VERCEL_PROJECT_ID_LANDING
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: vercel-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy-web:
+    name: Deploy apps/web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Install Vercel CLI
+        run: pnpm install -g vercel@latest
+      - name: Pull Vercel env (production)
+        working-directory: apps/web
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build (production)
+        working-directory: apps/web
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy (production)
+        working-directory: apps/web
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+  deploy-landing:
+    name: Deploy apps/landing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Install Vercel CLI
+        run: pnpm install -g vercel@latest
+      - name: Pull Vercel env (production)
+        working-directory: apps/landing
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build (production)
+        working-directory: apps/landing
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy (production)
+        working-directory: apps/landing
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/deploy-prod.yml` that drives production deploys for `apps/web` and `apps/landing` via the Vercel CLI, fired only by `push: tags: ['v*']`.

Replaces Vercel's automatic git integration (which currently deploys on every push to main).

## After merge — manual setup required

### 1. Disconnect Vercel git integration

For BOTH projects (`web` and `landing`):

1. Open the Vercel dashboard → Settings → Git
2. Click **Disconnect from Git**

This stops automatic main-branch + preview deploys entirely.

### 2. Add repo secrets

In `clan-world-game` → Settings → Secrets and variables → Actions → New repository secret. Add all four:

| Secret name | Value source |
|---|---|
| `VERCEL_TOKEN` | Create at https://vercel.com/account/tokens (scope to the team) |
| `VERCEL_ORG_ID` | `team_YZdNnTlbEqyXPmeEe0JmPZ93` (already known) |
| `VERCEL_PROJECT_ID_WEB` | `prj_II3YJz4tWFSGaxOCmmepjn1aMHBL` (from `apps/web/.vercel/project.json`) |
| `VERCEL_PROJECT_ID_LANDING` | Vercel landing project → Settings → General → Project ID |

### 3. Smoke test

```
git tag v2.8.2-test
git push origin v2.8.2-test
```

Watch the **Actions** tab. Workflow should run two jobs (`deploy-web` + `deploy-landing`) in parallel and both deploy to production. Once verified, delete the test tag:

```
git tag -d v2.8.2-test && git push origin :refs/tags/v2.8.2-test
```

From then on, only `git tag vX.Y.Z && git push origin vX.Y.Z` triggers production deploys.

## Test plan

- [ ] User disconnects Vercel git integration on both projects
- [ ] User adds all 4 secrets to repo
- [ ] User pushes `v2.8.2-test` tag — workflow fires
- [ ] Both jobs (web + landing) succeed
- [ ] Production deploys land on app.clan-world.com + clan-world.com (or wherever landing lives)
- [ ] Tag deleted post-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)