### PR TITLE
release: v2.8.2 — Vercel tag-only deploy workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,79 @@
+name: Deploy to Vercel (tags only)
+
+# Production deploys for apps/web and apps/landing fire ONLY on a v* tag push.
+# Vercel's automatic git integration MUST be disconnected for both projects.
+# Requires repo secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID_WEB, VERCEL_PROJECT_ID_LANDING
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: vercel-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy-web:
+    name: Deploy apps/web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Install Vercel CLI
+        run: pnpm install -g vercel@latest
+      - name: Pull Vercel env (production)
+        working-directory: apps/web
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build (production)
+        working-directory: apps/web
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy (production)
+        working-directory: apps/web
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+  deploy-landing:
+    name: Deploy apps/landing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Install Vercel CLI
+        run: pnpm install -g vercel@latest
+      - name: Pull Vercel env (production)
+        working-directory: apps/landing
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build (production)
+        working-directory: apps/landing
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy (production)
+        working-directory: apps/landing
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary

Single-PR ship: brings the new `.github/workflows/deploy-prod.yml` workflow onto `main` so production deploys are driven by `v*` tag pushes via the Vercel CLI, not by Vercel's automatic git integration.

## Diff

One commit (squash of #307):
- `6567d76` — ci: deploy to vercel only on v* tag push

Single file added: `.github/workflows/deploy-prod.yml` (~75 lines YAML)

No application code changes. No new dependencies.

## What happens on tag push

The workflow's first real exercise is the v2.8.2 tag itself — once merged + tagged, `apps/web` and `apps/landing` will deploy in parallel via Vercel CLI.

Required GitHub secrets (already set, verified):
- `VERCEL_TOKEN` ✓
- `VERCEL_ORG_ID` ✓
- `VERCEL_PROJECT_ID_WEB` ✓
- `VERCEL_PROJECT_ID_LANDING` ✓

Both Vercel projects already git-disconnected (confirmed by user).

## Risk

Low — CI workflow file, no executable application code change. Workflow fires only on `v*` tag push. Worst-case failure: deploy job fails → Vercel state unchanged, manual `vercel --prod` always available as backup.

## Skipping super-swarm

Per `feedback_quota_efficiency_skip_orch_swarm`: low-risk CI-only PR, single yaml file, no app code, the tag push IS the live test. Will super-swarm next substantive release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)