### PR TITLE
feat(whispers): elder-direct path + delete dead on-chain indexing

### DIFF
--- a/apps/server/convex/authShared.ts
+++ b/apps/server/convex/authShared.ts
@@ -6,7 +6,8 @@
  * the handler calls this helper before doing any writes. If INDEXER_SECRET is
  * unset on the Convex deployment, mutations reject all writes (fail-closed).
  *
- * Used by: bulletins.seedBulletin, comms.seed{Whisper,OrchEvent,HumanSteering}.
+ * Used by: bulletins.seedBulletin, comms.sendWhisper,
+ * comms.seed{OrchEvent,HumanSteering}.
  *
  * For mutations that have NO external callers (memory.seedEntry,
  * memory.seedEvent, clansmen.seedClansmen) we use `internalMutation` instead;

--- a/apps/server/convex/comms.test.ts
+++ b/apps/server/convex/comms.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { sendWhisper } from "./comms";
+
+function createDb(tables: Record<string, any[]> = {}) {
+  return {
+    tables,
+    db: {
+      async insert(table: string, value: Record<string, unknown>) {
+        tables[table] ??= [];
+        const doc = {
+          ...value,
+          _id: `${table}:${tables[table].length}`,
+          _creationTime: tables[table].length,
+        };
+        tables[table].push(doc);
+        return doc._id;
+      },
+      query(table: string) {
+        let rows = [...(tables[table] ?? [])];
+        const builder = {
+          withIndex(_name: string, apply: (q: any) => unknown) {
+            const clauses: Array<{ field: string; value: unknown }> = [];
+            const q = {
+              eq(field: string, value: unknown) {
+                clauses.push({ field, value });
+                return q;
+              },
+            };
+            apply(q);
+            rows = rows.filter((row) =>
+              clauses.every((clause) => row[clause.field] === clause.value),
+            );
+            return builder;
+          },
+          async first() {
+            return rows[0] ?? null;
+          },
+        };
+        return builder;
+      },
+    },
+  };
+}
+
+describe("sendWhisper", () => {
+  const originalSecret = process.env.INDEXER_SECRET;
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.INDEXER_SECRET;
+    } else {
+      process.env.INDEXER_SECRET = originalSecret;
+    }
+  });
+
+  it("dedups matching fromClanId, tick, and msgId", async () => {
+    process.env.INDEXER_SECRET = "test-secret";
+    const { db, tables } = createDb();
+    const args = {
+      secret: "test-secret",
+      tick: 7,
+      fromClanId: 2,
+      toClanIds: [3],
+      body: "hold the bridge",
+      msgId: "2:7:abc",
+    };
+
+    await (sendWhisper as any)._handler({ db }, args);
+    await (sendWhisper as any)._handler({ db }, args);
+
+    expect(tables.whispers).toHaveLength(1);
+  });
+
+  it("allows repeated whispers without msgId", async () => {
+    process.env.INDEXER_SECRET = "test-secret";
+    const { db, tables } = createDb();
+    const args = {
+      secret: "test-secret",
+      tick: 7,
+      fromClanId: 2,
+      toClanIds: [3],
+      body: "hold the bridge",
+    };
+
+    await (sendWhisper as any)._handler({ db }, args);
+    await (sendWhisper as any)._handler({ db }, args);
+
+    expect(tables.whispers).toHaveLength(2);
+  });
+});

