### PR TITLE
feat(command-bus): agentCommands + elderHeartbeat + commandResults schema + mutations (#351)

### DIFF
--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as agentLogs from "../agentLogs.js";
 import type * as authShared from "../authShared.js";
 import type * as bulletins from "../bulletins.js";
 import type * as clansmen from "../clansmen.js";
+import type * as commandBus from "../commandBus.js";
 import type * as comms from "../comms.js";
 import type * as crons from "../crons.js";
 import type * as events from "../events.js";
@@ -49,6 +50,7 @@ declare const fullApi: ApiFromModules<{
   authShared: typeof authShared;
   bulletins: typeof bulletins;
   clansmen: typeof clansmen;
+  commandBus: typeof commandBus;
   comms: typeof comms;
   crons: typeof crons;
   events: typeof events;

--- a/apps/server/convex/commandBus.test.ts
+++ b/apps/server/convex/commandBus.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  enqueueCommand,
+  claimNext,
+  ackCommand,
+  completeCommand,
+  failCommand,
+  sweepStaleDelivered,
+  heartbeat,
+} from "./commandBus";
+
+vi.stubEnv("BUS_OPERATOR_SECRET", "op-secret");
+vi.stubEnv("BUS_ELDER_SECRET_1", "elder-1-secret");
+vi.stubEnv("BUS_ELDER_SECRET_2", "elder-2-secret");
+
+function createDb(tables: Record<string, any[]> = {}) {
+  return {
+    tables,
+    db: {
+      async get(id: string) {
+        for (const rows of Object.values(tables)) {
+          const row = rows.find((r) => r._id === id);
+          if (row) return row;
+        }
+        return null;
+      },
+      async insert(table: string, value: Record<string, unknown>) {
+        tables[table] ??= [];
+        const doc = {
+          ...value,
+          _id: `${table}:${tables[table].length}`,
+          _creationTime: tables[table].length,
+        };
+        tables[table].push(doc);
+        return doc._id;
+      },
+      async patch(id: string, value: Record<string, unknown>) {
+        for (const rows of Object.values(tables)) {
+          const index = rows.findIndex((row) => row._id === id);
+          if (index >= 0) rows[index] = { ...rows[index], ...value };
+        }
+      },
+      query(table: string) {
+        let rows = [...(tables[table] ?? [])];
+        const builder = {
+          withIndex(_name: string, apply?: (q: any) => unknown) {
+            if (apply) {
+              const clauses: Array<{ field: string; value: unknown }> = [];
+              const q = {
+                eq(field: string, value: unknown) {
+                  clauses.push({ field, value });
+                  return q;
+                },
+              };
+              apply(q);
+              rows = rows.filter((row) =>
+                clauses.every((clause) => row[clause.field] === clause.value),
+              );
+            }
+            return builder;
+          },
+          filter(predicate: (q: any) => boolean) {
+            rows = rows.filter((row) => {
+              const rowQ = {
+                eq(a: unknown, b: unknown) {
+                  const aVal = typeof a === "function" ? (a as any)(row) : a;
+                  const bVal = typeof b === "function" ? (b as any)(row) : b;
+                  return aVal === bVal;
+                },
+                field(name: string) {
+                  return row[name];
+                },
+              };
+              return predicate(rowQ);
+            });
+            return builder;
+          },
+          order(direction: "asc" | "desc") {
+            rows = [...rows].sort((a, b) =>
+              direction === "desc"
+                ? b._creationTime - a._creationTime
+                : a._creationTime - b._creationTime,
+            );
+            return builder;
+          },
+          async first() {
+            return rows[0] ?? null;
+          },
+          async collect() {
+            return [...rows];
+          },
+        };
+        return builder;
+      },
+    },
+  };
+}
+
+describe("enqueueCommand", () => {
+  it("inserts a command at status=queued", async () => {
+    const { db, tables } = createDb();
+    await (enqueueCommand as any)._handler(
+      { db },
+      {
+        secret: "op-secret",
+        targetAgentId: "elder-1",
+        kind: "user_message",
+        payload: { text: "hello" },
+        source: "orchestrator",
+      },
+    );
+    expect(tables.agentCommands).toHaveLength(1);
+    expect(tables.agentCommands![0].status).toBe("queued");
+    expect(tables.agentCommands![0].retryCount).toBe(0);
+    expect(tables.agentCommands![0].payloadVersion).toBe(1);
+  });
+
+  it("throws on wrong operator secret", async () => {
+    const { db } = createDb();
+    await expect(
+      (enqueueCommand as any)._handler(
+        { db },
+        {
+          secret: "wrong-secret",
+          targetAgentId: "elder-1",
+          kind: "user_message",
+          payload: {},
+          source: "orchestrator",
+        },
+      ),
+    ).rejects.toThrow("Unauthorized");
+  });
+});
+
+describe("claimNext", () => {
+  it("claims oldest queued command for targetAgentId", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "queued",
+          createdAt: 1000,
+          retryCount: 0,
+        },
+        {
+          _id: "agentCommands:1",
+          _creationTime: 1,
+          targetAgentId: "elder-1",
+          status: "queued",
+          createdAt: 2000,
+          retryCount: 0,
+        },
+      ],
+    });
+    const claimedId = await (claimNext as any)._handler(
+      { db },
+      { secret: "elder-1-secret", agentId: "elder-1" },
+    );
+    expect(claimedId).toBe("agentCommands:0");
+    expect(tables.agentCommands![0].status).toBe("leased");
+    expect(tables.agentCommands![0].leaseOwner).toBe("elder-1");
+  });
+
+  it("returns null on empty queue", async () => {
+    const { db } = createDb({ agentCommands: [] });
+    const result = await (claimNext as any)._handler(
+      { db },
+      { secret: "elder-1-secret", agentId: "elder-1" },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("claims broadcast (*) if no targeted commands", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "*",
+          status: "queued",
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    const claimedId = await (claimNext as any)._handler(
+      { db },
+      { secret: "elder-1-secret", agentId: "elder-1" },
+    );
+    expect(claimedId).toBe("agentCommands:0");
+    expect(tables.agentCommands![0].status).toBe("leased");
+  });
+});
+
+describe("ackCommand", () => {
+  it("transitions leased to acked", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    await (ackCommand as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        commandId: "agentCommands:0",
+      },
+    );
+    expect(tables.agentCommands![0].status).toBe("acked");
+    expect(tables.agentCommands![0].ackedAt).toBeDefined();
+  });
+});
+
+describe("completeCommand", () => {
+  it("transitions acked to completed and writes commandResults row", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "acked",
+          leaseOwner: "elder-1",
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    await (completeCommand as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        commandId: "agentCommands:0",
+        resultPayload: { ok: true },
+        tookMs: 42,
+      },
+    );
+    expect(tables.agentCommands![0].status).toBe("completed");
+    expect(tables.agentCommands![0].completedAt).toBeDefined();
+    expect(tables.commandResults).toHaveLength(1);
+    expect(tables.commandResults![0].tookMs).toBe(42);
+    expect(tables.commandResults![0].commandId).toBe("agentCommands:0");
+  });
+});
+
+describe("failCommand", () => {
+  it("increments retryCount and re-queues if < MAX_RETRIES", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          createdAt: 1000,
+          retryCount: 1,
+        },
+      ],
+    });
+    await (failCommand as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        commandId: "agentCommands:0",
+        reason: "timeout",
+      },
+    );
+    expect(tables.agentCommands![0].status).toBe("queued");
+    expect(tables.agentCommands![0].retryCount).toBe(2);
+    expect(tables.agentCommands![0].leaseOwner).toBeUndefined();
+  });
+
+  it("marks failed if retryCount reaches MAX_RETRIES (3)", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          createdAt: 1000,
+          retryCount: 2,
+        },
+      ],
+    });
+    await (failCommand as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        commandId: "agentCommands:0",
+        reason: "timeout",
+      },
+    );
+    expect(tables.agentCommands![0].status).toBe("failed");
+    expect(tables.agentCommands![0].retryCount).toBe(3);
+  });
+});
+
+describe("sweepStaleDelivered", () => {
+  it("re-queues expired leases", async () => {
+    const now = Date.now();
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          leaseExpiresAt: now - 1000, // expired
+          createdAt: 1000,
+          retryCount: 0,
+        },
+        {
+          _id: "agentCommands:1",
+          _creationTime: 1,
+          targetAgentId: "elder-2",
+          status: "leased",
+          leaseOwner: "elder-2",
+          leaseExpiresAt: now + 999999, // not expired
+          createdAt: 2000,
+          retryCount: 0,
+        },
+      ],
+    });
+    const result = await (sweepStaleDelivered as any)._handler({ db }, {});
+    expect(result.swept).toBe(1);
+    expect(tables.agentCommands![0].status).toBe("queued");
+    expect(tables.agentCommands![1].status).toBe("leased"); // untouched
+  });
+});
+
+describe("heartbeat", () => {
+  it("inserts a new row on first call", async () => {
+    const { db, tables } = createDb();
+    await (heartbeat as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        lastTickProcessed: 42,
+        health: "green",
+      },
+    );
+    expect(tables.elderHeartbeat).toHaveLength(1);
+    expect(tables.elderHeartbeat![0].agentId).toBe("elder-1");
+    expect(tables.elderHeartbeat![0].health).toBe("green");
+  });
+
+  it("patches existing row on second call", async () => {
+    const { db, tables } = createDb();
+    await (heartbeat as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        lastTickProcessed: 42,
+        health: "green",
+      },
+    );
+    await (heartbeat as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        lastTickProcessed: 43,
+        health: "yellow",
+      },
+    );
+    expect(tables.elderHeartbeat).toHaveLength(1);
+    expect(tables.elderHeartbeat![0].lastTickProcessed).toBe(43);
+    expect(tables.elderHeartbeat![0].health).toBe("yellow");
+  });
+});
+
+describe("auth", () => {
+  it("throws on wrong elder secret", async () => {
+    const { db } = createDb();
+    await expect(
+      (heartbeat as any)._handler(
+        { db },
+        {
+          secret: "wrong-secret",
+          agentId: "elder-1",
+          lastTickProcessed: 1,
+          health: "green",
+        },
+      ),
+    ).rejects.toThrow("Unauthorized");
+  });
+});

