### PR TITLE
fix(cockpit): dead clansman grey-rectangle render artifact

### DIFF
--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -2752,7 +2752,7 @@ export function WorldMap() {
       halo = makeHaloGraphics();
       container.addChildAt(halo, 0);
     }
-    applyDeadVisualState(body, isDead);
+    applyDeadVisualState(body, isDead, clanId);
     const carry = makeCarryIndicator();
     carry.container.y = -24;
     container.addChild(carry.container);
@@ -2826,9 +2826,31 @@ export function WorldMap() {
    * For the inverse transition (dead→alive), use applyAliveVisualState — it
    * restores the feet-anchor (0.5, 0.82) and clears tint/rotation/alpha.
    */
-  function applyDeadVisualState(body: Sprite | Graphics | null, isDead: boolean) {
+  function applyDeadVisualState(body: Sprite | Graphics | null, isDead: boolean, clanId?: string) {
     if (!body) return;
     if (isDead) {
+      // The walk-sheet PNGs ship as RGB (no alpha channel) so tinting one to
+      // 0x808080 renders the entire 280×280 frame rect as a solid grey
+      // rectangle instead of just the figure silhouette. The legacy single-
+      // PNG sprites are RGBA with proper transparency — swap to one for the
+      // dead pose so the tint darkens the silhouette only. A corpse never
+      // animates so the walk-sheet's only advantage (frame cycling) is
+      // moot here.
+      if (clanId && 'texture' in body) {
+        const legacyTex = clansmanTextureCache[clanId];
+        if (legacyTex && (body as Sprite).texture !== legacyTex) {
+          const sprite = body as Sprite;
+          sprite.texture = legacyTex;
+          // Re-establish target size against the new texture — sprite.height
+          // = 34 puts scale.y = 34 / texture.height; swapping texture
+          // mid-flight without this leaves scale at the walk-sheet ratio
+          // (~34/280 = 0.12) applied to the 64-px legacy texture, shrinking
+          // the corpse to ~8px tall.
+          const targetH = 34;
+          sprite.height = targetH;
+          sprite.width = sprite.texture.width * (targetH / sprite.texture.height);
+        }
+      }
       // Anchor BEFORE rotation so the 90° flip pivots around the body
       // center, not the feet. Graphics fallback (circle drawn at origin)
       // has no .anchor — guard with `'anchor' in body`.
@@ -2857,8 +2879,29 @@ export function WorldMap() {
    * Note: the caller is responsible for restoring `halo.visible = true` on
    * the marker container — halo lives at marker level, not on `body`.
    */
-  function applyAliveVisualState(body: Sprite | Graphics | null) {
+  function applyAliveVisualState(body: Sprite | Graphics | null, spriteSheetId?: string) {
     if (!body) return;
+    // Symmetric inverse of applyDeadVisualState's texture swap: if the body
+    // currently shows the legacy single-PNG (left over from dead state) but
+    // a walk-sheet frame is available, restore it here so the revived
+    // clansman picks up the animation cycle again. `advanceClansmanAnimation`
+    // re-assigns sprite.texture per tick once it sees motion, but the FIRST
+    // frame post-revive (before any movement delta) would otherwise render
+    // the legacy texture standing-up — which looks wrong against the
+    // walk-sheet style.
+    if (spriteSheetId && 'texture' in body) {
+      const frameSet = getClansmanFrameSet(spriteSheetId);
+      if (frameSet) {
+        const sprite = body as Sprite;
+        const startTex = frameSet.rows.S[0]!;
+        if (sprite.texture !== startTex) {
+          sprite.texture = startTex;
+          const targetH = 34;
+          sprite.height = targetH;
+          sprite.width = sprite.texture.width * (targetH / sprite.texture.height);
+        }
+      }
+    }
     if ('anchor' in body) {
       (body as Sprite).anchor.set(0.5, 0.82);
     }
@@ -2908,7 +2951,7 @@ export function WorldMap() {
         // otherwise an alive→dead→alive cycle leaks state.
         if (wasDead !== marker.isDead) {
           if (marker.isDead) {
-            applyDeadVisualState(existing.body, true);
+            applyDeadVisualState(existing.body, true, marker.clanId);
             if (existing.halo) existing.halo.visible = false;
             if (existing.route) {
               // A corpse doesn't travel — drop the route line. We keep
@@ -2919,7 +2962,7 @@ export function WorldMap() {
               existing.route = undefined;
             }
           } else {
-            applyAliveVisualState(existing.body);
+            applyAliveVisualState(existing.body, marker.spriteSheetId);
             // Body size tracks missionActive too — a revived clansman with
             // missionActive=true needs the 42px body (not the 34px idle
             // size). Without this, the dead→alive revive restored anchor


### PR DESCRIPTION
## Summary

Dead clansmen in the cockpit Pixi scene rendered as solid grey rounded rectangles instead of recognizable lying-down silhouettes. Surgical fix swaps the sprite's texture to a legacy RGBA-backed single-PNG for the dead state, so tinting only darkens the figure (not the entire 280×280 frame-rect).

## Root Cause

The per-clan walk-sheet PNGs (`apps/web/src/assets/clansmen/clan-*-walk.png`) ship as **RGB** (no alpha channel) with near-white backgrounds — verified via `PIL`:

```
clan-iron-walk.png mode: RGB  corner: (241, 242, 241)
clan-ember-walk.png mode: RGB  corner: (238, 238, 238)
# All 7 walk-sheet PNGs are RGB, fully opaque background
```

The legacy single-PNG clansman sprites in `apps/web/public/clansmen/*.png` ARE RGBA with proper transparency:

```
clan-iron.png mode: RGBA size: (48, 64) corner: (0, 0, 0, 0)
```

When `applyDeadVisualState` sets `sprite.tint = 0x808080` on a walk-sheet-backed sprite, PixiJS multiplies the tint by every pixel — including the opaque background. Result: the full 280×280 frame-rect renders as a solid grey rectangle.

## Fix

`applyDeadVisualState` and `applyAliveVisualState` now accept the clan / sprite-sheet ID and swap the sprite's `texture`:

- **alive → dead**: swap to `clansmanTextureCache[clanId]` (RGBA legacy single-PNG)
- **dead → alive**: swap back to `frameSet.rows.S[0]` (walk-sheet frame)

Both swaps re-establish the sprite's display size (`sprite.height = 34`) against the new texture's natural dimensions to avoid scale.x/y drift (walk-sheet textures are 280px; legacy textures are 64px — without the size reset the corpse would shrink to ~8px tall).

A corpse never animates so the walk-sheet's only advantage (frame cycling) is moot for the dead state — no functional loss.

## Before / After

Before — dead clansman is a grey rounded rectangle blob:
![before](https://shared.claude.do/public/dead-clansman-before.png)

After — dead clansman is a darker-tinted figure lying horizontally with head/body distinguishable:
![after](https://shared.claude.do/public/dead-clansman-after.png)

Side-by-side:
![compare](https://shared.claude.do/public/dead-clansman-before-after.png)

## Verification

- `pnpm --filter @clan-world/web typecheck` — PASS
- Visually verified via Playwright screenshot harness: injected fake snapshot with a dead clansman, captured before/after via `/cockpit` route.

## Local 3-tier swarm review

- **codex (GPT-5)**: CLEAN. *"Texture swap fires in the right places. Dead markers skip `advanceClansmanAnimation` so the legacy RGBA corpse texture isn't immediately overwritten."*
- **gemini-3-flash**: CLEAN. *"Robust architectural solution. The fix correctly guards against redundant assignments and handles the Graphics fallback path."* (2 LOW nits noted; no blockers.)
- **Claude (self-review)**: covered fresh-dead, alive→dead, dead→alive, Graphics fallback, missionActive=42px revive, and asset-load eviction paths.

## Edge cases handled

- **Fresh dead marker with legacy texture not yet loaded**: walk-sheet sprite renders; bug returns briefly. Self-heals via existing texture-load eviction logic (`createBaseVisuals` evicts all markers for the clan when its legacy texture loads).
- **Graphics fallback** (no textures loaded at all): `'texture' in body` is false → no swap, but tint/rotation/anchor still applied. Renders as a tinted grey circle (existing behavior).
- **Dead → alive with mission active**: `applyAliveVisualState` resets to 34px; immediately followed by `applyMissionActiveBodySize` which bumps to 42px if needed (same single-frame pattern as before this change).

## Test plan

- [x] Typecheck
- [x] Visual smoke test on `/cockpit` route via Playwright
- [ ] Manual verification in live dev/staging with real chain-state clansmen transitioning alive→dead

🤖 Generated with [Claude Code](https://claude.com/claude-code)