### PR TITLE
feat(web): URL scheme rename — cockpit → root, map → /map (#354)

### DIFF
--- a/apps/clan-world-mobile/README.md
+++ b/apps/clan-world-mobile/README.md
@@ -39,7 +39,7 @@ The full reasoning is in `/home/claude/.claude/plans/my-purpose-here-is-delightf
 # From the worktree root:
 cd apps/clan-world-mobile
 ANDROID_HOME=/opt/android-sdk \
-  CLAN_WORLD_MAP_URL=https://app.clan-world.com \
+  CLAN_WORLD_MAP_URL=https://app.clan-world.com/map \
   CLAN_WORLD_TERMINAL_BASE_URL=https://cockpit.clan-world.com \
   CLAN_WORLD_VERSION_NAME=2.3.3 \
   CLAN_WORLD_VERSION_CODE=2003003 \

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/MapWebView.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/MapWebView.kt
@@ -14,12 +14,17 @@ import world.clan.app.BuildConfig
 import world.clan.app.ui.theme.CockpitTokens
 
 /**
- * Loads the full web cockpit route configured by [BuildConfig.MAP_URL]
- * (defaults to https://app.clan-world.com). After issue #326 unified the
- * map across `/`, `/cockpit`, and the Android webview, the root route
- * mounts the same canonical `WorldMap` surface as `/cockpit`, so any URL
- * served by the production web app surfaces the full world map plus
- * shared overlays (version badge, ghost layer, HUD, event ticker).
+ * Loads the canonical world-map surface configured by [BuildConfig.MAP_URL].
+ *
+ * As of issue #354 (URL scheme rename) the web app serves the raw map at
+ * `/map`. The Android webview is expected to point at that path directly —
+ * e.g. `https://app.clan-world.com/map` — so this surface and the iframe
+ * embedded inside the web cockpit share the exact same render pipeline
+ * (one Pixi canvas + version badge + ghost layer + HUD + event ticker).
+ *
+ * Operators set `CLAN_WORLD_MAP_URL` (env) or `clanWorldMapUrl` (Gradle
+ * property) to override at build time. See `app/build.gradle.kts` for the
+ * resolution order and `README.md` for the production value.
  *
  * JS + DOM storage are required by the Pixi map; everything else is left
  * at WebView defaults.

--- a/apps/web/public/manifest.webmanifest
+++ b/apps/web/public/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "Clan World",
   "short_name": "Clan World",
   "description": "Onchain realm where AI Elders command clans on Base.",
-  "start_url": "/cockpit",
+  "start_url": "/",
   "scope": "/",
   "display": "standalone",
   "orientation": "any",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -69,13 +69,32 @@ export { DEMO_MODE };
 /**
  * Top-level route decision. Lightweight path-based routing avoids a router
  * dep for a single side route. Reading window.location once at render is
- * fine here — the cockpit is a standalone judge view, not a SPA tab inside
- * the main app, so we never need to navigate between them client-side.
+ * fine here — the cockpit is the default surface and the world map lives
+ * on `/map`, so we never need client-side navigation between them.
+ *
+ * Phase 1.11 (issue #354) URL rename:
+ *   - `/`         → Cockpit (was `/cockpit`)
+ *   - `/map`      → World map (was `/`); also embedded as an iframe inside
+ *                   the cockpit for Android parity
+ *   - `/cockpit`  → 301-style client redirect to `/` for a 30-day back-compat
+ *                   window
+ *   - `/elder-N`  → ttyd (Caddy-handled, no React route — see #348)
+ *   - `/owner`    → owner editor (unchanged)
+ *   - `/agents/:id` → single-agent control page (unchanged)
  */
-function isCockpitRoute(): boolean {
+function isMapRoute(): boolean {
   return (
     typeof window !== 'undefined' &&
-    window.location.pathname.startsWith('/cockpit')
+    (window.location.pathname === '/map' ||
+      window.location.pathname.startsWith('/map/'))
+  );
+}
+
+function isLegacyCockpitRoute(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    (window.location.pathname === '/cockpit' ||
+      window.location.pathname.startsWith('/cockpit/'))
   );
 }
 
@@ -101,12 +120,26 @@ function parseAgentRoute(): number | null {
 }
 
 export function App() {
-  if (isCockpitRoute()) {
-    return (
-      <CockpitErrorBoundary>
-        <Cockpit />
-      </CockpitErrorBoundary>
-    );
+  // Back-compat: `/cockpit*` is the V2-era cockpit URL. After the #354
+  // rename it lives at root. We do a client-side redirect (replace, no
+  // history entry) so existing bookmarks + PWA installs continue to work.
+  // The Caddy front door also serves a 301 for the same path; this branch
+  // covers any client-side navigation that bypasses Caddy (e.g. local dev).
+  if (isLegacyCockpitRoute()) {
+    if (typeof window !== 'undefined') {
+      const suffix =
+        window.location.pathname === '/cockpit'
+          ? '/'
+          : window.location.pathname.replace(/^\/cockpit/, '') || '/';
+      const dest = suffix + window.location.search + window.location.hash;
+      window.location.replace(dest);
+    }
+    // Render nothing during the redirect — the location.replace above
+    // tears down this tree immediately.
+    return null;
+  }
+  if (isMapRoute()) {
+    return <MainApp />;
   }
   const agentId = parseAgentRoute();
   if (agentId !== null) {
@@ -119,9 +152,22 @@ export function App() {
   if (isOwnerRoute()) {
     return <OwnerEditor />;
   }
-  return <MainApp />;
+  // Default route (`/`) is now the cockpit. Map content is embedded inside
+  // it as an iframe pointing at `/map` to match Android-webview parity.
+  return (
+    <CockpitErrorBoundary>
+      <Cockpit />
+    </CockpitErrorBoundary>
+  );
 }
 
+/**
+ * `/map` — raw world-map surface (no cockpit chrome).
+ *
+ * This is the route the cockpit iframes for web/Android parity. It is also
+ * directly reachable for users who want the full-bleed map view without
+ * the cockpit panels.
+ */
 function MainApp() {
   return (
     <main

--- a/apps/web/src/components/WorldMapEmbed.tsx
+++ b/apps/web/src/components/WorldMapEmbed.tsx
@@ -3,7 +3,12 @@ import { WorldMapBoundary } from './cockpit/shared/WorldMapBoundary';
 
 /**
  * Sanctioned route-level mount for the canonical world map surface.
- * Use this for /, /cockpit, and Android webview-backed cockpit routes.
+ *
+ * Phase 1.11 (issue #354) URL rename: this is now used by the `/map` route
+ * only. The cockpit at `/` embeds the map via `<WorldMapIframe />` pointing
+ * at `/map`, and the Android `MapWebView` loads the same `/map` URL — so
+ * every map render in the app comes through this component exactly once
+ * per surface.
  */
 export function WorldMapEmbed() {
   return (

--- a/apps/web/src/components/WorldMapIframe.tsx
+++ b/apps/web/src/components/WorldMapIframe.tsx
@@ -1,0 +1,39 @@
+/**
+ * Cockpit-mounted world map, served via an `<iframe src="/map" />`.
+ *
+ * Phase 1.11 (issue #354) introduced the URL rename:
+ *   - `/`     → Cockpit (this surface's parent)
+ *   - `/map`  → Raw world map (this iframe's target)
+ *
+ * The cockpit iframes `/map` instead of mounting `<WorldMap />` directly so
+ * the web cockpit and the Android `MapWebView` share the exact same render
+ * pipeline (one Pixi canvas + one set of overlays), keeping the two
+ * surfaces visually identical and avoiding canvas-context contention if
+ * the parent ever mounted two `<WorldMap />` instances simultaneously.
+ *
+ * The `data-testid` is preserved from the previous direct-mount path so
+ * existing e2e selectors (`page.getByTestId('cockpit-worldmap')`) continue
+ * to match without churn — they just look at the iframe wrapper now and
+ * inspect the canvas inside via `.contentFrame().locator('canvas')` when
+ * pixel-level checks are needed.
+ */
+export function WorldMapIframe() {
+  return (
+    <iframe
+      src="/map"
+      title="Clan World map"
+      data-testid="cockpit-worldmap-iframe"
+      style={{
+        width: '100%',
+        height: '100%',
+        border: 'none',
+        display: 'block',
+        background: '#000',
+      }}
+      // Allow the embedded Pixi canvas + Convex client to do their thing
+      // without sandbox restrictions. The iframe is same-origin so no
+      // cross-origin permissions are required.
+      allow="autoplay; fullscreen"
+    />
+  );
+}

--- a/apps/web/src/components/cockpit/MobileCockpitLayout.tsx
+++ b/apps/web/src/components/cockpit/MobileCockpitLayout.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { tokens, ELDERS, type ElderDef } from '../../styles/cockpit-tokens';
 import { MiniCockpit } from './MiniCockpit';
-import { WorldMapEmbed } from '../WorldMapEmbed';
+import { WorldMapIframe } from '../WorldMapIframe';
 
 const STORAGE_KEY_CLAN = 'cockpit-mobile-active-clan';
 const STORAGE_KEY_COLLAPSED = 'cockpit-mobile-collapsed';
@@ -166,7 +166,7 @@ export function MobileCockpitLayout() {
           background: '#000',
         }}
       >
-        <WorldMapEmbed />
+        <WorldMapIframe />
         <CollapseToggle collapsed={collapsed} onToggle={toggleCollapsed} accent={accent} />
       </div>
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -40,26 +40,32 @@ const Provider = ConvexProvider as React.ComponentType<{
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 
-// `/cockpit` is a standalone judge view — always render it, even if Convex
-// env is missing. The Phase-A panels are pure placeholders; the embedded
+// The cockpit (now at `/`), `/map`, `/owner`, and `/agents/:id` are all
+// standalone surfaces that render without real Convex data — the embedded
 // WorldMap consumes Convex via useQuery which returns undefined when no
 // data is available, so a stub client is enough to satisfy the provider.
+// Without these exemptions, screenshot/dev environments without
+// VITE_CONVEX_URL render "Backend not configured" instead of the actual
+// page.
 //
-// `/agents/:id` (PR #9) + `/owner` (PR #14) are also Convex-free: they
-// render without any useQuery/useMutation calls, so the stub provider is
-// sufficient. Without these exemptions, screenshot/dev environments
-// without VITE_CONVEX_URL render "Backend not configured" instead of the
-// actual page.
+// `/cockpit*` is kept as a standalone path so the legacy URL doesn't trip
+// the "Backend not configured" fallback during the 30-day back-compat
+// window — App.tsx redirects it to `/` after mount.
 const pathname =
   typeof window !== 'undefined' ? window.location.pathname : '';
 // Match the actual route shapes defined in App.tsx:
-//   /cockpit          → isCockpitRoute (startsWith '/cockpit')
+//   /                 → Cockpit (root)
+//   /map              → MainApp / WorldMap
+//   /cockpit          → legacy alias → redirect to /
 //   /owner            → isOwnerRoute   (startsWith '/owner')
 //   /agents/:digits   → parseAgentRoute (regex /^\/agents\/(\d+)\/?$/)
 // Bare `/agents` is NOT a real route in App.tsx — it falls through to
-// MainApp (the WorldMap), which DOES need Convex. So `/agents` must only
-// be treated as standalone when followed by a digit segment.
+// the cockpit (which uses Convex). So `/agents` must only be treated as
+// standalone when followed by a digit segment.
 const isStandalonePath =
+  pathname === '/' ||
+  pathname === '/map' ||
+  pathname.startsWith('/map/') ||
   pathname === '/cockpit' ||
   pathname.startsWith('/cockpit/') ||
   pathname === '/owner' ||

--- a/apps/web/src/pages/Cockpit.tsx
+++ b/apps/web/src/pages/Cockpit.tsx
@@ -2,7 +2,7 @@ import { tokens, ELDERS } from '../styles/cockpit-tokens';
 import { MiniCockpit } from '../components/cockpit/MiniCockpit';
 import { CockpitHeader } from '../components/cockpit/CockpitHeader';
 import { MobileCockpitLayout } from '../components/cockpit/MobileCockpitLayout';
-import { WorldMapEmbed } from '../components/WorldMapEmbed';
+import { WorldMapIframe } from '../components/WorldMapIframe';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 
 /**
@@ -169,7 +169,7 @@ function DesktopCockpitLayout() {
             background: '#000',
           }}
         >
-          <WorldMapEmbed />
+          <WorldMapIframe />
         </div>
       </div>
     </>

--- a/apps/web/tests/e2e/00-smoke.spec.ts
+++ b/apps/web/tests/e2e/00-smoke.spec.ts
@@ -39,7 +39,11 @@ test('web app loads with no console errors', async ({ page }) => {
     pageErrors.push({ message: err.message, stack: err.stack });
   });
 
-  await page.goto('/');
+  // Phase 1.11 URL rename (issue #354): `/` is now the cockpit (which
+  // embeds the map as an iframe). The map canvas lives at `/map`, so the
+  // canvas-centric smoke test loads `/map` directly — same render
+  // pipeline, no iframe traversal needed.
+  await page.goto('/map');
 
   // Wait for canvas to mount — WorldMap renders one.
   // 10s gives PIXI v8 + Convex client time to initialize.

--- a/apps/web/tests/e2e/02-demo-mode.spec.ts
+++ b/apps/web/tests/e2e/02-demo-mode.spec.ts
@@ -40,7 +40,9 @@ test.describe('DEMO_MODE flag — mock clans (demo mode ON)', () => {
   );
 
   test('demo mode ON: mock clan names visible in scoreboard panel', async ({ page }) => {
-    await page.goto('/');
+    // Phase 1.11 URL rename (issue #354): scoreboard + placeholder live on
+    // the raw map surface at `/map`, not on the cockpit at `/`.
+    await page.goto('/map');
 
     // Scoreboard pulse panel is rendered only in DEMO_MODE with scoreboardClans > 0.
     // "IG" is the Iron Guard initials rendered in the compact scoreboard.
@@ -59,7 +61,9 @@ test.describe('DEMO_MODE flag — empty world (demo mode OFF)', () => {
   );
 
   test('demo mode OFF: "no chain data yet" placeholder visible', async ({ page }) => {
-    await page.goto('/');
+    // Phase 1.11 URL rename (issue #354): scoreboard + placeholder live on
+    // the raw map surface at `/map`, not on the cockpit at `/`.
+    await page.goto('/map');
 
     // Placeholder overlay is rendered when DEMO_MODE=false and no live snapshot clans.
     const placeholder = page.getByTestId('no-chain-data-placeholder');

--- a/apps/web/tests/e2e/04-cockpit-shell.spec.ts
+++ b/apps/web/tests/e2e/04-cockpit-shell.spec.ts
@@ -4,7 +4,8 @@ import { test, expect } from '@playwright/test';
  * Phase A — Cockpit layout shell.
  *
  * Verifies the structural skeleton:
- *   - /cockpit route renders without error
+ *   - `/` route renders the cockpit without error (was `/cockpit` before
+ *     issue #354 URL rename; legacy alias still redirects client-side)
  *   - 3-col 2-row grid is mounted
  *   - all 4 mini-cockpits visible
  *   - world map cell visible
@@ -39,7 +40,7 @@ test.describe('cockpit shell (Phase A)', () => {
   test('renders 3-col 2-row layout with 4 mini-cockpits + world map', async ({
     page,
   }, testInfo) => {
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     // No error boundary crash.
     const errorBoundary = page.locator('[data-testid="error-boundary"]');
@@ -117,7 +118,7 @@ test.describe('cockpit shell (Phase A)', () => {
       });
     });
 
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     const pill = page.locator('[data-testid="cockpit-connection-pill"]');
     await expect(pill).toBeVisible();
@@ -170,7 +171,7 @@ test.describe('cockpit shell (Phase A)', () => {
       });
     });
 
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     await expect
       .poll(() => documentLoads, { timeout: 8_000 })
@@ -198,7 +199,7 @@ test.describe('cockpit shell (Phase A)', () => {
       });
     });
 
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     await expect(
       page.locator('[data-testid="mini-cockpit-1-content-terminal"]'),

--- a/apps/web/tests/e2e/06-canvas-warmth.spec.ts
+++ b/apps/web/tests/e2e/06-canvas-warmth.spec.ts
@@ -84,9 +84,10 @@ const FOUR_CLAN_PAYLOAD = {
 async function clearSnapshotCache(page: Page): Promise<void> {
   // localStorage is per-origin. We must navigate to the origin first so
   // `page.evaluate` runs with a valid storage context (about:blank has none).
-  // Empty navigation to `/` is the cheapest way to bind the page to the origin
-  // — the page errors are ignored; we only care about establishing storage.
-  await page.goto('/');
+  // Navigate to `/map` (the raw map surface — same origin as `/`) which is
+  // the cheapest origin-binding for this storage-only use; we don't want
+  // the cockpit at `/` to spin up its iframe just to clear localStorage.
+  await page.goto('/map');
   await page.evaluate(() => {
     const toRemove: string[] = [];
     for (let i = 0; i < localStorage.length; i++) {
@@ -131,7 +132,9 @@ test.describe('canvas warmth state machine (DEMO_MODE=false)', () => {
     // Load fresh — useCachedSnapshot.useState() returns undefined; liveSnapshot
     // also stays undefined (no real Convex backend in e2e); hasClans=false →
     // grace timer arms for 5s.
-    await page.goto('/');
+    // Phase 1.11 URL rename (issue #354): the raw map (with ghost +
+    // placeholder) is at `/map`; `/` is the cockpit that iframes it.
+    await page.goto('/map');
 
     // At t=0 (well within grace) the placeholder MUST NOT be visible. We use
     // a small timeout to ride past any sync mount latency without giving the
@@ -155,7 +158,9 @@ test.describe('canvas warmth state machine (DEMO_MODE=false)', () => {
       ts: Date.now(),
     });
 
-    await page.goto('/');
+    // Phase 1.11 URL rename (issue #354): the raw map (with ghost +
+    // placeholder) is at `/map`; `/` is the cockpit that iframes it.
+    await page.goto('/map');
 
     // Ghost must be in the DOM and visible at first paint — primed cache
     // hydrates synchronously in useState initializer + useMemo, no useEffect
@@ -240,7 +245,9 @@ test.describe('canvas warmth state machine (DEMO_MODE=false)', () => {
     // page.waitForTimeout(4000) + a single post-wait assert would let a
     // mid-window flash slip past (it could appear at t=2s then disappear
     // before t=4s). We sample 8 times across the window to catch a flash.
-    await page.goto('/');
+    // Phase 1.11 URL rename (issue #354): the raw map (with ghost +
+    // placeholder) is at `/map`; `/` is the cockpit that iframes it.
+    await page.goto('/map');
 
     // First, confirm we got past mount with a primed cache by checking the
     // ghost is present AND rendering cache-derived per-clan content. The

--- a/apps/web/tests/e2e/07-cockpit-worldmap-unified.spec.ts
+++ b/apps/web/tests/e2e/07-cockpit-worldmap-unified.spec.ts
@@ -10,44 +10,70 @@ async function stubTerminalIframes(page: Page): Promise<void> {
   );
 }
 
+/**
+ * Phase 1.11 URL rename (issue #354):
+ *   - `/`     → Cockpit (was `/cockpit`). Map is iframed in via `<iframe src="/map" />`.
+ *   - `/map`  → Raw world map surface (was `/`).
+ *   - `/cockpit` → client-side redirect to `/` for back-compat.
+ *
+ * These tests cover the new layout: same map render pipeline serves both
+ * the cockpit's iframe and the standalone `/map` URL, so the version
+ * badge + canvas count stay 1:1 across both surfaces.
+ */
 test.describe('unified world map routes', () => {
   test.beforeEach(async ({ page }) => {
     await stubTerminalIframes(page);
   });
 
-  test('root and cockpit expose the same version badge text', async ({ page }) => {
-    await page.goto('/');
-    const rootBadge = page.getByTestId('version-badge');
-    await expect(rootBadge).toBeVisible();
+  test('/map and the cockpit iframe expose the same version badge text', async ({ page }) => {
+    await page.goto('/map');
+    const mapBadge = page.getByTestId('version-badge');
+    await expect(mapBadge).toBeVisible();
     await expect(page.locator('canvas')).toHaveCount(1, { timeout: 15_000 });
-    const rootVersion = (await rootBadge.textContent())?.trim();
-    expect(rootVersion).toBeTruthy();
+    const mapVersion = (await mapBadge.textContent())?.trim();
+    expect(mapVersion).toBeTruthy();
 
-    await page.goto('/cockpit');
-    const cockpitBadge = page.getByTestId('version-badge');
+    // Cockpit at `/` iframes `/map`. Find the iframe, then assert the
+    // version badge inside it matches.
+    await page.goto('/');
+    const iframeLocator = page.getByTestId('cockpit-worldmap-iframe');
+    await expect(iframeLocator).toBeVisible();
+    const mapFrame = page.frameLocator('[data-testid="cockpit-worldmap-iframe"]');
+    const cockpitBadge = mapFrame.getByTestId('version-badge');
     await expect(cockpitBadge).toBeVisible();
-    await expect(page.locator('canvas')).toHaveCount(1, { timeout: 15_000 });
-    await expect(cockpitBadge).toHaveText(rootVersion ?? '');
+    await expect(mapFrame.locator('canvas')).toHaveCount(1, { timeout: 15_000 });
+    await expect(cockpitBadge).toHaveText(mapVersion ?? '');
   });
 
-  test('desktop cockpit mounts one canonical world map', async ({ page }, testInfo) => {
+  test('desktop cockpit mounts the world map via iframe to /map', async ({ page }, testInfo) => {
     test.skip(testInfo.project.name.includes('mobile'), 'desktop-only cockpit layout check');
 
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     const mapCell = page.getByTestId('cockpit-worldmap');
     await expect(page.getByTestId('cockpit-root')).toBeVisible();
     await expect(page.getByTestId('cockpit-grid')).toBeVisible();
     await expect(mapCell).toBeVisible();
-    await expect(mapCell.locator('canvas')).toHaveCount(1, { timeout: 15_000 });
-    await expect(page.getByTestId('version-badge')).toBeVisible();
-    expect(await page.getByTestId('map-ghost-layer').count()).toBeLessThanOrEqual(1);
+
+    // The cockpit no longer mounts <WorldMap /> directly — it embeds /map
+    // via an iframe so web and Android share the same render path.
+    const iframeEl = mapCell.getByTestId('cockpit-worldmap-iframe');
+    await expect(iframeEl).toBeVisible();
+    await expect(iframeEl).toHaveAttribute('src', '/map');
+
+    // Canvas + version badge live INSIDE the iframe now. We must not see a
+    // duplicate canvas in the outer document (that would mean WorldMap got
+    // re-mounted in the cockpit by accident).
+    await expect(page.locator('canvas')).toHaveCount(0);
+    const mapFrame = page.frameLocator('[data-testid="cockpit-worldmap-iframe"]');
+    await expect(mapFrame.locator('canvas')).toHaveCount(1, { timeout: 15_000 });
+    await expect(mapFrame.getByTestId('version-badge')).toBeVisible();
   });
 
-  test('mobile cockpit keeps one map canvas through collapse', async ({ page }, testInfo) => {
+  test('mobile cockpit iframes /map through the collapse toggle', async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.includes('mobile'), 'mobile-only cockpit layout check');
 
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     const layout = page.getByTestId('cockpit-mobile-layout');
     const mapRegion = page.getByTestId('cockpit-mobile-worldmap-region');
@@ -55,12 +81,32 @@ test.describe('unified world map routes', () => {
 
     await expect(layout).toBeVisible();
     await expect(mapRegion).toBeVisible();
-    await expect(mapRegion.locator('canvas')).toHaveCount(1, { timeout: 15_000 });
-    await expect(page.getByTestId('version-badge')).toBeVisible();
+
+    // Mobile cockpit also iframes /map; the canvas lives in the iframe.
+    const iframeEl = mapRegion.getByTestId('cockpit-worldmap-iframe');
+    await expect(iframeEl).toBeVisible();
+    await expect(iframeEl).toHaveAttribute('src', '/map');
+
+    const mapFrame = page.frameLocator('[data-testid="cockpit-worldmap-iframe"]');
+    await expect(mapFrame.locator('canvas')).toHaveCount(1, { timeout: 15_000 });
+    await expect(mapFrame.getByTestId('version-badge')).toBeVisible();
 
     const before = await layout.getAttribute('data-collapsed');
     await toggle.click();
     await expect(layout).not.toHaveAttribute('data-collapsed', before ?? '');
-    await expect(mapRegion.locator('canvas')).toHaveCount(1);
+    // Iframe stays mounted through the collapse animation — no remount
+    // (would re-warm Pixi otherwise).
+    await expect(iframeEl).toBeVisible();
+    await expect(mapFrame.locator('canvas')).toHaveCount(1);
+  });
+
+  test('legacy /cockpit redirects to /', async ({ page }) => {
+    // 30-day back-compat window per issue #354. The legacy URL must end
+    // at `/` (which renders the cockpit). The redirect is implemented
+    // client-side in App.tsx via window.location.replace, so we just
+    // assert the final pathname after the navigation settles.
+    await page.goto('/cockpit');
+    await expect.poll(() => new URL(page.url()).pathname, { timeout: 5_000 }).toBe('/');
+    await expect(page.getByTestId('cockpit-root')).toBeVisible();
   });
 });


### PR DESCRIPTION
Closes #354. Phase 1.11. URL flip: `/` cockpit, `/map` map (iframed in cockpit for Android parity), `/cockpit` 301 → `/`. 14 files, Playwright 9 pass + tests for iframe + redirect. typecheck + build green. Manifest start_url `/`. Android MapWebView.kt Kdoc rewritten.