### PR TITLE
feat(convex): split getSnapshot into tickClock + worldSnapshot queries (#333)

### DIFF
--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -21,6 +21,7 @@ import type * as comms from "../comms.js";
 import type * as crons from "../crons.js";
 import type * as events from "../events.js";
 import type * as getSnapshot from "../getSnapshot.js";
+import type * as getTickClock from "../getTickClock.js";
 import type * as gold from "../gold.js";
 import type * as goldQuote from "../goldQuote.js";
 import type * as heartbeat from "../heartbeat.js";
@@ -51,6 +52,7 @@ declare const fullApi: ApiFromModules<{
   crons: typeof crons;
   events: typeof events;
   getSnapshot: typeof getSnapshot;
+  getTickClock: typeof getTickClock;
   gold: typeof gold;
   goldQuote: typeof goldQuote;
   heartbeat: typeof heartbeat;

--- a/apps/server/convex/getTickClock.ts
+++ b/apps/server/convex/getTickClock.ts
@@ -1,5 +1,5 @@
 import { query } from "./_generated/server";
-import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constants";
+import { HEARTBEAT_INTERVAL_SECONDS, SEASON_DURATION_TICKS } from "@clan-world/shared/generated/constants";
 
 export const getTickClock = query({
   handler: async (ctx) => {
@@ -11,7 +11,7 @@ export const getTickClock = query({
         tickEpochStartedAt: 0,
         tickEpochDurationMs: Number(HEARTBEAT_INTERVAL_SECONDS) * 1000,
         seasonStartTick: 0,
-        seasonEndTick: 360,
+        seasonEndTick: Number(SEASON_DURATION_TICKS),
         winterActive: false,
         winterStartsAtTick: undefined,
       };

--- a/apps/server/convex/getTickClock.ts
+++ b/apps/server/convex/getTickClock.ts
@@ -1,0 +1,30 @@
+import { query } from "./_generated/server";
+import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constants";
+
+export const getTickClock = query({
+  handler: async (ctx) => {
+    const clock = await ctx.db.query("tickClock").order("desc").first();
+    if (!clock) {
+      return {
+        tick: 0,
+        blockNumber: undefined,
+        tickEpochStartedAt: 0,
+        tickEpochDurationMs: Number(HEARTBEAT_INTERVAL_SECONDS) * 1000,
+        seasonStartTick: 0,
+        seasonEndTick: 360,
+        winterActive: false,
+        winterStartsAtTick: undefined,
+      };
+    }
+    return {
+      tick: clock.tick,
+      blockNumber: clock.blockNumber,
+      tickEpochStartedAt: clock.tickEpochStartedAt,
+      tickEpochDurationMs: clock.tickEpochDurationMs,
+      seasonStartTick: clock.seasonStartTick,
+      seasonEndTick: clock.seasonEndTick,
+      winterActive: clock.winterActive,
+      winterStartsAtTick: clock.winterStartsAtTick,
+    };
+  },
+});

--- a/apps/server/convex/getTickClock.ts
+++ b/apps/server/convex/getTickClock.ts
@@ -5,16 +5,9 @@ export const getTickClock = query({
   handler: async (ctx) => {
     const clock = await ctx.db.query("tickClock").order("desc").first();
     if (!clock) {
-      return {
-        tick: 0,
-        blockNumber: undefined,
-        tickEpochStartedAt: 0,
-        tickEpochDurationMs: Number(HEARTBEAT_INTERVAL_SECONDS) * 1000,
-        seasonStartTick: 0,
-        seasonEndTick: Number(SEASON_DURATION_TICKS),
-        winterActive: false,
-        winterStartsAtTick: undefined,
-      };
+      // Return null so callers can fall back to worldSnapshot.tick during
+      // migration window when tickClock table doesn't exist yet.
+      return null;
     }
     return {
       tick: clock.tick,

--- a/apps/server/convex/getTickClock.ts
+++ b/apps/server/convex/getTickClock.ts
@@ -1,5 +1,4 @@
 import { query } from "./_generated/server";
-import { HEARTBEAT_INTERVAL_SECONDS, SEASON_DURATION_TICKS } from "@clan-world/shared/generated/constants";
 
 export const getTickClock = query({
   handler: async (ctx) => {

--- a/apps/server/convex/heartbeat.ts
+++ b/apps/server/convex/heartbeat.ts
@@ -250,50 +250,56 @@ type AdvanceTickResult =
 
 export const advanceTick = internalMutation({
   handler: async (ctx): Promise<AdvanceTickResult> => {
+    // Read tickClock first — authoritative cursor after worldSnapshot delta-check (#333).
+    // worldSnapshot can freeze at tick N while tickClock advances to N+k.
+    const clockRow = await ctx.db.query("tickClock").order("desc").first();
     const snap = await ctx.db.query("worldSnapshot").order("desc").first();
     if (!snap) return { status: "no-op", reason: "no snapshot to refresh" };
 
+    const baseTick = clockRow?.tick ?? snap.tick;
+    const baseEpochStartedAt = clockRow?.tickEpochStartedAt ?? snap.tickEpochStartedAt;
+    const baseEpochDurationMs = clockRow?.tickEpochDurationMs ?? snap.tickEpochDurationMs;
+
     // Staleness gate: only advance if the current epoch has elapsed.
-    // Prevents cron from double-advancing (fires 4x/epoch) and concurrent
-    // calls from inserting duplicate tick rows.
     const nowSeconds = Math.floor(Date.now() / 1000);
-    const epochEndSeconds =
-      snap.tickEpochStartedAt + Math.floor(snap.tickEpochDurationMs / 1000);
+    const epochEndSeconds = baseEpochStartedAt + Math.floor(baseEpochDurationMs / 1000);
     if (nowSeconds < epochEndSeconds) {
       return { status: "no-op", reason: "epoch not yet elapsed" };
     }
 
-    const newTick = snap.tick + 1;
+    const newTick = baseTick + 1;
     const newEpochStartedAt = Math.floor(Date.now() / 1000);
     await ctx.db.insert("worldSnapshot", {
       tick: newTick,
       tickEpochStartedAt: newEpochStartedAt,
-      tickEpochDurationMs: snap.tickEpochDurationMs,
+      tickEpochDurationMs: baseEpochDurationMs,
       regions: snap.regions,
       clans: snap.clans,
     });
-    // Keep tickClock in sync — it's the stale-gate cursor in commitSnapshot (#333).
-    const tickClockRow = await ctx.db.query("tickClock").order("desc").first();
-    if (tickClockRow) {
-      await ctx.db.patch(tickClockRow._id, {
-        tick: newTick,
-        tickEpochStartedAt: newEpochStartedAt,
-      });
-    } else {
-      await ctx.db.insert("tickClock", {
-        tick: newTick,
-        tickEpochStartedAt: newEpochStartedAt,
-        tickEpochDurationMs: snap.tickEpochDurationMs,
-        seasonStartTick: 0,
-        seasonEndTick: 0,
-        winterActive: false,
-      });
-    }
     await ctx.db.insert("agentLogs", {
       level: "info",
-      message: `heartbeat: tick ${snap.tick} → ${newTick}`,
+      message: `heartbeat: tick ${baseTick} → ${newTick}`,
       timestamp: Date.now(),
     });
+
+    // Monotonic guard: never patch tickClock backward.
+    if (!clockRow || newTick > clockRow.tick) {
+      if (clockRow) {
+        await ctx.db.patch(clockRow._id, {
+          tick: newTick,
+          tickEpochStartedAt: newEpochStartedAt,
+        });
+      } else {
+        await ctx.db.insert("tickClock", {
+          tick: newTick,
+          tickEpochStartedAt: newEpochStartedAt,
+          tickEpochDurationMs: baseEpochDurationMs,
+          seasonStartTick: 0,
+          seasonEndTick: 0,
+          winterActive: false,
+        });
+      }
+    }
 
     return { status: "ok", tick: newTick };
   },

--- a/apps/server/convex/heartbeat.ts
+++ b/apps/server/convex/heartbeat.ts
@@ -269,20 +269,25 @@ export const advanceTick = internalMutation({
 
     const newTick = baseTick + 1;
     const newEpochStartedAt = Math.floor(Date.now() / 1000);
-    await ctx.db.insert("worldSnapshot", {
-      tick: newTick,
-      tickEpochStartedAt: newEpochStartedAt,
-      tickEpochDurationMs: baseEpochDurationMs,
-      regions: snap.regions,
-      clans: snap.clans,
-    });
+    // Monotonic guard covers both writes — prevents stale insert if a concurrent
+    // indexer commit advanced tickClock past newTick between our read and commit.
+    // Convex OCC serializes mutations, but this guard makes the intent explicit.
+    if (!clockRow || newTick > clockRow.tick) {
+      await ctx.db.insert("worldSnapshot", {
+        tick: newTick,
+        tickEpochStartedAt: newEpochStartedAt,
+        tickEpochDurationMs: baseEpochDurationMs,
+        regions: snap.regions,
+        clans: snap.clans,
+      });
+    }
     await ctx.db.insert("agentLogs", {
       level: "info",
       message: `heartbeat: tick ${baseTick} → ${newTick}`,
       timestamp: Date.now(),
     });
 
-    // Monotonic guard: never patch tickClock backward.
+    // Also keep tickClock in sync (same monotonic guard — reuses condition above).
     if (!clockRow || newTick > clockRow.tick) {
       if (clockRow) {
         await ctx.db.patch(clockRow._id, {

--- a/apps/server/convex/heartbeat.ts
+++ b/apps/server/convex/heartbeat.ts
@@ -264,13 +264,31 @@ export const advanceTick = internalMutation({
     }
 
     const newTick = snap.tick + 1;
+    const newEpochStartedAt = Math.floor(Date.now() / 1000);
     await ctx.db.insert("worldSnapshot", {
       tick: newTick,
-      tickEpochStartedAt: Math.floor(Date.now() / 1000),
+      tickEpochStartedAt: newEpochStartedAt,
       tickEpochDurationMs: snap.tickEpochDurationMs,
       regions: snap.regions,
       clans: snap.clans,
     });
+    // Keep tickClock in sync — it's the stale-gate cursor in commitSnapshot (#333).
+    const tickClockRow = await ctx.db.query("tickClock").order("desc").first();
+    if (tickClockRow) {
+      await ctx.db.patch(tickClockRow._id, {
+        tick: newTick,
+        tickEpochStartedAt: newEpochStartedAt,
+      });
+    } else {
+      await ctx.db.insert("tickClock", {
+        tick: newTick,
+        tickEpochStartedAt: newEpochStartedAt,
+        tickEpochDurationMs: snap.tickEpochDurationMs,
+        seasonStartTick: 0,
+        seasonEndTick: 0,
+        winterActive: false,
+      });
+    }
     await ctx.db.insert("agentLogs", {
       level: "info",
       message: `heartbeat: tick ${snap.tick} → ${newTick}`,

--- a/apps/server/convex/indexer.test.ts
+++ b/apps/server/convex/indexer.test.ts
@@ -540,7 +540,7 @@ describe("legacy snapshot backfill", () => {
       },
     );
 
-    const clansAfterFirst = JSON.stringify(tables.worldSnapshot?.[0]?.clans);
+    const tickAfterFirst = tables.worldSnapshot?.[0]?.tick;
 
     // Second commit — only cooldownEndsAtTs/lastMissionNonce change (monotonic, stripped by stableClansman)
     await (commitSnapshot as any)._handler(
@@ -554,7 +554,8 @@ describe("legacy snapshot backfill", () => {
       },
     );
 
-    // worldSnapshot.clans should be identical — monotonic fields were stripped
-    expect(JSON.stringify(tables.worldSnapshot?.[0]?.clans)).toBe(clansAfterFirst);
+    // worldSnapshot was NOT patched — tick stays at 1, not advanced to 2.
+    // If the delta-check incorrectly fired, it would patch worldSnapshot with tick=2.
+    expect(tables.worldSnapshot?.[0]?.tick).toBe(tickAfterFirst);
   });
 });

--- a/apps/server/convex/indexer.test.ts
+++ b/apps/server/convex/indexer.test.ts
@@ -7,6 +7,7 @@ import {
   ingestEvents,
   planPollLogRange,
   pricePointFromEvent,
+  stableJson,
 } from "./indexer";
 
 const address = "0x1111111111111111111111111111111111111111" as const;
@@ -107,6 +108,24 @@ function fixtureLog(
     removed: false,
   };
 }
+
+describe("stableJson", () => {
+  it("is key-order-independent", () => {
+    const a = { b: 1, a: 2 };
+    const b = { a: 2, b: 1 };
+    expect(stableJson(a)).toBe(stableJson(b));
+  });
+  it("two worldSnapshot-like objects differing only in tick-family fields produce equal stableJson when those fields are stripped", () => {
+    const strip = (o: Record<string, unknown>) => {
+      const { tick, tickEpochStartedAt, tickEpochDurationMs, currentTickSeed, nextHeartbeatAtTick, lastUpdatedAt, lastUpdatedBlock, txHash, ...rest } = o;
+      void tick; void tickEpochStartedAt; void tickEpochDurationMs; void currentTickSeed; void nextHeartbeatAtTick; void lastUpdatedAt; void lastUpdatedBlock; void txHash;
+      return rest;
+    };
+    const prev = { tick: 10, tickEpochStartedAt: 1000, regions: [{ id: "A" }], clans: [] };
+    const next = { tick: 11, tickEpochStartedAt: 1060, regions: [{ id: "A" }], clans: [] };
+    expect(stableJson(strip(prev))).toBe(stableJson(strip(next)));
+  });
+});
 
 describe("decodeClanWorldLogs", () => {
   it("decodes representative ClanWorld events with bigint-safe args", () => {

--- a/apps/server/convex/indexer.test.ts
+++ b/apps/server/convex/indexer.test.ts
@@ -434,9 +434,13 @@ describe("legacy snapshot backfill", () => {
       },
     );
 
-    const advancedTickSnapshot = tables.worldSnapshot?.[0];
-    expect(advancedTickSnapshot.tickEpochStartedAt).toBe(1_060);
-    expect(advancedTickSnapshot.tickEpochDurationMs).toBe(60_000);
+    // tickClock is always patched — it's the authoritative epoch source after the
+    // worldSnapshot delta-check (#333). worldSnapshot may not be updated when
+    // content (clans, regions) didn't change, so read epoch from tickClock.
+    const advancedClock = tables.tickClock?.[0];
+    expect(advancedClock.tick).toBe(13);
+    expect(advancedClock.tickEpochStartedAt).toBe(1_060);
+    expect(advancedClock.tickEpochDurationMs).toBe(60_000);
 
     now.mockRestore();
   });

--- a/apps/server/convex/indexer.test.ts
+++ b/apps/server/convex/indexer.test.ts
@@ -475,4 +475,86 @@ describe("legacy snapshot backfill", () => {
     expect(tables.worldSnapshot?.[0]?.lastUpdatedBlock).toBe(100);
     expect(tables.worldSnapshot?.[0]?.clans).toEqual([{ id: "current" }]);
   });
+
+  it("does not rewrite worldSnapshot when only monotonic clansman fields change", async () => {
+    const { db, tables } = createDb();
+
+    const makeClanView = (cooldownEndsAtTs: number) => ({
+      // view.clan.clan = the on-chain struct; view.clan = derived view with effectiveRegion
+      clan: {
+        clan: {
+          clanId: 1,
+          owner: "0x0000000000000000000000000000000000000000",
+          baseRegion: 1,
+          clanState: 0,
+          baseLevel: 1,
+          wallLevel: 1,
+          monumentLevel: 0,
+          livingClansmen: 1,
+          isStarving: false,
+          starvationStartsAtTick: 0,
+          coldDamage: 0,
+          goldBalance: "0",
+          blueprintBalance: "0",
+          vaultWood: "0",
+          vaultIron: "0",
+          vaultWheat: "0",
+          vaultFish: "0",
+          lootValue: "0",
+        },
+        derivedAtTick: 1,
+        effectiveRegion: 1,
+      },
+      // view.clansmen = top-level field consumed by the handler (line 611)
+      clansmen: [
+        {
+          clansman: {
+            clansman: {
+              clansmanId: 1,
+              clanId: 1,
+              state: 0,
+              currentRegion: 1,
+              cooldownEndsAtTs,       // monotonic — stripped by stableClansman
+              lastMissionNonce: cooldownEndsAtTs,  // monotonic — stripped
+              carryWood: "0",
+              carryIron: "0",
+              carryWheat: "0",
+              carryFish: "0",
+            },
+            effectiveRegion: 1,
+          },
+          activeMission: { active: false, action: 0, startRegion: 1, targetRegion: 1 },
+        },
+      ],
+    });
+
+    // First commit — establishes clanView + worldSnapshot
+    await (commitSnapshot as any)._handler(
+      { db },
+      {
+        snapshot: {
+          blockNumber: 1,
+          world: { currentTick: 1 },
+          clans: [makeClanView(100)],
+        },
+      },
+    );
+
+    const clansAfterFirst = JSON.stringify(tables.worldSnapshot?.[0]?.clans);
+
+    // Second commit — only cooldownEndsAtTs/lastMissionNonce change (monotonic, stripped by stableClansman)
+    await (commitSnapshot as any)._handler(
+      { db },
+      {
+        snapshot: {
+          blockNumber: 2,
+          world: { currentTick: 2 },
+          clans: [makeClanView(101)],
+        },
+      },
+    );
+
+    // worldSnapshot.clans should be identical — monotonic fields were stripped
+    expect(JSON.stringify(tables.worldSnapshot?.[0]?.clans)).toBe(clansAfterFirst);
+  });
 });

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -438,11 +438,15 @@ export const commitSnapshot = internalMutation({
       .query("worldSnapshot")
       .order("desc")
       .first();
-    const previousTick = asNumber(previousWorldSnapshot?.tick, -1);
-    const previousBlock = asNumber(previousWorldSnapshot?.lastUpdatedBlock, -1);
+    // Fetch tickClock first — it's the always-advancing monotonic cursor.
+    // worldSnapshot can freeze between content-change ticks (delta-check), so
+    // previousWorldSnapshot.tick is not a reliable stale-gate cursor anymore.
+    const tickClockRow = await ctx.db.query("tickClock").order("desc").first();
+    const previousTick = asNumber(tickClockRow?.tick ?? previousWorldSnapshot?.tick, -1);
+    const previousBlock = asNumber(tickClockRow?.blockNumber ?? previousWorldSnapshot?.lastUpdatedBlock, -1);
     const incomingBlock = snapshot.blockNumber ?? -1;
     if (
-      previousWorldSnapshot &&
+      (tickClockRow || previousWorldSnapshot) &&
       (tick < previousTick ||
         (tick === previousTick && incomingBlock <= previousBlock))
     ) {
@@ -452,10 +456,7 @@ export const commitSnapshot = internalMutation({
         skipped: "stale-snapshot",
       };
     }
-
     // Write tickClock on every tick — cheap single-row table (~50 bytes).
-    // Patch if it exists, insert if not.
-    const tickClockRow = await ctx.db.query("tickClock").order("desc").first();
     const tickClockData = {
       tick,
       blockNumber: snapshot.blockNumber,

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -51,14 +51,36 @@ const indexerApi = (internal as any).indexer;
 /**
  * Key-order-stable JSON serializer for Convex-safe values.
  * Accepts: string, number, boolean, null, plain object, array.
- * Do NOT pass: Date, BigInt, undefined, Symbol — these are not valid in Convex
+ *
+ * Undefined-key semantics: matches JSON.stringify — keys with undefined values
+ * are DROPPED from objects; undefined array elements become null. This makes
+ * `stableJson({ a: 1, b: undefined })` equal to `stableJson({ a: 1 })`, which
+ * means callers can use the spread-with-undefined-override pattern to strip
+ * fields from a Convex doc before comparison:
+ *
+ *   const previousComparable = { ...prev, _id: undefined, _creationTime: undefined };
+ *   if (stableJson(previousComparable) === stableJson(nextView)) // ...
+ *
+ * Without this drop-undefined behavior, the spread pattern leaves stripped keys
+ * present-but-undefined, making the two strings always differ (super-swarm r3
+ * H1, fix-round 5).
+ *
+ * Do NOT pass: Date, BigInt, Symbol — these are not valid in Convex
  * documents and will serialize incorrectly (Date→{}, BigInt→throws).
  */
 export function stableJson(val: unknown): string {
+  if (val === undefined) return "undefined";  // sentinel; callers shouldn't pass undefined at top-level
   if (val === null || typeof val !== "object") return JSON.stringify(val);
-  if (Array.isArray(val)) return `[${val.map(stableJson).join(",")}]`;
+  if (Array.isArray(val)) {
+    // JSON.stringify converts array `undefined` elements to `null`.
+    return `[${val.map(v => v === undefined ? "null" : stableJson(v)).join(",")}]`;
+  }
   const obj = val as Record<string, unknown>;
-  return `{${Object.keys(obj).sort().map(k => `${JSON.stringify(k)}:${stableJson(obj[k])}`).join(",")}}`;
+  return `{${Object.keys(obj)
+    .sort()
+    .filter(k => obj[k] !== undefined)
+    .map(k => `${JSON.stringify(k)}:${stableJson(obj[k])}`)
+    .join(",")}}`;
 }
 
 type ParsedIndexerEvent = {

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -578,11 +578,13 @@ export const commitSnapshot = internalMutation({
             _id: undefined,
             _creationTime: undefined,
             refreshedAt: undefined,
+            derivedAtTick: undefined,
+            lastUpdatedBlock: undefined,
           }
         : undefined;
       if (
         JSON.stringify(previousComparable) !==
-        JSON.stringify({ ...nextView, refreshedAt: undefined })
+        JSON.stringify({ ...nextView, refreshedAt: undefined, derivedAtTick: undefined, lastUpdatedBlock: undefined })
       ) {
         await ctx.db.insert("clanView", nextView);
       }

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -453,6 +453,28 @@ export const commitSnapshot = internalMutation({
       };
     }
 
+    // Write tickClock on every tick — cheap single-row table (~50 bytes).
+    // Patch if it exists, insert if not.
+    const tickClockRow = await ctx.db.query("tickClock").order("desc").first();
+    const tickClockData = {
+      tick,
+      blockNumber: snapshot.blockNumber,
+      tickEpochStartedAt:
+        previousWorldSnapshot?.tick === tick
+          ? previousWorldSnapshot.tickEpochStartedAt
+          : Math.floor(now / 1000),
+      tickEpochDurationMs: Number(HEARTBEAT_INTERVAL_SECONDS) * 1000,
+      seasonStartTick: asNumber(world.seasonStartTick),
+      seasonEndTick: asNumber(world.seasonEndTick),
+      winterActive: asBool(world.winterActive),
+      winterStartsAtTick: asNumber(world.winterStartsAtTick) || undefined,
+    };
+    if (tickClockRow) {
+      await ctx.db.patch(tickClockRow._id, tickClockData);
+    } else {
+      await ctx.db.insert("tickClock", tickClockData);
+    }
+
     if (snapshot.market) {
       const market = snapshot.market;
       await ctx.db.insert("marketState", {
@@ -622,10 +644,33 @@ export const commitSnapshot = internalMutation({
         };
       }),
     };
-    if (previousWorldSnapshot) {
-      await ctx.db.patch(previousWorldSnapshot._id, worldSnapshot);
-    } else {
-      await ctx.db.insert("worldSnapshot", worldSnapshot);
+    // Delta-check: only patch worldSnapshot when data actually changes.
+    // Strip audit/timestamp fields before comparing so a no-data tick is a no-op.
+    const previousComparableSnapshot = previousWorldSnapshot
+      ? (() => {
+          const { _id, _creationTime, lastUpdatedAt, lastUpdatedBlock, txHash, ...rest } =
+            previousWorldSnapshot as typeof previousWorldSnapshot & {
+              _id: unknown;
+              _creationTime: unknown;
+            };
+          void _id; void _creationTime; void lastUpdatedAt; void lastUpdatedBlock; void txHash;
+          return rest;
+        })()
+      : undefined;
+    const nextComparableSnapshot = (() => {
+      const { lastUpdatedAt, lastUpdatedBlock, txHash, ...rest } = worldSnapshot;
+      void lastUpdatedAt; void lastUpdatedBlock; void txHash;
+      return rest;
+    })();
+    if (
+      JSON.stringify(previousComparableSnapshot) !==
+      JSON.stringify(nextComparableSnapshot)
+    ) {
+      if (previousWorldSnapshot) {
+        await ctx.db.patch(previousWorldSnapshot._id, worldSnapshot);
+      } else {
+        await ctx.db.insert("worldSnapshot", worldSnapshot);
+      }
     }
 
     return { tick, clans: snapshot.clans.length };

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -461,8 +461,8 @@ export const commitSnapshot = internalMutation({
       tick,
       blockNumber: snapshot.blockNumber,
       tickEpochStartedAt:
-        previousWorldSnapshot?.tick === tick
-          ? previousWorldSnapshot.tickEpochStartedAt
+        tickClockRow?.tick === tick
+          ? tickClockRow.tickEpochStartedAt
           : Math.floor(now / 1000),
       tickEpochDurationMs: Number(HEARTBEAT_INTERVAL_SECONDS) * 1000,
       seasonStartTick: asNumber(world.seasonStartTick),

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -276,16 +276,26 @@ function stableClansman(row: unknown): unknown {
       },
       effectiveRegion: derived.effectiveRegion,
     },
-    activeMission: mission ? {
-      active: mission.active,
-      action: mission.action,
-      startRegion: mission.startRegion,
-      targetRegion: mission.targetRegion,
-      startTick: mission.startTick,
-      arrivalTick: mission.arrivalTick,
-      actionStartTick: mission.actionStartTick,
-      settlesAtTick: mission.settlesAtTick,
-    } : undefined,
+    // Build activeMission with only defined fields. Convex documents reject
+    // arbitrary `undefined` property values; without this filter, an
+    // activeMission fixture that omits e.g. `startTick` would materialize
+    // `{ startTick: undefined, ... }` via the legacy projection and break
+    // serialization on the worldSnapshot insert path. Per pr338-r4 super-
+    // swarm codex HIGH.
+    activeMission: mission
+      ? Object.fromEntries(
+          Object.entries({
+            active: mission.active,
+            action: mission.action,
+            startRegion: mission.startRegion,
+            targetRegion: mission.targetRegion,
+            startTick: mission.startTick,
+            arrivalTick: mission.arrivalTick,
+            actionStartTick: mission.actionStartTick,
+            settlesAtTick: mission.settlesAtTick,
+          }).filter(([, value]) => value !== undefined),
+        )
+      : undefined,
   };
 }
 

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -602,14 +602,10 @@ export const commitSnapshot = internalMutation({
     const legacyClans = legacyClansFromClanViews(
       latestClanViews.filter(isPresent),
     );
-    const tickEpochStartedAt =
-      previousWorldSnapshot?.tick === tick
-        ? previousWorldSnapshot.tickEpochStartedAt
-        : Math.floor(now / 1000);
     const worldSnapshot = {
       tick,
-      tickEpochStartedAt,
-      tickEpochDurationMs: Number(HEARTBEAT_INTERVAL_SECONDS) * 1000,
+      tickEpochStartedAt: tickClockData.tickEpochStartedAt,
+      tickEpochDurationMs: tickClockData.tickEpochDurationMs,
       currentSeasonNumber: asNumber(world.currentSeasonNumber),
       seasonStartTick: asNumber(world.seasonStartTick),
       seasonEndTick: asNumber(world.seasonEndTick),

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -48,6 +48,13 @@ const LEGACY_REGIONS = [
 ];
 const indexerApi = (internal as any).indexer;
 
+export function stableJson(val: unknown): string {
+  if (val === null || typeof val !== "object") return JSON.stringify(val);
+  if (Array.isArray(val)) return `[${val.map(stableJson).join(",")}]`;
+  const obj = val as Record<string, unknown>;
+  return `{${Object.keys(obj).sort().map(k => `${JSON.stringify(k)}:${stableJson(obj[k])}`).join(",")}}`;
+}
+
 type ParsedIndexerEvent = {
   eventName: string;
   args: Record<string, unknown>;
@@ -242,6 +249,40 @@ export function planPollLogRange(
   };
 }
 
+function stableClansman(row: unknown): unknown {
+  const r = row as Record<string, unknown>;
+  const derived = (r.clansman ?? r) as Record<string, unknown>;
+  const cs = (derived.clansman ?? derived) as Record<string, unknown>;
+  const mission = (r.activeMission ?? derived.activeMission) as Record<string, unknown> | undefined;
+  return {
+    clansman: {
+      clansman: {
+        clansmanId: cs.clansmanId,
+        clanId: cs.clanId,
+        state: cs.state,
+        currentRegion: cs.currentRegion,
+        carryWood: cs.carryWood,
+        carryIron: cs.carryIron,
+        carryWheat: cs.carryWheat,
+        carryFish: cs.carryFish,
+        // NOTE: intentionally omitting cooldownEndsAtTs, lastMissionNonce — monotonic per-tick,
+        // not read by WorldMap, would defeat worldSnapshot delta-check
+      },
+      effectiveRegion: derived.effectiveRegion,
+    },
+    activeMission: mission ? {
+      active: mission.active,
+      action: mission.action,
+      startRegion: mission.startRegion,
+      targetRegion: mission.targetRegion,
+      startTick: mission.startTick,
+      arrivalTick: mission.arrivalTick,
+      actionStartTick: mission.actionStartTick,
+      settlesAtTick: mission.settlesAtTick,
+    } : undefined,
+  };
+}
+
 export const legacyClansFromClanViews = (clanViews: LegacyClanView[]) =>
   clanViews
     .filter((view) => view.clanId > 0)
@@ -262,7 +303,7 @@ export const legacyClansFromClanViews = (clanViews: LegacyClanView[]) =>
       monumentLevel: asNumber(view.monumentLevel),
       livingClansmen: asNumber(view.livingClansmen),
       owner: asString(view.owner, ""),
-      clansmen: view.clansmen ?? [],
+      clansmen: (view.clansmen ?? []).map(stableClansman),
     }));
 
 // M-5: tighten internal-mutation arg shape. We can't enumerate every event
@@ -583,8 +624,8 @@ export const commitSnapshot = internalMutation({
           }
         : undefined;
       if (
-        JSON.stringify(previousComparable) !==
-        JSON.stringify({ ...nextView, refreshedAt: undefined, derivedAtTick: undefined, lastUpdatedBlock: undefined })
+        stableJson(previousComparable) !==
+        stableJson({ ...nextView, refreshedAt: undefined, derivedAtTick: undefined, lastUpdatedBlock: undefined })
       ) {
         await ctx.db.insert("clanView", nextView);
       }
@@ -672,8 +713,8 @@ export const commitSnapshot = internalMutation({
       return rest;
     })();
     if (
-      JSON.stringify(previousComparableSnapshot) !==
-      JSON.stringify(nextComparableSnapshot)
+      stableJson(previousComparableSnapshot) !==
+      stableJson(nextComparableSnapshot)
     ) {
       if (previousWorldSnapshot) {
         await ctx.db.patch(previousWorldSnapshot._id, worldSnapshot);

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -467,7 +467,7 @@ export const commitSnapshot = internalMutation({
       seasonStartTick: asNumber(world.seasonStartTick),
       seasonEndTick: asNumber(world.seasonEndTick),
       winterActive: asBool(world.winterActive),
-      winterStartsAtTick: asNumber(world.winterStartsAtTick) || undefined,
+      winterStartsAtTick: (() => { const wsat = asNumber(world.winterStartsAtTick); return wsat > 0 ? wsat : undefined; })(),
     };
     if (tickClockRow) {
       await ctx.db.patch(tickClockRow._id, tickClockData);
@@ -648,18 +648,28 @@ export const commitSnapshot = internalMutation({
     // Strip audit/timestamp fields before comparing so a no-data tick is a no-op.
     const previousComparableSnapshot = previousWorldSnapshot
       ? (() => {
-          const { _id, _creationTime, lastUpdatedAt, lastUpdatedBlock, txHash, ...rest } =
+          const {
+            _id, _creationTime, lastUpdatedAt, lastUpdatedBlock, txHash,
+            tick, tickEpochStartedAt, tickEpochDurationMs, currentTickSeed, nextHeartbeatAtTick,
+            ...rest
+          } =
             previousWorldSnapshot as typeof previousWorldSnapshot & {
               _id: unknown;
               _creationTime: unknown;
             };
           void _id; void _creationTime; void lastUpdatedAt; void lastUpdatedBlock; void txHash;
+          void tick; void tickEpochStartedAt; void tickEpochDurationMs; void currentTickSeed; void nextHeartbeatAtTick;
           return rest;
         })()
       : undefined;
     const nextComparableSnapshot = (() => {
-      const { lastUpdatedAt, lastUpdatedBlock, txHash, ...rest } = worldSnapshot;
+      const {
+        lastUpdatedAt, lastUpdatedBlock, txHash,
+        tick, tickEpochStartedAt, tickEpochDurationMs, currentTickSeed, nextHeartbeatAtTick,
+        ...rest
+      } = worldSnapshot;
       void lastUpdatedAt; void lastUpdatedBlock; void txHash;
+      void tick; void tickEpochStartedAt; void tickEpochDurationMs; void currentTickSeed; void nextHeartbeatAtTick;
       return rest;
     })();
     if (

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -48,6 +48,12 @@ const LEGACY_REGIONS = [
 ];
 const indexerApi = (internal as any).indexer;
 
+/**
+ * Key-order-stable JSON serializer for Convex-safe values.
+ * Accepts: string, number, boolean, null, plain object, array.
+ * Do NOT pass: Date, BigInt, undefined, Symbol — these are not valid in Convex
+ * documents and will serialize incorrectly (Date→{}, BigInt→throws).
+ */
 export function stableJson(val: unknown): string {
   if (val === null || typeof val !== "object") return JSON.stringify(val);
   if (Array.isArray(val)) return `[${val.map(stableJson).join(",")}]`;

--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -2,6 +2,16 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({
+  tickClock: defineTable({
+    tick: v.number(),
+    blockNumber: v.optional(v.number()),
+    tickEpochStartedAt: v.number(),
+    tickEpochDurationMs: v.number(),
+    seasonStartTick: v.number(),
+    seasonEndTick: v.number(),
+    winterActive: v.boolean(),
+    winterStartsAtTick: v.optional(v.number()),
+  }),
   worldSnapshot: defineTable({
     tick: v.number(),
     tickEpochStartedAt: v.number(),

--- a/apps/web/src/TopHud.tsx
+++ b/apps/web/src/TopHud.tsx
@@ -36,7 +36,7 @@ function useBanditWarning(liveTick: number, bandit: SnapshotBandit | null): { ac
 }
 
 export function TopHud({ liveTick }: { liveTick: number }) {
-  const snapshot = useQuery(api.getSnapshot.getSnapshot);
+  const clock = useQuery(api.getTickClock.getTickClock);
   const tickCountdownAnchorRef = useRef<TickCountdownAnchor>({
     tick: liveTick,
     startedAtMs: Date.now(),
@@ -46,25 +46,27 @@ export function TopHud({ liveTick }: { liveTick: number }) {
 
   useEffect(() => {
     if (tickCountdownAnchorRef.current.tick !== liveTick) {
-      const epoch = snapshot?.tickEpoch;
-      const canUseSnapshotEpoch =
-        snapshot?.tick === liveTick &&
+      const epoch = clock
+        ? { startedAt: clock.tickEpochStartedAt, durationMs: clock.tickEpochDurationMs }
+        : undefined;
+      const canUseClockEpoch =
+        clock?.tick === liveTick &&
         epoch &&
         typeof epoch.startedAt === 'number' &&
         typeof epoch.durationMs === 'number' &&
         epoch.durationMs > 0;
       tickCountdownAnchorRef.current = {
         tick: liveTick,
-        startedAtMs: canUseSnapshotEpoch
+        startedAtMs: canUseClockEpoch
           ? epoch.startedAt < 10_000_000_000
             ? epoch.startedAt * 1000
             : epoch.startedAt
           : Date.now(),
-        durationMs: canUseSnapshotEpoch ? epoch.durationMs : FALLBACK_TICK_DURATION_MS,
+        durationMs: canUseClockEpoch ? epoch.durationMs : FALLBACK_TICK_DURATION_MS,
       };
     }
     setNowMs(Date.now());
-  }, [liveTick, snapshot?.tick, snapshot?.tickEpoch]);
+  }, [liveTick, clock?.tick, clock?.tickEpochStartedAt, clock?.tickEpochDurationMs]);
 
   useEffect(() => {
     const id = window.setInterval(() => setNowMs(Date.now()), 250);
@@ -72,19 +74,13 @@ export function TopHud({ liveTick }: { liveTick: number }) {
   }, []);
 
   const { seasonStartTick, seasonEndTick, winterActive, winterStartsAtTick } = useMemo(() => {
-    // Try to read real season data from full worldSnapshot via getSnapshot.
-    // The lightweight getSnapshot query only returns tick + tickEpoch + clans + regions —
-    // season fields come from a broader snapshot query if exposed.
-    // Cast as any to access optional fields the TS type doesn't expose yet.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const s = snapshot as any;
     return {
-      seasonStartTick: typeof s?.seasonStartTick === 'number' ? s.seasonStartTick : null,
-      seasonEndTick: typeof s?.seasonEndTick === 'number' ? s.seasonEndTick : null,
-      winterActive: s?.winterActive === true,
-      winterStartsAtTick: typeof s?.winterStartsAtTick === 'number' ? s.winterStartsAtTick : null,
+      seasonStartTick: typeof clock?.seasonStartTick === 'number' ? clock.seasonStartTick : null,
+      seasonEndTick: typeof clock?.seasonEndTick === 'number' ? clock.seasonEndTick : null,
+      winterActive: clock?.winterActive === true,
+      winterStartsAtTick: typeof clock?.winterStartsAtTick === 'number' ? clock.winterStartsAtTick : null,
     };
-  }, [snapshot]);
+  }, [clock]);
 
   // Season progress bar: 0..1
   const seasonProgress = useMemo(() => {
@@ -109,8 +105,8 @@ export function TopHud({ liveTick }: { liveTick: number }) {
     return winterStartsAtTick - liveTick <= 20 && winterStartsAtTick > liveTick;
   }, [winterActive, winterStartsAtTick, liveTick]);
 
-  const snapshotBandit = snapshot?.bandit ?? null;
-  const { active: banditActive, ticksUntil: banditTicksUntil } = useBanditWarning(liveTick, snapshotBandit);
+  // Bandit warning not available from getTickClock — bandit data stays on getSnapshot (WorldMap).
+  const { active: banditActive, ticksUntil: banditTicksUntil } = useBanditWarning(liveTick, null);
   const tickCountdown = useMemo(() => {
     const { startedAtMs, durationMs } = tickCountdownAnchorRef.current;
     const elapsed = Math.max(0, nowMs - startedAtMs);
@@ -119,7 +115,7 @@ export function TopHud({ liveTick }: { liveTick: number }) {
       remainingPct: Math.max(0, Math.min(100, (1 - progress) * 100)),
       durationMs,
     };
-  }, [liveTick, nowMs, snapshot?.tick, snapshot?.tickEpoch]);
+  }, [liveTick, nowMs, clock?.tick, clock?.tickEpochStartedAt, clock?.tickEpochDurationMs]);
 
   // Bar fill color: green → amber → red as season ages
   const barColor = seasonProgress < 0.5

--- a/apps/web/src/TopHud.tsx
+++ b/apps/web/src/TopHud.tsx
@@ -37,6 +37,7 @@ function useBanditWarning(liveTick: number, bandit: SnapshotBandit | null): { ac
 
 export function TopHud({ liveTick }: { liveTick: number }) {
   const clock = useQuery(api.getTickClock.getTickClock);
+  const liveSnapshot = useQuery(api.getSnapshot.getSnapshot);
   const tickCountdownAnchorRef = useRef<TickCountdownAnchor>({
     tick: liveTick,
     startedAtMs: Date.now(),
@@ -105,8 +106,7 @@ export function TopHud({ liveTick }: { liveTick: number }) {
     return winterStartsAtTick - liveTick <= 20 && winterStartsAtTick > liveTick;
   }, [winterActive, winterStartsAtTick, liveTick]);
 
-  // Bandit warning not available from getTickClock — bandit data stays on getSnapshot (WorldMap).
-  const { active: banditActive, ticksUntil: banditTicksUntil } = useBanditWarning(liveTick, null);
+  const { active: banditActive, ticksUntil: banditTicksUntil } = useBanditWarning(liveTick, liveSnapshot?.bandit ?? null);
   const tickCountdown = useMemo(() => {
     const { startedAtMs, durationMs } = tickCountdownAnchorRef.current;
     const elapsed = Math.max(0, nowMs - startedAtMs);

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1235,6 +1235,7 @@ export function WorldMap() {
   const seenCombatEventKeysRef = useRef<Set<string>>(new Set());
   const combatEventsInitializedRef = useRef(false);
   const liveTickClockRef = useRef<{ tick: number; seenAtMs: number }>({ tick: 0, seenAtMs: Date.now() });
+  const tickClockEpochRef = useRef<{ tick: number; startedAt: number; durationMs: number } | null>(null);
   const liveTickRef = useRef(0);
 
   // Zone-pulse ticker (visual heartbeat for clan zone halos).
@@ -1384,6 +1385,16 @@ export function WorldMap() {
       liveTickClockRef.current = { tick: liveTick, seenAtMs: Date.now() };
     }
   }, [liveTick]);
+
+  useEffect(() => {
+    if (tickClock) {
+      tickClockEpochRef.current = {
+        tick: tickClock.tick,
+        startedAt: tickClock.tickEpochStartedAt,
+        durationMs: tickClock.tickEpochDurationMs,
+      };
+    }
+  }, [tickClock]);
 
   useEffect(() => {
     snapshotRef.current = snapshot;
@@ -3032,9 +3043,12 @@ export function WorldMap() {
   }
 
   function currentTickFloat() {
+    const clockEpoch = tickClockEpochRef.current;
     const snap = snapshotRef.current;
-    const tick = typeof snap?.tick === 'number' && Number.isFinite(snap.tick) ? snap.tick : liveTickRef.current;
-    const epoch = snap?.tickEpoch;
+    const tick = clockEpoch?.tick ?? (typeof snap?.tick === 'number' && Number.isFinite(snap.tick) ? snap.tick : liveTickRef.current);
+    const epoch = clockEpoch
+      ? { startedAt: clockEpoch.startedAt, durationMs: clockEpoch.durationMs }
+      : snap?.tickEpoch;
     if (!epoch || typeof epoch.startedAt !== 'number' || typeof epoch.durationMs !== 'number' || epoch.durationMs <= 0) {
       return tick;
     }

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1495,9 +1495,12 @@ export function WorldMap() {
   }, [snapshot]);
 
   function getDayNightProgress() {
+    const clockEpoch = tickClockEpochRef.current;
     const snap = snapshotRef.current;
-    const tick = snap?.tick;
-    const epoch = snap?.tickEpoch;
+    const tick = clockEpoch?.tick ?? snap?.tick;
+    const epoch = clockEpoch
+      ? { startedAt: clockEpoch.startedAt, durationMs: clockEpoch.durationMs }
+      : snap?.tickEpoch;
     const hasEpoch = !!epoch && typeof epoch.startedAt === 'number' && epoch.startedAt > 0;
     if (typeof tick === 'number' && Number.isFinite(tick) && (tick > 0 || hasEpoch)) {
       let subTickProgress = 0;
@@ -4587,13 +4590,16 @@ export function WorldMap() {
   }
 
   function getMsUntilTickClose() {
+    const clockEpoch = tickClockEpochRef.current;
     const snap = snapshotRef.current;
-    const epoch = snap?.tickEpoch;
+    const epoch = clockEpoch
+      ? { startedAt: clockEpoch.startedAt, durationMs: clockEpoch.durationMs }
+      : snap?.tickEpoch;
     const durationMs =
       epoch && typeof epoch.durationMs === 'number' && epoch.durationMs > 0
         ? epoch.durationMs
         : FALLBACK_DAY_TICK_MS;
-    if (epoch && typeof epoch.startedAt === 'number' && epoch.startedAt > 0 && snap?.tick === liveTickRef.current) {
+    if (epoch && typeof epoch.startedAt === 'number' && epoch.startedAt > 0 && (clockEpoch?.tick ?? snap?.tick) === liveTickRef.current) {
       const startedAtMs = epoch.startedAt < 10_000_000_000 ? epoch.startedAt * 1000 : epoch.startedAt;
       return Math.max(0, durationMs - (Date.now() - startedAtMs));
     }
@@ -4614,8 +4620,11 @@ export function WorldMap() {
       // only triggers post-close (line below). Detect fallback mode and
       // trigger as soon as we enter the pre-attack tick. Vignette occupies the
       // first 4s of the pre-attack tick instead of the last 4s; visually similar.
+      const clockEpoch = tickClockEpochRef.current;
       const snap = snapshotRef.current;
-      const epoch = snap?.tickEpoch;
+      const epoch = clockEpoch
+        ? { startedAt: clockEpoch.startedAt, durationMs: clockEpoch.durationMs }
+        : snap?.tickEpoch;
       const havePreciseEpoch =
         epoch && typeof epoch.startedAt === 'number' && epoch.startedAt > 0
         && typeof epoch.durationMs === 'number' && epoch.durationMs > 0;

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -1327,6 +1327,9 @@ export function WorldMap() {
 
   const logs = useAgentLogs();
   const liveSnapshot = useQuery(api.getSnapshot.getSnapshot);
+  // Lightweight tick-only subscription (~50 bytes/tick). Invalidates every tick
+  // so WorldMap always has a fresh tick counter without pulling 40KB of world data.
+  const tickClock = useQuery(api.getTickClock.getTickClock);
   // Cache the snapshot in localStorage so iOS Safari (and other browsers that
   // pause background tabs) can render the last-known world state instantly on
   // PWA return — instead of flashing the "no chain data yet" placeholder
@@ -1341,13 +1344,14 @@ export function WorldMap() {
   const [showNoChainDataPlaceholder, setShowNoChainDataPlaceholder] = useState(false);
   const rawChainEvents = useQuery(api.events.getRecentChainEvents) as ChainEvent[] | undefined;
 
-  // Derived live tick counter — the worldSnapshot.tick field is currently
-  // unwritten by the orchestrator script (it only writes to agentLogs), so
-  // we surface a moving counter by deriving from log count. Floors at the
-  // snapshot value so we never go BACKWARDS if the schema is wired later.
-  const liveTick = useMemo(() => {
-    return Math.max(snapshot?.tick ?? 0, logs.length);
-  }, [logs, snapshot?.tick]);
+  // Derived live tick counter — prefer tickClock (cheap, always fresh) over
+  // snapshot.tick (only updates when world data changes after delta-check).
+  // Fall back to snapshot.tick for continuity during tickClock cold-start.
+  // Floor against log count so we never go BACKWARDS.
+  const liveTick = useMemo(
+    () => Math.max(tickClock?.tick ?? snapshot?.tick ?? 0, logs.length),
+    [logs, tickClock?.tick, snapshot?.tick],
+  );
   const liveBandit = snapshot?.bandit ?? null;
   const visibleBandit = DEMO_MODE
     ? {

--- a/apps/web/src/components/cockpit/CockpitHeader.tsx
+++ b/apps/web/src/components/cockpit/CockpitHeader.tsx
@@ -12,9 +12,9 @@ function useMemoryWipeCountdown(): {
   ticksUntilWipe: number;
   intervalTicks: number;
 } {
-  const snapshot = useQuery(api.getSnapshot.getSnapshot);
-  const tick = typeof snapshot?.tick === 'number' && Number.isFinite(snapshot.tick)
-    ? snapshot.tick
+  const clock = useQuery(api.getTickClock.getTickClock);
+  const tick = typeof clock?.tick === 'number' && Number.isFinite(clock.tick)
+    ? clock.tick
     : 0;
   const remainder = tick % MEMORY_WIPE_INTERVAL_TICKS;
   const ticksUntilWipe = remainder === 0

--- a/apps/web/src/components/cockpit/CockpitHeader.tsx
+++ b/apps/web/src/components/cockpit/CockpitHeader.tsx
@@ -13,9 +13,12 @@ function useMemoryWipeCountdown(): {
   intervalTicks: number;
 } {
   const clock = useQuery(api.getTickClock.getTickClock);
+  const snapshot = useQuery(api.getSnapshot.getSnapshot);
   const tick = typeof clock?.tick === 'number' && Number.isFinite(clock.tick)
     ? clock.tick
-    : 0;
+    : typeof snapshot?.tick === 'number' && Number.isFinite(snapshot.tick)
+      ? snapshot.tick
+      : 0;
   const remainder = tick % MEMORY_WIPE_INTERVAL_TICKS;
   const ticksUntilWipe = remainder === 0
     ? MEMORY_WIPE_INTERVAL_TICKS


### PR DESCRIPTION
## Summary

Closes (ref) #333 — part of #332 (Convex bandwidth optimization, Phase 0).

Splits the monolithic `getSnapshot` query (~40 KB, invalidated every 5s) into:
- **`getTickClock`** (~50 bytes, invalidates every tick) — backed by new `tickClock` single-row table, patched unconditionally on every `commitSnapshot`
- **`getSnapshot`** (~40 KB, invalidates only when world content changes) — backed by `worldSnapshot`, now delta-checked before each write

### Key changes

**Server (`apps/server/convex/`)**
- `schema.ts` — new `tickClock` table (tick, epoch, season fields)
- `getTickClock.ts` (new) — cheap query; returns `null` on empty DB for safe fallback
- `indexer.ts` — `commitSnapshot` now: (1) fetches `tickClock` first as the stale-gate monotonic cursor (worldSnapshot is no longer always-advancing), (2) patches `tickClock` every tick, (3) delta-checks `worldSnapshot` before patching — strips tick-family fields (`tick`, `tickEpochStartedAt`, `tickEpochDurationMs`, `currentTickSeed`, `nextHeartbeatAtTick`) so only actual game-world changes trigger a write

**Web (`apps/web/src/`)**
- `CockpitHeader.tsx` — switched to `getTickClock` (only needs tick)
- `TopHud.tsx` — switched to `getTickClock` for tick/epoch/season; keeps `getSnapshot` for bandit chip data
- `WorldMap.tsx` — subscribes to both; `liveTick` prefers `tickClock?.tick`; `currentTickFloat()` uses new `tickClockEpochRef` for fresh epoch data so animations stay correct when worldSnapshot freezes

### Expected bandwidth impact

~50% egress reduction (29 MB/h → ~15 MB/h) from `worldSnapshot` no longer pushing 40 KB to all subscribers every 5s when game state is static.

### Verification

- `@clan-world/server` typecheck: CLEAN
- `@clan-world/web` typecheck: CLEAN
- 3-tier swarm (Codex × 3 passes + Gemini × 2 passes): CLEAN after fix-rounds

**Note:** Convex dashboard before/after metrics captured manually post-deploy (requires live environment). PR evidence will be added as a comment once staging metrics are available.

**Note:** `closes #333` intentionally omitted — base is `dev`, not default branch. Issue will be closed manually after merge per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)