### PR TITLE
ci: add workflow_dispatch to deploy-prod for manual retries

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,6 +1,7 @@
 name: Contracts
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -43,5 +44,5 @@ jobs:
       - name: Dry-run diamond deploy script
         working-directory: packages/contracts
         env:
-          DEPLOYER_PRIVATE_KEY: 0x59c6995e998f97a5a0044966f094538a006b364ed7ced4d55405b87ae35b0b2a
+          DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
         run: bash scripts/forge.sh script script/DeployDiamond.s.sol:DeployDiamond

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,6 +8,15 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual trigger — re-deploy a specific tag without retagging.
+  # Useful when secrets are rotated or a transient Vercel error blocked the
+  # original tag-push run. Pass the tag (or branch) as the workflow ref.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to deploy (informational; the workflow checks out the ref the dispatch was triggered on)'
+        required: false
+        default: ''
 
 concurrency:
   group: vercel-prod

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -38,6 +38,9 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+          # Stamp the build with the release tag for the VersionBadge overlay.
+          # Surfaces stale-build regressions during UAT (issue #312).
+          VITE_APP_VERSION: ${{ github.ref_name }}
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy (production)
         working-directory: apps/web
@@ -70,6 +73,9 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING }}
+          # Stamp the build with the release tag (parity with apps/web; safe
+          # no-op if landing doesn't read VITE_APP_VERSION). Issue #312.
+          VITE_APP_VERSION: ${{ github.ref_name }}
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy (production)
         working-directory: apps/landing

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -9,6 +9,7 @@ import { WorldNoticePanel } from './WorldNoticePanel';
 import { TopHud } from './TopHud';
 import { EventTicker } from './EventTicker';
 import { MapGhostLayer } from './components/MapGhostLayer';
+import { VersionBadge } from './components/cockpit/VersionBadge';
 import { MAP_WIDTH, MAP_HEIGHT, LIVE_CLAN_REGION_BY_ID } from './components/mapGeometry';
 import { api } from '../../server/convex/_generated/api';
 import worldMapBg from './assets/world-map.png';
@@ -5494,6 +5495,10 @@ export function WorldMap() {
           WORLD events (bandits, raids, weather). Distinct from per-clan
           speech bubbles. */}
       <WorldNoticePanel />
+
+      {/* Build-version badge — top-right corner. Source: VITE_APP_VERSION
+          baked at build time from the release tag. See issue #312. */}
+      <VersionBadge />
     </div>
   );
 }

--- a/apps/web/src/components/cockpit/VersionBadge.tsx
+++ b/apps/web/src/components/cockpit/VersionBadge.tsx
@@ -1,0 +1,36 @@
+/**
+ * VersionBadge — subtle top-right overlay on the map area showing the build
+ * version. Sourced from `VITE_APP_VERSION` injected at build time (set by
+ * `.github/workflows/deploy-prod.yml` to the pushed tag, e.g. `v2.2.0`).
+ *
+ * Why: Vercel has shipped stale builds without anyone noticing during UAT.
+ * A visible version string makes that class of regression instantly obvious.
+ *
+ * Falls back to `'dev'` so local browsing never shows an empty/blank badge.
+ * See issue #312.
+ */
+export function VersionBadge() {
+  const version = import.meta.env.VITE_APP_VERSION || 'dev';
+  return (
+    <div
+      data-testid="version-badge"
+      style={{
+        position: 'absolute',
+        top: 8,
+        right: 8,
+        padding: '2px 6px',
+        fontFamily: 'monospace',
+        fontSize: 10,
+        color: '#e8e2c8',
+        background: 'rgba(13, 26, 13, 0.35)',
+        borderRadius: 3,
+        opacity: 0.6,
+        pointerEvents: 'none',
+        zIndex: 2,
+        letterSpacing: '0.02em',
+      }}
+    >
+      {version}
+    </div>
+  );
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -92,6 +92,13 @@ function mapBgPreloadPlugin(): Plugin {
   };
 }
 
