### PR TITLE
feat(cockpit): version badge overlay in top-right of map (#312)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -38,6 +38,9 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+          # Stamp the build with the release tag for the VersionBadge overlay.
+          # Surfaces stale-build regressions during UAT (issue #312).
+          VITE_APP_VERSION: ${{ github.ref_name }}
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy (production)
         working-directory: apps/web
@@ -70,6 +73,9 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING }}
+          # Stamp the build with the release tag (parity with apps/web; safe
+          # no-op if landing doesn't read VITE_APP_VERSION). Issue #312.
+          VITE_APP_VERSION: ${{ github.ref_name }}
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy (production)
         working-directory: apps/landing

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -9,6 +9,7 @@ import { WorldNoticePanel } from './WorldNoticePanel';
 import { TopHud } from './TopHud';
 import { EventTicker } from './EventTicker';
 import { MapGhostLayer } from './components/MapGhostLayer';
+import { VersionBadge } from './components/cockpit/VersionBadge';
 import { MAP_WIDTH, MAP_HEIGHT, LIVE_CLAN_REGION_BY_ID } from './components/mapGeometry';
 import { api } from '../../server/convex/_generated/api';
 import worldMapBg from './assets/world-map.png';
@@ -5494,6 +5495,10 @@ export function WorldMap() {
           WORLD events (bandits, raids, weather). Distinct from per-clan
           speech bubbles. */}
       <WorldNoticePanel />
+
+      {/* Build-version badge — top-right corner. Source: VITE_APP_VERSION
+          baked at build time from the release tag. See issue #312. */}
+      <VersionBadge />
     </div>
   );
 }

--- a/apps/web/src/components/cockpit/VersionBadge.tsx
+++ b/apps/web/src/components/cockpit/VersionBadge.tsx
@@ -1,0 +1,36 @@
+/**
+ * VersionBadge — subtle top-right overlay on the map area showing the build
+ * version. Sourced from `VITE_APP_VERSION` injected at build time (set by
+ * `.github/workflows/deploy-prod.yml` to the pushed tag, e.g. `v2.2.0`).
+ *
+ * Why: Vercel has shipped stale builds without anyone noticing during UAT.
+ * A visible version string makes that class of regression instantly obvious.
+ *
+ * Falls back to `'dev'` so local browsing never shows an empty/blank badge.
+ * See issue #312.
+ */
+export function VersionBadge() {
+  const version = import.meta.env.VITE_APP_VERSION || 'dev';
+  return (
+    <div
+      data-testid="version-badge"
+      style={{
+        position: 'absolute',
+        top: 8,
+        right: 8,
+        padding: '2px 6px',
+        fontFamily: 'monospace',
+        fontSize: 10,
+        color: '#e8e2c8',
+        background: 'rgba(13, 26, 13, 0.35)',
+        borderRadius: 3,
+        opacity: 0.6,
+        pointerEvents: 'none',
+        zIndex: 2,
+        letterSpacing: '0.02em',
+      }}
+    >
+      {version}
+    </div>
+  );
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -92,6 +92,13 @@ function mapBgPreloadPlugin(): Plugin {
   };
 }
 
+// VITE_APP_VERSION: stamped at build time from the GitHub release tag (set by
+// `.github/workflows/deploy-prod.yml` to `${{ github.ref_name }}`). The
+// VersionBadge overlay displays this so deployed builds are visibly tagged
+// and stale-deploy regressions are obvious during UAT. Locally we fall back
+// to 'dev' so the badge is never empty. See issue #312.
+const APP_VERSION = process.env.VITE_APP_VERSION ?? 'dev';
+
 // envDir: load .env.local from the monorepo root, not the web app folder.
 // .env.local lives at <repo-root>/.env.local and is shared with server/agents.
 // Without this, VITE_* values are undefined at build time and the prod bundle
@@ -99,6 +106,9 @@ function mapBgPreloadPlugin(): Plugin {
 export default defineConfig({
   plugins: [react(), mapBgPreloadPlugin()],
   envDir: path.resolve(__dirname, '../..'),
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(APP_VERSION),
+  },
   server: {
     port: DEFAULT_PORT,
     host: '127.0.0.1',


### PR DESCRIPTION
## Summary

Adds a small, semi-transparent monospace version string to the top-right corner of the map area. Sourced from `VITE_APP_VERSION` baked at build time from the GitHub release tag; falls back to `'dev'` for local browsing. Surfaces stale-deploy regressions during UAT — a class of bug we recently hit silently on Vercel.

## Where the badge renders

Top-right of the map area (`top: 8, right: 8`), 10px monospace, `opacity: 0.6`, low-alpha green background to match the existing top-left clan summary panel. Rendered as the last sibling inside `WorldMap.tsx`'s outer `position: relative` div, so it overlays the PixiJS canvas (z-index 2) but stays beneath any modal/dialog. Works automatically in both the standalone `/` route and the cockpit `/cockpit` route since both render `<WorldMap />`. Reads `dev` when running `vite dev` locally; reads `v2.x.y` on tagged production deploys.

## Files changed

- `apps/web/src/components/cockpit/VersionBadge.tsx` — new component (29 lines, inline styles, no new deps)
- `apps/web/src/WorldMap.tsx` — import + render as last sibling in the map container
- `apps/web/vite.config.ts` — `define` block wires `VITE_APP_VERSION` with `'dev'` fallback so the bundle never has `undefined`
- `.github/workflows/deploy-prod.yml` — sets `VITE_APP_VERSION: ${{ github.ref_name }}` on the Build (production) step in both `deploy-web` and `deploy-landing` jobs

## Local build verification

- `pnpm --filter @clan-world/web build` succeeds cleanly
- Without env override: `"dev"` is baked into `dist/assets/index-*.js`
- With `VITE_APP_VERSION=v2.2.0 pnpm --filter @clan-world/web build`: `"v2.2.0"` is baked into `dist/assets/index-*.js`

## Test plan

- [ ] On the next tagged release, the deployed app shows the tag (e.g. `v2.3.0`) in the top-right of the map
- [ ] Local `pnpm dev` shows `dev` in the top-right
- [ ] Badge does not visually obscure clan bases or HUD elements

Closes #312