### PR TITLE
ci: fix contracts.yml validation rejection (#309)

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,6 +1,7 @@
 name: Contracts
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -43,5 +44,5 @@ jobs:
       - name: Dry-run diamond deploy script
         working-directory: packages/contracts
         env:
-          DEPLOYER_PRIVATE_KEY: 0x59c6995e998f97a5a0044966f094538a006b364ed7ced4d55405b87ae35b0b2a
+          DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
         run: bash scripts/forge.sh script script/DeployDiamond.s.sol:DeployDiamond


### PR DESCRIPTION
## Summary

Fixes `.github/workflows/contracts.yml` which has been silently rejected by GH Actions' workflow validator since 2026-05-09. 100/100 runs failed at 0 seconds with no jobs spawned.

Closes #309.

## Change

Two-line diff:

1. Replace hardcoded Anvil test private key (`DEPLOYER_PRIVATE_KEY: 0x59c6…`) with `${{ secrets.DEPLOYER_PRIVATE_KEY }}`. The secret is already configured with the same Anvil value, so runtime behavior is unchanged.
2. Add `workflow_dispatch:` trigger to the `on:` block for manual retesting after merge.

## Codex's hypothesis & reasoning

(from `.codex-fix-notes.md` in worktree — not committed)

> GitHub Actions was rejecting `.github/workflows/contracts.yml` during workflow validation because it contained a literal 64-hex-character private-key-shaped value under `DEPLOYER_PRIVATE_KEY`. Even though the value was the public Anvil test key, it matches secret-scanning/private-key patterns closely enough that GitHub may reject the workflow before registering metadata or spawning jobs.
> 
> I compared `contracts.yml` with the known-working `.github/workflows/chainclient-abi.yml` and `.gitmodules`. The Node version, Foundry action pin, pnpm setup, and recursive submodule checkout are consistent with the working workflow, so I did not change them. Those settings would also be expected to fail during a job step, not at GitHub's pre-job workflow validation stage.

## Test plan

1. Merge this PR to dev.
2. Workflow should fire on the merge push (since `push: branches: [dev, main]` is in the trigger).
3. Verify in the Actions tab: this run should NOT be 0s — it should actually spawn the `contracts` job and start running steps.
4. If validation still fails, the issue body (#309) lists 4 additional fallback hypotheses to try (delete+recreate file, rename file, pin foundry@v2, pin Node to 22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)