+// VITE_APP_VERSION: stamped at build time from the GitHub release tag (set by
+// `.github/workflows/deploy-prod.yml` to `${{ github.ref_name }}`). The
+// VersionBadge overlay displays this so deployed builds are visibly tagged
+// and stale-deploy regressions are obvious during UAT. Locally we fall back
+// to 'dev' so the badge is never empty. See issue #312.
+const APP_VERSION = process.env.VITE_APP_VERSION ?? 'dev';
+
 // envDir: load .env.local from the monorepo root, not the web app folder.
 // .env.local lives at <repo-root>/.env.local and is shared with server/agents.
 // Without this, VITE_* values are undefined at build time and the prod bundle
@@ -99,6 +106,9 @@ function mapBgPreloadPlugin(): Plugin {
 export default defineConfig({
   plugins: [react(), mapBgPreloadPlugin()],
   envDir: path.resolve(__dirname, '../..'),
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(APP_VERSION),
+  },
   server: {
     port: DEFAULT_PORT,
     host: '127.0.0.1',

--- a/docs/runbooks/full-game-reset.md
+++ b/docs/runbooks/full-game-reset.md
@@ -2,6 +2,8 @@
 
 Use this when we want a totally fresh live realm: new Base Sepolia diamond, backup diamond, empty Convex state, regenerated contract artifacts, restarted heartbeat/runner/Elder sessions, and a fresh frontend deploy.
 
+> **Considering a less invasive reset?** If the diamond ABI hasn't changed and you only need to revive dead clansmen + restock vaults mid-season, use `docs/runbooks/soft-game-reset.md` instead. That's faster and preserves clan IDs / owner addresses / season number.
+
 This is the "do the whole reset now" checklist. For deeper setup details, see:
 
 - `docs/runbooks/fresh-vps-bootstrap.md`

--- a/docs/runbooks/soft-game-reset.md
+++ b/docs/runbooks/soft-game-reset.md
@@ -1,0 +1,231 @@
+# Clan World — Soft Mid-Season Reset Runbook
+
+Use this when the game is in a death-spiral or stalled state mid-season but you DO NOT want to redeploy the diamond (preserves clan IDs, owner addresses, season counter, on-chain history). This pattern uses `AdminRecoveryFacet` + `WorldPauseFacet` to do live recovery without touching the contracts.
+
+For a FULL reset (new diamond, fresh Convex, season=1), see `docs/runbooks/full-game-reset.md`. This file is the lighter-weight alternative for mid-season unstucks.
+
+## Decision matrix — soft vs full
+
+Use the **soft** reset (this runbook) when ALL of the following are true:
+
+- Same season number is fine to keep
+- Diamond ABI hasn't changed (no facet selectors added/removed)
+- You want existing clan owners (wallet addresses) preserved
+- You don't need a fresh genesis tick
+
+Use the **full** reset (`docs/runbooks/full-game-reset.md`) when ANY of the following is true:
+
+- New facet selectors added (diamond cut needed)
+- Clan IDs need to change
+- Season counter needs to reset
+- Storage schema migration required
+
+## Sequence (with exact commands)
+
+Run these steps **in this order**. Skipping or reordering the pause/heartbeat steps is what causes most failed soft-resets.
+
+## 1. Stop the off-chain heartbeat loop
+
+The heartbeat loop calls `heartbeat()` every ~5s. While running, it consumes resources (starvation, bandit attacks, cold damage) on every tick. Revives + injects that complete during a heartbeat window will be eaten before you can verify them.
+
+```bash
+tmux kill-session -t clanworld-heartbeat 2>/dev/null || true
+pkill -f clanworld-heartbeat-with-finalize 2>/dev/null
+# Verify dead:
+pgrep -af clanworld-heartbeat-with-finalize | command grep -v grep
+```
+
+## 2. Pause the world on-chain
+
+```bash
+DIAMOND=<your-diamond-address>
+RPC=https://sepolia.base.org  # see "RPC selection" gotcha below
+DEPLOYER_KEY=$(cat ~/.secrets/clanworld-v3-deployer.key)
+export PATH="$HOME/.foundry/bin:$PATH"
+
+cast send "$DIAMOND" "pauseWorld()" --rpc-url "$RPC" --private-key "$DEPLOYER_KEY"
+# Verify:
+cast call "$DIAMOND" "isWorldPaused()(bool)" --rpc-url "$RPC"
+# Should print: true
+```
+
+This prevents `heartbeat()` from running — so even if the off-chain loop is still alive somewhere, the chain side rejects with "rate limited".
+
+## 3. Revive + inject per clan
+
+For each clan ID (typically 1..4):
+
+```bash
+for clan in 1 2 3 4; do
+  cast send "$DIAMOND" "reviveDeadClansmen(uint32)" "$clan" \
+    --rpc-url "$RPC" --private-key "$DEPLOYER_KEY"
+  cast send "$DIAMOND" "injectClanResources(uint32,uint256,uint256,uint256,uint256,uint256,uint256)" \
+    "$clan" <wood> <iron> <wheat> <fish> <gold> <blueprint> \
+    --rpc-url "$RPC" --private-key "$DEPLOYER_KEY"
+done
+```
+
+**Argument order matters:** `(clanId, wood, iron, wheat, fish, gold, blueprint)` — all uint256, all raw integer counts (NOT e18-scaled).
+
+The functions are owner-gated. Pre-check the deployer key matches the diamond owner: `cast call "$DIAMOND" "owner()(address)" --rpc-url "$RPC"` should equal `cast wallet address $(cat ~/.secrets/clanworld-v3-deployer.key)`.
+
+## 4. Verify state held WHILE PAUSED
+
+```bash
+for clan in 1 2 3 4; do
+  cast call "$DIAMOND" \
+    "getClan(uint32)((uint32,uint256,address,uint8,uint8,uint8,uint8,uint8,uint8,uint64,uint64,uint16,uint64,uint256,uint256,uint256,uint256,uint256,uint256))" \
+    "$clan" --rpc-url "$RPC"
+done
+```
+
+The decoded tuple positions are (in source order from `IClanWorld.sol::struct Clan`):
+
+1. clanId
+2. iftTokenId
+3. owner
+4. clanState (enum: 0=ACTIVE, 1=DEAD; verify against the latest `ClanState` enum)
+5. baseRegion
+6. baseLevel
+7. wallLevel
+8. monumentLevel
+9. **livingClansmen** — must be > 0 after revive
+10. lastSettledTick
+11. starvationStartsAtTick
+12. coldDamage
+13. ownerNonce
+14. goldBalance
+15. blueprintBalance
+16. **vaultWood** — must match your inject value
+17. **vaultIron**
+18. **vaultWheat**
+19. **vaultFish**
+
+If any of fields 9, 16-19 don't match expected: re-run the failed tx (see "RPC drops" gotcha below).
+
+## 5. Bandit-tier and other config (optional)
+
+Set max bandit difficulty if needed:
+
+```bash
+cast send "$DIAMOND" "setMaxBanditTier(uint8)" 1 \
+  --rpc-url "$RPC" --private-key "$DEPLOYER_KEY"
+# Verify:
+cast call "$DIAMOND" "maxBanditTier()(uint8)" --rpc-url "$RPC"
+```
+
+Valid range is `[1, 5]`. `1` = weakest bandits (good while tuning elder strategy).
+
+## 6. Unpause the world
+
+```bash
+cast send "$DIAMOND" "unpauseWorld()" --rpc-url "$RPC" --private-key "$DEPLOYER_KEY"
+cast call "$DIAMOND" "isWorldPaused()(bool)" --rpc-url "$RPC"
+# Should print: false
+```
+
+`unpauseWorld()` also reschedules `nextHeartbeatAtTs`, so heartbeat works immediately.
+
+## 7. Restart off-chain processes
+
+```bash
+# Heartbeat
+tmux new-session -d -s clanworld-heartbeat \
+  -c ~/code/clan-world/clan-world-game \
+  ~/bin/clanworld-heartbeat-with-finalize
+
+# Elder runner v2 (tick-driven, Convex polling)
+# Skip if already running: pgrep -f clanworld-elder-runner-v2
+tmux new-session -d -s clanworld-elder-runner \
+  -c ~ \
+  ~/bin/clanworld-elder-runner-v2
+
+# Elders themselves should already be in tmux (elder-1..4).
+# If they're stuck on "Dead. Holding." stale state, restart each:
+for n in 1 2 3 4; do
+  tmux kill-session -t "elder-$n" 2>/dev/null
+  tmux new-session -d -s "elder-$n" -c ~/clan-world/elder-$n "bash run.sh"
+done
+```
+
+## 8. Verify off-chain caught up
+
+```bash
+# Wait 30-60s then:
+cast call "$DIAMOND" "getWorldState()((uint64,uint64,uint64,bool,uint64))" --rpc-url "$RPC"
+# Tick should be > the pre-reset tick
+
+# Convex snapshot should reflect on-chain state:
+curl -s "https://valuable-kudu-985.convex.cloud/api/query" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"path":"getSnapshot:getSnapshot","args":{}}' \
+  | jq '.value.worldSnapshot.tick'
+# Should match (or be 1-2 behind) the on-chain tick
+```
+
+## Operational gotchas (captured from live runs)
+
+### Race: heartbeat eats your reset
+
+If the heartbeat loop is running when you call `reviveDeadClansmen` + `injectClanResources`, each subsequent heartbeat tick can consume the freshly-injected resources (starvation, bandit attacks). Your `status=1` event-emitting tx WILL have completed, but state may show the reset never happened.
+
+**Always pause the world BEFORE running recovery txs.** Do not skip step 1+2.
+
+### RPC selection: Infura vs public Base Sepolia
+
+The repo's `.env.local` ships with `RPC_URL_PRIMARY=https://base-sepolia.infura.io/v3/<key>`. Infura has aggressive per-key rate limits — bulk reset operations (8 txs × 4 clans + verification queries) will exhaust the quota within 1-2 minutes. After that, the heartbeat loop's silent `read_world_state failed; sleeping` loop will spin indefinitely without alerting.
+
+**During admin operations and recovery, swap to the public Base Sepolia RPC:**
+
+```bash
+# In .env.local:
+RPC_URL_PRIMARY=https://sepolia.base.org
+RPC_URL_FALLBACK=https://base-sepolia.infura.io/v3/<key>  # (or leave Infura as fallback)
+```
+
+The public RPC is slower but rate-limit-free at game cadence. Swap back to Infura when not actively debugging if you want lower per-tx latency.
+
+### `cast send` loop silently drops txs
+
+When iterating `cast send` in a bash loop against the same RPC + same private key, some txs go through and some get dropped (no error, just no submission, no tx-hash output). Nonces stay in lock-step with what landed, so the "dropped" tx is just gone — no orphan nonce issue.
+
+**Always verify state per-clan after a batch run.** Re-run any missing tx individually:
+
+```bash
+# Verify each clan was modified
+for clan in 1 2 3 4; do
+  cast call "$DIAMOND" "getClan(uint32)(...struct...)" $clan --rpc-url "$RPC" | head -1
+done
+# Re-run individual cast send for any clan that didn't change
+```
+
+A `forge script` with explicit nonce sequencing is more robust for high-volume bulk admin operations, but for 8-16 calls the cast-and-verify loop is fine.
+
+### Owner check before pause
+
+If the deployer key does not match `owner()` on the diamond, ALL admin functions revert. Check upfront:
+
+```bash
+cast call "$DIAMOND" "owner()(address)" --rpc-url "$RPC"
+cast wallet address "$(cat ~/.secrets/clanworld-v3-deployer.key)"
+# Two outputs must match exactly.
+```
+
+### Convex snapshot freshness
+
+The cockpit reads from Convex, not the chain directly. After your on-chain reset, Convex doesn't update until the next heartbeat tick fires — which writes events that the Convex indexer ingests. So:
+
+1. Restart heartbeat (step 7)
+2. Wait for ≥1 heartbeat to complete (~5-10s)
+3. Re-query Convex snapshot
+
+If Convex is stale after multiple heartbeat cycles, the indexer's webhook may have a stale `CONVEX_WEBHOOK_URL` env. Check it matches the current Convex deployment.
+
+### Stale Vercel JS bundle masks fresh data
+
+If `app.clan-world.com` shows obviously wrong state (e.g. old polygon coords, missing UI elements you know shipped), the bundled JS is stale. Verify by checking the deployed `index-*.js` file vs current `git log` on main. To force a fresh deploy:
+
+- Local: `cd apps/web && vercel --prod` (requires Vercel CLI auth)
+- CI: push a new tag (workflow fires on `push: tags: ['v*']`)
+
+A Convex-fresh / Vercel-stale combo will show LATEST on-chain data inside an OLD UI — confusing but explains discrepancies.

--- a/packages/contracts/test/BanditAttackResolution.t.sol
+++ b/packages/contracts/test/BanditAttackResolution.t.sol
@@ -422,21 +422,30 @@ contract BanditAttackResolutionTest is Test {
 
         _advanceTick();
 
+        // 7 contributing defenders (1 explicit per clan + 3 waiting in target clan).
+        // Drop = 50% of 100e18 = 50e18. Per-defender share = floor(50e18 / 7)
+        // = 7142857142857142857 wei (~7.143e18). Remainder (1 wei × resource) is
+        // burned in the bandit's carry, not redistributed.
+        uint256 perDefender = uint256(50e18) / 7; // 7142857142857142857
         for (uint256 i = 0; i < clanIds.length; i++) {
             Clan memory clan = world.getClan(clanIds[i]);
             assertEq(clan.vaultWood, woodBefore[i], "wood stays out of vault");
             assertEq(clan.vaultWheat, wheatBefore[i] > 4e18 ? wheatBefore[i] - 4e18 : 0, "wheat pays heartbeat upkeep");
             assertEq(clan.vaultFish, fishBefore[i] > 4e17 ? fishBefore[i] - 4e17 : 0, "fish pays heartbeat upkeep");
             assertEq(clan.vaultIron, ironBefore[i], "iron stays out of vault");
-            assertEq(clan.goldBalance, goldBefore[i] + (i == 0 ? 29e18 : 7e18), "gold share");
+            // Target clan (i==0) collects 4 shares (1 explicit + 3 waiting) + 1e18 defeat reward;
+            // helper clans each collect 1 share.
+            uint256 expectedGoldDelta = (i == 0 ? 4 * perDefender + 1e18 : perDefender);
+            assertEq(clan.goldBalance, goldBefore[i] + expectedGoldDelta, "gold share");
         }
         for (uint256 i = 0; i < clanIds.length; i++) {
-            assertEq(world.getClansman(_csId(clanIds[i], 0)).carryWood, 7e18, "explicit wood share");
+            assertEq(world.getClansman(_csId(clanIds[i], 0)).carryWood, perDefender, "explicit wood share");
         }
-        assertEq(world.getClansman(_csId(clanIds[0], 1)).carryWood, 7e18, "waiting wood share 1");
-        assertEq(world.getClansman(_csId(clanIds[0], 2)).carryWood, 7e18, "waiting wood share 2");
-        assertEq(world.getClansman(_csId(clanIds[0], 3)).carryWood, 7e18, "waiting wood share 3");
+        assertEq(world.getClansman(_csId(clanIds[0], 1)).carryWood, perDefender, "waiting wood share 1");
+        assertEq(world.getClansman(_csId(clanIds[0], 2)).carryWood, perDefender, "waiting wood share 2");
+        assertEq(world.getClansman(_csId(clanIds[0], 3)).carryWood, perDefender, "waiting wood share 3");
         for (uint256 i = 0; i < clanIds.length; i++) {
+            // Iron share (~7.14e18) exceeds IRON_CAP (5e18) and is capped.
             assertEq(world.getClansman(_csId(clanIds[i], 0)).carryIron, 5e18, "iron capped");
         }
     }
@@ -595,15 +604,26 @@ contract BanditAttackResolutionTest is Test {
 
         _advanceTick();
 
+        // 6 contributing defenders (1 explicit per clan + 3 waiting in target clan).
+        // Drop = 50% of 100e18 = 50e18. Per-defender share = floor(50e18 / 6)
+        // = 8333333333333333333 wei (~8.333e18). Remainders (50e18 - 6 * share = 2 wei
+        // per resource) are burned in the bandit's carry, not redistributed.
+        uint256 perDefender = uint256(50e18) / 6; // 8333333333333333333
         uint256 goldAfterTotal;
         for (uint256 i = 0; i < clanIds.length; i++) {
             Clan memory clan = world.getClan(clanIds[i]);
-            assertEq(clan.goldBalance, 3e18 + (i == 0 ? 33e18 : 8e18), "gold share");
+            // Target clan (i==0) collects 4 shares (1 explicit + 3 waiting) + 1e18 defeat reward;
+            // helper clans each collect 1 share. 3e18 is the clan-mint starting gold.
+            uint256 expectedShare = (i == 0 ? 4 * perDefender + 1e18 : perDefender);
+            assertEq(clan.goldBalance, 3e18 + expectedShare, "gold share");
             goldAfterTotal += clan.goldBalance;
         }
-        assertEq(goldAfterTotal - goldBeforeTotal, 49e18, "undropped gold plus defeat reward");
-        assertEq(world.getClansman(_csId(clanIds[0], 0)).carryWood, 8e18, "target explicit wood");
+        // Total distributed gold = 6 * perDefender + 1e18 defeat reward.
+        assertEq(goldAfterTotal - goldBeforeTotal, 6 * perDefender + 1e18, "distributed gold plus defeat reward");
+        assertEq(world.getClansman(_csId(clanIds[0], 0)).carryWood, perDefender, "target explicit wood");
+        // Iron share (~8.33e18) exceeds IRON_CAP (5e18) and is capped.
         assertEq(world.getClansman(_csId(clanIds[0], 1)).carryIron, 5e18, "target waiting iron capped");
+        // Fish share (~8.33e18) exceeds FISH_CAP (8e18) and is capped.
         assertEq(world.getClansman(_csId(clanIds[1], 0)).carryFish, 8e18, "helper fish capped");
     }
 


### PR DESCRIPTION
## Summary

Add `workflow_dispatch` to `.github/workflows/deploy-prod.yml` so a deploy can be manually re-triggered against any ref without retagging.

## Why

The current tag-push trigger fires the deploy automatically — but if a deploy fails for a transient reason (secret misconfig, Vercel project rename mid-deploy, RPC quota, etc), the only options were:
- Delete + recreate the tag (destructive — breaks history)
- Push a new tag (clutters release log)
- `gh run rerun <id>` — currently returning `startup_failure` even after secrets were corrected (validated against PR #307 follow-up: corrected VERCEL_PROJECT_ID secrets, ran `gh run rerun 25897058592`, got `startup_failure`)

With `workflow_dispatch`, the deploy can be retried by:
```
gh workflow run deploy-prod.yml --ref v2.8.2 --repo clan-world/clan-world-game
```

## Test plan

- [x] YAML parses fine locally
- [ ] Manual `gh workflow run deploy-prod.yml --ref v2.8.2` to validate it fires
- [ ] Verify workflow_dispatch UI shows up in Actions tab