--- a/apps/server/convex/comms.ts
+++ b/apps/server/convex/comms.ts
@@ -81,19 +81,25 @@ export const getCombinedComms = query({
 // but ALONE is not sufficient — without the secret gate, anyone with the
 // deployment URL could deface the cockpit-visible feed.
 
-export const seedWhisper = mutation({
+export const sendWhisper = mutation({
   args: {
     secret: v.string(),
     tick: v.number(),
     fromClanId: v.number(),
     toClanIds: v.array(v.number()),
     body: v.string(),
-    // Optional on-chain transaction hash from the whisper write — useful
-    // provenance for the cockpit feed. Optional in the whispers table.
-    txHash: v.optional(v.string()),
+    msgId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     requireIndexerSecret(args.secret);
+    if (args.msgId) {
+      const existing = await ctx.db
+        .query("whispers")
+        .withIndex("by_from_clan_tick_msgid", q =>
+          q.eq("fromClanId", args.fromClanId).eq("tick", args.tick).eq("msgId", args.msgId))
+        .first();
+      if (existing) return;
+    }
     const { secret: _omit, ...row } = args;
     await ctx.db.insert("whispers", { ...row, timestamp: Date.now() });
   },

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -349,35 +349,6 @@ export const ingestEvents = internalMutation({
         });
       }
 
-      // AXL Whisper indexing for the cockpit Comms feed. The chain emits a
-      // "Whisper" event (singular point-to-point) and a "WhisperBroadcast"
-      // event (multi-recipient). Both shapes funnel into the `whispers` table.
-      if (raw.eventName === "Whisper" || raw.eventName === "WhisperBroadcast") {
-        const fromClanId = eventNumber(raw, "fromClanId");
-        const tick = eventNumber(raw, "tick") ?? eventNumber(raw, "atTick") ?? 0;
-        const body = asString(raw.args.body) ?? asString(raw.args.message) ?? "";
-        let toClanIds: number[] = [];
-        if (raw.eventName === "Whisper") {
-          const to = eventNumber(raw, "toClanId");
-          if (to !== undefined) toClanIds = [to];
-        } else {
-          const arr = (raw.args.toClanIds ?? raw.args.recipients) as unknown;
-          if (Array.isArray(arr)) {
-            toClanIds = arr.map(x => Number(x)).filter(n => Number.isFinite(n));
-          }
-        }
-        if (fromClanId !== undefined && toClanIds.length > 0 && body) {
-          await ctx.db.insert("whispers", {
-            tick,
-            fromClanId,
-            toClanIds,
-            body,
-            txHash,
-            timestamp: Date.now(),
-          });
-        }
-      }
-
       const pricePoint = pricePointFromEvent(raw, blockNumber);
       if (pricePoint) await ctx.db.insert("pricePoint", pricePoint);
     }

--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -298,18 +298,19 @@ export default defineSchema({
   // These three feed the per-elder "AXL" view; bulletins (above) feeds the
   // "0G Bulletin" view + the cross-clan flyout.
 
-  /** AXL chain whispers between clans. Recorded by the chain indexer. */
+  /** AXL direct whispers between clans. Recorded by elder CLI via Convex. */
   whispers: defineTable({
     tick: v.number(),
     fromClanId: v.number(),
     /** Recipient clan IDs. Whispers are point-to-point or broadcast. */
     toClanIds: v.array(v.number()),
     body: v.string(),
-    txHash: v.optional(v.string()),
+    msgId: v.optional(v.string()),
     timestamp: v.number(),
   })
     .index("by_tick", ["tick"])
-    .index("by_from_clan", ["fromClanId", "tick"]),
+    .index("by_from_clan", ["fromClanId", "tick"])
+    .index("by_from_clan_tick_msgid", ["fromClanId", "tick", "msgId"]),
 
   /** Orchestrator-emitted world events surfaced to the cockpit Comms tab. */
   orchEvents: defineTable({

--- a/apps/web/src/components/cockpit/tabs/CommsTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/CommsTab.tsx
@@ -26,86 +26,6 @@ interface BulletinPost {
   body: string;
 }
 
-// Demo stub — ticks 0..6 so the fade ladder + sent-to recipient chips both
-// demonstrate visibly. Self-sent whispers carry recipients.
-const STUB_LINES: Record<number, CommsLine[]> = {
-  1: [
-    { tick: 6, kind: 'whisper', speaker: 'clan-1', body: 'Forest patrol — reporting two travelers near west bank.', recipients: [2, 3, 4] },
-    { tick: 6, kind: 'orch',    speaker: 'orchestrator', body: 'Tick T06 begun. Yield <directives>.' },
-    { tick: 5, kind: 'whisper', speaker: 'clan-3', body: 'AXL: "trade ore for wood, 2:1?"' },
-    { tick: 4, kind: 'human',   speaker: 'iNFT Owner', body: 'Slow your raids — diplomacy first.' },
-    { tick: 4, kind: 'whisper', speaker: 'clan-2', body: 'AXL: declined; counter offered 3:1.' },
-    { tick: 3, kind: 'whisper', speaker: 'clan-1', body: 'Acknowledged — pulling raid plan. Patrols only.', recipients: [3] },
-    { tick: 3, kind: 'orch',    speaker: 'orchestrator', body: 'Bandit camp surfaced at forest.' },
-    { tick: 2, kind: 'whisper', speaker: 'clan-4', body: 'AXL: "north pass clear, sharing scout report."' },
-    { tick: 1, kind: 'whisper', speaker: 'clan-1', body: 'Trade window — willing to swap ore favor for wood.', recipients: [2, 4] },
-    { tick: 0, kind: 'orch',    speaker: 'orchestrator', body: 'Season started. Four clans seeded.' },
-  ],
-  2: [
-    { tick: 6, kind: 'orch',    speaker: 'orchestrator', body: 'Tick T06 begun. Yield <directives>.' },
-    { tick: 6, kind: 'whisper', speaker: 'clan-2', body: 'Counter to clan-3: ore for wood at 3:1.', recipients: [3] },
-    { tick: 5, kind: 'whisper', speaker: 'clan-1', body: 'AXL: "patrol report — bandit camp confirmed forest."' },
-    { tick: 4, kind: 'human',   speaker: 'iNFT Owner', body: 'Hold positions. Do not engage bandits this tick.' },
-    { tick: 4, kind: 'whisper', speaker: 'clan-2', body: 'Confirmed — defensive hold maintained.', recipients: [1, 3, 4] },
-    { tick: 3, kind: 'whisper', speaker: 'clan-2', body: 'Vault status: 240 ore / 180 wood. Stockpile holding.', recipients: [1, 4] },
-    { tick: 2, kind: 'orch',    speaker: 'orchestrator', body: 'Bandit camp surfaced at forest.' },
-    { tick: 1, kind: 'whisper', speaker: 'clan-4', body: 'AXL: "trade window — wood for ore?"' },
-    { tick: 0, kind: 'orch',    speaker: 'orchestrator', body: 'Season started. Four clans seeded.' },
-  ],
-  3: [
-    { tick: 6, kind: 'whisper', speaker: 'clan-3', body: '"Volatile day. Considering raid on bandit camp."', recipients: [1, 2, 4] },
-    { tick: 5, kind: 'orch',    speaker: 'orchestrator', body: 'Tick T05 begun. Yield <directives>.' },
-    { tick: 5, kind: 'whisper', speaker: 'clan-3', body: 'AXL: "trade ore for wood, 2:1?"', recipients: [2] },
-    { tick: 4, kind: 'whisper', speaker: 'clan-2', body: 'AXL: declined; counter offered 3:1.' },
-    { tick: 3, kind: 'human',   speaker: 'iNFT Owner', body: "Crimson — pace yourself. Don't blow the season on T08." },
-    { tick: 3, kind: 'orch',    speaker: 'orchestrator', body: 'Bandit camp surfaced at forest.' },
-    { tick: 2, kind: 'whisper', speaker: 'clan-3', body: 'Noted. Eyes still on the forest.', recipients: [1] },
-    { tick: 1, kind: 'whisper', speaker: 'clan-1', body: 'AXL: "Storm Riders moving — forest sweep T07."' },
-    { tick: 0, kind: 'orch',    speaker: 'orchestrator', body: 'Season started. Four clans seeded.' },
-  ],
-  4: [
-    { tick: 6, kind: 'whisper', speaker: 'clan-4', body: '"north pass clear, sharing scout report."', recipients: [1, 2, 3] },
-    { tick: 5, kind: 'orch',    speaker: 'orchestrator', body: 'Tick T05 begun. Yield <directives>.' },
-    { tick: 5, kind: 'whisper', speaker: 'clan-1', body: 'AXL: "patrol moving north, request escort."' },
-    { tick: 4, kind: 'human',   speaker: 'iNFT Owner', body: 'Verdant — hold the orchard rotation through T08.' },
-    { tick: 4, kind: 'whisper', speaker: 'clan-4', body: 'Confirmed. Five-tick yield protected.', recipients: [1, 2, 3] },
-    { tick: 3, kind: 'orch',    speaker: 'orchestrator', body: 'Bandit camp surfaced at forest.' },
-    { tick: 2, kind: 'whisper', speaker: 'clan-4', body: 'Ore reserves stable; wood surplus building.', recipients: [2] },
-    { tick: 1, kind: 'whisper', speaker: 'clan-2', body: 'AXL: trade window — wood for ore?' },
-    { tick: 0, kind: 'orch',    speaker: 'orchestrator', body: 'Season started. Four clans seeded.' },
-  ],
-};
-
-const STUB_BULLETINS: Record<number, BulletinPost[]> = {
-  1: [
-    { tick: 6, speaker: 'clan-1', body: 'STORM RIDERS DECLARE: forest sweep tick T07. Allied clans welcome.' },
-    { tick: 5, speaker: 'clan-1', body: '"Speed wins what stillness loses." — Aldric.' },
-    { tick: 4, speaker: 'clan-1', body: 'Patrols out from west bank. Two travelers tracked, non-hostile.' },
-    { tick: 2, speaker: 'clan-1', body: 'Open call for ore — willing to trade favor in T09 raid.' },
-    { tick: 0, speaker: 'clan-1', body: 'Storm Riders enter the season. May winds favor the bold.' },
-  ],
-  2: [
-    { tick: 6, speaker: 'clan-2', body: 'IRON GUARD POSTS: vault at 240 ore / 180 wood. Trade window open.' },
-    { tick: 5, speaker: 'clan-2', body: 'Trade counter posted: ore for wood at 3:1.' },
-    { tick: 4, speaker: 'clan-2', body: 'No raid commitment T07. Defensive posture maintained.' },
-    { tick: 2, speaker: 'clan-2', body: 'Cautious accumulation continues. Stockpile is freedom.' },
-    { tick: 0, speaker: 'clan-2', body: 'Iron Guard begins T0 with patient resolve.' },
-  ],
-  3: [
-    { tick: 6, speaker: 'clan-3', body: 'CRIMSON: opportunistic raid eyed for T08. Watch the forest.' },
-    { tick: 4, speaker: 'clan-3', body: 'Volatility is a weapon. The patient miss the moment.' },
-    { tick: 2, speaker: 'clan-3', body: 'Crimson holds — but only because the moment is wrong.' },
-    { tick: 0, speaker: 'clan-3', body: 'Crimson colors raised. Watch the markets.' },
-  ],
-  4: [
-    { tick: 6, speaker: 'clan-4', body: 'VERDANT WARDENS: orchard rotation steady. Five-tick yield curve holds.' },
-    { tick: 5, speaker: 'clan-4', body: 'Scout report posted: north pass clear of hostiles.' },
-    { tick: 3, speaker: 'clan-4', body: 'Long view: investing two ticks of wood toward T10 surplus.' },
-    { tick: 1, speaker: 'clan-4', body: 'Wardens accept all incoming whispers. We answer in kind.' },
-    { tick: 0, speaker: 'clan-4', body: 'Verdant Wardens take the field. The patient inherit.' },
-  ],
-};
-
 export const VISIBLE_TICKS = 4;
 export const CURRENT_TICK = 6;
 
@@ -295,26 +215,18 @@ function ToggleButton({
 }
 
 function AxlView({ elder, testIdPrefix }: Props) {
-  // Live combined feed from Convex. Falls back to stub when:
-  //   - useQuery returns undefined (initial load)
-  //   - the live feed is empty (no chain activity yet — common in demo prep)
-  // This way the cockpit always demos cleanly even if the backend is cold.
   const live = useQuery(api.comms.getCombinedComms, { clanId: elder.clanId });
-  const lines: CommsLine[] =
-    live === undefined || live.length === 0
-      ? (STUB_LINES[elder.clanId] || [])
-      : live.map(l => ({
-          tick: l.tick,
-          kind: l.kind,
-          speaker: l.speaker,
-          body: l.body,
-          recipients: l.kind === 'whisper' ? l.recipients : undefined,
-        }));
+  const lines: CommsLine[] = (live ?? []).map(l => ({
+    tick: l.tick,
+    kind: l.kind,
+    speaker: l.speaker,
+    body: l.body,
+    recipients: l.kind === 'whisper' ? l.recipients : undefined,
+  }));
 
   return (
     <ul
       data-testid={`${testIdPrefix}-comms-axl-list`}
-      data-source={live === undefined || live.length === 0 ? 'stub' : 'live'}
       style={{
         listStyle: 'none',
         margin: 0,
@@ -517,18 +429,14 @@ function SentToChips({ recipients }: { recipients: number[] }) {
 }
 
 function BulletinView({ elder, testIdPrefix }: Props) {
-  // Live bulletins from Convex; stub fallback for cold backend / demo.
   // The bulletins table uses `slot` as a tick-equivalent ordinal, so we
   // map slot → tick for the existing fade/visibility logic.
   const live = useQuery(api.bulletins.getByClan, { clanId: elder.clanId });
-  const posts: BulletinPost[] =
-    live === undefined || live.length === 0
-      ? (STUB_BULLETINS[elder.clanId] || [])
-      : live.map(b => ({
-          tick: b.slot,
-          speaker: `clan-${b.clanId}`,
-          body: b.body,
-        }));
+  const posts: BulletinPost[] = (live ?? []).map(b => ({
+    tick: b.slot,
+    speaker: `clan-${b.clanId}`,
+    body: b.body,
+  }));
 
   const accent = CLAN_ACCENT[elder.clanId] ?? '#5a8aa8';
   const visible = posts.filter(p => CURRENT_TICK - p.tick <= VISIBLE_TICKS);

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -10,6 +10,25 @@ export class UsageError extends Error {}
 
 const RESTRICTED_FILE_MODE = 0o600;
 
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms,
+    );
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
 function writeRestrictedFileSync(
   file: string,
   data: string,
@@ -646,13 +665,42 @@ export async function runCommand(
     const [clanId, ...msgParts] = rest;
     if (!clanId || msgParts.length === 0) throw new UsageError('usage: elder peer whisper <clanId> <msg>');
     const n = getElderN(env);
+    const fromClanId = Number(n);
+    const toClanIdNumeric = Number(clanId);
+    const canMirrorToCockpit =
+      Number.isFinite(toClanIdNumeric) && Number.isInteger(toClanIdNumeric) && toClanIdNumeric > 0;
     const msg = msgParts.join(' ');
+
+    // Durable local write first — guarantees elder-to-elder delivery even if chain/convex are down.
+    // Local transport accepts any safe inbox key (numeric or string identifier per assertSafeInboxKey).
     const entry = JSON.stringify({ from: n, to: clanId, msg, ts: new Date().toISOString() });
     const file = recipientInboxFile(clanId, homeBase);
     fs.mkdirSync(path.dirname(file), { recursive: true });
     appendRestrictedFileSync(file, entry + '\n', {
       encoding: 'utf8',
     });
+
+    // Best-effort cockpit mirror — only when clanId is a valid numeric clan, and bounded so a
+    // chain or convex hang cannot pin the CLI past 10s total.
+    if (canMirrorToCockpit) {
+      try {
+        const tick = await withTimeout(deps.chain.getCurrentTick(), 5000, 'chain.getCurrentTick');
+        const msgId = `${fromClanId}:${tick}:${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+        await withTimeout(
+          deps.convex.postWhisper({
+            tick,
+            fromClanId,
+            toClanIds: [toClanIdNumeric],
+            body: msg,
+            msgId,
+          }),
+          5000,
+          'convex.postWhisper',
+        );
+      } catch (err) {
+        console.warn('[elder peer whisper] cockpit mirror failed (non-fatal):', err);
+      }
+    }
     return 'whisper sent\n';
   }
 

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -10,13 +10,18 @@ export class UsageError extends Error {}
 
 const RESTRICTED_FILE_MODE = 0o600;
 
-function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+function withTimeout<T>(
+  factory: (signal: AbortSignal) => Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  const controller = new AbortController();
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error(`${label} timed out after ${ms}ms`)),
-      ms,
-    );
-    p.then(
+    const timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+    factory(controller.signal).then(
       (v) => {
         clearTimeout(timer);
         resolve(v);
@@ -684,15 +689,20 @@ export async function runCommand(
     // chain or convex hang cannot pin the CLI past 10s total.
     if (canMirrorToCockpit) {
       try {
-        const tick = await withTimeout(deps.chain.getCurrentTick(), 5000, 'chain.getCurrentTick');
+        const tick = await withTimeout(
+          (signal) => deps.chain.getCurrentTick(signal),
+          5000,
+          'chain.getCurrentTick',
+        );
         const msgId = `${fromClanId}:${tick}:${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
         await withTimeout(
-          deps.convex.postWhisper({
+          (signal) => deps.convex.postWhisper({
             tick,
             fromClanId,
             toClanIds: [toClanIdNumeric],
             body: msg,
             msgId,
+            signal,
           }),
           5000,
           'convex.postWhisper',

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -21,7 +21,17 @@ function withTimeout<T>(
       controller.abort();
       reject(new Error(`${label} timed out after ${ms}ms`));
     }, ms);
-    factory(controller.signal).then(
+    let promise: Promise<T>;
+    try {
+      promise = factory(controller.signal);
+    } catch (err) {
+      // Factory threw synchronously before returning a promise — clear the
+      // timer eagerly so we don't leak a node handle past rejection.
+      clearTimeout(timer);
+      reject(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+    promise.then(
       (v) => {
         clearTimeout(timer);
         resolve(v);

--- a/packages/agents/test/cli.test.ts
+++ b/packages/agents/test/cli.test.ts
@@ -44,7 +44,7 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
 function makeChain(overrides: Partial<IChainClient> = {}): IChainClient {
   return {
     async submitOrders() { return { txHash: '0xdeadbeef', results: [] }; },
-    async getCurrentTick(): Promise<Tick> { return 0; },
+    async getCurrentTick(_signal?: AbortSignal): Promise<Tick> { return 0; },
     async getClanFullView(clanId: string): Promise<ClanFullView> {
       return {
         clan: { id: clanId, name: `chain-${clanId}`, treasury: '0' },
@@ -270,8 +270,10 @@ describe('peer whisper', () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const postWhisper = vi.fn().mockResolvedValue(undefined);
-    // getCurrentTick never resolves — must not pin the CLI.
-    const getCurrentTick = vi.fn().mockImplementation(() => new Promise<number>(() => {}));
+    // getCurrentTick stays pending until the timeout aborts it — must not pin the CLI.
+    const getCurrentTick = vi.fn().mockImplementation((signal?: AbortSignal) => new Promise<number>((_resolve, reject) => {
+      signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+    }));
     deps = {
       convex: makeConvex({ postWhisper }),
       chain: makeChain({ getCurrentTick }),
@@ -289,6 +291,31 @@ describe('peer whisper', () => {
       expect.stringContaining('cockpit mirror failed'),
       expect.objectContaining({ message: expect.stringContaining('timed out') }),
     );
+
+    warn.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('aborts the underlying chain call when timeout fires', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let receivedSignal: AbortSignal | undefined;
+    const getCurrentTick = vi.fn().mockImplementation((signal?: AbortSignal) => {
+      receivedSignal = signal;
+      return new Promise<number>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      });
+    });
+    deps = {
+      convex: makeConvex(),
+      chain: makeChain({ getCurrentTick }),
+    };
+
+    const runPromise = runCommand('peer', 'whisper', ['5', 'attack'], deps, { ELDER_N: '2' }, tmpDir);
+    await vi.advanceTimersByTimeAsync(5_001);
+    await runPromise;
+
+    expect(receivedSignal?.aborted).toBe(true);
 
     warn.mockRestore();
     vi.useRealTimers();

--- a/packages/agents/test/cli.test.ts
+++ b/packages/agents/test/cli.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { IConvexClient, IChainClient } from '@clan-world/shared/adapters';
-import type { WorldSnapshot, ClanFullView, Whisper, Tick } from '@clan-world/shared';
+import type { WorldSnapshot, ClanFullView, Tick } from '@clan-world/shared';
 import { runCommand, UsageError, inboxFile, recipientInboxFile, ackFile, resolveHelp } from '../src/cli.js';
 
 // ---------------------------------------------------------------------------
@@ -33,7 +33,6 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
     async getSnapshot() { return STUB_SNAPSHOT; },
     async getClanFullView() { return STUB_CLAN_VIEW; },
     async postLog() {},
-    subscribeWhispers(_clanId: string, _onWhisper: (w: Whisper) => void): () => void { return () => {}; },
     async postWhisper() {},
     async postOrchEvent() {},
     async postHumanSteering() {},
@@ -214,6 +213,85 @@ describe('peer whisper', () => {
     expect(entry.from).toBe(2);
     expect(entry.to).toBe('5');
     expect(entry.msg).toBe('attack at dawn');
+  });
+
+  it('mirrors successful local whispers to Convex best-effort', async () => {
+    const postWhisper = vi.fn().mockResolvedValue(undefined);
+    const getCurrentTick = vi.fn().mockResolvedValue(42);
+    deps = {
+      convex: makeConvex({ postWhisper }),
+      chain: makeChain({ getCurrentTick }),
+    };
+
+    await runCommand('peer', 'whisper', ['5', 'attack at dawn'], deps, { ELDER_N: '2' }, tmpDir);
+
+    expect(postWhisper).toHaveBeenCalledWith(expect.objectContaining({
+      tick: 42,
+      fromClanId: 2,
+      toClanIds: [5],
+      body: 'attack at dawn',
+    }));
+    expect(postWhisper.mock.calls[0]?.[0].msgId).toMatch(/^2:42:/);
+  });
+
+  it('keeps the local whisper when Convex mirroring fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    deps = {
+      convex: makeConvex({ postWhisper: vi.fn().mockRejectedValue(new Error('convex down')) }),
+      chain: makeChain(),
+    };
+
+    await expect(
+      runCommand('peer', 'whisper', ['5', 'attack at dawn'], deps, { ELDER_N: '2' }, tmpDir),
+    ).resolves.toBe('whisper sent\n');
+    expect(fs.existsSync(recipientInboxFile('5', tmpDir))).toBe(true);
+
+    warn.mockRestore();
+  });
+
+  it('skips cockpit mirror entirely for non-numeric clan ids (local-only inbox key)', async () => {
+    const postWhisper = vi.fn().mockResolvedValue(undefined);
+    const getCurrentTick = vi.fn().mockResolvedValue(7);
+    deps = {
+      convex: makeConvex({ postWhisper }),
+      chain: makeChain({ getCurrentTick }),
+    };
+
+    await expect(
+      runCommand('peer', 'whisper', ['valid-clan', 'hold position'], deps, { ELDER_N: '2' }, tmpDir),
+    ).resolves.toBe('whisper sent\n');
+
+    expect(fs.existsSync(recipientInboxFile('valid-clan', tmpDir))).toBe(true);
+    expect(postWhisper).not.toHaveBeenCalled();
+    expect(getCurrentTick).not.toHaveBeenCalled();
+  });
+
+  it('keeps the local whisper when chain.getCurrentTick hangs (mirror bounded by timeout)', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const postWhisper = vi.fn().mockResolvedValue(undefined);
+    // getCurrentTick never resolves — must not pin the CLI.
+    const getCurrentTick = vi.fn().mockImplementation(() => new Promise<number>(() => {}));
+    deps = {
+      convex: makeConvex({ postWhisper }),
+      chain: makeChain({ getCurrentTick }),
+    };
+
+    const runPromise = runCommand('peer', 'whisper', ['5', 'attack at dawn'], deps, { ELDER_N: '2' }, tmpDir);
+
+    // Advance fake timers past the 5s withTimeout window so the mirror rejects + falls into catch.
+    await vi.advanceTimersByTimeAsync(5_001);
+
+    await expect(runPromise).resolves.toBe('whisper sent\n');
+    expect(fs.existsSync(recipientInboxFile('5', tmpDir))).toBe(true);
+    expect(postWhisper).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('cockpit mirror failed'),
+      expect.objectContaining({ message: expect.stringContaining('timed out') }),
+    );
+
+    warn.mockRestore();
+    vi.useRealTimers();
   });
 });
 

--- a/packages/agents/test/mcp.test.ts
+++ b/packages/agents/test/mcp.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { IChainClient, IConvexClient } from '@clan-world/shared/adapters';
-import type { ClanFullView, Tick, Whisper, WorldSnapshot } from '@clan-world/shared';
+import type { ClanFullView, Tick, WorldSnapshot } from '@clan-world/shared';
 import { callElderTool } from '../src/mcp.js';
 
 const STUB_SNAPSHOT: WorldSnapshot = {
@@ -25,7 +25,6 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
     async getSnapshot() { return STUB_SNAPSHOT; },
     async getClanFullView() { return STUB_CLAN_VIEW; },
     async postLog() {},
-    subscribeWhispers(_clanId: string, _onWhisper: (w: Whisper) => void): () => void { return () => {}; },
     async postWhisper() {},
     async postOrchEvent() {},
     async postHumanSteering() {},

--- a/packages/runner/test/tickLoop.test.ts
+++ b/packages/runner/test/tickLoop.test.ts
@@ -29,9 +29,6 @@ function fakeConvex(tick: number): IConvexClient {
       };
     },
     async postLog() {},
-    subscribeWhispers() {
-      return () => {};
-    },
     async postWhisper() {},
     async postOrchEvent() {},
     async postHumanSteering() {},

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -101,7 +101,7 @@ export function validateSubmitOrderPayload(order: ClanOrder, submitterClanId: nu
 }
 
 export interface IChainClient {
-  getCurrentTick(): Promise<Tick>;
+  getCurrentTick(signal?: AbortSignal): Promise<Tick>;
   submitOrders(clanId: string, orders: ClanOrder[]): Promise<SubmitOrdersResult>;
   getClanFullView(clanId: string): Promise<ClanFullView>;
   getWallUpgradeCost(currentLevel: number): Promise<{ wood: bigint; iron: bigint }>;
@@ -4035,7 +4035,7 @@ export function parseClanId(clanId: string, fnName: string): number {
 }
 
 class StubChainClient implements IChainClient {
-  async getCurrentTick(): Promise<Tick> {
+  async getCurrentTick(_signal?: AbortSignal): Promise<Tick> {
     return 0;
   }
   async submitOrders(_clanId: string, _orders: ClanOrder[]): Promise<SubmitOrdersResult> {
@@ -4076,15 +4076,14 @@ class RealChainClient implements IChainClient {
   private readonly transport:
     | ReturnType<typeof http>
     | ReturnType<typeof fallback>;
+  private readonly primaryRpc: string | undefined;
+  private readonly fallbackRpc: string | undefined;
 
   constructor() {
-    const primaryRpc = readEnv('RPC_URL_PRIMARY');
-    const fallbackRpc = readEnv('RPC_URL_FALLBACK');
+    this.primaryRpc = readEnv('RPC_URL_PRIMARY');
+    this.fallbackRpc = readEnv('RPC_URL_FALLBACK');
 
-    this.transport =
-      primaryRpc && fallbackRpc
-        ? fallback([http(primaryRpc), http(fallbackRpc)])
-        : http(primaryRpc ?? fallbackRpc);
+    this.transport = this.createTransport();
 
     const configuredContractAddress = readEnv('CLAN_WORLD_CONTRACT_ADDRESS')?.trim();
     const configuredLensAddress = readEnv('CLAN_WORLD_LENS_ADDRESS');
@@ -4106,12 +4105,27 @@ class RealChainClient implements IChainClient {
     });
   }
 
-  async getCurrentTick(): Promise<Tick> {
-    const snapshot = await this.client.readContract({
+  private createTransport(signal?: AbortSignal): ReturnType<typeof http> | ReturnType<typeof fallback> {
+    const httpConfig = signal ? { fetchOptions: { signal } } : undefined;
+    return this.primaryRpc && this.fallbackRpc
+      ? fallback([http(this.primaryRpc, httpConfig), http(this.fallbackRpc, httpConfig)])
+      : http(this.primaryRpc ?? this.fallbackRpc, httpConfig);
+  }
+
+  async getCurrentTick(signal?: AbortSignal): Promise<Tick> {
+    signal?.throwIfAborted();
+    const client = signal
+      ? createPublicClient({
+          chain: baseSepolia,
+          transport: this.createTransport(signal),
+        })
+      : this.client;
+    const snapshot = await client.readContract({
       address: this.lensAddress,
       abi: CLAN_WORLD_LENS_ABI,
       functionName: 'getWorldSnapshot',
     }) as { currentTick: number | bigint };
+    signal?.throwIfAborted();
     return Number(snapshot.currentTick); // safe: tick values are small enough to fit Number precisely in Wave 0
   }
 

--- a/packages/shared/src/adapters/IConvexClient.ts
+++ b/packages/shared/src/adapters/IConvexClient.ts
@@ -1,5 +1,5 @@
 import { ConvexHttpClient } from 'convex/browser';
-import type { ClanFullView, Whisper, WorldSnapshot } from '../types';
+import type { ClanFullView, WorldSnapshot } from '../types';
 import { readEnv } from './_env';
 import { convexApiRefs } from './convexApiRefs';
 
@@ -7,7 +7,6 @@ export interface IConvexClient {
   getSnapshot(): Promise<WorldSnapshot>;
   getClanFullView(clanId: string): Promise<ClanFullView>;
   postLog(level: 'info' | 'warn' | 'error', message: string): Promise<void>;
-  subscribeWhispers(clanId: string, onWhisper: (w: Whisper) => void): () => void;
 
   // Cockpit Comms write-side. Each method is best-effort: callers wrap in
   // try/catch + treat failures as non-fatal so the cockpit display stays
@@ -18,7 +17,7 @@ export interface IConvexClient {
     fromClanId: number;
     toClanIds: number[];
     body: string;
-    txHash?: string;
+    msgId?: string;
   }): Promise<void>;
   postOrchEvent(args: {
     tick: number;
@@ -61,20 +60,15 @@ class StubConvexClient implements IConvexClient {
   async postLog(_level: 'info' | 'warn' | 'error', _message: string): Promise<void> {
     // no-op stub
   }
-  subscribeWhispers(_clanId: string, _onWhisper: (w: Whisper) => void): () => void {
-    return () => {
-      // no-op unsubscribe
-    };
-  }
 
-  async postWhisper(_args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; txHash?: string }): Promise<void> {}
+  async postWhisper(_args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; msgId?: string }): Promise<void> {}
   async postOrchEvent(_args: { tick: number; kind: 'world_event' | 'directive' | 'narration'; body: string; targetClanId?: number }): Promise<void> {}
   async postHumanSteering(_args: { tick: number; targetClanId: number; body: string; sentBy?: string }): Promise<void> {}
   async postBulletin(_args: { clanId: number; slot: number; body: string; dataHash?: string; txHash?: string }): Promise<void> {}
 }
 
 const getSnapshotRef = convexApiRefs.getSnapshot.getSnapshot;
-const seedWhisperRef = convexApiRefs.comms.seedWhisper;
+const sendWhisperRef = convexApiRefs.comms.sendWhisper;
 const seedOrchEventRef = convexApiRefs.comms.seedOrchEvent;
 const seedHumanSteeringRef = convexApiRefs.comms.seedHumanSteering;
 const seedBulletinRef = convexApiRefs.bulletins.seedBulletin;
@@ -112,11 +106,6 @@ class RealConvexClient implements IConvexClient {
     // Phase 4: postLog via Convex not yet used by CLI path
   }
 
-  subscribeWhispers(_clanId: string, _onWhisper: (w: Whisper) => void): () => void {
-    // ConvexHttpClient is non-reactive; WebSocket subscriptions need ConvexClient
-    return () => {};
-  }
-
   // Cockpit Comms write-side — best-effort, swallow + warn on failure so the
   // domain operation that triggered the post (chain whisper, orchestrator
   // tick, etc.) is never blocked by a Convex outage.
@@ -129,14 +118,14 @@ class RealConvexClient implements IConvexClient {
     return readEnv('INDEXER_SECRET');
   }
 
-  async postWhisper(args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; txHash?: string }): Promise<void> {
+  async postWhisper(args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; msgId?: string }): Promise<void> {
     const secret = this.indexerSecret();
     if (!secret) {
       console.warn('[ConvexClient] postWhisper skipped: INDEXER_SECRET not set');
       return;
     }
     try {
-      await this.http.mutation(seedWhisperRef, { secret, ...args });
+      await this.http.mutation(sendWhisperRef, { secret, ...args });
     } catch (err) {
       console.warn('[ConvexClient] postWhisper failed (non-fatal):', err);
     }

--- a/packages/shared/src/adapters/IConvexClient.ts
+++ b/packages/shared/src/adapters/IConvexClient.ts
@@ -18,6 +18,7 @@ export interface IConvexClient {
     toClanIds: number[];
     body: string;
     msgId?: string;
+    signal?: AbortSignal;
   }): Promise<void>;
   postOrchEvent(args: {
     tick: number;
@@ -61,7 +62,7 @@ class StubConvexClient implements IConvexClient {
     // no-op stub
   }
 
-  async postWhisper(_args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; msgId?: string }): Promise<void> {}
+  async postWhisper(_args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; msgId?: string; signal?: AbortSignal }): Promise<void> {}
   async postOrchEvent(_args: { tick: number; kind: 'world_event' | 'directive' | 'narration'; body: string; targetClanId?: number }): Promise<void> {}
   async postHumanSteering(_args: { tick: number; targetClanId: number; body: string; sentBy?: string }): Promise<void> {}
   async postBulletin(_args: { clanId: number; slot: number; body: string; dataHash?: string; txHash?: string }): Promise<void> {}
@@ -118,16 +119,24 @@ class RealConvexClient implements IConvexClient {
     return readEnv('INDEXER_SECRET');
   }
 
-  async postWhisper(args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; msgId?: string }): Promise<void> {
+  async postWhisper(args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; msgId?: string; signal?: AbortSignal }): Promise<void> {
     const secret = this.indexerSecret();
     if (!secret) {
       console.warn('[ConvexClient] postWhisper skipped: INDEXER_SECRET not set');
       return;
     }
+    const { signal, ...mutationArgs } = args;
     try {
-      await this.http.mutation(sendWhisperRef, { secret, ...args });
+      if (signal) {
+        (this.http as unknown as { setFetchOptions(fetchOptions: RequestInit): void }).setFetchOptions({ signal });
+      }
+      await this.http.mutation(sendWhisperRef, { secret, ...mutationArgs });
     } catch (err) {
       console.warn('[ConvexClient] postWhisper failed (non-fatal):', err);
+    } finally {
+      if (signal) {
+        (this.http as unknown as { setFetchOptions(fetchOptions: RequestInit): void }).setFetchOptions({});
+      }
     }
   }
 

--- a/packages/shared/src/adapters/IConvexClient.ts
+++ b/packages/shared/src/adapters/IConvexClient.ts
@@ -3,6 +3,21 @@ import type { ClanFullView, WorldSnapshot } from '../types';
 import { readEnv } from './_env';
 import { convexApiRefs } from './convexApiRefs';
 
+// Module augmentation: `setFetchOptions` is a real public method on the
+// `ConvexHttpClient` runtime class (see `convex@1.17.4` source at
+// `dist/esm/browser/http_client.js` → `setFetchOptions(opts)`), used by the
+// official `convex/nextjs` helpers to thread `cache: 'no-store'` and other
+// `RequestInit` fields through to `fetch`. The SDK does not declare it in
+// its `.d.ts`, so this augmentation patches the typing gap rather than
+// reaching through with an `as unknown as` cast. If a future SDK version
+// removes the runtime method, the augmentation will keep compiling but
+// calls will throw at runtime — surfacing the breakage immediately.
+declare module 'convex/browser' {
+  interface ConvexHttpClient {
+    setFetchOptions(options: RequestInit): void;
+  }
+}
+
 export interface IConvexClient {
   getSnapshot(): Promise<WorldSnapshot>;
   getClanFullView(clanId: string): Promise<ClanFullView>;
@@ -76,9 +91,23 @@ const seedBulletinRef = convexApiRefs.bulletins.seedBulletin;
 
 class RealConvexClient implements IConvexClient {
   private readonly http: ConvexHttpClient;
+  private readonly url: string;
 
   constructor(url: string) {
+    this.url = url;
     this.http = new ConvexHttpClient(url);
+  }
+
+  // Per-call client for signal-bearing mutations. `ConvexHttpClient.setFetchOptions`
+  // mutates instance state, so calling it on the shared `this.http` creates a race
+  // when two callers issue concurrent signal-bearing mutations (call B overwrites
+  // call A's signal, then A's `finally` clears B's). A fresh client per call
+  // isolates the fetch options per signal. Cheap — only constructed when a signal
+  // is provided.
+  private clientForSignal(signal: AbortSignal): ConvexHttpClient {
+    const c = new ConvexHttpClient(this.url);
+    c.setFetchOptions({ signal });
+    return c;
   }
 
   async getSnapshot(): Promise<WorldSnapshot> {
@@ -126,17 +155,12 @@ class RealConvexClient implements IConvexClient {
       return;
     }
     const { signal, ...mutationArgs } = args;
+    signal?.throwIfAborted();
+    const client = signal ? this.clientForSignal(signal) : this.http;
     try {
-      if (signal) {
-        (this.http as unknown as { setFetchOptions(fetchOptions: RequestInit): void }).setFetchOptions({ signal });
-      }
-      await this.http.mutation(sendWhisperRef, { secret, ...mutationArgs });
+      await client.mutation(sendWhisperRef, { secret, ...mutationArgs });
     } catch (err) {
       console.warn('[ConvexClient] postWhisper failed (non-fatal):', err);
-    } finally {
-      if (signal) {
-        (this.http as unknown as { setFetchOptions(fetchOptions: RequestInit): void }).setFetchOptions({});
-      }
     }
   }
 

--- a/packages/shared/src/adapters/convexApiRefs.ts
+++ b/packages/shared/src/adapters/convexApiRefs.ts
@@ -5,13 +5,13 @@ import type { WorldSnapshot } from '../types';
 type PublicQuery<Args extends Record<string, unknown>, Result> = FunctionReference<'query', 'public', Args, Result>;
 type PublicMutation<Args extends Record<string, unknown>, Result = null> = FunctionReference<'mutation', 'public', Args, Result>;
 
-type SeedWhisperArgs = {
+type SendWhisperArgs = {
   secret: string;
   tick: number;
   fromClanId: number;
   toClanIds: number[];
   body: string;
-  txHash?: string;
+  msgId?: string;
 };
 
 type SeedOrchEventArgs = {
@@ -44,7 +44,7 @@ type ClanWorldConvexApi = {
     getSnapshot: PublicQuery<Record<string, never>, WorldSnapshot>;
   };
   comms: {
-    seedWhisper: PublicMutation<SeedWhisperArgs>;
+    sendWhisper: PublicMutation<SendWhisperArgs>;
     seedOrchEvent: PublicMutation<SeedOrchEventArgs>;
     seedHumanSteering: PublicMutation<SeedHumanSteeringArgs>;
   };


### PR DESCRIPTION
## Summary

Whispers are now written by elders directly to Convex (best-effort cockpit mirror), not indexed from on-chain events the contract never emitted. Closes the gap from the abandoned Phase-8 AXL transport plan.

**Net delta:** +257 / −169 (12 files changed, 1 new test file).

## What changed

| File | Change |
|---|---|
| `apps/server/convex/indexer.ts` | DELETE dead `Whisper`/`WhisperBroadcast` event block (ABI never declared these events) |
| `apps/server/convex/comms.ts` | rename `seedWhisper` → `sendWhisper`; add `(fromClanId, tick, msgId)` dedup |
| `apps/server/convex/schema.ts` | drop `txHash`, add `msgId` optional, add `by_from_clan_tick_msgid` index |
| `apps/server/convex/comms.test.ts` | **NEW** dedup tests |
| `packages/agents/src/cli.ts` | `peer whisper` handler: durable local JSONL write FIRST, then bounded best-effort cockpit mirror (5s `withTimeout` on chain + convex); `canMirrorToCockpit` gates mirror to numeric clan IDs |
| `packages/agents/test/cli.test.ts` | new tests: non-numeric clanId skips mirror; hung `getCurrentTick` doesn't pin CLI |
| `packages/shared/src/adapters/IConvexClient.ts` | drop vestigial `subscribeWhispers`; update `postWhisper` arg shape |
| `packages/shared/src/adapters/convexApiRefs.ts` | `seedWhisper` → `sendWhisper` rename + arg type rename |
| `apps/web/src/components/cockpit/tabs/CommsTab.tsx` | drop `STUB_LINES` + `STUB_BULLETINS` fallback per Liam directive |
| `apps/server/convex/authShared.ts` | docstring rename |
| `packages/agents/test/mcp.test.ts`, `packages/runner/test/tickLoop.test.ts` | follow-on test updates |

## Why on-chain whispers were dead code

`apps/server/convex/indexer.ts:355` checked `eventName === "Whisper" || "WhisperBroadcast"` — but the contract ABI declares zero whisper events. Investigation traced this to the abandoned Phase-8 "Gensyn AXL private messaging transport" plan (see `packages/agents/src/seams/IElderPeerInbox.ts`). The whispers table was never populated in production.

## Architectural design

Local file inbox remains the elder-to-elder transport (`recipientInboxFile`). The new path adds a best-effort Convex mirror so the cockpit `CommsTab` can render whispers via `useQuery(api.comms.getCombinedComms)`. The local write is the durability boundary; the mirror is bounded so chain/convex hangs cannot pin the CLI.

## Local swarm review trail

- **R1 Claude tier-1:** CLEAN
- **R1 Codex tier-2:** 2 HIGH — both fixed (chain-read-before-local-write ordering; no timeout on `postWhisper`)
- **R1 Gemini tier-3:** 1 MED (NaN guard) — fixed via `canMirrorToCockpit` gating
- **R2 all 3 tiers:** CLEAN

## Deferred (LOW, both academic)

1. `withTimeout` rejects the wrapper promise but does not abort the underlying socket. If the network operation hangs, the Node event loop may stay alive briefly after the 5s timeout. For a short-lived elder CLI invocation this is acceptable; an AbortController-based fix is a follow-up.
2. `"05"` leading-zero clanId would mirror to clan `5` on Convex but local write would create `elder-05.jsonl`. Only relevant if a caller passes non-canonical numeric strings — not possible from standard `ELDER_N` env args.

## Tests

- 36 server tests pass (incl. 2 new `comms.test.ts` dedup tests)
- 52 agents tests pass (incl. 2 new whisper edge-case tests)
- 27 shared tests pass
- typecheck clean on `@clan-world/server`, `@clan-world/shared`, `@clan-world/agents`, `@clan-world/web`

## Test plan

- [ ] Manual: run elder CLI, `elder peer whisper 2 "test"`, confirm row appears in Convex `whispers` table
- [ ] E2E: cockpit `AxlView` renders empty when no whispers (no more stub fallback)
- [ ] Android: verify Kotlin app continues to parse `getCombinedComms` correctly after the schema field swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)