### PR TITLE
fix(e2e): #398 stub URL + legacy /elder-N-tty/ doc sweep

### DIFF
--- a/agents/shared/README-caddy.md
+++ b/agents/shared/README-caddy.md
@@ -94,9 +94,10 @@ This snippet introduces `app.clan-world.com` as a NEW top-level site
 block. It does NOT touch the existing `*.clan-world.com` wildcard block
 or any of the other tunneled services (pm-dobot, narrator, cockpit,
 gstack, etc.). The pre-existing `cockpit.clan-world.com` block with its
-`/elder-N-tty/` routes proxying to ports 38790-38793 is the legacy
-phase-5 mirror — it remains untouched and continues to serve that
-hostname during the coexist window.
+`/elder-N-tty/` routes is the legacy Phase 5 (bare-metal) mirror. As of
+Phase 1 completion (2026-05-16), the canonical terminal URLs are
+`app.clan-world.com/elder-N/` — the legacy `cockpit.clan-world.com/elder-N-tty/`
+paths are deprecated and may be removed after the cutover soak period.
 
 ## Limitations / known v1 caveats
 

--- a/apps/web/tests/e2e/07-cockpit-worldmap-unified.spec.ts
+++ b/apps/web/tests/e2e/07-cockpit-worldmap-unified.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 
 async function stubTerminalIframes(page: Page): Promise<void> {
-  await page.route('**/cockpit.clan-world.com/elder-*-tty/**', (route) =>
+  await page.route('**/app.clan-world.com/elder-*/**', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'text/html',

--- a/docs/runbooks/full-game-reset.md
+++ b/docs/runbooks/full-game-reset.md
@@ -281,49 +281,37 @@ tmux new-session -d -s clanworld-heartbeat -c "$PWD" \
 
 Restart runner and four Elder sessions using the current package scripts or host wrappers. Confirm each new process reads the new `.env.local` / elder `.env` values.
 
-For TTYD in the public cockpit, match Caddy, not only `port-for`. As of the
-2026-05-11 host config, `https://cockpit.clan-world.com/elder-N-tty/` proxies
-to:
+For TTYD in the public cockpit, verify the canonical Phase 1 dockerized
+URLs are reachable. As of Phase 1 (2026-05-16), ttyd runs inside each
+elder container bound to `127.0.0.1` and is routed via host-Caddy at:
 
-| Elder | Public path | Local upstream |
-|---|---|---|
-| 1 | `/elder-1-tty/` | `127.0.0.1:38790` |
-| 2 | `/elder-2-tty/` | `127.0.0.1:38791` |
-| 3 | `/elder-3-tty/` | `127.0.0.1:38792` |
-| 4 | `/elder-4-tty/` | `127.0.0.1:38793` |
+| Elder | Public URL |
+|---|---|
+| 1 | `https://app.clan-world.com/elder-1/` |
+| 2 | `https://app.clan-world.com/elder-2/` |
+| 3 | `https://app.clan-world.com/elder-3/` |
+| 4 | `https://app.clan-world.com/elder-4/` |
 
-Start read-only terminal mirrors:
+See `docker-compose.yml` and `agents/shared/README-caddy.md` for the
+canonical port mapping. ttyd ports are bound to loopback inside each
+elder container and exposed via the host-Caddy `/elder-N/` prefix.
+
+Verify dockerized elder containers and TTYD routes:
 
 ```bash
+# Check all elder containers are healthy
+docker compose ps elder-1 elder-2 elder-3 elder-4
+
+# Verify TTYD routes via Caddy
 for n in 1 2 3 4; do
-  tmux has-session -t "elder-$n" 2>/dev/null ||
-    tmux new-session -d -s "elder-$n" -c "$HOME/clan-world/elder-$n" './run.sh'
-
-  tmux kill-session -t "ttyd-elder-$n" 2>/dev/null || true
-  port=$((38789+n))
-  tmux new-session -d -s "ttyd-elder-$n" \
-    "/home/claude/bin/ttyd -p $port \
-      -I /home/claude/clan-world/ttyd/index.html \
-      -t fontSize=11 -t cursorStyle=bar \
-      tmux attach-session -t elder-$n \
-      2>&1 | tee -a /tmp/clanworld-ttyd-elder-$n.log"
+  curl -I "https://app.clan-world.com/elder-$n/"
 done
 ```
 
-Verify both local Caddy and public Cloudflare routes. A direct TTYD `200` is
-not enough if Caddy points at a different port.
-
-```bash
-ss -ltnp | grep -E '3879[0-3]'
-for path in elder-1-tty elder-2-tty elder-3-tty elder-4-tty; do
-  curl -I -H 'Host: cockpit.clan-world.com' "http://127.0.0.1:18080/$path/"
-  curl -I "https://cockpit.clan-world.com/$path/"
-done
-```
-
-If public cockpit returns `502 Bad Gateway`, inspect Caddy logs. The common
-reset failure is `dial tcp 127.0.0.1:3879N: connect: connection refused`,
-which means TTYD is either down or listening on the wrong port.
+If `https://app.clan-world.com/elder-N/` returns `502 Bad Gateway`, inspect
+Caddy and container logs: `docker compose logs elder-N | tail -50`. The common
+reset failure is the elder container's ttyd service not running (check that
+the elder container healthcheck passes and the tmux session exists inside).
 
 Clear old runner/Elder inbox artifacts before the first tick if they contain stale situation blocks, old diamond addresses, or old clan IDs.
 


### PR DESCRIPTION
## Summary

- **07-cockpit-worldmap-unified.spec.ts**: `stubTerminalIframes` route pattern updated from `cockpit.clan-world.com/elder-*-tty/**` → `app.clan-world.com/elder-*/**` (aligns with canonical Phase 1 URLs; matches 04-cockpit-shell.spec.ts which was correctly updated in #396)
- **docs/runbooks/full-game-reset.md**: Replace bare-metal TTYD section (ports 38790-38793, cockpit.clan-world.com/elder-N-tty/) with dockerized URLs and `docker compose` verification commands
- **agents/shared/README-caddy.md**: Update coexist-window note — legacy `cockpit.clan-world.com/elder-N-tty/` paths now deprecated post Phase 1 (2026-05-16)

Remaining `elder-*-tty` refs in `runtime/elders/` are the legacy bare-metal harness (superseded by `agents/` dockerized setup) — left as-is per brief scope.

## Test plan

- [ ] `git grep -i "elder.*-tty" -- ':!*.md' ':!runtime/**'` returns empty (no live code refs)
- [ ] Playwright spec 07 stub pattern matches `app.clan-world.com/elder-*/` iframes

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)