### PR TITLE
feat(server): storage retention purges for Convex tables (#337)

### DIFF
--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -32,6 +32,7 @@ import type * as memory from "../memory.js";
 import type * as mock from "../mock.js";
 import type * as ops from "../ops.js";
 import type * as resetLock from "../resetLock.js";
+import type * as retention from "../retention.js";
 import type * as vault from "../vault.js";
 
 /**
@@ -62,6 +63,7 @@ declare const fullApi: ApiFromModules<{
   mock: typeof mock;
   ops: typeof ops;
   resetLock: typeof resetLock;
+  retention: typeof retention;
   vault: typeof vault;
 }>;
 export declare const api: FilterApi<

--- a/apps/server/convex/crons.ts
+++ b/apps/server/convex/crons.ts
@@ -25,4 +25,14 @@ crons.interval("gold-quote-refresh", { minutes: 5 }, internal.goldQuote.refreshG
 crons.interval("kickstart-leaderboard-refresh", { minutes: 5 }, internal.kickstart.refreshKickstartLeaderboard, {});
 crons.interval("kickstart-watched-candles-refresh", { minutes: 1 }, internal.kickstart.refreshWatchedTokenCandles, {});
 
+// Issue #337: nightly storage retention purge. 04:00 UTC is low-traffic for
+// the game (early-morning EU / late-night Americas). Convex cron schedules
+// are UTC-anchored — see https://docs.convex.dev/scheduling/cron-jobs.
+crons.daily(
+  "retention-purge-stale-data",
+  { hourUTC: 4, minuteUTC: 0 },
+  internal.retention.purgeStaleData,
+  {},
+);
+
 export default crons;

--- a/apps/server/convex/crons.ts
+++ b/apps/server/convex/crons.ts
@@ -25,12 +25,11 @@ crons.interval("gold-quote-refresh", { minutes: 5 }, internal.goldQuote.refreshG
 crons.interval("kickstart-leaderboard-refresh", { minutes: 5 }, internal.kickstart.refreshKickstartLeaderboard, {});
 crons.interval("kickstart-watched-candles-refresh", { minutes: 1 }, internal.kickstart.refreshWatchedTokenCandles, {});
 
-// Issue #337: nightly storage retention purge. 04:00 UTC is low-traffic for
-// the game (early-morning EU / late-night Americas). Convex cron schedules
-// are UTC-anchored — see https://docs.convex.dev/scheduling/cron-jobs.
-crons.daily(
+// Issue #337: hourly storage retention purge. Frequent smaller runs keep
+// append-only tables bounded without spiky mutation load.
+crons.hourly(
   "retention-purge-stale-data",
-  { hourUTC: 4, minuteUTC: 0 },
+  { minuteUTC: 0 },
   internal.retention.purgeStaleData,
   {},
 );

--- a/apps/server/convex/retention.config.ts
+++ b/apps/server/convex/retention.config.ts
@@ -1,0 +1,39 @@
+/**
+ * Retention policy constants for Convex tables.
+ *
+ * Issue #337: bound storage growth without breaking resume-from-pause.
+ *
+ * The game never replays history more than ~24-36h back, so anything older
+ * than `RETENTION_HOURS` is safe to purge — EXCEPT for tables where we need
+ * the latest row preserved for resume-from-pause semantics (clanView,
+ * banditView, marketState; see `retention.ts`).
+ *
+ * Single source of truth — tune here, not in individual purge calls.
+ */
+
+/** Default retention window for time-bucketed tables (hours). */
+export const RETENTION_HOURS = 36;
+
+/** Convex mutation row-write soft cap. Process at most this many rows per
+ *  purge invocation per table to stay within per-mutation limits (Convex
+ *  caps a single mutation at ~16k document operations). The daily cron at
+ *  04:00 UTC keeps daily deltas well below this; if a table exceeds the
+ *  cap in one run, `purgeStaleData` returns `truncated=true` for that
+ *  table and the next nightly run drains the rest.
+ *
+ *  Budget per run (worst case): 6 time-window tables × 1000 + 3 grouped
+ *  tables × ~1100 ≈ 9000 ops, well under the per-mutation cap. */
+export const PURGE_BATCH_SIZE = 1000;
+
+/** Tables with simple time-window retention (delete everything older than
+ *  `cutoff`). All ordered by `_creationTime` (Convex implicit index). */
+export const TIME_WINDOW_TABLES = [
+  "chainEvents",
+  "agentLogs",
+  "whispers",
+  "orchEvents",
+  "humanSteeringMessages",
+  "pricePoint",
+] as const;
+
+export type TimeWindowTable = (typeof TIME_WINDOW_TABLES)[number];

--- a/apps/server/convex/retention.config.ts
+++ b/apps/server/convex/retention.config.ts
@@ -16,13 +16,27 @@ export const RETENTION_HOURS = 36;
 
 /** Convex mutation row-write soft cap. Process at most this many rows per
  *  purge invocation per table to stay within per-mutation limits (Convex
- *  caps a single mutation at ~16k document operations). The hourly cron
- *  keeps deltas smooth; if a table exceeds the
- *  cap in one run, `purgeStaleData` returns `truncated=true` for that
- *  table and the next hourly run drains the rest.
+ *  caps a single mutation at ~16k document operations split across reads
+ *  and writes; concurrent I/O is also capped around ~1000). The hourly
+ *  cron keeps deltas smooth; if a table exceeds the cap in one run,
+ *  `purgeStaleData` returns `truncated=true` for that table and the next
+ *  hourly run drains the rest.
  *
- *  Budget per run (worst case): one table may delete up to this cap; grouped
- *  tables add reads for latest-row checks and delete fewer/all stale rows. */
+ *  Per-table op budget (worst case):
+ *    - Time-window table: 1 read (TAKE up to this cap) + this-cap deletes
+ *      = up to (PURGE_BATCH_SIZE + 1) ops.
+ *    - Grouped (preserve-latest) table: 1 stale-row TAKE +
+ *      up-to-distinct-groups reads (one per cached groupKey via
+ *      `latestFor`) + up-to-stale-row deletes. Worst case is the same
+ *      shape as time-window when every stale row belongs to a different
+ *      group, so ~(2 * PURGE_BATCH_SIZE + 1) ops.
+ *
+ *  Per-RUN op budget: the orchestrator `purgeStaleData` does NOT process
+ *  all tables in a single mutation — it schedules a separate internal
+ *  mutation per table via `ctx.scheduler.runAfter(0, ...)`. Each scheduled
+ *  mutation is independent and gets its own per-mutation op budget. That
+ *  keeps the worst case bounded by the per-table budget above regardless
+ *  of how many retention-managed tables exist. */
 export const PURGE_BATCH_SIZE = 5000;
 
 /** Tables with simple time-window retention (delete everything older than

--- a/apps/server/convex/retention.config.ts
+++ b/apps/server/convex/retention.config.ts
@@ -6,7 +6,7 @@
  * The game never replays history more than ~24-36h back, so anything older
  * than `RETENTION_HOURS` is safe to purge — EXCEPT for tables where we need
  * the latest row preserved for resume-from-pause semantics (clanView,
- * banditView, marketState; see `retention.ts`).
+ * banditView, marketState, worldSnapshot; see `retention.ts`).
  *
  * Single source of truth — tune here, not in individual purge calls.
  */
@@ -16,14 +16,14 @@ export const RETENTION_HOURS = 36;
 
 /** Convex mutation row-write soft cap. Process at most this many rows per
  *  purge invocation per table to stay within per-mutation limits (Convex
- *  caps a single mutation at ~16k document operations). The daily cron at
- *  04:00 UTC keeps daily deltas well below this; if a table exceeds the
+ *  caps a single mutation at ~16k document operations). The hourly cron
+ *  keeps deltas smooth; if a table exceeds the
  *  cap in one run, `purgeStaleData` returns `truncated=true` for that
- *  table and the next nightly run drains the rest.
+ *  table and the next hourly run drains the rest.
  *
- *  Budget per run (worst case): 6 time-window tables × 1000 + 3 grouped
- *  tables × ~1100 ≈ 9000 ops, well under the per-mutation cap. */
-export const PURGE_BATCH_SIZE = 1000;
+ *  Budget per run (worst case): one table may delete up to this cap; grouped
+ *  tables add reads for latest-row checks and delete fewer/all stale rows. */
+export const PURGE_BATCH_SIZE = 5000;
 
 /** Tables with simple time-window retention (delete everything older than
  *  `cutoff`). All ordered by `_creationTime` (Convex implicit index). */
@@ -34,6 +34,10 @@ export const TIME_WINDOW_TABLES = [
   "orchEvents",
   "humanSteeringMessages",
   "pricePoint",
+  "tickHistory",
+  "memoryEvents",
+  "goldTxReceipts",
+  "inftTransfers",
 ] as const;
 
 export type TimeWindowTable = (typeof TIME_WINDOW_TABLES)[number];

--- a/apps/server/convex/retention.test.ts
+++ b/apps/server/convex/retention.test.ts
@@ -1,0 +1,596 @@
+/**
+ * Tests for retention purge logic (issue #337).
+ *
+ * Strategy: build a richer in-memory `createDb` mock than the one in
+ * `indexer.test.ts` because purge needs `.lt`, `.take`, `.delete`, and
+ * the implicit `by_creation_time` index. The mock is hand-rolled (not
+ * `convex-test`) to stay consistent with the rest of `apps/server/convex/`.
+ *
+ * Each scenario:
+ *   1. Seed the mock DB with a mix of "old" (pre-cutoff) and "new"
+ *      (post-cutoff) rows.
+ *   2. Invoke either the public `purgeStaleData._handler(ctx)` or one of
+ *      the exported helpers.
+ *   3. Assert which rows survived.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  purgeGroupedPreserveLatest,
+  purgeStaleData,
+  purgeTimeWindowTable,
+} from "./retention";
+import { RETENTION_HOURS } from "./retention.config";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Mock Convex DB
+// ─────────────────────────────────────────────────────────────────────────
+
+interface Row {
+  _id: string;
+  _creationTime: number;
+  [k: string]: unknown;
+}
+
+type Clause =
+  | { op: "eq"; field: string; value: unknown }
+  | { op: "lt"; field: string; value: number }
+  | { op: "gt"; field: string; value: number };
+
+function applyClauses(rows: Row[], clauses: Clause[]): Row[] {
+  return rows.filter((row) =>
+    clauses.every((c) => {
+      const v = row[c.field];
+      if (c.op === "eq") return v === c.value;
+      if (c.op === "lt") return typeof v === "number" && v < c.value;
+      if (c.op === "gt") return typeof v === "number" && v > c.value;
+      return false;
+    }),
+  );
+}
+
+function createDb(initial: Record<string, Row[]> = {}) {
+  const tables: Record<string, Row[]> = {};
+  for (const [name, rows] of Object.entries(initial)) {
+    tables[name] = rows.map((r) => ({ ...r }));
+  }
+
+  let creationCounter = 0;
+  const nextCreationTime = () => ++creationCounter;
+  // Bump counter past any seeded `_creationTime` so future inserts don't
+  // collide with seeded values.
+  for (const rows of Object.values(tables)) {
+    for (const r of rows) {
+      if (r._creationTime > creationCounter) creationCounter = r._creationTime;
+    }
+  }
+
+  const db = {
+    async insert(table: string, value: Record<string, unknown>) {
+      tables[table] ??= [];
+      const doc: Row = {
+        ...value,
+        _id: `${table}:${tables[table].length}`,
+        _creationTime:
+          typeof value._creationTime === "number"
+            ? (value._creationTime as number)
+            : nextCreationTime(),
+      };
+      tables[table].push(doc);
+      return doc._id;
+    },
+    async delete(id: string) {
+      for (const rows of Object.values(tables)) {
+        const idx = rows.findIndex((row) => row._id === id);
+        if (idx >= 0) {
+          rows.splice(idx, 1);
+          return;
+        }
+      }
+    },
+    async get(id: string): Promise<Row | null> {
+      for (const rows of Object.values(tables)) {
+        const found = rows.find((row) => row._id === id);
+        if (found) return found;
+      }
+      return null;
+    },
+    query(table: string) {
+      let rows = [...(tables[table] ?? [])];
+      const builder = {
+        withIndex(_name: string, apply?: (q: any) => unknown) {
+          const clauses: Clause[] = [];
+          if (apply) {
+            const q = {
+              eq(field: string, value: unknown) {
+                clauses.push({ op: "eq", field, value });
+                return q;
+              },
+              lt(field: string, value: number) {
+                clauses.push({ op: "lt", field, value });
+                return q;
+              },
+              gt(field: string, value: number) {
+                clauses.push({ op: "gt", field, value });
+                return q;
+              },
+            };
+            apply(q);
+          }
+          rows = applyClauses(rows, clauses);
+          return builder;
+        },
+        order(direction: "asc" | "desc") {
+          rows = [...rows].sort((a, b) =>
+            direction === "desc"
+              ? b._creationTime - a._creationTime
+              : a._creationTime - b._creationTime,
+          );
+          return builder;
+        },
+        async first(): Promise<Row | null> {
+          return rows[0] ?? null;
+        },
+        async take(n: number): Promise<Row[]> {
+          return rows.slice(0, n);
+        },
+        async collect(): Promise<Row[]> {
+          return rows.slice();
+        },
+      };
+      return builder;
+    },
+  };
+
+  return { tables, db };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────
+
+const NOW = 1_700_000_000_000; // arbitrary fixed "now" in ms
+const HOUR_MS = 60 * 60 * 1000;
+const CUTOFF = NOW - RETENTION_HOURS * HOUR_MS;
+
+const old = (offsetHours: number) => CUTOFF - offsetHours * HOUR_MS;
+const fresh = (offsetHours: number) => CUTOFF + offsetHours * HOUR_MS;
+
+function rows(table: string, creationTimes: number[], extra: (i: number) => Record<string, unknown> = () => ({})): Row[] {
+  return creationTimes.map((t, i) => ({
+    _id: `${table}:seed-${i}`,
+    _creationTime: t,
+    ...extra(i),
+  }));
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// purgeTimeWindowTable — pure age-based delete
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("purgeTimeWindowTable", () => {
+  it("deletes rows older than cutoff and leaves fresh rows", async () => {
+    const { db, tables } = createDb({
+      chainEvents: [
+        ...rows("chainEvents", [old(10), old(5), old(1)]),
+        ...rows("chainEvents", [fresh(1), fresh(5), fresh(10), fresh(20)]),
+      ],
+    });
+
+    const result = await purgeTimeWindowTable(
+      { db } as any,
+      "chainEvents",
+      CUTOFF,
+    );
+
+    expect(result.deleted).toBe(3);
+    expect(result.truncated).toBe(false);
+    expect(tables.chainEvents).toHaveLength(4);
+    expect(tables.chainEvents!.every((r) => r._creationTime >= CUTOFF)).toBe(
+      true,
+    );
+  });
+
+  it("is a no-op when no rows are older than cutoff", async () => {
+    const { db, tables } = createDb({
+      agentLogs: rows("agentLogs", [fresh(0), fresh(1), fresh(10)]),
+    });
+
+    const result = await purgeTimeWindowTable(
+      { db } as any,
+      "agentLogs",
+      CUTOFF,
+    );
+
+    expect(result.deleted).toBe(0);
+    expect(result.truncated).toBe(false);
+    expect(tables.agentLogs).toHaveLength(3);
+  });
+
+  it("is a no-op on an empty table", async () => {
+    const { db } = createDb();
+    const result = await purgeTimeWindowTable(
+      { db } as any,
+      "whispers",
+      CUTOFF,
+    );
+    expect(result.deleted).toBe(0);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("truncates and reports truncated=true when stale rows exceed PURGE_BATCH_SIZE", async () => {
+    // Seed PURGE_BATCH_SIZE + 5 old rows. After one run, exactly
+    // PURGE_BATCH_SIZE should be deleted and truncated=true. (We don't
+    // actually want to wait for a second cron run in the test — just
+    // verify the flag is set.)
+    const { PURGE_BATCH_SIZE } = await import("./retention.config");
+    const oldCreationTimes = Array.from(
+      { length: PURGE_BATCH_SIZE + 5 },
+      (_, i) => old(20 + i / 100),
+    );
+    const { db, tables } = createDb({
+      chainEvents: rows("chainEvents", oldCreationTimes),
+    });
+
+    const result = await purgeTimeWindowTable(
+      { db } as any,
+      "chainEvents",
+      CUTOFF,
+    );
+
+    expect(result.deleted).toBe(PURGE_BATCH_SIZE);
+    expect(result.truncated).toBe(true);
+    expect(tables.chainEvents).toHaveLength(5);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// purgeGroupedPreserveLatest — keep latest-per-group
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("purgeGroupedPreserveLatest", () => {
+  it("clanView: when every clan has fresh rows, ALL old rows are deleted", async () => {
+    // 3 clans × 3 old each = 9 olds; each clan also has 2 fresh.
+    // For every old row, latestFor(clanId) === a fresh row → all olds
+    // deleted. Survivors: 3 clans × 2 fresh = 6.
+    const seedRows: Row[] = [];
+    let idCounter = 0;
+    for (const clanId of [1, 2, 3]) {
+      for (const ct of [old(20), old(15), old(10)]) {
+        seedRows.push({
+          _id: `clanView:seed-${idCounter++}`,
+          _creationTime: ct,
+          clanId,
+        });
+      }
+      for (const ct of [fresh(1), fresh(5)]) {
+        seedRows.push({
+          _id: `clanView:seed-${idCounter++}`,
+          _creationTime: ct,
+          clanId,
+        });
+      }
+    }
+    const { db, tables } = createDb({ clanView: seedRows });
+
+    const result = await purgeGroupedPreserveLatest({ db } as any, {
+      table: "clanView",
+      cutoff: CUTOFF,
+      indexName: "by_clanId",
+      indexField: "clanId",
+      groupKeyOf: (row) => row.clanId,
+    });
+
+    expect(result.deleted).toBe(9);
+    expect(tables.clanView).toHaveLength(6);
+    expect(tables.clanView!.every((r) => r._creationTime >= CUTOFF)).toBe(true);
+    for (const clanId of [1, 2, 3]) {
+      expect(tables.clanView!.filter((r) => r.clanId === clanId)).toHaveLength(
+        2,
+      );
+    }
+  });
+
+  it("clanView: clan with only old rows keeps its single latest row", async () => {
+    // Clan 1: 3 old, no fresh → latest old must survive.
+    // Clan 2: 3 fresh → all survive.
+    const seed: Row[] = [
+      { _id: "clanView:0", _creationTime: old(20), clanId: 1 },
+      { _id: "clanView:1", _creationTime: old(15), clanId: 1 },
+      { _id: "clanView:2", _creationTime: old(10), clanId: 1 }, // latest for clan 1
+      { _id: "clanView:3", _creationTime: fresh(1), clanId: 2 },
+      { _id: "clanView:4", _creationTime: fresh(5), clanId: 2 },
+      { _id: "clanView:5", _creationTime: fresh(10), clanId: 2 }, // latest for clan 2
+    ];
+    const { db, tables } = createDb({ clanView: seed });
+
+    await purgeGroupedPreserveLatest({ db } as any, {
+      table: "clanView",
+      cutoff: CUTOFF,
+      indexName: "by_clanId",
+      indexField: "clanId",
+      groupKeyOf: (row) => row.clanId,
+    });
+
+    // Clan 1: only the latest old (clanView:2) survives.
+    const clan1 = tables.clanView!.filter((r) => r.clanId === 1);
+    expect(clan1).toHaveLength(1);
+    expect(clan1[0]!._id).toBe("clanView:2");
+
+    // Clan 2: all 3 fresh rows survive.
+    const clan2 = tables.clanView!.filter((r) => r.clanId === 2);
+    expect(clan2).toHaveLength(3);
+  });
+
+  it("clanView: with both old and fresh, only fresh survive (latest is fresh)", async () => {
+    const seed: Row[] = [
+      { _id: "clanView:0", _creationTime: old(20), clanId: 1 },
+      { _id: "clanView:1", _creationTime: old(10), clanId: 1 },
+      { _id: "clanView:2", _creationTime: fresh(1), clanId: 1 },
+      { _id: "clanView:3", _creationTime: fresh(5), clanId: 1 },
+    ];
+    const { db, tables } = createDb({ clanView: seed });
+
+    const result = await purgeGroupedPreserveLatest({ db } as any, {
+      table: "clanView",
+      cutoff: CUTOFF,
+      indexName: "by_clanId",
+      indexField: "clanId",
+      groupKeyOf: (row) => row.clanId,
+    });
+
+    expect(result.deleted).toBe(2);
+    expect(tables.clanView).toHaveLength(2);
+    expect(tables.clanView!.every((r) => r._creationTime >= CUTOFF)).toBe(true);
+  });
+
+  it("banditView: groups by bandit id, preserves latest per bandit", async () => {
+    const seed: Row[] = [
+      // Bandit 1: 2 old, 1 fresh → only fresh survives.
+      { _id: "banditView:0", _creationTime: old(20), id: 1 },
+      { _id: "banditView:1", _creationTime: old(10), id: 1 },
+      { _id: "banditView:2", _creationTime: fresh(5), id: 1 },
+      // Bandit 2: 2 old, 0 fresh → latest old (banditView:4) survives.
+      { _id: "banditView:3", _creationTime: old(30), id: 2 },
+      { _id: "banditView:4", _creationTime: old(15), id: 2 },
+    ];
+    const { db, tables } = createDb({ banditView: seed });
+
+    await purgeGroupedPreserveLatest({ db } as any, {
+      table: "banditView",
+      cutoff: CUTOFF,
+      indexName: "by_bandit_id",
+      indexField: "id",
+      groupKeyOf: (row) => row.id,
+    });
+
+    const b1 = tables.banditView!.filter((r) => r.id === 1);
+    expect(b1).toHaveLength(1);
+    expect(b1[0]!._id).toBe("banditView:2");
+
+    const b2 = tables.banditView!.filter((r) => r.id === 2);
+    expect(b2).toHaveLength(1);
+    expect(b2[0]!._id).toBe("banditView:4");
+  });
+
+  it("marketState (singleton): preserves only the most-recent row when all are old", async () => {
+    const seed: Row[] = [
+      { _id: "marketState:0", _creationTime: old(30) },
+      { _id: "marketState:1", _creationTime: old(20) },
+      { _id: "marketState:2", _creationTime: old(10) }, // latest
+    ];
+    const { db, tables } = createDb({ marketState: seed });
+
+    await purgeGroupedPreserveLatest({ db } as any, {
+      table: "marketState",
+      cutoff: CUTOFF,
+      indexName: null,
+      indexField: null,
+      groupKeyOf: () => null,
+    });
+
+    expect(tables.marketState).toHaveLength(1);
+    expect(tables.marketState![0]!._id).toBe("marketState:2");
+  });
+
+  it("marketState: with fresh rows, fresh + (no old) survives", async () => {
+    const seed: Row[] = [
+      { _id: "marketState:0", _creationTime: old(30) },
+      { _id: "marketState:1", _creationTime: fresh(1) },
+      { _id: "marketState:2", _creationTime: fresh(5) },
+    ];
+    const { db, tables } = createDb({ marketState: seed });
+
+    await purgeGroupedPreserveLatest({ db } as any, {
+      table: "marketState",
+      cutoff: CUTOFF,
+      indexName: null,
+      indexField: null,
+      groupKeyOf: () => null,
+    });
+
+    // Old(30) is deleted because fresh(5) is strictly newer. Both fresh
+    // rows are post-cutoff so they're never even fetched as "stale".
+    expect(tables.marketState).toHaveLength(2);
+    expect(tables.marketState!.map((r) => r._id).sort()).toEqual([
+      "marketState:1",
+      "marketState:2",
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// purgeStaleData — full cron entry point, all tables in one run
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("purgeStaleData (cron entry)", () => {
+  it("purges all retention-managed tables in one run", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(NOW);
+    try {
+      // Seed: 5 old + 3 fresh in each time-window table.
+      const timeWindowSeed = {
+        chainEvents: [
+          ...rows("chainEvents", [old(10), old(8), old(6), old(4), old(2)]),
+          ...rows("chainEvents", [fresh(1), fresh(2), fresh(3)]),
+        ],
+        agentLogs: [
+          ...rows("agentLogs", [old(10), old(8), old(6), old(4), old(2)]),
+          ...rows("agentLogs", [fresh(1), fresh(2), fresh(3)]),
+        ],
+        whispers: [
+          ...rows("whispers", [old(10), old(8), old(6), old(4), old(2)]),
+          ...rows("whispers", [fresh(1), fresh(2), fresh(3)]),
+        ],
+        orchEvents: [
+          ...rows("orchEvents", [old(10), old(8), old(6), old(4), old(2)]),
+          ...rows("orchEvents", [fresh(1), fresh(2), fresh(3)]),
+        ],
+        humanSteeringMessages: [
+          ...rows("humanSteeringMessages", [old(10), old(8), old(6), old(4), old(2)]),
+          ...rows("humanSteeringMessages", [fresh(1), fresh(2), fresh(3)]),
+        ],
+        pricePoint: [
+          ...rows("pricePoint", [old(10), old(8), old(6), old(4), old(2)]),
+          ...rows("pricePoint", [fresh(1), fresh(2), fresh(3)]),
+        ],
+
+        // clanView: 2 clans, each with 3 old + 2 fresh.
+        clanView: [
+          { _id: "clanView:0", _creationTime: old(20), clanId: 1 },
+          { _id: "clanView:1", _creationTime: old(15), clanId: 1 },
+          { _id: "clanView:2", _creationTime: old(10), clanId: 1 },
+          { _id: "clanView:3", _creationTime: fresh(1), clanId: 1 },
+          { _id: "clanView:4", _creationTime: fresh(5), clanId: 1 },
+          { _id: "clanView:5", _creationTime: old(20), clanId: 2 },
+          { _id: "clanView:6", _creationTime: old(15), clanId: 2 },
+          { _id: "clanView:7", _creationTime: old(10), clanId: 2 },
+          { _id: "clanView:8", _creationTime: fresh(1), clanId: 2 },
+          { _id: "clanView:9", _creationTime: fresh(5), clanId: 2 },
+        ],
+
+        // banditView: bandit 1 (mix), bandit 2 (only old → must preserve latest).
+        banditView: [
+          { _id: "banditView:0", _creationTime: old(15), id: 1 },
+          { _id: "banditView:1", _creationTime: old(5), id: 1 },
+          { _id: "banditView:2", _creationTime: fresh(2), id: 1 },
+          { _id: "banditView:3", _creationTime: old(20), id: 2 },
+          { _id: "banditView:4", _creationTime: old(10), id: 2 }, // latest for #2
+        ],
+
+        // marketState: 2 old, 1 fresh.
+        marketState: [
+          { _id: "marketState:0", _creationTime: old(20) },
+          { _id: "marketState:1", _creationTime: old(10) },
+          { _id: "marketState:2", _creationTime: fresh(5) },
+        ],
+      };
+
+      const { db, tables } = createDb(timeWindowSeed);
+
+      const out = await (purgeStaleData as any)._handler({ db });
+
+      // Time-window tables: only 3 fresh remain each.
+      for (const t of [
+        "chainEvents",
+        "agentLogs",
+        "whispers",
+        "orchEvents",
+        "humanSteeringMessages",
+        "pricePoint",
+      ]) {
+        expect(tables[t]).toHaveLength(3);
+        expect(tables[t]!.every((r) => r._creationTime >= CUTOFF)).toBe(true);
+      }
+
+      // clanView: each clan keeps its 2 fresh rows; both old groups deleted
+      // because each clan has fresh rows newer than all olds.
+      expect(tables.clanView).toHaveLength(4);
+      expect(tables.clanView!.every((r) => r._creationTime >= CUTOFF)).toBe(
+        true,
+      );
+
+      // banditView: bandit 1 keeps its fresh row; bandit 2 keeps its latest
+      // old row (id=banditView:4) because no fresh row exists for bandit 2.
+      expect(tables.banditView).toHaveLength(2);
+      const b1 = tables.banditView!.filter((r) => r.id === 1);
+      const b2 = tables.banditView!.filter((r) => r.id === 2);
+      expect(b1).toHaveLength(1);
+      expect(b1[0]!._id).toBe("banditView:2");
+      expect(b2).toHaveLength(1);
+      expect(b2[0]!._id).toBe("banditView:4");
+
+      // marketState: 2 olds deleted (fresh is newer); fresh survives.
+      expect(tables.marketState).toHaveLength(1);
+      expect(tables.marketState![0]!._id).toBe("marketState:2");
+
+      // Return value: totals are sane.
+      expect(out.totalDeleted).toBeGreaterThan(0);
+      expect(out.cutoff).toBe(CUTOFF);
+      expect(out.results).toHaveLength(9);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("preserves resume-from-pause: never deletes the last row for any clan, bandit, or market", async () => {
+    // Long-pause scenario: every row is old (older than 36h).
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(NOW);
+    try {
+      const { db, tables } = createDb({
+        chainEvents: rows("chainEvents", [old(50), old(40)]),
+        agentLogs: rows("agentLogs", [old(50)]),
+        whispers: rows("whispers", [old(50)]),
+        orchEvents: rows("orchEvents", [old(50)]),
+        humanSteeringMessages: rows("humanSteeringMessages", [old(50)]),
+        pricePoint: rows("pricePoint", [old(50)]),
+
+        clanView: [
+          { _id: "clanView:0", _creationTime: old(50), clanId: 1 },
+          { _id: "clanView:1", _creationTime: old(40), clanId: 1 },
+          { _id: "clanView:2", _creationTime: old(50), clanId: 2 },
+        ],
+        banditView: [
+          { _id: "banditView:0", _creationTime: old(50), id: 99 },
+          { _id: "banditView:1", _creationTime: old(40), id: 99 },
+        ],
+        marketState: [
+          { _id: "marketState:0", _creationTime: old(60) },
+          { _id: "marketState:1", _creationTime: old(50) },
+        ],
+      });
+
+      await (purgeStaleData as any)._handler({ db });
+
+      // All time-window tables: empty (no fresh, no preservation guarantee).
+      expect(tables.chainEvents).toHaveLength(0);
+      expect(tables.agentLogs).toHaveLength(0);
+      expect(tables.whispers).toHaveLength(0);
+      expect(tables.orchEvents).toHaveLength(0);
+      expect(tables.humanSteeringMessages).toHaveLength(0);
+      expect(tables.pricePoint).toHaveLength(0);
+
+      // clanView: clan 1 keeps its latest (clanView:1); clan 2 keeps its
+      // only row (clanView:2). Total 2 rows survive.
+      expect(tables.clanView).toHaveLength(2);
+      expect(tables.clanView!.map((r) => r._id).sort()).toEqual([
+        "clanView:1",
+        "clanView:2",
+      ]);
+
+      // banditView: latest of bandit 99 (banditView:1) survives.
+      expect(tables.banditView).toHaveLength(1);
+      expect(tables.banditView![0]!._id).toBe("banditView:1");
+
+      // marketState: latest singleton (marketState:1) survives.
+      expect(tables.marketState).toHaveLength(1);
+      expect(tables.marketState![0]!._id).toBe("marketState:1");
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+});

--- a/apps/server/convex/retention.test.ts
+++ b/apps/server/convex/retention.test.ts
@@ -20,7 +20,7 @@ import {
   purgeStaleData,
   purgeTimeWindowTable,
 } from "./retention";
-import { RETENTION_HOURS } from "./retention.config";
+import { RETENTION_HOURS, TIME_WINDOW_TABLES } from "./retention.config";
 
 // ─────────────────────────────────────────────────────────────────────────
 // Mock Convex DB
@@ -422,6 +422,48 @@ describe("purgeGroupedPreserveLatest", () => {
       "marketState:2",
     ]);
   });
+
+  it("worldSnapshot (singleton): preserves only the most-recent row when all are old", async () => {
+    const seed: Row[] = [
+      { _id: "worldSnapshot:0", _creationTime: old(30), tick: 10 },
+      { _id: "worldSnapshot:1", _creationTime: old(20), tick: 11 },
+      { _id: "worldSnapshot:2", _creationTime: old(10), tick: 12 },
+    ];
+    const { db, tables } = createDb({ worldSnapshot: seed });
+
+    await purgeGroupedPreserveLatest({ db } as any, {
+      table: "worldSnapshot",
+      cutoff: CUTOFF,
+      indexName: null,
+      indexField: null,
+      groupKeyOf: () => null,
+    });
+
+    expect(tables.worldSnapshot).toHaveLength(1);
+    expect(tables.worldSnapshot![0]!._id).toBe("worldSnapshot:2");
+  });
+
+  it("does not report truncated when a full stale batch only contains preserved latest rows", async () => {
+    const { PURGE_BATCH_SIZE } = await import("./retention.config");
+    const seed = Array.from({ length: PURGE_BATCH_SIZE }, (_, i) => ({
+      _id: `clanView:${i}`,
+      _creationTime: old(10 + i / 100),
+      clanId: i,
+    }));
+    const { db, tables } = createDb({ clanView: seed });
+
+    const result = await purgeGroupedPreserveLatest({ db } as any, {
+      table: "clanView",
+      cutoff: CUTOFF,
+      indexName: "by_clanId",
+      indexField: "clanId",
+      groupKeyOf: (row) => row.clanId,
+    });
+
+    expect(result.deleted).toBe(0);
+    expect(result.truncated).toBe(false);
+    expect(tables.clanView).toHaveLength(PURGE_BATCH_SIZE);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -458,6 +500,22 @@ describe("purgeStaleData (cron entry)", () => {
           ...rows("pricePoint", [old(10), old(8), old(6), old(4), old(2)]),
           ...rows("pricePoint", [fresh(1), fresh(2), fresh(3)]),
         ],
+        tickHistory: [
+          ...rows("tickHistory", [old(10), old(8), old(6), old(4), old(2)]),
+          ...rows("tickHistory", [fresh(1), fresh(2), fresh(3)]),
+        ],
+        memoryEvents: [
+          ...rows("memoryEvents", [old(10), old(8), old(6), old(4), old(2)]),
+          ...rows("memoryEvents", [fresh(1), fresh(2), fresh(3)]),
+        ],
+        goldTxReceipts: [
+          ...rows("goldTxReceipts", [old(10), old(8), old(6), old(4), old(2)]),
+          ...rows("goldTxReceipts", [fresh(1), fresh(2), fresh(3)]),
+        ],
+        inftTransfers: [
+          ...rows("inftTransfers", [old(10), old(8), old(6), old(4), old(2)]),
+          ...rows("inftTransfers", [fresh(1), fresh(2), fresh(3)]),
+        ],
 
         // clanView: 2 clans, each with 3 old + 2 fresh.
         clanView: [
@@ -488,6 +546,13 @@ describe("purgeStaleData (cron entry)", () => {
           { _id: "marketState:1", _creationTime: old(10) },
           { _id: "marketState:2", _creationTime: fresh(5) },
         ],
+
+        // worldSnapshot: 2 old, 1 fresh.
+        worldSnapshot: [
+          { _id: "worldSnapshot:0", _creationTime: old(20), tick: 1 },
+          { _id: "worldSnapshot:1", _creationTime: old(10), tick: 2 },
+          { _id: "worldSnapshot:2", _creationTime: fresh(5), tick: 3 },
+        ],
       };
 
       const { db, tables } = createDb(timeWindowSeed);
@@ -495,14 +560,7 @@ describe("purgeStaleData (cron entry)", () => {
       const out = await (purgeStaleData as any)._handler({ db });
 
       // Time-window tables: only 3 fresh remain each.
-      for (const t of [
-        "chainEvents",
-        "agentLogs",
-        "whispers",
-        "orchEvents",
-        "humanSteeringMessages",
-        "pricePoint",
-      ]) {
+      for (const t of TIME_WINDOW_TABLES) {
         expect(tables[t]).toHaveLength(3);
         expect(tables[t]!.every((r) => r._creationTime >= CUTOFF)).toBe(true);
       }
@@ -528,16 +586,20 @@ describe("purgeStaleData (cron entry)", () => {
       expect(tables.marketState).toHaveLength(1);
       expect(tables.marketState![0]!._id).toBe("marketState:2");
 
+      // worldSnapshot: same singleton semantics as marketState.
+      expect(tables.worldSnapshot).toHaveLength(1);
+      expect(tables.worldSnapshot![0]!._id).toBe("worldSnapshot:2");
+
       // Return value: totals are sane.
       expect(out.totalDeleted).toBeGreaterThan(0);
       expect(out.cutoff).toBe(CUTOFF);
-      expect(out.results).toHaveLength(9);
+      expect(out.results).toHaveLength(TIME_WINDOW_TABLES.length + 4);
     } finally {
       nowSpy.mockRestore();
     }
   });
 
-  it("preserves resume-from-pause: never deletes the last row for any clan, bandit, or market", async () => {
+  it("preserves resume-from-pause: never deletes the last row for any clan, bandit, market, or snapshot", async () => {
     // Long-pause scenario: every row is old (older than 36h).
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(NOW);
     try {
@@ -548,6 +610,10 @@ describe("purgeStaleData (cron entry)", () => {
         orchEvents: rows("orchEvents", [old(50)]),
         humanSteeringMessages: rows("humanSteeringMessages", [old(50)]),
         pricePoint: rows("pricePoint", [old(50)]),
+        tickHistory: rows("tickHistory", [old(50)]),
+        memoryEvents: rows("memoryEvents", [old(50)]),
+        goldTxReceipts: rows("goldTxReceipts", [old(50)]),
+        inftTransfers: rows("inftTransfers", [old(50)]),
 
         clanView: [
           { _id: "clanView:0", _creationTime: old(50), clanId: 1 },
@@ -562,6 +628,10 @@ describe("purgeStaleData (cron entry)", () => {
           { _id: "marketState:0", _creationTime: old(60) },
           { _id: "marketState:1", _creationTime: old(50) },
         ],
+        worldSnapshot: [
+          { _id: "worldSnapshot:0", _creationTime: old(60), tick: 1 },
+          { _id: "worldSnapshot:1", _creationTime: old(50), tick: 2 },
+        ],
       });
 
       await (purgeStaleData as any)._handler({ db });
@@ -573,6 +643,10 @@ describe("purgeStaleData (cron entry)", () => {
       expect(tables.orchEvents).toHaveLength(0);
       expect(tables.humanSteeringMessages).toHaveLength(0);
       expect(tables.pricePoint).toHaveLength(0);
+      expect(tables.tickHistory).toHaveLength(0);
+      expect(tables.memoryEvents).toHaveLength(0);
+      expect(tables.goldTxReceipts).toHaveLength(0);
+      expect(tables.inftTransfers).toHaveLength(0);
 
       // clanView: clan 1 keeps its latest (clanView:1); clan 2 keeps its
       // only row (clanView:2). Total 2 rows survive.
@@ -589,6 +663,10 @@ describe("purgeStaleData (cron entry)", () => {
       // marketState: latest singleton (marketState:1) survives.
       expect(tables.marketState).toHaveLength(1);
       expect(tables.marketState![0]!._id).toBe("marketState:1");
+
+      // worldSnapshot: latest singleton (worldSnapshot:1) survives.
+      expect(tables.worldSnapshot).toHaveLength(1);
+      expect(tables.worldSnapshot![0]!._id).toBe("worldSnapshot:1");
     } finally {
       nowSpy.mockRestore();
     }

--- a/apps/server/convex/retention.test.ts
+++ b/apps/server/convex/retention.test.ts
@@ -14,9 +14,12 @@
  *   3. Assert which rows survived.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getFunctionName } from "convex/server";
 import {
   purgeGroupedPreserveLatest,
+  purgeOneGroupedTable,
+  purgeOneTimeWindowTable,
   purgeStaleData,
   purgeTimeWindowTable,
 } from "./retention";
@@ -168,6 +171,48 @@ beforeEach(() => {
   vi.spyOn(console, "log").mockImplementation(() => {});
   vi.spyOn(console, "warn").mockImplementation(() => {});
 });
+
+// Restore console spies so they don't leak into other test files / later
+// `vi.spyOn(console, ...)` calls. Without this, Convex's global `restoreMocks`
+// is not configured and the mocks would persist file-to-file.
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Mock scheduler for purgeStaleData (orchestrator) tests
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a mock `ctx.scheduler` that runs each scheduled mutation
+ * synchronously by dispatching to the per-table worker's `_handler`.
+ *
+ * Convex's `internal.retention.*` resolves to a Proxy at runtime; calling
+ * `getFunctionName(ref)` on it returns the string `"retention:purgeOne…"`.
+ * We use that name to route to the correct worker handle.
+ *
+ * The scheduler mock runs jobs SYNCHRONOUSLY (still awaits each) so the
+ * orchestrator tests can assert end-to-end purge behavior — the same
+ * observable rows-deleted outcome as if the real scheduler ran the workers.
+ */
+function createSchedulerMock(db: any) {
+  const calls: Array<{ name: string; args: any }> = [];
+  const scheduler = {
+    async runAfter(_delay: number, ref: any, args: any) {
+      const name = getFunctionName(ref);
+      calls.push({ name, args });
+
+      if (name === "retention:purgeOneTimeWindowTable") {
+        await (purgeOneTimeWindowTable as any)._handler({ db, scheduler }, args);
+      } else if (name === "retention:purgeOneGroupedTable") {
+        await (purgeOneGroupedTable as any)._handler({ db, scheduler }, args);
+      } else {
+        throw new Error(`mock scheduler got unknown function ref: ${name}`);
+      }
+    },
+  };
+  return { scheduler, calls };
+}
 
 // ─────────────────────────────────────────────────────────────────────────
 // purgeTimeWindowTable — pure age-based delete
@@ -467,6 +512,80 @@ describe("purgeGroupedPreserveLatest", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────
+// Per-table workers (purgeOneTimeWindowTable / purgeOneGroupedTable)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("purgeOneTimeWindowTable (per-table worker)", () => {
+  it("drains a single time-window table and returns its PurgeResult", async () => {
+    const { db, tables } = createDb({
+      chainEvents: [
+        ...rows("chainEvents", [old(10), old(5), old(1)]),
+        ...rows("chainEvents", [fresh(1), fresh(5)]),
+      ],
+    });
+
+    const result = await (purgeOneTimeWindowTable as any)._handler(
+      { db },
+      { table: "chainEvents", cutoff: CUTOFF },
+    );
+
+    expect(result.deleted).toBe(3);
+    expect(result.truncated).toBe(false);
+    expect(result.table).toBe("chainEvents");
+    expect(tables.chainEvents).toHaveLength(2);
+  });
+
+  it("rejects an unknown table name", async () => {
+    const { db } = createDb();
+    await expect(
+      (purgeOneTimeWindowTable as any)._handler(
+        { db },
+        { table: "notATable", cutoff: CUTOFF },
+      ),
+    ).rejects.toThrow(/unknown table/);
+  });
+});
+
+describe("purgeOneGroupedTable (per-table worker)", () => {
+  it("purges clanView and preserves latest per clan", async () => {
+    const seed: Row[] = [
+      { _id: "clanView:0", _creationTime: old(20), clanId: 1 },
+      { _id: "clanView:1", _creationTime: old(10), clanId: 1 },
+      { _id: "clanView:2", _creationTime: fresh(5), clanId: 1 },
+      { _id: "clanView:3", _creationTime: old(20), clanId: 2 }, // sole row for clan 2
+    ];
+    const { db, tables } = createDb({ clanView: seed });
+
+    const result = await (purgeOneGroupedTable as any)._handler(
+      { db },
+      { table: "clanView", cutoff: CUTOFF },
+    );
+
+    expect(result.table).toBe("clanView");
+    expect(result.deleted).toBe(2); // both old clan-1 rows; clan-2 sole row preserved
+    expect(tables.clanView).toHaveLength(2);
+    expect(tables.clanView!.find((r) => r._id === "clanView:3")).toBeTruthy();
+  });
+
+  it("purges worldSnapshot singleton-style", async () => {
+    const seed: Row[] = [
+      { _id: "worldSnapshot:0", _creationTime: old(30), tick: 1 },
+      { _id: "worldSnapshot:1", _creationTime: old(20), tick: 2 },
+      { _id: "worldSnapshot:2", _creationTime: old(10), tick: 3 }, // latest
+    ];
+    const { db, tables } = createDb({ worldSnapshot: seed });
+
+    await (purgeOneGroupedTable as any)._handler(
+      { db },
+      { table: "worldSnapshot", cutoff: CUTOFF },
+    );
+
+    expect(tables.worldSnapshot).toHaveLength(1);
+    expect(tables.worldSnapshot![0]!._id).toBe("worldSnapshot:2");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
 // purgeStaleData — full cron entry point, all tables in one run
 // ─────────────────────────────────────────────────────────────────────────
 
@@ -556,8 +675,32 @@ describe("purgeStaleData (cron entry)", () => {
       };
 
       const { db, tables } = createDb(timeWindowSeed);
+      const { scheduler, calls } = createSchedulerMock(db);
 
-      const out = await (purgeStaleData as any)._handler({ db });
+      const out = await (purgeStaleData as any)._handler({ db, scheduler });
+
+      // Orchestrator scheduled one mutation per retention-managed table.
+      expect(out.scheduled).toBe(TIME_WINDOW_TABLES.length + 4);
+      expect(out.cutoff).toBe(CUTOFF);
+      expect(calls).toHaveLength(TIME_WINDOW_TABLES.length + 4);
+      // All time-window calls came first, in TIME_WINDOW_TABLES order.
+      for (let i = 0; i < TIME_WINDOW_TABLES.length; i++) {
+        expect(calls[i]!.name).toBe("retention:purgeOneTimeWindowTable");
+        expect(calls[i]!.args.table).toBe(TIME_WINDOW_TABLES[i]);
+        expect(calls[i]!.args.cutoff).toBe(CUTOFF);
+      }
+      // Grouped calls follow in [clanView, banditView, marketState, worldSnapshot] order.
+      const groupedCalls = calls.slice(TIME_WINDOW_TABLES.length);
+      expect(groupedCalls.map((c) => c.args.table)).toEqual([
+        "clanView",
+        "banditView",
+        "marketState",
+        "worldSnapshot",
+      ]);
+      for (const c of groupedCalls) {
+        expect(c.name).toBe("retention:purgeOneGroupedTable");
+        expect(c.args.cutoff).toBe(CUTOFF);
+      }
 
       // Time-window tables: only 3 fresh remain each.
       for (const t of TIME_WINDOW_TABLES) {
@@ -589,11 +732,6 @@ describe("purgeStaleData (cron entry)", () => {
       // worldSnapshot: same singleton semantics as marketState.
       expect(tables.worldSnapshot).toHaveLength(1);
       expect(tables.worldSnapshot![0]!._id).toBe("worldSnapshot:2");
-
-      // Return value: totals are sane.
-      expect(out.totalDeleted).toBeGreaterThan(0);
-      expect(out.cutoff).toBe(CUTOFF);
-      expect(out.results).toHaveLength(TIME_WINDOW_TABLES.length + 4);
     } finally {
       nowSpy.mockRestore();
     }
@@ -634,7 +772,8 @@ describe("purgeStaleData (cron entry)", () => {
         ],
       });
 
-      await (purgeStaleData as any)._handler({ db });
+      const { scheduler } = createSchedulerMock(db);
+      await (purgeStaleData as any)._handler({ db, scheduler });
 
       // All time-window tables: empty (no fresh, no preservation guarantee).
       expect(tables.chainEvents).toHaveLength(0);

--- a/apps/server/convex/retention.ts
+++ b/apps/server/convex/retention.ts
@@ -1,0 +1,235 @@
+/**
+ * Storage retention purges for Convex tables (Issue #337).
+ *
+ * Two patterns:
+ *
+ *  1. **Time-window** (`purgeTimeWindowTable`): keep last `RETENTION_HOURS`
+ *     of rows; delete everything older. Used for append-only history
+ *     (chainEvents, agentLogs, whispers, orchEvents, humanSteeringMessages,
+ *     pricePoint).
+ *
+ *  2. **Preserve-latest-per-group** (`purgeGroupedPreserveLatest`): keep
+ *     last `RETENTION_HOURS` of rows AND always preserve the newest row
+ *     for each group key, even if it's older than the cutoff. This is the
+ *     resume-from-pause guarantee — clanView/banditView/marketState rows
+ *     are the only source of truth for "what's the current world state?"
+ *     after a long pause, so we must never delete the last row for a clan
+ *     / bandit / market.
+ *
+ * Cron registration lives in `crons.ts`. Public entry is
+ * `purgeStaleData` (internalMutation) — run daily at 04:00 UTC.
+ *
+ * Filtering uses Convex's implicit `by_creation_time` index via
+ * `q.field("_creationTime")`. No schema changes required.
+ */
+
+import { internalMutation } from "./_generated/server";
+import type { DataModel } from "./_generated/dataModel";
+import type { GenericMutationCtx } from "convex/server";
+import {
+  PURGE_BATCH_SIZE,
+  RETENTION_HOURS,
+  TIME_WINDOW_TABLES,
+  type TimeWindowTable,
+} from "./retention.config";
+
+type MutationCtx = GenericMutationCtx<DataModel>;
+
+type GroupedTable = "clanView" | "banditView" | "marketState";
+type PurgeTable = TimeWindowTable | GroupedTable;
+
+interface PurgeResult {
+  table: PurgeTable;
+  deleted: number;
+  /** True if we hit `PURGE_BATCH_SIZE` of stale rows AND deleted them all
+   *  — i.e. there are likely MORE stale rows that didn't fit in this
+   *  mutation's quota. The next nightly run mops them up. */
+  truncated: boolean;
+}
+
+/**
+ * Delete all rows with `_creationTime < cutoff`, in a single batch capped
+ * at `PURGE_BATCH_SIZE`. Returns the count deleted and whether the cap
+ * was reached.
+ *
+ * Why not scan post-purge to count remaining rows? Convex mutations are
+ * capped at ~16k document operations per call. Scanning every retention
+ * table to count rows would blow that budget. The `truncated` flag is the
+ * sufficient health signal — it goes true whenever we couldn't drain the
+ * stale set in one run, which is the actual "retention isn't keeping up"
+ * condition.
+ */
+export async function purgeTimeWindowTable(
+  ctx: MutationCtx,
+  table: TimeWindowTable,
+  cutoff: number,
+): Promise<PurgeResult> {
+  const stale = await ctx.db
+    .query(table)
+    .withIndex("by_creation_time", (q) => q.lt("_creationTime", cutoff))
+    .take(PURGE_BATCH_SIZE);
+
+  await Promise.all(stale.map((row) => ctx.db.delete(row._id)));
+
+  return {
+    table,
+    deleted: stale.length,
+    truncated: stale.length === PURGE_BATCH_SIZE,
+  };
+}
+
+/**
+ * Preserve-latest-per-group purge for append-only views.
+ *
+ * Algorithm:
+ *   1. Collect old rows (`_creationTime < cutoff`) up to `PURGE_BATCH_SIZE`.
+ *   2. For each old row, look up the newest row in its group via the
+ *      group index.
+ *   3. Delete the old row IFF a strictly newer row exists in the same
+ *      group (i.e. the old row is not the latest for its group).
+ *
+ * `groupKeyOf` extracts the group-key value from a row; `indexName` /
+ * `indexField` describe the Convex index used to find the latest per group.
+ * For `marketState` (singleton, no group key) pass `groupKeyOf: () => null`
+ * and `indexName: null`; we'll fall back to "is there ANY newer row?"
+ */
+export async function purgeGroupedPreserveLatest<T extends GroupedTable>(
+  ctx: MutationCtx,
+  args: {
+    table: T;
+    cutoff: number;
+    indexName: string | null;
+    indexField: string | null;
+    groupKeyOf: (row: any) => number | null;
+  },
+): Promise<PurgeResult> {
+  const { table, cutoff, indexName, indexField, groupKeyOf } = args;
+
+  // Generic-`T` table forces TS to keep the per-schema index/field types as
+  // a union — `q.lt("_creationTime", number)` then fails the union-narrowing
+  // check (even though `_creationTime` is a `number` on every table). Cast
+  // through `any` here; the runtime is fine, and the outer signature still
+  // restricts `T` to the three preserve-latest tables.
+  const stale = await (ctx.db.query(table) as any)
+    .withIndex("by_creation_time", (q: any) => q.lt("_creationTime", cutoff))
+    .take(PURGE_BATCH_SIZE);
+
+  // Cache "latest row per group" lookups so we don't re-query for every
+  // stale row from the same group.
+  const latestByGroup = new Map<string, { _id: string; _creationTime: number } | null>();
+
+  async function latestFor(groupKey: number | null) {
+    const cacheKey = groupKey === null ? "__singleton__" : String(groupKey);
+    if (latestByGroup.has(cacheKey)) return latestByGroup.get(cacheKey)!;
+
+    let latest: { _id: string; _creationTime: number } | null;
+    if (indexName && indexField && groupKey !== null) {
+      latest = (await (ctx.db.query(table) as any)
+        .withIndex(indexName, (q: any) => q.eq(indexField, groupKey))
+        .order("desc")
+        .first()) as { _id: string; _creationTime: number } | null;
+    } else {
+      // Singleton-style: find the newest row in the whole table.
+      latest = (await (ctx.db.query(table) as any)
+        .withIndex("by_creation_time")
+        .order("desc")
+        .first()) as { _id: string; _creationTime: number } | null;
+    }
+    latestByGroup.set(cacheKey, latest);
+    return latest;
+  }
+
+  let deleted = 0;
+  await Promise.all(
+    stale.map(async (row: any) => {
+      const groupKey = groupKeyOf(row);
+      const latest = await latestFor(groupKey);
+      // Preserve if this row IS the latest for its group, or no newer row
+      // exists for the group. Otherwise it's safe to delete.
+      if (!latest || latest._id === row._id) return;
+      if (latest._creationTime <= row._creationTime) return;
+      await ctx.db.delete(row._id);
+      deleted += 1;
+    }),
+  );
+
+  return {
+    table,
+    deleted,
+    truncated: stale.length === PURGE_BATCH_SIZE,
+  };
+}
+
+/**
+ * Daily purge entry point. Walks every retention-managed table, emits
+ * per-table summary logs, and warns when any per-table purge truncates
+ * (signal that retention isn't keeping up — see #337 acceptance criteria).
+ */
+export const purgeStaleData = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const cutoff = now - RETENTION_HOURS * 60 * 60 * 1000;
+    const results: PurgeResult[] = [];
+
+    // Time-window tables: pure age-based purge.
+    for (const table of TIME_WINDOW_TABLES) {
+      const result = await purgeTimeWindowTable(ctx, table, cutoff);
+      results.push(result);
+    }
+
+    // Preserve-latest tables: keep newest-per-group even if it's old.
+    results.push(
+      await purgeGroupedPreserveLatest(ctx, {
+        table: "clanView",
+        cutoff,
+        indexName: "by_clanId",
+        indexField: "clanId",
+        groupKeyOf: (row) => (typeof row.clanId === "number" ? row.clanId : null),
+      }),
+    );
+    results.push(
+      await purgeGroupedPreserveLatest(ctx, {
+        table: "banditView",
+        cutoff,
+        indexName: "by_bandit_id",
+        indexField: "id",
+        groupKeyOf: (row) => (typeof row.id === "number" ? row.id : null),
+      }),
+    );
+    results.push(
+      await purgeGroupedPreserveLatest(ctx, {
+        table: "marketState",
+        cutoff,
+        indexName: null,
+        indexField: null,
+        groupKeyOf: () => null,
+      }),
+    );
+
+    // Observability: one log line per table + a summary. `truncated=true`
+    // is the "retention not keeping up" signal — it means the daily purge
+    // couldn't drain the stale set in one mutation. Dashboard alerts can
+    // grep for "truncated=true".
+    for (const r of results) {
+      console.log(
+        `[retention] purged ${r.deleted} rows from ${r.table}` +
+          (r.truncated ? " (truncated=true; more pending)" : ""),
+      );
+      if (r.truncated) {
+        console.warn(
+          `[retention] table ${r.table} purge truncated at batch size ` +
+            `${PURGE_BATCH_SIZE}; backlog will be drained on next nightly run`,
+        );
+      }
+    }
+
+    const totalDeleted = results.reduce((sum, r) => sum + r.deleted, 0);
+    console.log(
+      `[retention] purge run complete: deleted=${totalDeleted}` +
+        ` across ${results.length} tables (cutoff=${new Date(cutoff).toISOString()})`,
+    );
+
+    return { results, totalDeleted, cutoff };
+  },
+});

--- a/apps/server/convex/retention.ts
+++ b/apps/server/convex/retention.ts
@@ -25,8 +25,10 @@
  */
 
 import { internalMutation } from "./_generated/server";
+import { internal } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
 import type { GenericMutationCtx } from "convex/server";
+import { v } from "convex/values";
 import {
   PURGE_BATCH_SIZE,
   RETENTION_HOURS,
@@ -70,11 +72,19 @@ export async function purgeTimeWindowTable(
     .withIndex("by_creation_time", (q) => q.lt("_creationTime", cutoff))
     .take(PURGE_BATCH_SIZE);
 
-  await Promise.all(stale.map((row) => ctx.db.delete(row._id)));
+  // Sequential delete loop — Convex enforces a per-function concurrent I/O
+  // cap (~1000); Promise.all over PURGE_BATCH_SIZE=5000 deletes would blow
+  // through that and fail the mutation. `deleted` is incremented post-await
+  // so it accurately reflects rows actually purged even on partial failure.
+  let deleted = 0;
+  for (const row of stale) {
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
 
   return {
     table,
-    deleted: stale.length,
+    deleted,
     truncated: stale.length === PURGE_BATCH_SIZE,
   };
 }
@@ -116,28 +126,32 @@ export async function purgeGroupedPreserveLatest<T extends GroupedTable>(
     .take(PURGE_BATCH_SIZE);
 
   // Cache "latest row per group" lookups so we don't re-query for every
-  // stale row from the same group.
-  const latestByGroup = new Map<string, { _id: string; _creationTime: number } | null>();
+  // stale row from the same group. We cache the PROMISE (not the resolved
+  // value) so that even if callers ever process stale rows concurrently
+  // (today they don't — the loop below is sequential — but defense in
+  // depth), the second caller awaits the in-flight query rather than
+  // launching a duplicate.
+  const latestByGroup = new Map<string, Promise<{ _id: string; _creationTime: number } | null>>();
 
-  async function latestFor(groupKey: number | null) {
+  function latestFor(groupKey: number | null) {
     const cacheKey = groupKey === null ? "__singleton__" : String(groupKey);
-    if (latestByGroup.has(cacheKey)) return latestByGroup.get(cacheKey)!;
+    const cached = latestByGroup.get(cacheKey);
+    if (cached) return cached;
 
-    let latest: { _id: string; _creationTime: number } | null;
-    if (indexName && indexField && groupKey !== null) {
-      latest = (await (ctx.db.query(table) as any)
-        .withIndex(indexName, (q: any) => q.eq(indexField, groupKey))
-        .order("desc")
-        .first()) as { _id: string; _creationTime: number } | null;
-    } else {
-      // Singleton-style: find the newest row in the whole table.
-      latest = (await (ctx.db.query(table) as any)
-        .withIndex("by_creation_time")
-        .order("desc")
-        .first()) as { _id: string; _creationTime: number } | null;
-    }
-    latestByGroup.set(cacheKey, latest);
-    return latest;
+    const lookup: Promise<{ _id: string; _creationTime: number } | null> =
+      indexName && indexField && groupKey !== null
+        ? ((ctx.db.query(table) as any)
+            .withIndex(indexName, (q: any) => q.eq(indexField, groupKey))
+            .order("desc")
+            .first() as Promise<{ _id: string; _creationTime: number } | null>)
+        : // Singleton-style: find the newest row in the whole table.
+          ((ctx.db.query(table) as any)
+            .withIndex("by_creation_time")
+            .order("desc")
+            .first() as Promise<{ _id: string; _creationTime: number } | null>);
+
+    latestByGroup.set(cacheKey, lookup);
+    return lookup;
   }
 
   let deleted = 0;
@@ -160,84 +174,158 @@ export async function purgeGroupedPreserveLatest<T extends GroupedTable>(
 }
 
 /**
- * Hourly purge entry point. Walks every retention-managed table, emits
- * per-table summary logs, and warns when any per-table purge truncates
- * (signal that retention isn't keeping up — see #337 acceptance criteria).
+ * Per-grouped-table arg packs. Centralized so the orchestrator and the
+ * `purgeOneGroupedTable` worker agree on the index/groupKey shape for each
+ * preserve-latest table.
+ */
+type GroupedTableConfig = {
+  table: GroupedTable;
+  indexName: string | null;
+  indexField: string | null;
+  groupKeyOf: (row: any) => number | null;
+};
+
+const GROUPED_TABLE_CONFIGS: readonly GroupedTableConfig[] = [
+  {
+    table: "clanView",
+    indexName: "by_clanId",
+    indexField: "clanId",
+    groupKeyOf: (row) => (typeof row.clanId === "number" ? row.clanId : null),
+  },
+  {
+    table: "banditView",
+    indexName: "by_bandit_id",
+    indexField: "id",
+    groupKeyOf: (row) => (typeof row.id === "number" ? row.id : null),
+  },
+  {
+    table: "marketState",
+    indexName: null,
+    indexField: null,
+    groupKeyOf: () => null,
+  },
+  {
+    table: "worldSnapshot",
+    indexName: null,
+    indexField: null,
+    groupKeyOf: () => null,
+  },
+] as const;
+
+function logPurgeResult(r: PurgeResult): void {
+  console.log(
+    `[retention] purged ${r.deleted} rows from ${r.table}` +
+      (r.truncated ? " (truncated=true; more pending)" : ""),
+  );
+  if (r.truncated) {
+    console.warn(
+      `[retention] table ${r.table} purge truncated at batch size ` +
+        `${PURGE_BATCH_SIZE}; backlog will be drained on next hourly run`,
+    );
+  }
+}
+
+/**
+ * Per-table worker: purge ONE time-window table. Exposed as an internal
+ * mutation so the orchestrator can schedule one of these per table — each
+ * scheduled call runs in its own mutation transaction with its own op
+ * budget, preventing cumulative-cap failures across tables.
+ */
+export const purgeOneTimeWindowTable = internalMutation({
+  args: {
+    table: v.string(),
+    cutoff: v.number(),
+  },
+  handler: async (ctx, { table, cutoff }) => {
+    if (!(TIME_WINDOW_TABLES as readonly string[]).includes(table)) {
+      throw new Error(
+        `[retention] purgeOneTimeWindowTable: unknown table "${table}"`,
+      );
+    }
+    const result = await purgeTimeWindowTable(
+      ctx,
+      table as TimeWindowTable,
+      cutoff,
+    );
+    logPurgeResult(result);
+    return result;
+  },
+});
+
+/**
+ * Per-table worker: purge ONE preserve-latest grouped table. Same isolation
+ * rationale as `purgeOneTimeWindowTable`.
+ */
+export const purgeOneGroupedTable = internalMutation({
+  args: {
+    table: v.union(
+      v.literal("clanView"),
+      v.literal("banditView"),
+      v.literal("marketState"),
+      v.literal("worldSnapshot"),
+    ),
+    cutoff: v.number(),
+  },
+  handler: async (ctx, { table, cutoff }) => {
+    const config = GROUPED_TABLE_CONFIGS.find((c) => c.table === table);
+    if (!config) {
+      throw new Error(
+        `[retention] purgeOneGroupedTable: unknown table "${table}"`,
+      );
+    }
+    const result = await purgeGroupedPreserveLatest(ctx, {
+      table: config.table,
+      cutoff,
+      indexName: config.indexName,
+      indexField: config.indexField,
+      groupKeyOf: config.groupKeyOf,
+    });
+    logPurgeResult(result);
+    return result;
+  },
+});
+
+/**
+ * Hourly purge orchestrator. Schedules one independent mutation per
+ * retention-managed table so each table's purge gets its own per-mutation
+ * op budget (Convex caps a single mutation at ~16k document ops). With 10+
+ * tables × PURGE_BATCH_SIZE=5000, running them all inline could exceed the
+ * cap and silently skip retention work; the scheduler split prevents that.
+ *
+ * Per-table observability lives inside each per-table worker (see
+ * `purgeOneTimeWindowTable` / `purgeOneGroupedTable`). The orchestrator
+ * emits a single line stating how many tables were scheduled.
  */
 export const purgeStaleData = internalMutation({
   args: {},
   handler: async (ctx) => {
     const now = Date.now();
     const cutoff = now - RETENTION_HOURS * 60 * 60 * 1000;
-    const results: PurgeResult[] = [];
+    let scheduled = 0;
 
-    // Time-window tables: pure age-based purge.
     for (const table of TIME_WINDOW_TABLES) {
-      const result = await purgeTimeWindowTable(ctx, table, cutoff);
-      results.push(result);
-    }
-
-    // Preserve-latest tables: keep newest-per-group even if it's old.
-    results.push(
-      await purgeGroupedPreserveLatest(ctx, {
-        table: "clanView",
-        cutoff,
-        indexName: "by_clanId",
-        indexField: "clanId",
-        groupKeyOf: (row) => (typeof row.clanId === "number" ? row.clanId : null),
-      }),
-    );
-    results.push(
-      await purgeGroupedPreserveLatest(ctx, {
-        table: "banditView",
-        cutoff,
-        indexName: "by_bandit_id",
-        indexField: "id",
-        groupKeyOf: (row) => (typeof row.id === "number" ? row.id : null),
-      }),
-    );
-    results.push(
-      await purgeGroupedPreserveLatest(ctx, {
-        table: "marketState",
-        cutoff,
-        indexName: null,
-        indexField: null,
-        groupKeyOf: () => null,
-      }),
-    );
-    results.push(
-      await purgeGroupedPreserveLatest(ctx, {
-        table: "worldSnapshot",
-        cutoff,
-        indexName: null,
-        indexField: null,
-        groupKeyOf: () => null,
-      }),
-    );
-
-    // Observability: one log line per table + a summary. `truncated=true`
-    // is the "retention not keeping up" signal — it means the hourly purge
-    // couldn't drain the stale set in one mutation. Dashboard alerts can
-    // grep for "truncated=true".
-    for (const r of results) {
-      console.log(
-        `[retention] purged ${r.deleted} rows from ${r.table}` +
-          (r.truncated ? " (truncated=true; more pending)" : ""),
+      await ctx.scheduler.runAfter(
+        0,
+        internal.retention.purgeOneTimeWindowTable,
+        { table, cutoff },
       );
-      if (r.truncated) {
-        console.warn(
-          `[retention] table ${r.table} purge truncated at batch size ` +
-            `${PURGE_BATCH_SIZE}; backlog will be drained on next hourly run`,
-        );
-      }
+      scheduled += 1;
     }
 
-    const totalDeleted = results.reduce((sum, r) => sum + r.deleted, 0);
+    for (const config of GROUPED_TABLE_CONFIGS) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.retention.purgeOneGroupedTable,
+        { table: config.table, cutoff },
+      );
+      scheduled += 1;
+    }
+
     console.log(
-      `[retention] purge run complete: deleted=${totalDeleted}` +
-        ` across ${results.length} tables (cutoff=${new Date(cutoff).toISOString()})`,
+      `[retention] orchestrator scheduled ${scheduled} per-table purges ` +
+        `(cutoff=${new Date(cutoff).toISOString()})`,
     );
 
-    return { results, totalDeleted, cutoff };
+    return { scheduled, cutoff };
   },
 });

--- a/apps/server/convex/retention.ts
+++ b/apps/server/convex/retention.ts
@@ -6,18 +6,19 @@
  *  1. **Time-window** (`purgeTimeWindowTable`): keep last `RETENTION_HOURS`
  *     of rows; delete everything older. Used for append-only history
  *     (chainEvents, agentLogs, whispers, orchEvents, humanSteeringMessages,
- *     pricePoint).
+ *     pricePoint, tickHistory, memoryEvents, goldTxReceipts, inftTransfers).
  *
  *  2. **Preserve-latest-per-group** (`purgeGroupedPreserveLatest`): keep
  *     last `RETENTION_HOURS` of rows AND always preserve the newest row
  *     for each group key, even if it's older than the cutoff. This is the
- *     resume-from-pause guarantee — clanView/banditView/marketState rows
+ *     resume-from-pause guarantee — clanView/banditView/marketState/
+ *     worldSnapshot rows
  *     are the only source of truth for "what's the current world state?"
  *     after a long pause, so we must never delete the last row for a clan
- *     / bandit / market.
+ *     / bandit / market / world snapshot.
  *
  * Cron registration lives in `crons.ts`. Public entry is
- * `purgeStaleData` (internalMutation) — run daily at 04:00 UTC.
+ * `purgeStaleData` (internalMutation) — run hourly.
  *
  * Filtering uses Convex's implicit `by_creation_time` index via
  * `q.field("_creationTime")`. No schema changes required.
@@ -35,15 +36,15 @@ import {
 
 type MutationCtx = GenericMutationCtx<DataModel>;
 
-type GroupedTable = "clanView" | "banditView" | "marketState";
+type GroupedTable = "clanView" | "banditView" | "marketState" | "worldSnapshot";
 type PurgeTable = TimeWindowTable | GroupedTable;
 
 interface PurgeResult {
   table: PurgeTable;
   deleted: number;
-  /** True if we hit `PURGE_BATCH_SIZE` of stale rows AND deleted them all
+  /** True if we hit `PURGE_BATCH_SIZE` of stale rows and deleted at least one
    *  — i.e. there are likely MORE stale rows that didn't fit in this
-   *  mutation's quota. The next nightly run mops them up. */
+   *  mutation's quota. The next hourly run mops them up. */
   truncated: boolean;
 }
 
@@ -109,7 +110,7 @@ export async function purgeGroupedPreserveLatest<T extends GroupedTable>(
   // a union — `q.lt("_creationTime", number)` then fails the union-narrowing
   // check (even though `_creationTime` is a `number` on every table). Cast
   // through `any` here; the runtime is fine, and the outer signature still
-  // restricts `T` to the three preserve-latest tables.
+  // restricts `T` to the preserve-latest tables.
   const stale = await (ctx.db.query(table) as any)
     .withIndex("by_creation_time", (q: any) => q.lt("_creationTime", cutoff))
     .take(PURGE_BATCH_SIZE);
@@ -140,28 +141,26 @@ export async function purgeGroupedPreserveLatest<T extends GroupedTable>(
   }
 
   let deleted = 0;
-  await Promise.all(
-    stale.map(async (row: any) => {
-      const groupKey = groupKeyOf(row);
-      const latest = await latestFor(groupKey);
-      // Preserve if this row IS the latest for its group, or no newer row
-      // exists for the group. Otherwise it's safe to delete.
-      if (!latest || latest._id === row._id) return;
-      if (latest._creationTime <= row._creationTime) return;
-      await ctx.db.delete(row._id);
-      deleted += 1;
-    }),
-  );
+  for (const row of stale) {
+    const groupKey = groupKeyOf(row);
+    const latest = await latestFor(groupKey);
+    // Preserve if this row IS the latest for its group, or no newer row
+    // exists for the group. Otherwise it's safe to delete.
+    if (!latest || latest._id === row._id) continue;
+    if (latest._creationTime <= row._creationTime) continue;
+    await ctx.db.delete(row._id);
+    deleted += 1;
+  }
 
   return {
     table,
     deleted,
-    truncated: stale.length === PURGE_BATCH_SIZE,
+    truncated: deleted > 0 && stale.length === PURGE_BATCH_SIZE,
   };
 }
 
 /**
- * Daily purge entry point. Walks every retention-managed table, emits
+ * Hourly purge entry point. Walks every retention-managed table, emits
  * per-table summary logs, and warns when any per-table purge truncates
  * (signal that retention isn't keeping up — see #337 acceptance criteria).
  */
@@ -206,9 +205,18 @@ export const purgeStaleData = internalMutation({
         groupKeyOf: () => null,
       }),
     );
+    results.push(
+      await purgeGroupedPreserveLatest(ctx, {
+        table: "worldSnapshot",
+        cutoff,
+        indexName: null,
+        indexField: null,
+        groupKeyOf: () => null,
+      }),
+    );
 
     // Observability: one log line per table + a summary. `truncated=true`
-    // is the "retention not keeping up" signal — it means the daily purge
+    // is the "retention not keeping up" signal — it means the hourly purge
     // couldn't drain the stale set in one mutation. Dashboard alerts can
     // grep for "truncated=true".
     for (const r of results) {
@@ -219,7 +227,7 @@ export const purgeStaleData = internalMutation({
       if (r.truncated) {
         console.warn(
           `[retention] table ${r.table} purge truncated at batch size ` +
-            `${PURGE_BATCH_SIZE}; backlog will be drained on next nightly run`,
+            `${PURGE_BATCH_SIZE}; backlog will be drained on next hourly run`,
         );
       }
     }


### PR DESCRIPTION
**Walkthrough draft** — part of the 2026-05-16 phase-1+phase-0 rollback recovery.

**Phase:** Phase 0
**Original PR:** #343 (squash-merged into the bundled `#392 release: Phase 0 + Phase 1` that was reverted via `973da7c`)
**Recovery branch:** `recover/issue-337-retention-policies` — restored from `pull/343/head` to preserve full per-commit history
**Diff vs dev:**  5 files changed (server retention purges + tests + cron registration + generated api typings)

This PR is DRAFT for walkthrough. Liam decides salvage / cherry-pick / drop.

Per the gitflow-light convention (memory: `feedback_gitflow_light_pr_base_is_dev.md`), this targets `dev`. Once approved, work that survives the walkthrough will be merged into a `dev → main` release PR with super-swarm review.

## Current cadence + scope (updated 2026-05-20 cloud-review fix-round)

- **Cron cadence:** hourly at `minuteUTC: 0` (see `apps/server/convex/crons.ts`). The earlier draft of this PR scheduled the purge daily at 04:00 UTC; the prior fix-round switched it to hourly because `agentLogs` (~17k rows/day under fake-heartbeat) and `pricePoint` (~5 inserts/sec from the indexer cycle) would saturate the daily budget. Stale gemini summaries on this PR still refer to a "daily cron" — current code is hourly.
- **Per-mutation isolation:** `purgeStaleData` is now an **orchestrator** that schedules one internal mutation per retention-managed table via `ctx.scheduler.runAfter(0, ...)`. Each scheduled mutation gets its own per-mutation op budget (~16k document ops), so the worst-case op count is bounded by the per-table budget regardless of how many retention-managed tables exist. (Fix-round 2 / cloud-review.)
- **`worldSnapshot` IS purged** (preserve-latest semantics — same as `marketState`). `worldSnapshot` is INSERTed (not patched in-place) by heartbeat + indexer, so without purging it grows unboundedly. The preserve-latest rule keeps the newest snapshot intact so resume-from-pause still works. (The original PR description said `worldSnapshot` was "intentionally skipped" — that direction was reversed in the prior fix-round on Liam's call.)

## Retention tables

**Time-window (delete everything older than `RETENTION_HOURS`):**
chainEvents, agentLogs, whispers, orchEvents, humanSteeringMessages, pricePoint, tickHistory, memoryEvents, goldTxReceipts, inftTransfers

**Preserve-latest-per-group (keep last-N-hours + newest row per group key):**
clanView (by clanId), banditView (by bandit id), marketState (singleton), worldSnapshot (singleton)

## Config knobs
`apps/server/convex/retention.config.ts`:
- `RETENTION_HOURS = 36`
- `PURGE_BATCH_SIZE = 5000` (per-table per-run cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
