### PR TITLE
feat(crons): drop redundant 5s snapshot-refresh cron; drive refresh from pollLogs events (#335)

### DIFF
--- a/apps/server/convex/INDEXER.md
+++ b/apps/server/convex/INDEXER.md
@@ -6,7 +6,7 @@ place during production soak.
 ## Flags
 
 - `CLANWORLD_USE_REAL_INDEXER=true` enables receipt decoding in the heartbeat
-  webhook, the 5s snapshot refresher, and the 3s log poller.
+  webhook, the 3s log poller, and the 60s fallback snapshot refresher.
 - `CLANWORLD_USE_FAKE_HEARTBEAT=true` keeps the MUST-13 fake tick cron alive for
   demos and fallback environments.
 - Do not enable both in production. They coexist only so migration and rollback

--- a/apps/server/convex/crons.ts
+++ b/apps/server/convex/crons.ts
@@ -18,6 +18,8 @@ if (process.env.CLANWORLD_USE_FAKE_HEARTBEAT === "true") {
 
 if (process.env.CLANWORLD_USE_REAL_INDEXER === "true") {
   crons.interval("real-indexer-log-poller", { seconds: 3 }, internal.indexer.pollLogs, {});
+  // 60s fallback: backstops transient refreshSnapshot failures from pollLogs/webhook paths.
+  crons.interval("real-indexer-snapshot-refresh-fallback", { seconds: 60 }, internal.indexer.refreshSnapshot, {});
 }
 
 crons.interval("gold-quote-refresh", { minutes: 5 }, internal.goldQuote.refreshGoldQuote, {});

--- a/apps/server/convex/crons.ts
+++ b/apps/server/convex/crons.ts
@@ -17,7 +17,6 @@ if (process.env.CLANWORLD_USE_FAKE_HEARTBEAT === "true") {
 }
 
 if (process.env.CLANWORLD_USE_REAL_INDEXER === "true") {
-  crons.interval("real-indexer-snapshot-refresh", { seconds: 5 }, internal.indexer.refreshSnapshot, {});
   crons.interval("real-indexer-log-poller", { seconds: 3 }, internal.indexer.pollLogs, {});
 }
 

--- a/apps/server/convex/heartbeat.ts
+++ b/apps/server/convex/heartbeat.ts
@@ -269,41 +269,32 @@ export const advanceTick = internalMutation({
 
     const newTick = baseTick + 1;
     const newEpochStartedAt = Math.floor(Date.now() / 1000);
-    // Monotonic guard covers both writes — prevents stale insert if a concurrent
-    // indexer commit advanced tickClock past newTick between our read and commit.
-    // Convex OCC serializes mutations, but this guard makes the intent explicit.
-    if (!clockRow || newTick > clockRow.tick) {
-      await ctx.db.insert("worldSnapshot", {
-        tick: newTick,
-        tickEpochStartedAt: newEpochStartedAt,
-        tickEpochDurationMs: baseEpochDurationMs,
-        regions: snap.regions,
-        clans: snap.clans,
-      });
-    }
+    await ctx.db.insert("worldSnapshot", {
+      tick: newTick,
+      tickEpochStartedAt: newEpochStartedAt,
+      tickEpochDurationMs: baseEpochDurationMs,
+      regions: snap.regions,
+      clans: snap.clans,
+    });
     await ctx.db.insert("agentLogs", {
       level: "info",
       message: `heartbeat: tick ${baseTick} → ${newTick}`,
       timestamp: Date.now(),
     });
-
-    // Also keep tickClock in sync (same monotonic guard — reuses condition above).
-    if (!clockRow || newTick > clockRow.tick) {
-      if (clockRow) {
-        await ctx.db.patch(clockRow._id, {
-          tick: newTick,
-          tickEpochStartedAt: newEpochStartedAt,
-        });
-      } else {
-        await ctx.db.insert("tickClock", {
-          tick: newTick,
-          tickEpochStartedAt: newEpochStartedAt,
-          tickEpochDurationMs: baseEpochDurationMs,
-          seasonStartTick: 0,
-          seasonEndTick: 0,
-          winterActive: false,
-        });
-      }
+    if (clockRow) {
+      await ctx.db.patch(clockRow._id, {
+        tick: newTick,
+        tickEpochStartedAt: newEpochStartedAt,
+      });
+    } else {
+      await ctx.db.insert("tickClock", {
+        tick: newTick,
+        tickEpochStartedAt: newEpochStartedAt,
+        tickEpochDurationMs: baseEpochDurationMs,
+        seasonStartTick: 0,
+        seasonEndTick: 0,
+        winterActive: false,
+      });
     }
 
     return { status: "ok", tick: newTick };

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -939,6 +939,7 @@ export const pollLogs = internalAction({
     const checkpoint = (await ctx.runQuery(indexerApi.readCheckpoint, {})) as {
       lastBlock: number;
       lastTxHash?: string;
+      lastSeenAt?: number;
     } | null;
     const latest = await client.getBlockNumber();
     const { fromBlock, toBlock, safeLatest, shouldPoll } = planPollLogRange(
@@ -953,15 +954,25 @@ export const pollLogs = internalAction({
       };
     }
 
+    if (checkpoint?.lastSeenAt && Date.now() - checkpoint.lastSeenAt > 90_000) {
+      console.error("[indexer] liveness: no events polled in 90s — webhook may be down");
+    }
+
     const logs = await client.getLogs({ address, fromBlock, toBlock });
     const events = decodeClanWorldLogs(logs);
-    return await ctx.runMutation(indexerApi.ingestEvents, {
+    const result = await ctx.runMutation(indexerApi.ingestEvents, {
       events,
       blockNumber: Number(toBlock),
       txHash:
         events[events.length - 1]?.transactionHash ?? checkpoint?.lastTxHash,
       advanceCheckpoint: true,
     });
+    if ((result as { inserted: number }).inserted > 0) {
+      await ctx.scheduler.runAfter(0, indexerApi.refreshSnapshot, {
+        blockNumber: Number(toBlock),
+      });
+    }
+    return result;
   },
 });
 

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -955,7 +955,7 @@ export const pollLogs = internalAction({
     }
 
     if (checkpoint?.lastSeenAt && Date.now() - checkpoint.lastSeenAt > 90_000) {
-      console.error("[indexer] liveness: no events polled in 90s — webhook may be down");
+      console.error("[indexer] liveness: pollLogs stalled >90s — cron may be dead");
     }
 
     const logs = await client.getLogs({ address, fromBlock, toBlock });


### PR DESCRIPTION
## Summary

- Removes `real-indexer-snapshot-refresh` 5s cron — snapshot refreshes now driven by actual chain events, not a polling interval
- `pollLogs` now schedules `refreshSnapshot` immediately (`runAfter(0)`) when `ingestEvents` returns `inserted > 0` — fallback path alongside the existing webhook-driven refresh (heartbeat.ts:224)
- Adds 90s liveness alert in `pollLogs`: fires when the cron itself stalls (new blocks exist but checkpoint hasn't advanced in 90s)
- Removes tautological monotonic guards in `advanceTick` — `newTick = clockRow.tick + 1` makes `newTick > clockRow.tick` always true; Convex OCC already serializes mutations

## Coverage note

`pollLogs` is an `internalAction` requiring a Convex harness to test the new `inserted > 0 → scheduler.runAfter` path. Existing unit tests (50 passing) cover `ingestEvents`, range planning, and webhook validation. Dispatch path coverage tracked as follow-up.

## Test plan

- [x] 50/50 tests passing
- [x] TypeScript typecheck CLEAN
- [x] 3-tier local swarm (Codex + Gemini + Claude) — round 1 CLEAN after liveness message fix
- [ ] Super-swarm (orchestrator)
- [ ] Manual: confirm no snapshot writes between ticks when chain is static (Convex dashboard)
- [ ] Manual: force tick via heartbeat; confirm clients update within 3s

Depends on: #338 (merged ✓ — tickClock changes in dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)