### PR TITLE
fix(convex): no-op delta guards on banditView + marketState writes (#334)

### DIFF
--- a/apps/server/convex/indexer.test.ts
+++ b/apps/server/convex/indexer.test.ts
@@ -317,6 +317,116 @@ describe("ingestEvents checkpoint isolation", () => {
 });
 
 describe("legacy snapshot backfill", () => {
+  it("skips append-only view writes when only audit fields change", async () => {
+    const { db, tables } = createDb();
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(1_000_000);
+
+    const market = {
+      currentTick: 12,
+      currentTickQueue: [],
+      nextTickQueue: [],
+      wood: {
+        resourceToken: "0x0000000000000000000000000000000000000001",
+        resourceReserve: "100",
+        goldReserve: "200",
+        spotPriceGoldPerResource: "2",
+      },
+      wheat: {
+        resourceToken: "0x0000000000000000000000000000000000000002",
+        resourceReserve: "300",
+        goldReserve: "600",
+        spotPriceGoldPerResource: "2",
+      },
+      fish: {
+        resourceToken: "0x0000000000000000000000000000000000000003",
+        resourceReserve: "400",
+        goldReserve: "800",
+        spotPriceGoldPerResource: "2",
+      },
+      iron: {
+        resourceToken: "0x0000000000000000000000000000000000000004",
+        resourceReserve: "500",
+        goldReserve: "1000",
+        spotPriceGoldPerResource: "2",
+      },
+    };
+    const bandit = {
+      exists: true,
+      banditId: 1,
+      currentRegion: 2,
+      state: 3,
+      attackPower: 4,
+      tier: 1,
+      attackAttemptsMade: 0,
+      maxAttemptsRemaining: 2,
+      stateEnteredTick: 10,
+      nextActionTick: 13,
+      carryWood: "1",
+      carryIron: "2",
+      carryWheat: "3",
+      carryFish: "4",
+      projectedTargetClanId: 2,
+      projectedTargetLootValue: "99",
+    };
+    const clan = {
+      clan: {
+        clan: {
+          clanId: 2,
+          owner: "0x0000000000000000000000000000000000000000",
+          goldBalance: "250",
+          blueprintBalance: "5",
+          vaultWood: "1000000000000000000",
+          vaultIron: "2000000000000000000",
+          vaultWheat: "3000000000000000000",
+          vaultFish: "4000000000000000000",
+        },
+        derivedAtTick: 12,
+      },
+    };
+
+    await (commitSnapshot as any)._handler(
+      { db },
+      {
+        snapshot: {
+          blockNumber: 99,
+          world: { currentTick: 12 },
+          market,
+          bandit,
+          clans: [clan],
+        },
+      },
+    );
+
+    // Second refresh: chain clock advances (tick 12 → 13) but on-chain content
+    // is unchanged. Same blockNumber (99) keeps clanView's HEAD-logic delta
+    // strip list happy — `lastUpdatedBlock` isn't stripped by clanView yet
+    // (that refinement lives in PR #338). After PR #338 lands we can also
+    // exercise the blockNumber-advance case. Bumping `market.currentTick` to 13
+    // exercises the MARKET_STATE_NON_CONTENT_FIELDS strip of `currentTick` /
+    // `lastUpdatedTick` — those advance every tick even when the AMM pools
+    // are static.
+    now.mockReturnValue(1_015_000);
+    await (commitSnapshot as any)._handler(
+      { db },
+      {
+        snapshot: {
+          blockNumber: 99,
+          world: { currentTick: 13 },
+          market: { ...market, currentTick: 13 },
+          bandit,
+          clans: [clan],
+        },
+      },
+    );
+
+    expect(tables.marketState).toHaveLength(1);
+    expect(tables.banditView).toHaveLength(1);
+    expect(tables.clanView).toHaveLength(1);
+
+    now.mockRestore();
+  });
+
   it("commitSnapshot writes non-empty legacy clans from clanView rows", async () => {
     const { db, tables } = createDb();
 

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -80,6 +80,51 @@ type LegacyClanView = Partial<Doc<"clanView">> &
 const isPresent = <T>(value: T | null | undefined): value is T =>
   value !== null && value !== undefined;
 
+// Non-content fields stripped before delta-comparison in commitSnapshot's
+// banditView / marketState writes (see #334). Convex auto-fields (_id,
+// _creationTime) plus per-insert audit/timestamp fields that advance every
+// heartbeat even when on-chain state is identical. marketState additionally
+// carries tick cursors (currentTick / lastUpdatedTick) that advance every
+// tick — these must be stripped too or the no-op guard never fires.
+const BANDIT_VIEW_NON_CONTENT_FIELDS = [
+  "_id",
+  "_creationTime",
+  "refreshedAt",
+  "lastUpdatedBlock",
+] as const;
+const MARKET_STATE_NON_CONTENT_FIELDS = [
+  "_id",
+  "_creationTime",
+  "refreshedAt",
+  "lastUpdatedBlock",
+  "currentTick",
+  "lastUpdatedTick",
+] as const;
+
+const stripNonContentFields = (
+  row: object | null | undefined,
+  fieldsToStrip: readonly string[],
+): Record<string, unknown> | undefined => {
+  if (!row) return undefined;
+  const skip = new Set(fieldsToStrip);
+  return Object.fromEntries(
+    Object.entries(row).filter(([key]) => !skip.has(key)),
+  );
+};
+
+// JSON.stringify-based content equality. Matches the existing `clanView`
+// delta pattern in `commitSnapshot` (`previousComparable` block). Field
+// order in object literals is stable across V8 for same-shape inserts,
+// so this is sound without a deep-equal dep — and consistent with the
+// pattern that PR #338 may later upgrade to fast-deep-equal.
+const isContentEqualIgnoring = (
+  previous: object | null | undefined,
+  next: object,
+  fieldsToStrip: readonly string[],
+) =>
+  JSON.stringify(stripNonContentFields(previous, fieldsToStrip)) ===
+  JSON.stringify(stripNonContentFields(next, fieldsToStrip));
+
 export function bigintSafe(value: unknown): unknown {
   if (typeof value === "bigint") return value.toString();
   if (Array.isArray(value)) return value.map(bigintSafe);
@@ -455,7 +500,7 @@ export const commitSnapshot = internalMutation({
 
     if (snapshot.market) {
       const market = snapshot.market;
-      await ctx.db.insert("marketState", {
+      const nextMarketState = {
         pools: RESOURCE_NAMES.map((resourceType) => {
           const pool = objectAt(market, resourceType);
           return {
@@ -477,12 +522,25 @@ export const commitSnapshot = internalMutation({
         lastUpdatedTick: tick,
         lastUpdatedBlock: snapshot.blockNumber,
         refreshedAt: now,
-      });
+      };
+      const previousMarketState = await ctx.db
+        .query("marketState")
+        .order("desc")
+        .first();
+      if (
+        !isContentEqualIgnoring(
+          previousMarketState,
+          nextMarketState,
+          MARKET_STATE_NON_CONTENT_FIELDS,
+        )
+      ) {
+        await ctx.db.insert("marketState", nextMarketState);
+      }
     }
 
     if (snapshot.bandit) {
       const bandit = snapshot.bandit;
-      await ctx.db.insert("banditView", {
+      const nextBanditView = {
         exists: asBool(bandit.exists),
         id: asNumber(bandit.banditId),
         region: asNumber(bandit.currentRegion),
@@ -501,7 +559,20 @@ export const commitSnapshot = internalMutation({
         projectedTargetLootValue: asString(bandit.projectedTargetLootValue),
         refreshedAt: now,
         lastUpdatedBlock: snapshot.blockNumber,
-      });
+      };
+      const previousBanditView = await ctx.db
+        .query("banditView")
+        .order("desc")
+        .first();
+      if (
+        !isContentEqualIgnoring(
+          previousBanditView,
+          nextBanditView,
+          BANDIT_VIEW_NON_CONTENT_FIELDS,
+        )
+      ) {
+        await ctx.db.insert("banditView", nextBanditView);
+      }
     }
 
     for (const view of snapshot.clans) {


### PR DESCRIPTION
## Summary

Adds content-equality guards before inserting into `banditView` and `marketState` in `commitSnapshot`, matching the existing `clanView` pattern. Strips per-table non-content fields before comparing via \`JSON.stringify\`.

Closes #334.

## What changed

- `apps/server/convex/indexer.ts` — +79 / -4. New helpers `stripNonContentFields` + `isContentEqualIgnoring`. Two new delta-check sites wrapping the marketState and banditView inserts. Per-table strip lists.
- `apps/server/convex/indexer.test.ts` — +110. One new test \`skips append-only view writes when only audit fields change\` covering all three tables.

## Per-table strip lists

- \`BANDIT_VIEW_NON_CONTENT_FIELDS\`: \`_id, _creationTime, refreshedAt, lastUpdatedBlock\`
- \`MARKET_STATE_NON_CONTENT_FIELDS\`: above + \`currentTick, lastUpdatedTick\`

## Notes on scope vs PR #338

- worldSnapshot delta-check is in PR #338 (in flight)
- clanView delta-check extension (adding \`derivedAtTick\` + \`lastUpdatedBlock\` to strip list) is in PR #338's fix-round 2

This PR is scoped to ONLY the two tables PR #338 didn't touch. Once #338 merges, the two patterns can be swept into one helper in a follow-up.

## Notes on diverged scope from issue

The issue body's generic strip list (\`createdAt, refreshedAt, lastUpdatedAt, txHash\`) was insufficient for marketState — it carries \`currentTick\` and \`lastUpdatedTick\` which advance every tick even when AMM pool state is unchanged. Without stripping those, the guard never fires. Per-table strip lists added.

\`createdAt\`, \`lastUpdatedAt\`, \`txHash\` from the brief don't exist on these schemas (verified in \`schema.ts\`). Dropped from the per-table lists rather than ship dead field names.

## Test results

- \`pnpm --filter @clan-world/server typecheck\`: PASS
- \`pnpm --filter @clan-world/server test\`: 35/35 PASS (baseline 34, +1 new test)

## Estimated bandwidth impact

Per the parent #332 estimate, banditView+marketState writes contribute to the ~10-15% reduction band (mostly via reactive-query invalidation on downstream consumers). Will measure post-merge with Convex dashboard metrics.

## Test plan

- [x] Server unit tests pass
- [x] Server typecheck clean
- [ ] Sanity check on live dev: confirm no new banditView/marketState rows insert during a 60s static-state heartbeat run
- [ ] Local 3-tier swarm review

🤖 Generated with [Claude Code](https://claude.com/claude-code)