--- a/apps/server/convex/commandBus.test.ts
+++ b/apps/server/convex/commandBus.test.ts
@@ -301,6 +301,37 @@ describe("completeCommand", () => {
   });
 });
 
+describe("completeCommand (lease-expiry)", () => {
+  it("throws on expired lease when completing", async () => {
+    const { db } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "acked",
+          leaseOwner: "elder-1",
+          leaseExpiresAt: Date.now() - 1000, // expired
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    await expect(
+      (completeCommand as any)._handler(
+        { db },
+        {
+          secret: "elder-1-secret",
+          agentId: "elder-1",
+          commandId: "agentCommands:0",
+          resultPayload: { ok: true },
+          tookMs: 42,
+        },
+      ),
+    ).rejects.toThrow("Lease expired");
+  });
+});
+
 describe("failCommand", () => {
   it("increments retryCount and re-queues if < MAX_RETRIES", async () => {
     const { db, tables } = createDb({
@@ -360,6 +391,34 @@ describe("failCommand", () => {
     );
     expect(tables.agentCommands![0].status).toBe("failed");
     expect(tables.agentCommands![0].retryCount).toBe(3);
+  });
+
+  it("throws on expired lease when failing", async () => {
+    const { db } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          leaseExpiresAt: Date.now() - 1000, // expired
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    await expect(
+      (failCommand as any)._handler(
+        { db },
+        {
+          secret: "elder-1-secret",
+          agentId: "elder-1",
+          commandId: "agentCommands:0",
+          reason: "timeout",
+        },
+      ),
+    ).rejects.toThrow("Lease expired");
   });
 });
 

--- a/apps/server/convex/commandBus.test.ts
+++ b/apps/server/convex/commandBus.test.ts
@@ -37,7 +37,14 @@ function createDb(tables: Record<string, any[]> = {}) {
       async patch(id: string, value: Record<string, unknown>) {
         for (const rows of Object.values(tables)) {
           const index = rows.findIndex((row) => row._id === id);
-          if (index >= 0) rows[index] = { ...rows[index], ...value };
+          if (index >= 0) {
+            const updated = { ...rows[index] };
+            for (const [k, v] of Object.entries(value)) {
+              if (v === undefined) delete (updated as any)[k];
+              else (updated as any)[k] = v;
+            }
+            rows[index] = updated;
+          }
         }
       },
       query(table: string) {
@@ -45,16 +52,22 @@ function createDb(tables: Record<string, any[]> = {}) {
         const builder = {
           withIndex(_name: string, apply?: (q: any) => unknown) {
             if (apply) {
-              const clauses: Array<{ field: string; value: unknown }> = [];
+              const eqClauses: Array<{ field: string; value: unknown }> = [];
+              const ltClauses: Array<{ field: string; value: unknown }> = [];
               const q = {
                 eq(field: string, value: unknown) {
-                  clauses.push({ field, value });
+                  eqClauses.push({ field, value });
+                  return q;
+                },
+                lt(field: string, value: unknown) {
+                  ltClauses.push({ field, value });
                   return q;
                 },
               };
               apply(q);
               rows = rows.filter((row) =>
-                clauses.every((clause) => row[clause.field] === clause.value),
+                eqClauses.every((clause) => row[clause.field] === clause.value) &&
+                ltClauses.every((clause) => (row[clause.field] as number) < (clause.value as number)),
               );
             }
             return builder;
@@ -130,6 +143,27 @@ describe("enqueueCommand", () => {
       ),
     ).rejects.toThrow("Unauthorized");
   });
+
+  it("fan-out: inserts one row per elder for targetAgentId='*'", async () => {
+    vi.stubEnv("ELDER_IDS", "elder-1,elder-2,elder-3,elder-4");
+    const { db, tables } = createDb();
+    const result = await (enqueueCommand as any)._handler(
+      { db },
+      {
+        secret: "op-secret",
+        targetAgentId: "*",
+        kind: "system_message",
+        payload: { text: "freeze" },
+        source: "orchestrator",
+      },
+    );
+    expect(Array.isArray(result)).toBe(true);
+    expect(tables.agentCommands).toHaveLength(4);
+    const targets = tables.agentCommands!.map((c: any) => c.targetAgentId);
+    expect(targets).toEqual(["elder-1", "elder-2", "elder-3", "elder-4"]);
+    const seqs = tables.agentCommands!.map((c: any) => c.broadcastSequence);
+    expect(new Set(seqs).size).toBe(1); // all same broadcastSequence
+  });
 });
 
 describe("claimNext", () => {
@@ -172,16 +206,17 @@ describe("claimNext", () => {
     expect(result).toBeNull();
   });
 
-  it("claims broadcast (*) if no targeted commands", async () => {
+  it("claims fan-out broadcast row targeted at this elder", async () => {
     const { db, tables } = createDb({
       agentCommands: [
         {
           _id: "agentCommands:0",
           _creationTime: 0,
-          targetAgentId: "*",
+          targetAgentId: "elder-1",
           status: "queued",
           createdAt: 1000,
           retryCount: 0,
+          broadcastSequence: 1,
         },
       ],
     });

--- a/apps/server/convex/commandBus.test.ts
+++ b/apps/server/convex/commandBus.test.ts
@@ -5,6 +5,7 @@ import {
   ackCommand,
   completeCommand,
   failCommand,
+  getQueuedFor,
   sweepStaleDelivered,
   heartbeat,
 } from "./commandBus";
@@ -142,6 +143,16 @@ describe("enqueueCommand", () => {
         },
       ),
     ).rejects.toThrow("Unauthorized");
+  });
+
+  it("throws on invalid targetAgentId", async () => {
+    const { db } = createDb();
+    await expect(
+      (enqueueCommand as any)._handler(
+        { db },
+        { secret: "op-secret", targetAgentId: "elder-99", kind: "reset", payload: {}, source: "orchestrator" },
+      ),
+    ).rejects.toThrow("Invalid targetAgentId");
   });
 
   it("fan-out: inserts one row per elder for targetAgentId='*'", async () => {
@@ -300,10 +311,12 @@ describe("failCommand", () => {
           targetAgentId: "elder-1",
           status: "leased",
           leaseOwner: "elder-1",
+          ackedAt: 999,
           createdAt: 1000,
           retryCount: 1,
         },
       ],
+      commandResults: [],
     });
     await (failCommand as any)._handler(
       { db },
@@ -317,6 +330,9 @@ describe("failCommand", () => {
     expect(tables.agentCommands![0].status).toBe("queued");
     expect(tables.agentCommands![0].retryCount).toBe(2);
     expect(tables.agentCommands![0].leaseOwner).toBeUndefined();
+    expect(tables.agentCommands![0].ackedAt).toBeUndefined();
+    expect(tables.commandResults).toHaveLength(1);
+    expect(tables.commandResults![0].resultPayload.reason).toBe("timeout");
   });
 
   it("marks failed if retryCount reaches MAX_RETRIES (3)", async () => {
@@ -378,6 +394,52 @@ describe("sweepStaleDelivered", () => {
     expect(result.swept).toBe(1);
     expect(tables.agentCommands![0].status).toBe("queued");
     expect(tables.agentCommands![1].status).toBe("leased"); // untouched
+  });
+
+  it("re-queues expired acked commands (stuck after elder crash)", async () => {
+    const now = Date.now();
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "acked",
+          leaseOwner: "elder-1",
+          leaseExpiresAt: now - 1000,
+          ackedAt: now - 2000,
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    const result = await (sweepStaleDelivered as any)._handler({ db }, {});
+    expect(result.swept).toBe(1);
+    expect(tables.agentCommands![0].status).toBe("queued");
+    expect(tables.agentCommands![0].leaseOwner).toBeUndefined();
+    expect(tables.agentCommands![0].ackedAt).toBeUndefined();
+  });
+});
+
+describe("getQueuedFor", () => {
+  it("returns queued commands for agentId", async () => {
+    const { db } = createDb({
+      agentCommands: [
+        { _id: "agentCommands:0", _creationTime: 0, targetAgentId: "elder-1", status: "queued", createdAt: 1000, retryCount: 0 },
+      ],
+    });
+    const result = await (getQueuedFor as any)._handler(
+      { db },
+      { secret: "elder-1-secret", agentId: "elder-1" },
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("rejects wrong secret", async () => {
+    const { db } = createDb();
+    await expect(
+      (getQueuedFor as any)._handler({ db }, { secret: "wrong", agentId: "elder-1" }),
+    ).rejects.toThrow("Unauthorized");
   });
 });
 

--- a/apps/server/convex/commandBus.ts
+++ b/apps/server/convex/commandBus.ts
@@ -1,0 +1,227 @@
+import { mutation, query, internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+
+const LEASE_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_RETRIES = 3;
+
+function checkOperatorAuth(secret: string) {
+  if (!process.env.BUS_OPERATOR_SECRET || secret !== process.env.BUS_OPERATOR_SECRET) {
+    throw new Error("Unauthorized: BUS_OPERATOR_SECRET required");
+  }
+}
+
+function checkElderAuth(secret: string, agentId: string) {
+  const m = agentId.match(/^elder-(\d+)$/);
+  if (!m) throw new Error("Invalid agentId format");
+  const expected = process.env[`BUS_ELDER_SECRET_${m[1]}`];
+  if (!expected || secret !== expected) {
+    throw new Error(`Unauthorized: BUS_ELDER_SECRET_${m[1]} required`);
+  }
+}
+
+// 1. enqueueCommand — operator enqueues a command
+export const enqueueCommand = mutation({
+  args: {
+    secret: v.string(),
+    targetAgentId: v.string(),
+    kind: v.union(
+      v.literal("user_message"), v.literal("system_message"),
+      v.literal("snapshot_request"), v.literal("reset"),
+      v.literal("freeze"), v.literal("unfreeze"),
+    ),
+    payload: v.any(),
+    source: v.string(),
+  },
+  handler: async (ctx, args) => {
+    checkOperatorAuth(args.secret);
+    let broadcastSequence: number | undefined;
+    if (args.targetAgentId === "*") {
+      const last = await ctx.db.query("agentCommands")
+        .withIndex("by_broadcast_sequence")
+        .order("desc")
+        .first();
+      broadcastSequence = (last?.broadcastSequence ?? 0) + 1;
+    }
+    return await ctx.db.insert("agentCommands", {
+      targetAgentId: args.targetAgentId,
+      kind: args.kind,
+      payload: args.payload,
+      payloadVersion: 1,
+      source: args.source,
+      createdAt: Date.now(),
+      status: "queued",
+      retryCount: 0,
+      broadcastSequence,
+    });
+  },
+});
+
+// 2. claimNext — elder claims oldest queued command
+export const claimNext = mutation({
+  args: { secret: v.string(), agentId: v.string() },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    // Check targeted commands first, then broadcasts
+    const targeted = await ctx.db.query("agentCommands")
+      .withIndex("by_target_status", q =>
+        q.eq("targetAgentId", args.agentId).eq("status", "queued"),
+      )
+      .order("asc")
+      .first();
+    const broadcast = await ctx.db.query("agentCommands")
+      .withIndex("by_target_status", q =>
+        q.eq("targetAgentId", "*").eq("status", "queued"),
+      )
+      .order("asc")
+      .first();
+    // Pick the older of the two (lower createdAt)
+    const cmd = !targeted ? broadcast
+      : !broadcast ? targeted
+      : targeted.createdAt <= broadcast.createdAt ? targeted : broadcast;
+    if (!cmd) return null;
+    const now = Date.now();
+    await ctx.db.patch(cmd._id, {
+      status: "leased",
+      leaseOwner: args.agentId,
+      leaseExpiresAt: now + LEASE_MS,
+    });
+    return cmd._id;
+  },
+});
+
+// 3. ackCommand — elder acks receipt
+export const ackCommand = mutation({
+  args: { secret: v.string(), agentId: v.string(), commandId: v.id("agentCommands") },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    const cmd = await ctx.db.get(args.commandId);
+    if (!cmd || cmd.status !== "leased" || cmd.leaseOwner !== args.agentId) {
+      throw new Error("Command not found or not leased by this elder");
+    }
+    await ctx.db.patch(args.commandId, { status: "acked", ackedAt: Date.now() });
+  },
+});
+
+// 4. completeCommand — elder marks done + writes result
+export const completeCommand = mutation({
+  args: {
+    secret: v.string(),
+    agentId: v.string(),
+    commandId: v.id("agentCommands"),
+    resultPayload: v.any(),
+    tookMs: v.number(),
+  },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    const cmd = await ctx.db.get(args.commandId);
+    if (!cmd || (cmd.status !== "acked" && cmd.status !== "leased") || cmd.leaseOwner !== args.agentId) {
+      throw new Error("Command not found or not owned by this elder");
+    }
+    const now = Date.now();
+    await ctx.db.patch(args.commandId, { status: "completed", completedAt: now });
+    await ctx.db.insert("commandResults", {
+      commandId: args.commandId,
+      agentId: args.agentId,
+      resultPayload: args.resultPayload,
+      tookMs: args.tookMs,
+      createdAt: now,
+    });
+  },
+});
+
+// 5. failCommand — elder gives up; retry or mark failed
+export const failCommand = mutation({
+  args: {
+    secret: v.string(),
+    agentId: v.string(),
+    commandId: v.id("agentCommands"),
+    reason: v.string(),
+  },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    const cmd = await ctx.db.get(args.commandId);
+    if (!cmd || cmd.leaseOwner !== args.agentId) {
+      throw new Error("Command not found or not owned by this elder");
+    }
+    const newRetryCount = cmd.retryCount + 1;
+    await ctx.db.patch(args.commandId, {
+      status: newRetryCount >= MAX_RETRIES ? "failed" : "queued",
+      retryCount: newRetryCount,
+      leaseOwner: undefined,
+      leaseExpiresAt: undefined,
+    });
+  },
+});
+
+// 6. getQueuedFor — reactive query for elder's queue
+export const getQueuedFor = query({
+  args: { agentId: v.string() },
+  handler: async (ctx, args) => {
+    const targeted = await ctx.db.query("agentCommands")
+      .withIndex("by_target_status", q =>
+        q.eq("targetAgentId", args.agentId).eq("status", "queued"),
+      )
+      .collect();
+    const broadcast = await ctx.db.query("agentCommands")
+      .withIndex("by_target_status", q =>
+        q.eq("targetAgentId", "*").eq("status", "queued"),
+      )
+      .collect();
+    return [...targeted, ...broadcast].sort((a, b) => a.createdAt - b.createdAt);
+  },
+});
+
+// 7. sweepStaleDelivered — cron: re-queue expired leases
+export const sweepStaleDelivered = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const leased = await ctx.db.query("agentCommands")
+      .filter(q => q.eq(q.field("status"), "leased"))
+      .collect();
+    const expired = leased.filter(cmd =>
+      cmd.leaseExpiresAt !== undefined && cmd.leaseExpiresAt < now
+    );
+    let swept = 0;
+    for (const cmd of expired) {
+      const newRetryCount = cmd.retryCount + 1;
+      await ctx.db.patch(cmd._id, {
+        status: newRetryCount >= MAX_RETRIES ? "failed" : "queued",
+        retryCount: newRetryCount,
+        leaseOwner: undefined,
+        leaseExpiresAt: undefined,
+      });
+      swept++;
+    }
+    return { swept };
+  },
+});
+
+// 8. heartbeat — elder-runtime upserts heartbeat row
+export const heartbeat = mutation({
+  args: {
+    secret: v.string(),
+    agentId: v.string(),
+    lastTickProcessed: v.number(),
+    currentStrategy: v.optional(v.string()),
+    health: v.union(v.literal("green"), v.literal("yellow"), v.literal("red")),
+  },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    const existing = await ctx.db.query("elderHeartbeat")
+      .withIndex("by_agentId", q => q.eq("agentId", args.agentId))
+      .first();
+    const data = {
+      agentId: args.agentId,
+      lastSeenAt: Date.now(),
+      lastTickProcessed: args.lastTickProcessed,
+      currentStrategy: args.currentStrategy,
+      health: args.health,
+    };
+    if (existing) {
+      await ctx.db.patch(existing._id, data);
+    } else {
+      await ctx.db.insert("elderHeartbeat", data);
+    }
+  },
+});

--- a/apps/server/convex/commandBus.ts
+++ b/apps/server/convex/commandBus.ts
@@ -34,6 +34,11 @@ export const enqueueCommand = mutation({
   },
   handler: async (ctx, args) => {
     checkOperatorAuth(args.secret);
+    const validElderIds = (process.env.ELDER_IDS ?? "elder-1,elder-2,elder-3,elder-4")
+      .split(",").map(s => s.trim()).filter(Boolean);
+    if (args.targetAgentId !== "*" && !validElderIds.includes(args.targetAgentId)) {
+      throw new Error(`Invalid targetAgentId: ${args.targetAgentId}`);
+    }
     let broadcastSequence: number | undefined;
     if (args.targetAgentId === "*") {
       const last = await ctx.db.query("agentCommands")
@@ -41,10 +46,8 @@ export const enqueueCommand = mutation({
         .order("desc")
         .first();
       broadcastSequence = (last?.broadcastSequence ?? 0) + 1;
-      const elderIds = (process.env.ELDER_IDS ?? "elder-1,elder-2,elder-3,elder-4")
-        .split(",").map(s => s.trim()).filter(Boolean);
       const ids: string[] = [];
-      for (const elderId of elderIds) {
+      for (const elderId of validElderIds) {
         ids.push(await ctx.db.insert("agentCommands", {
           targetAgentId: elderId,
           kind: args.kind,
@@ -150,19 +153,29 @@ export const failCommand = mutation({
       throw new Error("Command not found or not owned by this elder");
     }
     const newRetryCount = cmd.retryCount + 1;
+    const now = Date.now();
+    await ctx.db.insert("commandResults", {
+      commandId: args.commandId,
+      agentId: args.agentId,
+      resultPayload: { reason: args.reason, retryCount: newRetryCount },
+      tookMs: 0,
+      createdAt: now,
+    });
     await ctx.db.patch(args.commandId, {
       status: newRetryCount >= MAX_RETRIES ? "failed" : "queued",
       retryCount: newRetryCount,
       leaseOwner: undefined,
       leaseExpiresAt: undefined,
+      ackedAt: undefined,
     });
   },
 });
 
 // 6. getQueuedFor — reactive query for elder's queue
 export const getQueuedFor = query({
-  args: { agentId: v.string() },
+  args: { secret: v.string(), agentId: v.string() },
   handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
     return await ctx.db.query("agentCommands")
       .withIndex("by_target_status", q =>
         q.eq("targetAgentId", args.agentId).eq("status", "queued"),
@@ -176,11 +189,17 @@ export const sweepStaleDelivered = internalMutation({
   args: {},
   handler: async (ctx) => {
     const now = Date.now();
-    const expired = await ctx.db.query("agentCommands")
+    const expiredLeased = await ctx.db.query("agentCommands")
       .withIndex("by_status_lease", q =>
         q.eq("status", "leased").lt("leaseExpiresAt", now)
       )
       .collect();
+    const expiredAcked = await ctx.db.query("agentCommands")
+      .withIndex("by_status_lease", q =>
+        q.eq("status", "acked").lt("leaseExpiresAt", now)
+      )
+      .collect();
+    const expired = [...expiredLeased, ...expiredAcked];
     let swept = 0;
     for (const cmd of expired) {
       const newRetryCount = cmd.retryCount + 1;
@@ -189,6 +208,7 @@ export const sweepStaleDelivered = internalMutation({
         retryCount: newRetryCount,
         leaseOwner: undefined,
         leaseExpiresAt: undefined,
+        ackedAt: undefined,
       });
       swept++;
     }

--- a/apps/server/convex/commandBus.ts
+++ b/apps/server/convex/commandBus.ts
@@ -126,6 +126,9 @@ export const completeCommand = mutation({
     if (!cmd || (cmd.status !== "acked" && cmd.status !== "leased") || cmd.leaseOwner !== args.agentId) {
       throw new Error("Command not found or not owned by this elder");
     }
+    if (cmd.leaseExpiresAt !== undefined && cmd.leaseExpiresAt <= Date.now()) {
+      throw new Error("Lease expired — re-claim the command before completing");
+    }
     const now = Date.now();
     await ctx.db.patch(args.commandId, { status: "completed", completedAt: now, leaseOwner: undefined, leaseExpiresAt: undefined });
     await ctx.db.insert("commandResults", {
@@ -151,6 +154,9 @@ export const failCommand = mutation({
     const cmd = await ctx.db.get(args.commandId);
     if (!cmd || (cmd.status !== "leased" && cmd.status !== "acked") || cmd.leaseOwner !== args.agentId) {
       throw new Error("Command not found or not owned by this elder");
+    }
+    if (cmd.leaseExpiresAt !== undefined && cmd.leaseExpiresAt <= Date.now()) {
+      throw new Error("Lease expired — re-claim the command before failing");
     }
     const newRetryCount = cmd.retryCount + 1;
     const now = Date.now();

--- a/apps/server/convex/commandBus.ts
+++ b/apps/server/convex/commandBus.ts
@@ -41,6 +41,23 @@ export const enqueueCommand = mutation({
         .order("desc")
         .first();
       broadcastSequence = (last?.broadcastSequence ?? 0) + 1;
+      const elderIds = (process.env.ELDER_IDS ?? "elder-1,elder-2,elder-3,elder-4")
+        .split(",").map(s => s.trim()).filter(Boolean);
+      const ids: string[] = [];
+      for (const elderId of elderIds) {
+        ids.push(await ctx.db.insert("agentCommands", {
+          targetAgentId: elderId,
+          kind: args.kind,
+          payload: args.payload,
+          payloadVersion: 1,
+          source: args.source,
+          createdAt: Date.now(),
+          status: "queued",
+          retryCount: 0,
+          broadcastSequence,
+        }));
+      }
+      return ids;
     }
     return await ctx.db.insert("agentCommands", {
       targetAgentId: args.targetAgentId,
@@ -61,23 +78,12 @@ export const claimNext = mutation({
   args: { secret: v.string(), agentId: v.string() },
   handler: async (ctx, args) => {
     checkElderAuth(args.secret, args.agentId);
-    // Check targeted commands first, then broadcasts
-    const targeted = await ctx.db.query("agentCommands")
+    const cmd = await ctx.db.query("agentCommands")
       .withIndex("by_target_status", q =>
         q.eq("targetAgentId", args.agentId).eq("status", "queued"),
       )
       .order("asc")
       .first();
-    const broadcast = await ctx.db.query("agentCommands")
-      .withIndex("by_target_status", q =>
-        q.eq("targetAgentId", "*").eq("status", "queued"),
-      )
-      .order("asc")
-      .first();
-    // Pick the older of the two (lower createdAt)
-    const cmd = !targeted ? broadcast
-      : !broadcast ? targeted
-      : targeted.createdAt <= broadcast.createdAt ? targeted : broadcast;
     if (!cmd) return null;
     const now = Date.now();
     await ctx.db.patch(cmd._id, {
@@ -118,7 +124,7 @@ export const completeCommand = mutation({
       throw new Error("Command not found or not owned by this elder");
     }
     const now = Date.now();
-    await ctx.db.patch(args.commandId, { status: "completed", completedAt: now });
+    await ctx.db.patch(args.commandId, { status: "completed", completedAt: now, leaseOwner: undefined, leaseExpiresAt: undefined });
     await ctx.db.insert("commandResults", {
       commandId: args.commandId,
       agentId: args.agentId,
@@ -140,7 +146,7 @@ export const failCommand = mutation({
   handler: async (ctx, args) => {
     checkElderAuth(args.secret, args.agentId);
     const cmd = await ctx.db.get(args.commandId);
-    if (!cmd || cmd.leaseOwner !== args.agentId) {
+    if (!cmd || (cmd.status !== "leased" && cmd.status !== "acked") || cmd.leaseOwner !== args.agentId) {
       throw new Error("Command not found or not owned by this elder");
     }
     const newRetryCount = cmd.retryCount + 1;
@@ -157,17 +163,11 @@ export const failCommand = mutation({
 export const getQueuedFor = query({
   args: { agentId: v.string() },
   handler: async (ctx, args) => {
-    const targeted = await ctx.db.query("agentCommands")
+    return await ctx.db.query("agentCommands")
       .withIndex("by_target_status", q =>
         q.eq("targetAgentId", args.agentId).eq("status", "queued"),
       )
       .collect();
-    const broadcast = await ctx.db.query("agentCommands")
-      .withIndex("by_target_status", q =>
-        q.eq("targetAgentId", "*").eq("status", "queued"),
-      )
-      .collect();
-    return [...targeted, ...broadcast].sort((a, b) => a.createdAt - b.createdAt);
   },
 });
 
@@ -176,12 +176,11 @@ export const sweepStaleDelivered = internalMutation({
   args: {},
   handler: async (ctx) => {
     const now = Date.now();
-    const leased = await ctx.db.query("agentCommands")
-      .filter(q => q.eq(q.field("status"), "leased"))
+    const expired = await ctx.db.query("agentCommands")
+      .withIndex("by_status_lease", q =>
+        q.eq("status", "leased").lt("leaseExpiresAt", now)
+      )
       .collect();
-    const expired = leased.filter(cmd =>
-      cmd.leaseExpiresAt !== undefined && cmd.leaseExpiresAt < now
-    );
     let swept = 0;
     for (const cmd of expired) {
       const newRetryCount = cmd.retryCount + 1;

--- a/apps/server/convex/crons.ts
+++ b/apps/server/convex/crons.ts
@@ -25,6 +25,7 @@ if (process.env.CLANWORLD_USE_REAL_INDEXER === "true") {
 crons.interval("gold-quote-refresh", { minutes: 5 }, internal.goldQuote.refreshGoldQuote, {});
 crons.interval("kickstart-leaderboard-refresh", { minutes: 5 }, internal.kickstart.refreshKickstartLeaderboard, {});
 crons.interval("kickstart-watched-candles-refresh", { minutes: 1 }, internal.kickstart.refreshWatchedTokenCandles, {});
+crons.interval("bus-sweep-stale-delivered", { seconds: 60 }, internal.commandBus.sweepStaleDelivered, {});
 
 // Issue #337: nightly storage retention purge. 04:00 UTC is low-traffic for
 // the game (early-morning EU / late-night Americas). Convex cron schedules

--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -364,11 +364,9 @@ export default defineSchema({
     status: v.union(
       v.literal("queued"),
       v.literal("leased"),
-      v.literal("delivered"),
       v.literal("acked"),
       v.literal("completed"),
       v.literal("failed"),
-      v.literal("skipped"),
     ),
     leaseOwner: v.optional(v.string()),
     leaseExpiresAt: v.optional(v.number()),

--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -346,4 +346,57 @@ export default defineSchema({
   })
     .index("by_target_clan", ["targetClanId", "tick"])
     .index("by_tick", ["tick"]),
+
+  agentCommands: defineTable({
+    targetAgentId: v.string(),
+    kind: v.union(
+      v.literal("user_message"),
+      v.literal("system_message"),
+      v.literal("snapshot_request"),
+      v.literal("reset"),
+      v.literal("freeze"),
+      v.literal("unfreeze"),
+    ),
+    payload: v.any(),
+    payloadVersion: v.number(),
+    source: v.string(),
+    createdAt: v.number(),
+    status: v.union(
+      v.literal("queued"),
+      v.literal("leased"),
+      v.literal("delivered"),
+      v.literal("acked"),
+      v.literal("completed"),
+      v.literal("failed"),
+      v.literal("skipped"),
+    ),
+    leaseOwner: v.optional(v.string()),
+    leaseExpiresAt: v.optional(v.number()),
+    deliveredAt: v.optional(v.number()),
+    ackedAt: v.optional(v.number()),
+    completedAt: v.optional(v.number()),
+    retryCount: v.number(),
+    broadcastSequence: v.optional(v.number()),
+  })
+    .index("by_target_status", ["targetAgentId", "status"])
+    .index("by_status_lease", ["status", "leaseExpiresAt"])
+    .index("by_broadcast_sequence", ["broadcastSequence"]),
+
+  elderHeartbeat: defineTable({
+    agentId: v.string(),
+    lastSeenAt: v.number(),
+    lastTickProcessed: v.number(),
+    currentStrategy: v.optional(v.string()),
+    health: v.union(v.literal("green"), v.literal("yellow"), v.literal("red")),
+  })
+    .index("by_agentId", ["agentId"]),
+
+  commandResults: defineTable({
+    commandId: v.id("agentCommands"),
+    agentId: v.string(),
+    resultPayload: v.any(),
+    tookMs: v.number(),
+    createdAt: v.number(),
+  })
+    .index("by_commandId", ["commandId"]),
 });

--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -370,7 +370,6 @@ export default defineSchema({
     ),
     leaseOwner: v.optional(v.string()),
     leaseExpiresAt: v.optional(v.number()),
-    deliveredAt: v.optional(v.number()),
     ackedAt: v.optional(v.number()),
     completedAt: v.optional(v.number()),
     retryCount: v.number(),


### PR DESCRIPTION
## Summary

- Adds 3 new Convex tables: `agentCommands` (5-state FSM: queued → leased → acked → completed/failed), `elderHeartbeat` (green/yellow/red health), `commandResults` (execution receipts)
- Adds `commandBus.ts` with 8 handlers: `enqueueCommand`, `claimNext`, `ackCommand`, `completeCommand`, `failCommand`, `getQueuedFor`, `sweepStaleDelivered` (internal cron), `heartbeat`
- Broadcast fan-out: `enqueueCommand` with `targetAgentId="*"` inserts one row per elder (parsed from `ELDER_IDS` env, default elder-1..4) sharing a `broadcastSequence` for correlation
- Auth: explicit `secret: string` arg (operator secret for enqueue, per-elder `BUS_ELDER_SECRET_N` for claim/ack/complete/fail/heartbeat)
- `sweepStaleDelivered` cron every 60s re-queues expired leased/acked commands via `by_status_lease` index; retries up to `MAX_RETRIES=3` then marks failed
- Explicit lease-expiry guards on `completeCommand` + `failCommand` (fast-fail on slow elders; Convex OCC handles concurrency correctness)
- 20 tests (85/85 suite-wide), typecheck clean

## Follow-up issues (filed)
- #376 — sweepStaleDelivered: .take(500) bound + negative-path auth tests
- #377 — checkElderAuth: enforce ELDER_IDS allowlist
- #378 — defensive throw on ELDER_IDS="" + sweep cron naming
- #379 — long-running command lease renewal (extend on ack)
- #380 — broadcastSequence monotonicity integration test

## Acceptance criteria

- [x] agentCommands table with 5-state FSM + 3 indexes (queued/leased/acked/completed/failed)
- [x] elderHeartbeat table with health enum + by_agentId index
- [x] commandResults table with commandId FK + by_commandId index
- [x] enqueueCommand mutation (operator auth, broadcast fan-out, targetAgentId validation)
- [x] claimNext mutation (elder auth, oldest-first, OCC-safe)
- [x] ackCommand / completeCommand / failCommand mutations (status + lease guards, lease cleanup)
- [x] getQueuedFor query (elder auth, reactive, targeted only)
- [x] sweepStaleDelivered internalMutation + cron registration (sweeps leased + acked)
- [x] heartbeat mutation (upsert)
- [x] No existing schema modified; indexer.ts / heartbeat.ts untouched

## Test plan

- [x] 85/85 tests green
- [x] typecheck clean
- [ ] CI green

Closes #351