### PR TITLE
feat(agents): elder container image Dockerfile (#345)

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -1,0 +1,94 @@
+# syntax=docker/dockerfile:1.7
+#
+# clan-world/agent:dev — per-elder container image
+#
+# Phase 1.2 of docs/plans/dockerize-elder-infra-v1.md
+# Implements: GitHub issue clan-world/clan-world-game#345
+#
+# Layout note: the agents/shared/* tree (run.sh, home-claude/, elder-bootstrap/)
+# is NOT baked into the image — it is bind-mounted at runtime at
+# /opt/clan-world/shared. Only the entrypoint scripts + elder CLI stub +
+# sudoers rule live in the image.
+
+FROM node:24-slim
+
+# Build args
+ARG ELDER_UID=1000
+ARG ELDER_GID=1000
+
+# System deps — tmux for shell multiplexing, iptables/sudo for the egress
+# firewall, foundry's cast prerequisites (curl/bash), tini for PID 1.
+# Note: ttyd is NOT in Debian Bookworm; installed from GitHub release below.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      tmux \
+      ca-certificates \
+      curl \
+      jq \
+      iptables \
+      tini \
+      sudo \
+      bash \
+      git \
+      dnsutils \
+      iproute2 \
+      procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# ttyd — Debian Bookworm has no package, pull the static x86_64 binary.
+# Pinned to 1.7.7 (latest as of 2026-05-16); bump intentionally.
+ARG TTYD_VERSION=1.7.7
+RUN curl -fsSL -o /usr/local/bin/ttyd \
+      "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" \
+    && chmod 0755 /usr/local/bin/ttyd \
+    && /usr/local/bin/ttyd --version
+
+# Claude Code CLI + Codex CLI installed globally so every user (incl. elder UID 1000)
+# can invoke them off PATH.
+RUN npm install -g @anthropic-ai/claude-code @openai/codex \
+    && npm cache clean --force
+
+# Foundry (cast only — elder CLI's chain reads use it). Install into a system
+# location rather than root's home so the elder user can find the binary
+# without an extra PATH dance.
+RUN curl -L https://foundry.paradigm.xyz | bash \
+    && /root/.foundry/bin/foundryup \
+    && mv /root/.foundry/bin/cast /usr/local/bin/cast \
+    && mv /root/.foundry/bin/forge /usr/local/bin/forge \
+    && mv /root/.foundry/bin/anvil /usr/local/bin/anvil \
+    && mv /root/.foundry/bin/chisel /usr/local/bin/chisel \
+    && rm -rf /root/.foundry
+
+# Non-root user. UID 1000 keeps host file ownership sane for bind-mounted volumes.
+# node:24-slim ships a `node` user/group at UID/GID 1000; we remove it and
+# replace with `elder` at the same UID/GID so semantics are unchanged.
+RUN userdel -r node 2>/dev/null || true \
+    && groupadd -g ${ELDER_GID} elder \
+    && useradd -m -u ${ELDER_UID} -g ${ELDER_GID} -s /bin/bash elder \
+    && mkdir -p /home/elder/.claude /workspace /opt/clan-world \
+    && chown -R elder:elder /home/elder /workspace
+
+# Entrypoint scripts. init-firewall.sh requires CAP_NET_ADMIN; it runs via
+# sudo with a strict allowlist (see /etc/sudoers.d/elder-firewall).
+COPY --chmod=755 entrypoint.sh    /opt/clan-world/entrypoint.sh
+COPY --chmod=755 init-firewall.sh /opt/clan-world/init-firewall.sh
+COPY --chmod=755 elder            /usr/local/bin/elder
+
+# Sudoers rule: elder may run init-firewall.sh as root, no password, no other commands.
+# /etc/sudoers.d/* files must be chmod 0440.
+RUN echo "elder ALL=(root) NOPASSWD: /opt/clan-world/init-firewall.sh" > /etc/sudoers.d/elder-firewall \
+    && chmod 0440 /etc/sudoers.d/elder-firewall
+
+USER elder
+WORKDIR /workspace
+
+ENV HOME=/home/elder
+ENV CLAUDE_CONFIG_DIR=/home/elder/.claude
+ENV PATH=/usr/local/bin:/usr/bin:/bin
+
+# Healthcheck — tmux daemon alive AND ttyd accepting connections on 7681.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD pgrep -f tmux >/dev/null && curl -sf http://localhost:7681 >/dev/null || exit 1
+
+# tini = PID 1; reaps zombies and forwards signals to entrypoint.sh, which
+# applies the firewall and execs run.sh from the bind-mounted shared tree.
+ENTRYPOINT ["/usr/bin/tini", "--", "/opt/clan-world/entrypoint.sh"]

--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -83,7 +83,7 @@ WORKDIR /workspace
 
 ENV HOME=/home/elder
 ENV CLAUDE_CONFIG_DIR=/home/elder/.claude
-ENV PATH=/usr/local/bin:/usr/bin:/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Healthcheck — tmux daemon alive AND ttyd accepting connections on 7681.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \

--- a/agents/elder
+++ b/agents/elder
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# elder — clan-world elder CLI wrapper (STUB)
+#
+# Phase 1.2 of docs/plans/dockerize-elder-infra-v1.md.
+#
+# This is a placeholder. The real elder CLI (chain reads via `cast`,
+# Convex command-bus interaction, snapshot ingestion, etc.) is scoped to a
+# later issue. For v1 we ship a stub so the entrypoint test
+# `which elder` resolves and downstream phases can wire calls without
+# blocking on the CLI implementation.
+
+cat >&2 <<'EOF'
+elder CLI not yet implemented — this is a v1 stub.
+
+Use the MCP tools or `cast` directly for chain interactions until the
+elder CLI is filled in. Tracking issue: TBD (Phase 2+ scope).
+EOF
+
+exit 0

--- a/agents/entrypoint.sh
+++ b/agents/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# clan-world/agent:dev container entrypoint.
+#
+# Phase 1.2 of docs/plans/dockerize-elder-infra-v1.md.
+#
+# Runs as the `elder` non-root user (UID 1000). Calls the iptables egress
+# lockdown via sudo (which is allowed only for /opt/clan-world/init-firewall.sh
+# via /etc/sudoers.d/elder-firewall), then hands off to the canonical run.sh
+# from the bind-mounted shared tree at /opt/clan-world/shared/run.sh.
+
+set -euo pipefail
+
+# Apply egress firewall. Requires CAP_NET_ADMIN on the container; without it,
+# the iptables calls inside init-firewall.sh fail. We log the failure but do
+# NOT exit — a missing-cap dev container still needs to come up so the
+# operator can debug. Production compose MUST set cap_add: [NET_ADMIN].
+if [[ -x /opt/clan-world/init-firewall.sh ]]; then
+  if ! sudo /opt/clan-world/init-firewall.sh; then
+    echo "[entrypoint] WARNING: init-firewall.sh failed (likely missing CAP_NET_ADMIN). Continuing — egress NOT locked down." >&2
+  fi
+fi
+
+# Hand off to run.sh from the shared bind-mount. run.sh is owned by Phase 1.7
+# (issue #350); for v1, if the mount is missing we fall back to an interactive
+# bash so the operator can introspect.
+if [[ -x /opt/clan-world/shared/run.sh ]]; then
+  exec /opt/clan-world/shared/run.sh
+else
+  echo "[entrypoint] /opt/clan-world/shared/run.sh not found — Phase 1.7 not yet wired. Dropping to interactive bash." >&2
+  exec /bin/bash
+fi

--- a/agents/init-firewall.sh
+++ b/agents/init-firewall.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Egress firewall for clan-world/agent:dev.
+#
+# Phase 1.2 of docs/plans/dockerize-elder-infra-v1.md.
+# Modeled on https://github.com/anthropics/claude-code/blob/main/.devcontainer/init-firewall.sh
+#
+# Policy (round 3 / round 4 spec):
+#   - Default DROP for OUTPUT and INPUT
+#   - ACCEPT loopback
+#   - ACCEPT ESTABLISHED, RELATED
+#   - ACCEPT outbound to the Docker bridge networks (so we can reach
+#     convex-backend, anvil-fork, caddy, heartbeat without per-IP rules)
+#   - ACCEPT outbound DNS to /etc/resolv.conf nameservers + Docker embedded DNS
+#   - ACCEPT outbound HTTPS (443) to the resolved IPs of:
+#         api.anthropic.com, claude.ai, accounts.anthropic.com,
+#         statsig.anthropic.com, sentry.io  (telemetry endpoints CC may hit)
+#   - DROP everything else
+#
+# Runs as root via sudo NOPASSWD entry in /etc/sudoers.d/elder-firewall.
+
+set -euo pipefail
+
+log() { echo "[init-firewall] $*"; }
+
+# Sanity: must run as root (sudo guarantees this; double-check).
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "[init-firewall] FATAL: must run as root" >&2
+  exit 1
+fi
+
+# --- Flush existing rules and chains ----------------------------------------
+log "flushing existing rules"
+iptables -F
+iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+
+# --- Default policy: DROP ----------------------------------------------------
+log "setting default policy DROP"
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
+
+# --- Loopback ----------------------------------------------------------------
+iptables -A INPUT  -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# --- Established / Related --------------------------------------------------
+iptables -A INPUT  -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# --- Docker bridge networks (internal compose traffic) ----------------------
+# Docker's user-defined networks live in 172.16.0.0/12 by default;
+# user-defined bridges may also use 10.0.0.0/8. Allow both.
+log "allowing Docker bridge networks (172.16.0.0/12, 10.0.0.0/8)"
+iptables -A OUTPUT -d 172.16.0.0/12 -j ACCEPT
+iptables -A OUTPUT -d 10.0.0.0/8    -j ACCEPT
+iptables -A INPUT  -s 172.16.0.0/12 -j ACCEPT
+iptables -A INPUT  -s 10.0.0.0/8    -j ACCEPT
+
+# --- DNS ---------------------------------------------------------------------
+# Docker embedded DNS lives at 127.0.0.11 (special — already covered by lo
+# allow above, but be explicit). Plus resolv.conf nameservers.
+log "allowing DNS"
+iptables -A OUTPUT -p udp -d 127.0.0.11 --dport 53 -j ACCEPT
+iptables -A OUTPUT -p tcp -d 127.0.0.11 --dport 53 -j ACCEPT
+
+if [[ -r /etc/resolv.conf ]]; then
+  while read -r ns; do
+    [[ -z "$ns" ]] && continue
+    log "  allowing DNS nameserver $ns"
+    iptables -A OUTPUT -p udp -d "$ns" --dport 53 -j ACCEPT
+    iptables -A OUTPUT -p tcp -d "$ns" --dport 53 -j ACCEPT
+  done < <(awk '/^nameserver/ {print $2}' /etc/resolv.conf)
+fi
+
+# --- Allowed external hosts (HTTPS only) ------------------------------------
+ALLOWED_HOSTS=(
+  api.anthropic.com
+  claude.ai
+  console.anthropic.com
+  accounts.anthropic.com
+  statsig.anthropic.com
+  sentry.io
+)
+
+log "resolving and allowing HTTPS to allowed hosts"
+for host in "${ALLOWED_HOSTS[@]}"; do
+  # `getent ahosts` returns both A and AAAA; we only handle IPv4 for now
+  # (Docker default networks are v4-only). Multiple A records iterate.
+  if ! ips=$(getent ahostsv4 "$host" 2>/dev/null | awk '{print $1}' | sort -u); then
+    log "  WARN: failed to resolve $host — skipping"
+    continue
+  fi
+  if [[ -z "$ips" ]]; then
+    log "  WARN: no A records for $host — skipping"
+    continue
+  fi
+  while read -r ip; do
+    [[ -z "$ip" ]] && continue
+    log "  allow https://$host ($ip)"
+    iptables -A OUTPUT -p tcp -d "$ip" --dport 443 -j ACCEPT
+  done <<< "$ips"
+done
+
+# --- Final state ------------------------------------------------------------
+log "firewall applied. Active OUTPUT rules:"
+iptables -L OUTPUT -n -v --line-numbers
+
+log "done"

--- a/agents/init-firewall.sh
+++ b/agents/init-firewall.sh
@@ -43,6 +43,28 @@ iptables -P INPUT DROP
 iptables -P FORWARD DROP
 iptables -P OUTPUT DROP
 
+# --- IPv6 lockdown ----------------------------------------------------------
+# Default-DROP IPv6 too. Without this, any host with an AAAA record bypasses
+# the IPv4 allowlist via v6. We don't allow ANY IPv6 egress — Anthropic API
+# is reachable via IPv4. If the container has IPv6 connectivity but ip6tables
+# is missing (unlikely but possible), the script logs and continues — the
+# IPv4 DROP still applies, which is the primary defense.
+if command -v ip6tables >/dev/null 2>&1; then
+  log "setting IPv6 default policy DROP (ip6tables)"
+  ip6tables -P INPUT DROP
+  ip6tables -P FORWARD DROP
+  ip6tables -P OUTPUT DROP
+  ip6tables -F
+  ip6tables -X
+  # Allow loopback + established/related under IPv6 (mirrors IPv4 below)
+  ip6tables -A INPUT  -i lo -j ACCEPT
+  ip6tables -A OUTPUT -o lo -j ACCEPT
+  ip6tables -A INPUT  -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+  ip6tables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+else
+  log "WARN: ip6tables not found — IPv6 lockdown skipped (IPv4 DROP still applies)"
+fi
+
 # --- Loopback ----------------------------------------------------------------
 iptables -A INPUT  -i lo -j ACCEPT
 iptables -A OUTPUT -o lo -j ACCEPT


### PR DESCRIPTION
Closes #345. Phase 1.2 of the dockerize migration.

## Summary

node:24-slim base. tmux + ttyd 1.7.7 + foundry (cast/forge/anvil) + claude-code + @openai/codex + tini + sudo + iptables. elder user UID/GID 1000. HEALTHCHECK pings tmux+ttyd:7681. Entrypoint = tini → entrypoint.sh → sudo init-firewall.sh → exec run.sh from /opt/clan-world/shared (Phase 1.7 mount).

## Files (4)

- \`agents/Dockerfile\` (94 lines)
- \`agents/entrypoint.sh\` (31 lines)
- \`agents/init-firewall.sh\` (112 lines) — default-DROP egress, allows api.anthropic.com + claude.ai + console.anthropic.com + accounts + statsig + sentry, Docker bridges, DNS
- \`agents/elder\` (19 lines, stub for v1)

## Image size

**401MB content** (1.5GB on disk uncompressed). Reasonable for node+tmux+ttyd+foundry+claude-code+codex stack.

## Verification (all PASS)

- \`docker build\` succeeds (~21s warm cache)
- \`id\` → \`uid=1000(elder)\`
- \`claude --version\` → 2.1.143
- \`codex --version\` → codex-cli 0.130.0
- All tools on PATH
- Firewall applies with \`--cap-add NET_ADMIN\`
- Egress matrix verified: api.anthropic.com returns 405 (TLS reaches), google/github/npm all blocked
- \`sudo -l\` confirms elder can ONLY run \`init-firewall.sh\`

## Notable divergences from issue brief

1. \`@openai/codex-cli\` doesn't exist on npm → correct package is \`@openai/codex\`
2. \`foundryup --quiet\` flag doesn't exist in 1.7.1 → dropped
3. \`ttyd\` not in Debian Bookworm → pulled tsl0922/ttyd 1.7.7 binary via \`ARG TTYD_VERSION\`
4. node:24-slim ships \`node\` user at UID 1000 → \`userdel -r node\` before creating \`elder\` at same UID
5. Added \`procps\` for pgrep (HEALTHCHECK), \`dnsutils\` + \`iproute2\` (operator debug)
6. Image curl-test acceptance was strict-exit-zero on \`https://api.anthropic.com\` — anthropic returns 4xx to unauth GETs; documented HTTP 405 = TLS handshake worked = connectivity proven

## Coordination

- Depends on PR #364 (#350 agents/shared/) for runtime mount at \`/opt/clan-world/shared\` — falls back to bash if shared mount missing, so this PR is independently testable
- Independent of PR #363 (#344 compose) — image can be built standalone; compose just references the placeholder \`clanworld/agents:dev\` tag

## Test plan

- [x] Image builds clean
- [x] Container runs as elder UID
- [x] All tools resolve on PATH
- [x] Firewall blocks non-Anthropic egress
- [ ] CI green
- [ ] Local 3-tier swarm review

🤖 Generated with [Claude Code](https://claude.com/claude-code)