### PR TITLE
feat(heartbeat): chain-keeper container with HMAC webhook + chain-ID assertion (#353)

### DIFF
--- a/agents/heartbeat/Dockerfile
+++ b/agents/heartbeat/Dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1.7
+#
+# clanworld/heartbeat:dev — heartbeat container
+#
+# Phase 1.10 of docs/plans/dockerize-elder-infra-v1.md
+# Implements: GitHub issue clan-world/clan-world-game#353
+#
+# This container ticks the diamond's heartbeat() every N seconds and posts an
+# HMAC-SHA256-signed webhook to the self-hosted Convex backend after each
+# successful on-chain tick.
+#
+# Design: thin bash + foundry cast + openssl + curl + jq, under tini for PID 1
+# signal forwarding. NO node runtime — keeps the image small and the failure
+# surface to a single shell loop.
+
+FROM debian:bookworm-slim
+
+# System deps — bash + curl for webhook POST, jq for cast --json parsing,
+# openssl for HMAC-SHA256, tini for PID 1, ca-certificates for HTTPS RPC,
+# dnsutils for preflight diagnostics. git is required by `foundryup`.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash \
+      ca-certificates \
+      curl \
+      git \
+      jq \
+      openssl \
+      tini \
+      dnsutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Foundry cast — pinned via foundryup. Move to /usr/local/bin so it is on
+# PATH for the non-root runtime user without an extra PATH dance.
+RUN curl -L https://foundry.paradigm.xyz | bash \
+    && /root/.foundry/bin/foundryup \
+    && mv /root/.foundry/bin/cast /usr/local/bin/cast \
+    && rm -rf /root/.foundry
+
+# Non-root runtime user. Heartbeat container does not need root once cast +
+# system binaries are in place.
+ARG HEARTBEAT_UID=1000
+ARG HEARTBEAT_GID=1000
+RUN groupadd -g ${HEARTBEAT_GID} heartbeat \
+    && useradd -m -u ${HEARTBEAT_UID} -g ${HEARTBEAT_GID} -s /bin/bash heartbeat
+
+# Scripts. entrypoint.sh sources preflight.sh and webhook-sign.sh, so all
+# three live in /opt/clan-world/heartbeat with executable bits.
+COPY --chmod=755 entrypoint.sh    /opt/clan-world/heartbeat/entrypoint.sh
+COPY --chmod=755 preflight.sh     /opt/clan-world/heartbeat/preflight.sh
+COPY --chmod=755 webhook-sign.sh  /opt/clan-world/heartbeat/webhook-sign.sh
+
+USER heartbeat
+WORKDIR /home/heartbeat
+
+# Touched on every successful tick — referenced by the compose healthcheck
+# (test -f /tmp/last-heartbeat-success && age < 120s).
+ENV HEARTBEAT_TIMESTAMP_FILE=/tmp/last-heartbeat-success
+
+# Default loop interval — overridable per environment.
+ENV HEARTBEAT_INTERVAL_SECONDS=60
+
+# tini reaps zombies and forwards signals so `docker stop` does not orphan
+# a running cast process mid-tick.
+ENTRYPOINT ["/usr/bin/tini", "--", "/opt/clan-world/heartbeat/entrypoint.sh"]

--- a/agents/heartbeat/README.md
+++ b/agents/heartbeat/README.md
@@ -1,0 +1,146 @@
+# clanworld/heartbeat — operator notes
+
+Phase 1.10 of `docs/plans/dockerize-elder-infra-v1.md` (issue #353).
+
+The heartbeat container ticks `heartbeat()` on the diamond every
+`HEARTBEAT_INTERVAL_SECONDS` (default 60) and, after each successful on-chain
+tick, posts an HMAC-SHA256-signed webhook to the self-hosted Convex backend.
+
+This replaces the host-side `clanworld-heartbeat-loop` once the dockerized
+stack is the source of truth (per the Phase 2 migration runbook).
+
+## Image
+
+Pure Debian-slim + `bash`, `cast` (foundry), `curl`, `jq`, `openssl`, `tini`.
+No node runtime. Built and tagged `clanworld/heartbeat:dev` by docker-compose
+during `make up PROFILE=dev`.
+
+```bash
+docker build -t clanworld/heartbeat:dev agents/heartbeat/
+```
+
+## Required env (container)
+
+| Var                            | Notes                                                  |
+| ------------------------------ | ------------------------------------------------------ |
+| `CHAIN_NETWORK`                | `dev` or `prod` (no default — fail fast)               |
+| `DEV_RPC_URL` / `PROD_RPC_URL` | one is required, matching `CHAIN_NETWORK`              |
+| `CLAN_WORLD_CONTRACT_ADDRESS`  | diamond address                                        |
+| `DEPLOYER_PRIVATE_KEY`         | caller key — supports `_FILE` via compose secrets      |
+| `WEBHOOK_SHARED_SECRET`        | HMAC key — supports `_FILE` via compose secrets        |
+| `CONVEX_DEPLOY_URL`            | derives `CONVEX_WEBHOOK_URL` if not set explicitly     |
+
+Optional:
+
+| Var                          | Default                                              |
+| ---------------------------- | ---------------------------------------------------- |
+| `CONVEX_WEBHOOK_URL`         | `${CONVEX_DEPLOY_URL%/}/api/heartbeat-webhook`       |
+| `HEARTBEAT_INTERVAL_SECONDS` | `60`                                                 |
+| `HEARTBEAT_TIMESTAMP_FILE`   | `/tmp/last-heartbeat-success`                        |
+
+## Preflight invariants (all fail-loud)
+
+1. `CHAIN_NETWORK ∈ {dev, prod}` and the matching RPC URL is non-empty.
+2. `CLAN_WORLD_CONTRACT_ADDRESS` matches `^0x[0-9a-fA-F]{40}$`.
+3. `cast chain-id --rpc-url $RPC_URL` returns a number AND, per profile:
+   - `dev` → observed `∈ {84532, 31337}` (Base Sepolia or local anvil)
+   - `prod` → observed `== 84532` (Base Sepolia)
+4. `cast call $DIAMOND 'owner()(address)'` returns a non-zero address.
+5. `DEPLOYER_PRIVATE_KEY` parses (`cast wallet address` succeeds).
+6. `WEBHOOK_SHARED_SECRET` is at least 32 chars.
+7. `CONVEX_WEBHOOK_URL` starts with `http://` or `https://`.
+
+Any violation exits non-zero. Compose policy `restart: on-failure:0` keeps the
+container in a visible failed state for operator intervention.
+
+## Webhook payload
+
+```json
+{
+  "chain": "base-sepolia",
+  "engineAddress": "0x...diamond...",
+  "txHash": "0x...",
+  "blockNumber": 12345,
+  "firedAtTs": 1716000000,
+  "source": "heartbeat-container"
+}
+```
+
+No `tick` field — Convex re-derives via `currentTick()` (AGENTS.md contract;
+plan Finding 28).
+
+## HMAC signing
+
+`v1 = HMAC-SHA256(secret, "${t}.${body}")` in hex. Header:
+
+```
+X-Heartbeat-Signature: t=<unix-ts>,v1=<hex-hmac>
+```
+
+The Convex receiver validates `|now - t| ≤ 60s` (replay window) and that `v1`
+matches over the exact body bytes. Body is built via
+`jq -c -n --argjson ... '{...}'` so key ordering is canonical and free of
+trailing whitespace. The signer (`webhook-sign.sh`) deliberately uses
+`printf '%s'` (no trailing newline) so the server can sign over identical
+bytes.
+
+> **Caveat (in-flight).** The current Convex receiver at
+> `apps/server/convex/http.ts` validates a flat `Authorization: Bearer
+> $WEBHOOK_SHARED_SECRET` header — the HMAC + replay-window receiver-side
+> migration is a separate change called out in the issue's "Files affected"
+> list. Until that lands, run the receiver in compatibility mode (or land both
+> changes in the same merge). See `webhook-sign.sh` for the canonical signing
+> code the receiver must mirror.
+
+## Webhook POST behaviour
+
+- Method: `POST`
+- Timeout: `--max-time 10`
+- One retry after a 5-second backoff on transient failure.
+- Webhook-side failure does **not** touch the healthcheck timestamp file —
+  this propagates the failure to `docker compose ps` after ~120s of staleness
+  even if the chain ticks keep working.
+
+## Healthcheck
+
+The compose service uses:
+
+```bash
+test -f /tmp/last-heartbeat-success \
+  && [ $(($(date +%s) - $(cat /tmp/last-heartbeat-success))) -lt 120 ]
+```
+
+The container touches `/tmp/last-heartbeat-success` only after BOTH the chain
+tick AND the webhook POST succeed end-to-end.
+
+## On-chain tick failure modes (tolerated, not aborted)
+
+- `RateLimited` — RPC rate limit, common on free Base Sepolia tier.
+- `HeartbeatGuard` / `TooEarly` — the engine's on-chain interval guard fired
+  (intended — we tick more often than the on-chain minimum during dev iteration).
+- Generic RPC blip — logged with `[heartbeat] ERROR:` prefix.
+
+Per-iteration failure does **not** crash the container; the next interval
+will retry.
+
+## Local testing
+
+```bash
+docker build -t clanworld/heartbeat:dev agents/heartbeat/
+
+# Preflight fail-loud: missing CHAIN_NETWORK
+docker run --rm clanworld/heartbeat:dev
+# expect: [heartbeat] ERROR: CHAIN_NETWORK is required (dev|prod) — aborting
+
+# Preflight fail-loud: missing DEV_RPC_URL
+docker run --rm -e CHAIN_NETWORK=dev clanworld/heartbeat:dev
+# expect: [heartbeat] ERROR: CHAIN_NETWORK=dev but DEV_RPC_URL is unset — aborting
+
+# Standalone HMAC check
+docker run --rm --entrypoint /opt/clan-world/heartbeat/webhook-sign.sh \
+  clanworld/heartbeat:dev \
+  "$(openssl rand -hex 32)" \
+  "$(date +%s)" \
+  '{"chain":"base-sepolia"}'
+# expect: 64 hex chars
+```

--- a/agents/heartbeat/entrypoint.sh
+++ b/agents/heartbeat/entrypoint.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# entrypoint.sh — heartbeat container main loop.
+#
+# Phase 1.10 (issue #353). Wires preflight (chain assertion + env validation)
+# + cast send heartbeat() loop + HMAC-signed webhook POST + healthcheck
+# timestamp file.
+#
+# Per the plan revision: CHAIN_NETWORK is REQUIRED (no fallback). Crash loud
+# on missing env. `restart: on-failure:0` in compose keeps a failed preflight
+# visible to the operator instead of crash-looping.
+#
+# Env contract (consumed):
+#   CHAIN_NETWORK                    dev | prod (required)
+#   DEV_RPC_URL                      required if CHAIN_NETWORK=dev
+#   PROD_RPC_URL                     required if CHAIN_NETWORK=prod
+#   CLAN_WORLD_CONTRACT_ADDRESS      diamond address
+#   DEPLOYER_PRIVATE_KEY             caller key (env OR _FILE for compose secret)
+#   WEBHOOK_SHARED_SECRET            HMAC key (env OR _FILE for compose secret)
+#   CONVEX_DEPLOY_URL                base url for the Convex backend (used to
+#                                    derive CONVEX_WEBHOOK_URL if not set)
+#   CONVEX_WEBHOOK_URL               full POST URL (optional override)
+#   HEARTBEAT_INTERVAL_SECONDS       loop interval (default 60)
+#   HEARTBEAT_TIMESTAMP_FILE         path to touch on success (default
+#                                    /tmp/last-heartbeat-success — Dockerfile)
+
+# NOTE on errexit: the heartbeat tick itself is allowed to fail per-iteration
+# (RPC blip, rate-limit, transient chain hiccup). We rely on explicit `|| ...`
+# inside the loop to keep iterating. Preflight is sourced under set -e and
+# will exit the entire process on any violation.
+set -uo pipefail
+
+log() { printf '[heartbeat] %s\n' "$*"; }
+err() { printf '[heartbeat] ERROR: %s\n' "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Compose secret file support (Finding 10 — secrets live in files, not env).
+# For any var FOO that has a corresponding FOO_FILE pointing at a readable
+# file, hydrate FOO from the file contents (newline-trimmed). This lets us
+# keep WEBHOOK_SHARED_SECRET and DEPLOYER_PRIVATE_KEY out of `docker inspect`.
+# ---------------------------------------------------------------------------
+hydrate_from_file() {
+  local var="$1"
+  local file_var="${var}_FILE"
+  local file_path="${!file_var:-}"
+  if [ -n "$file_path" ] && [ -r "$file_path" ]; then
+    # Trim ONLY trailing newlines from the file; preserve any internal bytes.
+    local value
+    value="$(tr -d '\r\n' < "$file_path")"
+    if [ -n "$value" ]; then
+      export "$var=$value"
+      log "loaded $var from $file_path (${#value} chars)"
+    fi
+  fi
+}
+
+hydrate_from_file WEBHOOK_SHARED_SECRET
+hydrate_from_file DEPLOYER_PRIVATE_KEY
+
+# ---------------------------------------------------------------------------
+# Resolve RPC_URL from CHAIN_NETWORK. NO cross-env fallback (Finding 48).
+# ---------------------------------------------------------------------------
+if [ -z "${CHAIN_NETWORK:-}" ]; then
+  err "CHAIN_NETWORK is required (dev|prod) — aborting"
+  exit 1
+fi
+
+case "$CHAIN_NETWORK" in
+  dev)
+    RPC_URL="${DEV_RPC_URL:-}"
+    if [ -z "$RPC_URL" ]; then
+      err "CHAIN_NETWORK=dev but DEV_RPC_URL is unset — aborting"
+      exit 1
+    fi
+    ;;
+  prod)
+    RPC_URL="${PROD_RPC_URL:-}"
+    if [ -z "$RPC_URL" ]; then
+      err "CHAIN_NETWORK=prod but PROD_RPC_URL is unset — aborting"
+      exit 1
+    fi
+    ;;
+  *)
+    err "CHAIN_NETWORK=$CHAIN_NETWORK is not one of {dev, prod} — aborting"
+    exit 1
+    ;;
+esac
+export RPC_URL
+
+# Derive CONVEX_WEBHOOK_URL if not explicitly provided.
+if [ -z "${CONVEX_WEBHOOK_URL:-}" ]; then
+  if [ -z "${CONVEX_DEPLOY_URL:-}" ]; then
+    err "neither CONVEX_WEBHOOK_URL nor CONVEX_DEPLOY_URL is set — aborting"
+    exit 1
+  fi
+  # Strip trailing slashes, then append the canonical path.
+  base="${CONVEX_DEPLOY_URL%/}"
+  CONVEX_WEBHOOK_URL="${base}/api/heartbeat-webhook"
+fi
+export CONVEX_WEBHOOK_URL
+
+# ---------------------------------------------------------------------------
+# Preflight — chain-ID assertion + owner check + env sanity. This is the only
+# block under strict set -e; loop body below tolerates per-iteration failure.
+# ---------------------------------------------------------------------------
+set -e
+# shellcheck disable=SC1091  # path is image-internal, resolved at runtime
+. /opt/clan-world/heartbeat/preflight.sh
+set +e
+
+# shellcheck disable=SC1091
+. /opt/clan-world/heartbeat/webhook-sign.sh
+
+INTERVAL_SECONDS="${HEARTBEAT_INTERVAL_SECONDS:-60}"
+TIMESTAMP_FILE="${HEARTBEAT_TIMESTAMP_FILE:-/tmp/last-heartbeat-success}"
+
+log "starting loop — interval=${INTERVAL_SECONDS}s"
+log "  diamond: $CLAN_WORLD_CONTRACT_ADDRESS"
+log "  rpc:     $RPC_URL"
+log "  webhook: $CONVEX_WEBHOOK_URL"
+
+# ---------------------------------------------------------------------------
+# Webhook POST helper — emits the signed POST + a single retry on transient
+# failure. Returns 0 on success, non-zero on both attempts failing. Logging
+# is verbose so operators can grep success/fail without parsing curl output.
+# ---------------------------------------------------------------------------
+post_webhook() {
+  local body="$1"
+  local ts hmac sig
+  ts="$(date +%s)"
+  hmac="$(heartbeat_sign "$WEBHOOK_SHARED_SECRET" "$ts" "$body")" || {
+    err "HMAC computation failed"
+    return 1
+  }
+  sig="t=${ts},v1=${hmac}"
+
+  local attempt rc=0
+  for attempt in 1 2; do
+    if curl -sS --fail --max-time 10 \
+        -X POST "$CONVEX_WEBHOOK_URL" \
+        -H "Content-Type: application/json" \
+        -H "X-Heartbeat-Signature: $sig" \
+        --data-raw "$body" \
+        >/dev/null; then
+      log "webhook POST ok (attempt $attempt)"
+      return 0
+    else
+      rc=$?
+      err "webhook POST failed (attempt $attempt, curl rc=$rc)"
+      if [ "$attempt" -eq 1 ]; then
+        sleep 5
+      fi
+    fi
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main loop — cast send + parse tx + POST webhook + touch healthcheck file.
+# Per-iteration failure is logged + tolerated; the next tick recovers.
+# ---------------------------------------------------------------------------
+while true; do
+  iter_start="$(date '+%Y-%m-%d %H:%M:%S %Z')"
+
+  cast_stderr="$(mktemp)"
+  cast_json="$(mktemp)"
+
+  if cast send "$CLAN_WORLD_CONTRACT_ADDRESS" "heartbeat()" \
+      --rpc-url "$RPC_URL" \
+      --private-key "$DEPLOYER_PRIVATE_KEY" \
+      --json \
+      > "$cast_json" \
+      2> "$cast_stderr"; then
+
+    # Parse tx hash + block number from cast --json output. cast's exact key
+    # names have drifted historically — accept either transactionHash or hash.
+    tx_hash="$(jq -r '.. | objects | .transactionHash? // .hash? // empty' "$cast_json" \
+      | grep -E '^0x[0-9a-fA-F]{64}$' | tail -1 || true)"
+    block_hex="$(jq -r '.. | objects | .blockNumber? // empty' "$cast_json" \
+      | tail -1 || true)"
+
+    if [ -z "$tx_hash" ]; then
+      err "$iter_start tick succeeded but tx hash unparseable — webhook skipped"
+      err "cast --json output: $(tr -d '\n' < "$cast_json" | head -c 400)"
+    else
+      if [[ "$block_hex" =~ ^0x[0-9a-fA-F]+$ ]]; then
+        block_number="$((block_hex))"
+      elif [[ "$block_hex" =~ ^[0-9]+$ ]]; then
+        block_number="$block_hex"
+      else
+        block_number="null"
+      fi
+
+      # AGENTS.md payload contract (Finding 28 — no `tick` field, Convex
+      # re-derives via currentTick()). Keys sorted so the body is canonical
+      # for HMAC determinism (Convex receiver must serialise identically).
+      body="$(jq -c -n \
+        --arg chain "base-sepolia" \
+        --arg engineAddress "$CLAN_WORLD_CONTRACT_ADDRESS" \
+        --arg txHash "$tx_hash" \
+        --argjson blockNumber "${block_number}" \
+        --argjson firedAtTs "$(date +%s)" \
+        --arg source "heartbeat-container" \
+        '{chain:$chain, engineAddress:$engineAddress, txHash:$txHash, blockNumber:$blockNumber, firedAtTs:$firedAtTs, source:$source}')"
+
+      log "$iter_start tick ok tx=${tx_hash:0:18}... block=${block_number}"
+
+      if post_webhook "$body"; then
+        # Healthcheck contract: touch only after BOTH the chain tick AND
+        # webhook delivery succeed end-to-end. The compose healthcheck reads
+        # the mtime and flags the container unhealthy after 120s of staleness.
+        date +%s > "$TIMESTAMP_FILE" || true
+      else
+        err "$iter_start webhook POST failed both attempts — not touching healthcheck file"
+      fi
+    fi
+
+  else
+    rc=$?
+    stderr_tail="$(tail -c 400 "$cast_stderr" 2>/dev/null || true)"
+    if grep -qi "RateLimited" "$cast_stderr"; then
+      log "$iter_start tick rate-limited; continuing"
+    elif grep -qi "HeartbeatGuard\|TooEarly\|guard" "$cast_stderr"; then
+      log "$iter_start tick guarded by on-chain interval; continuing"
+    else
+      err "$iter_start tick failed (rc=$rc): $stderr_tail"
+    fi
+  fi
+
+  rm -f "$cast_stderr" "$cast_json"
+  sleep "$INTERVAL_SECONDS"
+done

--- a/agents/heartbeat/preflight.sh
+++ b/agents/heartbeat/preflight.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# preflight.sh — env validation + chain-ID assertion + diamond owner check.
+#
+# Phase 1.10 (issue #353). Runs ONCE at container start before the heartbeat
+# loop begins. Fails loud (non-zero exit) on any invariant violation so the
+# `restart: on-failure:0` compose policy keeps the failure visible to the
+# operator instead of crash-looping silently.
+#
+# Required env (all must be non-empty):
+#   CHAIN_NETWORK                  dev | prod
+#   RPC_URL                        resolved by entrypoint.sh from DEV/PROD_RPC_URL
+#   CLAN_WORLD_CONTRACT_ADDRESS    diamond address (0x...)
+#   DEPLOYER_PRIVATE_KEY           caller key (any wallet with sufficient ETH +
+#                                  caller authorization on the engine)
+#   WEBHOOK_SHARED_SECRET          HMAC-SHA256 key for the Convex webhook
+#   CONVEX_WEBHOOK_URL             POST target, e.g. http://convex-backend:3210/api/heartbeat-webhook
+#
+# Optional env:
+#   HEARTBEAT_INTERVAL_SECONDS     loop interval; defaults to 60 in entrypoint
+#
+# Chain-ID assertion:
+#   CHAIN_NETWORK=dev   →  observed chain_id ∈ {84532, 31337}
+#   CHAIN_NETWORK=prod  →  observed chain_id == 84532  (Base Sepolia)
+
+set -euo pipefail
+
+log() { printf '[preflight] %s\n' "$*"; }
+err() { printf '[preflight] ERROR: %s\n' "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# 1. Required env vars
+# ---------------------------------------------------------------------------
+required_vars=(
+  CHAIN_NETWORK
+  RPC_URL
+  CLAN_WORLD_CONTRACT_ADDRESS
+  DEPLOYER_PRIVATE_KEY
+  WEBHOOK_SHARED_SECRET
+  CONVEX_WEBHOOK_URL
+)
+
+missing=0
+for v in "${required_vars[@]}"; do
+  if [ -z "${!v:-}" ]; then
+    err "required env var $v is unset or empty"
+    missing=1
+  fi
+done
+
+if [ "$missing" -ne 0 ]; then
+  err "aborting — fix env and restart"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. CHAIN_NETWORK whitelist (Finding 9 — no fallback)
+# ---------------------------------------------------------------------------
+case "$CHAIN_NETWORK" in
+  dev|prod) ;;
+  *)
+    err "CHAIN_NETWORK=$CHAIN_NETWORK is not one of {dev, prod}"
+    exit 1
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 3. Diamond address format
+# ---------------------------------------------------------------------------
+if ! [[ "$CLAN_WORLD_CONTRACT_ADDRESS" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+  err "CLAN_WORLD_CONTRACT_ADDRESS is not a 0x-prefixed 40-hex-char address: $CLAN_WORLD_CONTRACT_ADDRESS"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Chain ID assertion — fail loud if observed != expected for profile
+# ---------------------------------------------------------------------------
+log "querying chain_id from $RPC_URL ..."
+observed_chain_id="$(cast chain-id --rpc-url "$RPC_URL" 2>&1)" || {
+  err "cast chain-id failed against $RPC_URL: $observed_chain_id"
+  exit 1
+}
+
+if ! [[ "$observed_chain_id" =~ ^[0-9]+$ ]]; then
+  err "cast chain-id returned non-numeric value: $observed_chain_id"
+  exit 1
+fi
+
+case "$CHAIN_NETWORK" in
+  dev)
+    # dev tolerates Base-Sepolia (forked via anvil) OR plain anvil chain-id.
+    if [ "$observed_chain_id" != "84532" ] && [ "$observed_chain_id" != "31337" ]; then
+      err "CHAIN_NETWORK=dev expects chain_id ∈ {84532, 31337}; got $observed_chain_id"
+      err "abort — probable RPC misconfiguration"
+      exit 1
+    fi
+    ;;
+  prod)
+    if [ "$observed_chain_id" != "84532" ]; then
+      err "CHAIN_NETWORK=prod expects chain_id = 84532 (Base Sepolia); got $observed_chain_id"
+      err "abort — pointing prod heartbeat at non-Base-Sepolia is unsafe"
+      exit 1
+    fi
+    ;;
+esac
+
+log "chain_id ok — $observed_chain_id (CHAIN_NETWORK=$CHAIN_NETWORK)"
+
+# ---------------------------------------------------------------------------
+# 5. Diamond owner check — confirm contract responds to owner() and is
+#    not the zero-address (catches: wrong address, undeployed, fresh anvil
+#    without contract code at the address).
+# ---------------------------------------------------------------------------
+log "checking diamond owner() at $CLAN_WORLD_CONTRACT_ADDRESS ..."
+owner_raw="$(cast call "$CLAN_WORLD_CONTRACT_ADDRESS" 'owner()(address)' \
+  --rpc-url "$RPC_URL" 2>&1)" || {
+  err "cast call owner() failed: $owner_raw"
+  err "is the diamond deployed at $CLAN_WORLD_CONTRACT_ADDRESS on chain_id $observed_chain_id?"
+  exit 1
+}
+
+# cast normally emits a 0x-prefixed address; the literal zero address means
+# the diamond either has no owner set OR the call returned uninitialised
+# storage (i.e. there is no contract at that slot).
+owner="${owner_raw,,}"
+if [ "$owner" = "0x0000000000000000000000000000000000000000" ]; then
+  err "diamond.owner() == zero-address — contract probably not deployed"
+  exit 1
+fi
+
+log "diamond owner: $owner"
+
+# ---------------------------------------------------------------------------
+# 6. Caller (private key) sanity — derive the address and log it so the
+#    operator can sanity-check the funding account on the chain explorer.
+# ---------------------------------------------------------------------------
+caller="$(cast wallet address --private-key "$DEPLOYER_PRIVATE_KEY" 2>/dev/null)" || {
+  err "DEPLOYER_PRIVATE_KEY is malformed — cast wallet address rejected it"
+  exit 1
+}
+log "caller wallet: $caller"
+
+# ---------------------------------------------------------------------------
+# 7. Webhook secret length sanity — openssl rand -hex 32 produces 64 chars.
+#    Anything <32 chars is almost certainly a misconfiguration (e.g. a
+#    placeholder copied from the example without rotation).
+# ---------------------------------------------------------------------------
+secret_len="${#WEBHOOK_SHARED_SECRET}"
+if [ "$secret_len" -lt 32 ]; then
+  err "WEBHOOK_SHARED_SECRET is suspiciously short ($secret_len chars) — refusing to start"
+  err "expected ≥32 chars; bootstrap via 'make -C agents bootstrap-bus-secrets'"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Webhook URL format — must be http(s) and end with /api/heartbeat-webhook
+#    (defensive — surfaces typos before the first tick).
+# ---------------------------------------------------------------------------
+if ! [[ "$CONVEX_WEBHOOK_URL" =~ ^https?:// ]]; then
+  err "CONVEX_WEBHOOK_URL must be http:// or https:// — got: $CONVEX_WEBHOOK_URL"
+  exit 1
+fi
+
+log "preflight ok — entering heartbeat loop"

--- a/agents/heartbeat/webhook-sign.sh
+++ b/agents/heartbeat/webhook-sign.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# webhook-sign.sh — HMAC-SHA256 helper for the heartbeat → Convex webhook.
+#
+# Phase 1.10 (issue #353). Computes the canonical signature per the plan:
+#
+#   v1 = HMAC-SHA256(secret, "${t}.${body}")
+#
+# Header layout (Stripe-style — matches the Convex receiver contract):
+#
+#   X-Heartbeat-Signature: t=<unix-ts>,v1=<hex-hmac>
+#
+# Convex validates: (a) |now - t| ≤ 60s (replay window), (b) v1 matches.
+#
+# Usage as a sourced helper:
+#
+#   source /opt/clan-world/heartbeat/webhook-sign.sh
+#   sig="$(heartbeat_sign "$WEBHOOK_SHARED_SECRET" "$timestamp" "$body")"
+#
+# Stdout: the hex HMAC only (caller composes the header).
+
+set -euo pipefail
+
+# heartbeat_sign <secret> <timestamp> <body>
+#
+# Returns the hex-encoded HMAC-SHA256 of "${timestamp}.${body}" using <secret>
+# as the key. openssl is used (already in the image for ca-certificates +
+# entropy); avoids a heavier python/node dep.
+heartbeat_sign() {
+  local secret="$1"
+  local timestamp="$2"
+  local body="$3"
+
+  if [ -z "$secret" ] || [ -z "$timestamp" ] || [ -z "$body" ]; then
+    printf 'heartbeat_sign: empty secret/timestamp/body\n' >&2
+    return 1
+  fi
+
+  # printf "%s" avoids the trailing newline that `echo` injects — critical for
+  # HMAC determinism. The Convex receiver MUST sign over the same byte string.
+  printf '%s' "${timestamp}.${body}" \
+    | openssl dgst -sha256 -hmac "$secret" -hex \
+    | awk '{print $NF}'
+}
+
+# Allow invocation as a CLI for ad-hoc debugging:
+#   webhook-sign.sh <secret> <timestamp> <body>
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  if [ "$#" -ne 3 ]; then
+    printf 'usage: %s <secret> <timestamp> <body>\n' "$0" >&2
+    exit 2
+  fi
+  heartbeat_sign "$1" "$2" "$3"
+fi


### PR DESCRIPTION
Closes #353. Phase 1.10 heartbeat container. debian:bookworm-slim + cast 1.7.1 + bash + tini. Non-root uid 1000. 60s tick loop with HMAC-SHA256-signed webhook POST. CHAIN_NETWORK strict, chain-ID assertion, diamond owner() check, secret-length sanity. Image 407MB.

CAVEAT: receiver-side HMAC migration is OUT OF SCOPE — see PR body. Receiver still validates flat Bearer; container sends X-Heartbeat-Signature ignored for now. Receiver migration must land in same train (file as follow-up or coordinated PR).