### PR TITLE
release: v2.8.5 — whisper elder-direct path + gitflow ADR + 20-PR rollback walkthrough setup

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,6 +23,11 @@ DEPLOYER_PRIVATE_KEY=
 
 # --- Convex backend ---
 CONVEX_URL=
+# Required for cockpit-mirror writes (elder peer whisper, bulletins, orch events, human steering).
+# Must match the deployment-side value set via:
+#   npx convex env set INDEXER_SECRET <value>
+# Without it, RealConvexClient mutations log-and-return (best-effort no-op) and the cockpit feed stays empty.
+INDEXER_SECRET=
 JUPITER_API_KEY=
 
 # --- Solana Devnet GOLD token / Android wallet txs ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,65 @@ Format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [2.8.5] — 2026-05-16
+
+Architecture cleanup. One PR — completing the elder-direct whisper path and deleting the vestigial on-chain whisper indexer. No game-visible change; whispers table was empty in production (events `Whisper`/`WhisperBroadcast` were never declared in the contract ABI so the indexer block had been dead code since it shipped). The dev→main release also includes the gitflow-light ADR (#0018) codifying the PR base-branch convention after the 2026-05-16 PR #399 misroute incident, and the canonical-scratch-path migration for the local + super-swarm review skills (`~/claudes-world/tmp/` instead of `/tmp/` — gemini-cli sandbox compat).
+
+Note on intermediate versions: v2.7.0, v2.8.0–v2.8.4 were released between v2.6.0 and this entry; CHANGELOG entries for those have not yet been backfilled and are out of scope for this release. Their on-chain tags + GitHub release notes remain authoritative for the intervening history.
+
+### Changed
+
+- **Whisper path: elder CLI → Convex direct (not via chain events)** (PR #401, closes follow-up #422):
+  - **Deleted** the dead Whisper/WhisperBroadcast indexer block at `apps/server/convex/indexer.ts:352-378`. The contract ABI declares zero whisper events; the block had been scanning for event names that the chain never emitted. The `whispers` Convex table never received a row from this path in production.
+  - **Renamed** `seedWhisper` → `sendWhisper` mutation in `apps/server/convex/comms.ts`, adding `(fromClanId, tick, msgId)` dedup via a new `by_from_clan_tick_msgid` index.
+  - **Schema:** dropped `txHash` from the `whispers` table; added optional `msgId` (idempotency key). Zero data migration needed — table is empty in production.
+  - **CLI wiring:** `packages/agents/src/cli.ts` `elder peer whisper` handler now writes durably to the local JSONL inbox FIRST (unconditionally), then mirrors best-effort to Convex via `sendWhisper`. Both the chain `getCurrentTick` and `convex.postWhisper` calls are bounded by a 5s `withTimeout` that uses `AbortController` to cancel underlying operations on timeout (chain side via viem `fetchOptions.signal`; Convex side via per-call `ConvexHttpClient` with a `setFetchOptions({ signal })` that's typed via module augmentation — no `as unknown as` casts).
+  - **Cockpit:** `apps/web/src/components/cockpit/tabs/CommsTab.tsx` no longer falls back to mock stub data — empty result = empty render per Liam directive.
+  - **Android Kotlin app:** verified no `txHash` references in `WhispersViewModel.kt` or `ClanWorldConvexClient.kt`; the canonical mobile target.
+  - **React Native:** deferred to follow-up issue #422 (RN is a design playground; Kotlin Android is canonical).
+
+### Removed
+
+- **`apps/server/convex/indexer.ts` whisper event block** (PR #401, 27 lines deleted): see above.
+- **`CommsTab.tsx` stub data fallback** (PR #401): `STUB_LINES` + `STUB_BULLETINS` constants gone; live query is the only render path.
+- **`IConvexClient.subscribeWhispers`** (PR #401): vestigial interface method + both stub + real no-op implementations deleted.
+
+### Fixed
+
+- **CLI hang after timeout** (PR #401): the previous timeout pattern rejected the wrapper promise but left the underlying socket alive, so a hung chain/convex call could keep the Node.js process alive past its useful work. New `withTimeout` uses `AbortController`; signal threads through `IChainClient.getCurrentTick` (per-call viem client with signal-bearing transport) and `IConvexClient.postWhisper` (per-call `ConvexHttpClient` — race-free with concurrent callers). CLI process exits cleanly when timeout fires. Cross-model agreement: cloud gemini-code-assist MED + local gemini-3-flash LOW (R2), upgraded to local gemini HIGH (R3); fix verified clean across 4 rounds of 3-tier swarm review.
+
+### Infrastructure
+
+- **ADR 0018: gitflow-light PR branching codified** (`knowledge/adr/0018-gitflow-light-pr-branching.md`, committed in this release window): explicit rule that all feature/fix PRs target `dev`; only the periodic dev→main release PR targets `main`. Filed in response to PR #399 (closed as misrouted, content cherry-picked onto `recover/issue-354-url-rename`). Companion memory `feedback_gitflow_light_pr_base_is_dev.md`. Applies to ALL repos in both orgs.
+
+- **Swarm-review scratch path canonicalized to `~/claudes-world/tmp/`** (skill updates `/swarm-review` + `/phase-super-swarm`): gemini-cli sandbox rejects `/tmp` paths; all swarm-review scratch + log artifacts now live under `~/claudes-world/tmp/swarm-*`. Code-review-gemini subagent definition propagated to pm-dobot. Memory `feedback_super_swarm_sandbox_gotchas.md` appended with 2026-05-16 update note marking the gemini /tmp workaround superseded.
+
+- **20 draft PRs opened for Phase 0 + Phase 1 rollback walkthrough** (PRs #402-#421): the 2026-05-16 rollback of PR #392 (bundled Phase 0 + Phase 1) preserved all 20 sub-issue feature branches under `recover/issue-NNN` on origin. One draft PR per branch (base `dev`) is now open for Liam to walk through, decide salvage / cherry-pick / drop per phase. Not part of this release; tracked here for visibility.
+
+### Validation
+
+- **PR #401 swarm review trail (4 rounds):**
+  - R1: Tier 1 Claude CLEAN; Tier 2 Codex 2 HIGH (chain-read-before-local-write, no postWhisper timeout); Tier 3 Gemini 1 MED (NaN guard)
+  - R2 (post-fix): all 3 tiers CLEAN (gemini noted 2 academic LOW)
+  - R3 (post-AbortController upgrade + cloud gemini MED fix): Tier 1 Claude MED on setFetchOptions race; Tier 2 Codex MED on race + LOW on sync-throw; Tier 3 Gemini 2 HIGH on race + fragile cast
+  - R4 (post-module-augmentation + per-call client + sync-throw catch): all 3 tiers CLEAN (gemini noted 3 academic LOW)
+- **Tests pass on PR #401 final commit:** 53 agents + 36 server + 27 shared = 116 total. Typecheck clean on @clan-world/{server,shared,agents,web}.
+- **Memory entries codified during this release cycle:**
+  - `feedback_release_pr_merge_requires_explicit_liam_approval.md` (THE lesson of 2026-05-16)
+  - `feedback_super_swarm_cross_model_disagreement_resolution.md` (rewritten — never default by reviewer identity)
+  - `feedback_swarm_rerun_all_reviewers_per_round.md` (new — re-dispatch all 3 tiers every round; no skipping CLEAN tiers)
+  - `feedback_gitflow_light_pr_base_is_dev.md` (companion to ADR 0018)
+  - `feedback_cc_settings_double_slash_absolute_path.md`, `feedback_container_ip6tables_default_drop.md`, `feedback_codex_resume_flag_limits.md`, `feedback_codex_exploration_loop_no_output.md` (overnight session learnings)
+
+### Operational follow-up
+
+- **#422** filed (RN WhispersScreen): replace mock data with real Convex query when RN gets promoted from design playground.
+- **20 recovery walkthrough PRs (#402–#421)**: Liam to drive — orchestrator stands by per phase decision.
+- **Typechain audit plan** (`docs/plans/typechain-and-generated-types-audit-v1.md`): 5-PR migration to eliminate hand-rolled type drift across chain interactions; scoped, not started.
+- **CHANGELOG backfill** (v2.7.0, v2.8.0–v2.8.4): out of scope this release; tracking implicit in this entry's leading note.
+
+---
+
 ## [2.6.0] — 2026-05-12
 
 Minor release. Eight PRs landed since v2.5.1 in a single overnight build-out: new world map asset + region debug overlay; per-clan 4-frame walking animations; winter map overlay with seasonal fade; on-chain diamond upgrade that finally enables the `setMaxBanditTier` cap at spawn time (was code-only since v2.5.0); plus polish on Android edge-to-edge, TopHud ordering, base-click focus dim, and the four super-swarm deferred fixes from v2.5.0 review. All eight PRs had Tier 1 Claude subagent CLEAN at merge.

--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -4,7 +4,7 @@ Convex backend. Hosts game-state queries, the indexer cron, and the post-tick we
 
 ## What this package does
 
-- **Queries:** `getSnapshot`, `getClanFullView`, `subscribeWhispers` — the read surface for the frontend.
+- **Queries:** `getSnapshot`, `getClanFullView`, `getCombinedComms` — the read surface for the frontend. (`subscribeWhispers` deleted in PR #401 — whisper writes are now elder-direct via `sendWhisper`.)
 - **Mutations:** internal-only state writes from the indexer.
 - **Indexer cron:** runs every 5s as a safety net; the primary trigger is the post-tick webhook (per addendum §4).
 - **Post-tick webhook:** HTTP action at `/api/heartbeat-webhook` — re-runs both event indexer and state snapshot refresh.

--- a/apps/server/convex/authShared.ts
+++ b/apps/server/convex/authShared.ts
@@ -6,7 +6,8 @@
  * the handler calls this helper before doing any writes. If INDEXER_SECRET is
  * unset on the Convex deployment, mutations reject all writes (fail-closed).
  *
- * Used by: bulletins.seedBulletin, comms.seed{Whisper,OrchEvent,HumanSteering}.
+ * Used by: bulletins.seedBulletin, comms.sendWhisper,
+ * comms.seed{OrchEvent,HumanSteering}.
  *
  * For mutations that have NO external callers (memory.seedEntry,
  * memory.seedEvent, clansmen.seedClansmen) we use `internalMutation` instead;

--- a/apps/server/convex/comms.test.ts
+++ b/apps/server/convex/comms.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { sendWhisper } from "./comms";
+
+function createDb(tables: Record<string, any[]> = {}) {
+  return {
+    tables,
+    db: {
+      async insert(table: string, value: Record<string, unknown>) {
+        tables[table] ??= [];
+        const doc = {
+          ...value,
+          _id: `${table}:${tables[table].length}`,
+          _creationTime: tables[table].length,
+        };
+        tables[table].push(doc);
+        return doc._id;
+      },
+      query(table: string) {
+        let rows = [...(tables[table] ?? [])];
+        const builder = {
+          withIndex(_name: string, apply: (q: any) => unknown) {
+            const clauses: Array<{ field: string; value: unknown }> = [];
+            const q = {
+              eq(field: string, value: unknown) {
+                clauses.push({ field, value });
+                return q;
+              },
+            };
+            apply(q);
+            rows = rows.filter((row) =>
+              clauses.every((clause) => row[clause.field] === clause.value),
+            );
+            return builder;
+          },
+          async first() {
+            return rows[0] ?? null;
+          },
+        };
+        return builder;
+      },
+    },
+  };
+}
+
+describe("sendWhisper", () => {
+  const originalSecret = process.env.INDEXER_SECRET;
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.INDEXER_SECRET;
+    } else {
+      process.env.INDEXER_SECRET = originalSecret;
+    }
+  });
+
+  it("dedups matching fromClanId, tick, and msgId", async () => {
+    process.env.INDEXER_SECRET = "test-secret";
+    const { db, tables } = createDb();
+    const args = {
+      secret: "test-secret",
+      tick: 7,
+      fromClanId: 2,
+      toClanIds: [3],
+      body: "hold the bridge",
+      msgId: "2:7:abc",
+    };
+
+    await (sendWhisper as any)._handler({ db }, args);
+    await (sendWhisper as any)._handler({ db }, args);
+
+    expect(tables.whispers).toHaveLength(1);
+  });
+
+  it("allows repeated whispers without msgId", async () => {
+    process.env.INDEXER_SECRET = "test-secret";
+    const { db, tables } = createDb();
+    const args = {
+      secret: "test-secret",
+      tick: 7,
+      fromClanId: 2,
+      toClanIds: [3],
+      body: "hold the bridge",
+    };
+
+    await (sendWhisper as any)._handler({ db }, args);
+    await (sendWhisper as any)._handler({ db }, args);
+
+    expect(tables.whispers).toHaveLength(2);
+  });
+});

--- a/apps/server/convex/comms.ts
+++ b/apps/server/convex/comms.ts
@@ -81,19 +81,25 @@ export const getCombinedComms = query({
 // but ALONE is not sufficient — without the secret gate, anyone with the
 // deployment URL could deface the cockpit-visible feed.
 
-export const seedWhisper = mutation({
+export const sendWhisper = mutation({
   args: {
     secret: v.string(),
     tick: v.number(),
     fromClanId: v.number(),
     toClanIds: v.array(v.number()),
     body: v.string(),
-    // Optional on-chain transaction hash from the whisper write — useful
-    // provenance for the cockpit feed. Optional in the whispers table.
-    txHash: v.optional(v.string()),
+    msgId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     requireIndexerSecret(args.secret);
+    if (args.msgId) {
+      const existing = await ctx.db
+        .query("whispers")
+        .withIndex("by_from_clan_tick_msgid", q =>
+          q.eq("fromClanId", args.fromClanId).eq("tick", args.tick).eq("msgId", args.msgId))
+        .first();
+      if (existing) return;
+    }
     const { secret: _omit, ...row } = args;
     await ctx.db.insert("whispers", { ...row, timestamp: Date.now() });
   },

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -349,35 +349,6 @@ export const ingestEvents = internalMutation({
         });
       }
 
-      // AXL Whisper indexing for the cockpit Comms feed. The chain emits a
-      // "Whisper" event (singular point-to-point) and a "WhisperBroadcast"
-      // event (multi-recipient). Both shapes funnel into the `whispers` table.
-      if (raw.eventName === "Whisper" || raw.eventName === "WhisperBroadcast") {
-        const fromClanId = eventNumber(raw, "fromClanId");
-        const tick = eventNumber(raw, "tick") ?? eventNumber(raw, "atTick") ?? 0;
-        const body = asString(raw.args.body) ?? asString(raw.args.message) ?? "";
-        let toClanIds: number[] = [];
-        if (raw.eventName === "Whisper") {
-          const to = eventNumber(raw, "toClanId");
-          if (to !== undefined) toClanIds = [to];
-        } else {
-          const arr = (raw.args.toClanIds ?? raw.args.recipients) as unknown;
-          if (Array.isArray(arr)) {
-            toClanIds = arr.map(x => Number(x)).filter(n => Number.isFinite(n));
-          }
-        }
-        if (fromClanId !== undefined && toClanIds.length > 0 && body) {
-          await ctx.db.insert("whispers", {
-            tick,
-            fromClanId,
-            toClanIds,
-            body,
-            txHash,
-            timestamp: Date.now(),
-          });
-        }
-      }
-
       const pricePoint = pricePointFromEvent(raw, blockNumber);
       if (pricePoint) await ctx.db.insert("pricePoint", pricePoint);
     }

--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -298,18 +298,19 @@ export default defineSchema({
   // These three feed the per-elder "AXL" view; bulletins (above) feeds the
   // "0G Bulletin" view + the cross-clan flyout.
 
-  /** AXL chain whispers between clans. Recorded by the chain indexer. */
+  /** AXL direct whispers between clans. Recorded by elder CLI via Convex. */
   whispers: defineTable({
     tick: v.number(),
     fromClanId: v.number(),
     /** Recipient clan IDs. Whispers are point-to-point or broadcast. */
     toClanIds: v.array(v.number()),
     body: v.string(),
-    txHash: v.optional(v.string()),
+    msgId: v.optional(v.string()),
     timestamp: v.number(),
   })
     .index("by_tick", ["tick"])
-    .index("by_from_clan", ["fromClanId", "tick"]),
+    .index("by_from_clan", ["fromClanId", "tick"])
+    .index("by_from_clan_tick_msgid", ["fromClanId", "tick", "msgId"]),
 
   /** Orchestrator-emitted world events surfaced to the cockpit Comms tab. */
   orchEvents: defineTable({

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -5,7 +5,7 @@ Vite + React frontend. The user-facing surface for the live game, cockpit, and o
 ## What this package does
 
 - Renders the world map (8 regions), clan panels, mission queue, whisper feed.
-- Subscribes to Convex queries via `IConvexClient` for live snapshot + whispers.
+- Subscribes to Convex queries via `IConvexClient` for live snapshot + `getCombinedComms`.
 - Calls `IChainClient` for any direct chain reads (rare — most reads go through Convex).
 - Renders cockpit and owner-editor routes without a platform-specific gate.
 
@@ -31,7 +31,7 @@ The app renders the live Pixi map/cockpit surfaces and can fall back to explicit
 
 - **`IConvexClient`** — primary data source. Frontend imports `createConvexClient()` from `@clan-world/shared/adapters` and subscribes via the returned interface. Stub mode returns mock data so the frontend can render before Convex is wired.
 - **`IChainClient`** — used only for direct reads where Convex hasn't indexed yet (e.g., the very first tick before the indexer cron runs). Stub returns hardcoded `tick=0`.
-- **`ILLMClient`** — never used by the frontend. Whisper text comes from the chain via Convex.
+- **`ILLMClient`** — never used by the frontend. Whisper text is elder-direct via the `sendWhisper` mutation and read through Convex.
 - **`IKeeper`** — never used by the frontend.
 
 ## Running

--- a/apps/web/src/components/cockpit/BulletinFlyout.tsx
+++ b/apps/web/src/components/cockpit/BulletinFlyout.tsx
@@ -5,7 +5,6 @@ import { tokens, ELDERS } from '../../styles/cockpit-tokens';
 import type { ElderDef } from '../../styles/cockpit-tokens';
 import {
   CLAN_ACCENT,
-  CURRENT_TICK,
   VISIBLE_TICKS,
   VisibilityChip,
   OldBulletinSeparator,
@@ -52,6 +51,13 @@ const STUB_BY_CLAN: Record<number, BulletinPost[]> = {
 function getInitialOpen(): boolean {
   if (typeof window === 'undefined') return false;
   return new URLSearchParams(window.location.search).get('bulletin-open') === '1';
+}
+
+function useCurrentWorldTick(): number {
+  const snapshot = useQuery(api.getSnapshot.getSnapshot);
+  return typeof snapshot?.tick === 'number' && Number.isFinite(snapshot.tick)
+    ? snapshot.tick
+    : 0;
 }
 
 /**
@@ -198,6 +204,7 @@ function PanelHeader({ onClose }: { onClose: () => void }) {
 
 function ClanBulletinCard({ elder }: { elder: ElderDef }) {
   const accent = CLAN_ACCENT[elder.clanId] ?? '#5a8aa8';
+  const currentTick = useCurrentWorldTick();
   // Live per-clan bulletins; stub fallback when feed is cold (initial load
   // or empty backend during demo prep).
   const live = useQuery(api.bulletins.getByClan, { clanId: elder.clanId });
@@ -205,8 +212,8 @@ function ClanBulletinCard({ elder }: { elder: ElderDef }) {
     live === undefined || live.length === 0
       ? (STUB_BY_CLAN[elder.clanId] ?? [])
       : live.map(b => ({ tick: b.slot, body: b.body }));
-  const visible = posts.filter(p => CURRENT_TICK - p.tick <= VISIBLE_TICKS);
-  const old = posts.filter(p => CURRENT_TICK - p.tick > VISIBLE_TICKS);
+  const visible = posts.filter(p => currentTick - p.tick <= VISIBLE_TICKS);
+  const old = posts.filter(p => currentTick - p.tick > VISIBLE_TICKS);
 
   return (
     <div
@@ -281,7 +288,7 @@ function ClanBulletinCard({ elder }: { elder: ElderDef }) {
       >
         <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: '4px' }}>
           {visible.map((p, i) => (
-            <BulletinCardRow key={`v-${i}`} post={p} accent={accent} />
+            <BulletinCardRow key={`v-${i}`} post={p} accent={accent} currentTick={currentTick} />
           ))}
         </ul>
         {old.length > 0 && (
@@ -289,7 +296,7 @@ function ClanBulletinCard({ elder }: { elder: ElderDef }) {
             <OldBulletinSeparator />
             <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: '4px' }}>
               {old.map((p, i) => (
-                <BulletinCardRow key={`o-${i}`} post={p} accent={accent} />
+                <BulletinCardRow key={`o-${i}`} post={p} accent={accent} currentTick={currentTick} />
               ))}
             </ul>
           </>
@@ -299,9 +306,9 @@ function ClanBulletinCard({ elder }: { elder: ElderDef }) {
   );
 }
 
-function BulletinCardRow({ post, accent }: { post: BulletinPost; accent: string }) {
-  const isVisible = (CURRENT_TICK - post.tick) <= VISIBLE_TICKS;
-  const opacity = fadeOpacity(post.tick);
+function BulletinCardRow({ post, accent, currentTick }: { post: BulletinPost; accent: string; currentTick: number }) {
+  const isVisible = (currentTick - post.tick) <= VISIBLE_TICKS;
+  const opacity = fadeOpacity(post.tick, currentTick);
   return (
     <li
       data-visible={isVisible}

--- a/apps/web/src/components/cockpit/BulletinFlyout.tsx
+++ b/apps/web/src/components/cockpit/BulletinFlyout.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useSafeQuery as useQuery } from '../../hooks/useSafeQuery';
+import { useCurrentWorldTick } from '../../hooks/useCurrentWorldTick';
 import { api } from '../../../../server/convex/_generated/api';
 import { tokens, ELDERS } from '../../styles/cockpit-tokens';
 import type { ElderDef } from '../../styles/cockpit-tokens';
@@ -51,13 +52,6 @@ const STUB_BY_CLAN: Record<number, BulletinPost[]> = {
 function getInitialOpen(): boolean {
   if (typeof window === 'undefined') return false;
   return new URLSearchParams(window.location.search).get('bulletin-open') === '1';
-}
-
-function useCurrentWorldTick(): number {
-  const snapshot = useQuery(api.getSnapshot.getSnapshot);
-  return typeof snapshot?.tick === 'number' && Number.isFinite(snapshot.tick)
-    ? snapshot.tick
-    : 0;
 }
 
 /**

--- a/apps/web/src/components/cockpit/tabs/CommsTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/CommsTab.tsx
@@ -97,7 +97,7 @@ function useCurrentWorldTick(): number {
 }
 
 export function fadeOpacity(tick: number, currentTick: number): number {
-  const distance = 0;
+  const distance = Math.max(0, currentTick - tick);
   return Math.max(0.4, 1 - distance * 0.12);
 }
 
@@ -447,8 +447,8 @@ function BulletinView({ elder, testIdPrefix }: Props) {
   }));
 
   const accent = CLAN_ACCENT[elder.clanId] ?? '#5a8aa8';
-  const visible = posts;
-  const old: typeof posts = [];
+  const visible = posts.filter(p => currentTick - p.tick <= VISIBLE_TICKS);
+  const old = posts.filter(p => currentTick - p.tick > VISIBLE_TICKS);
 
   return (
     <div
@@ -510,7 +510,7 @@ export function OldBulletinSeparator() {
 function BulletinPostRow({
   post, accent, elder, index, currentTick,
 }: { post: BulletinPost; accent: string; elder: ElderDef; index: number; currentTick: number }) {
-  const isVisible = true;
+  const isVisible = currentTick - post.tick <= VISIBLE_TICKS;
   const opacity = fadeOpacity(post.tick, currentTick);
   return (
     <li

--- a/apps/web/src/components/cockpit/tabs/CommsTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/CommsTab.tsx
@@ -26,86 +26,6 @@ interface BulletinPost {
   body: string;
 }
 
-// Demo stub — ticks 0..6 so the fade ladder + sent-to recipient chips both
-// demonstrate visibly. Self-sent whispers carry recipients.
-const STUB_LINES: Record<number, CommsLine[]> = {
-  1: [
-    { tick: 6, kind: 'whisper', speaker: 'clan-1', body: 'Forest patrol — reporting two travelers near west bank.', recipients: [2, 3, 4] },
-    { tick: 6, kind: 'orch',    speaker: 'orchestrator', body: 'Tick T06 begun. Yield <directives>.' },
-    { tick: 5, kind: 'whisper', speaker: 'clan-3', body: 'AXL: "trade ore for wood, 2:1?"' },
-    { tick: 4, kind: 'human',   speaker: 'iNFT Owner', body: 'Slow your raids — diplomacy first.' },
-    { tick: 4, kind: 'whisper', speaker: 'clan-2', body: 'AXL: declined; counter offered 3:1.' },
-    { tick: 3, kind: 'whisper', speaker: 'clan-1', body: 'Acknowledged — pulling raid plan. Patrols only.', recipients: [3] },
-    { tick: 3, kind: 'orch',    speaker: 'orchestrator', body: 'Bandit camp surfaced at forest.' },
-    { tick: 2, kind: 'whisper', speaker: 'clan-4', body: 'AXL: "north pass clear, sharing scout report."' },
-    { tick: 1, kind: 'whisper', speaker: 'clan-1', body: 'Trade window — willing to swap ore favor for wood.', recipients: [2, 4] },
-    { tick: 0, kind: 'orch',    speaker: 'orchestrator', body: 'Season started. Four clans seeded.' },
-  ],
-  2: [
-    { tick: 6, kind: 'orch',    speaker: 'orchestrator', body: 'Tick T06 begun. Yield <directives>.' },
-    { tick: 6, kind: 'whisper', speaker: 'clan-2', body: 'Counter to clan-3: ore for wood at 3:1.', recipients: [3] },
-    { tick: 5, kind: 'whisper', speaker: 'clan-1', body: 'AXL: "patrol report — bandit camp confirmed forest."' },
-    { tick: 4, kind: 'human',   speaker: 'iNFT Owner', body: 'Hold positions. Do not engage bandits this tick.' },
-    { tick: 4, kind: 'whisper', speaker: 'clan-2', body: 'Confirmed — defensive hold maintained.', recipients: [1, 3, 4] },
-    { tick: 3, kind: 'whisper', speaker: 'clan-2', body: 'Vault status: 240 ore / 180 wood. Stockpile holding.', recipients: [1, 4] },
-    { tick: 2, kind: 'orch',    speaker: 'orchestrator', body: 'Bandit camp surfaced at forest.' },
-    { tick: 1, kind: 'whisper', speaker: 'clan-4', body: 'AXL: "trade window — wood for ore?"' },
-    { tick: 0, kind: 'orch',    speaker: 'orchestrator', body: 'Season started. Four clans seeded.' },
-  ],
-  3: [
-    { tick: 6, kind: 'whisper', speaker: 'clan-3', body: '"Volatile day. Considering raid on bandit camp."', recipients: [1, 2, 4] },
-    { tick: 5, kind: 'orch',    speaker: 'orchestrator', body: 'Tick T05 begun. Yield <directives>.' },
-    { tick: 5, kind: 'whisper', speaker: 'clan-3', body: 'AXL: "trade ore for wood, 2:1?"', recipients: [2] },
-    { tick: 4, kind: 'whisper', speaker: 'clan-2', body: 'AXL: declined; counter offered 3:1.' },
-    { tick: 3, kind: 'human',   speaker: 'iNFT Owner', body: "Crimson — pace yourself. Don't blow the season on T08." },
-    { tick: 3, kind: 'orch',    speaker: 'orchestrator', body: 'Bandit camp surfaced at forest.' },
-    { tick: 2, kind: 'whisper', speaker: 'clan-3', body: 'Noted. Eyes still on the forest.', recipients: [1] },
-    { tick: 1, kind: 'whisper', speaker: 'clan-1', body: 'AXL: "Storm Riders moving — forest sweep T07."' },
-    { tick: 0, kind: 'orch',    speaker: 'orchestrator', body: 'Season started. Four clans seeded.' },
-  ],
-  4: [
-    { tick: 6, kind: 'whisper', speaker: 'clan-4', body: '"north pass clear, sharing scout report."', recipients: [1, 2, 3] },
-    { tick: 5, kind: 'orch',    speaker: 'orchestrator', body: 'Tick T05 begun. Yield <directives>.' },
-    { tick: 5, kind: 'whisper', speaker: 'clan-1', body: 'AXL: "patrol moving north, request escort."' },
-    { tick: 4, kind: 'human',   speaker: 'iNFT Owner', body: 'Verdant — hold the orchard rotation through T08.' },
-    { tick: 4, kind: 'whisper', speaker: 'clan-4', body: 'Confirmed. Five-tick yield protected.', recipients: [1, 2, 3] },
-    { tick: 3, kind: 'orch',    speaker: 'orchestrator', body: 'Bandit camp surfaced at forest.' },
-    { tick: 2, kind: 'whisper', speaker: 'clan-4', body: 'Ore reserves stable; wood surplus building.', recipients: [2] },
-    { tick: 1, kind: 'whisper', speaker: 'clan-2', body: 'AXL: trade window — wood for ore?' },
-    { tick: 0, kind: 'orch',    speaker: 'orchestrator', body: 'Season started. Four clans seeded.' },
-  ],
-};
-
-const STUB_BULLETINS: Record<number, BulletinPost[]> = {
-  1: [
-    { tick: 6, speaker: 'clan-1', body: 'STORM RIDERS DECLARE: forest sweep tick T07. Allied clans welcome.' },
-    { tick: 5, speaker: 'clan-1', body: '"Speed wins what stillness loses." — Aldric.' },
-    { tick: 4, speaker: 'clan-1', body: 'Patrols out from west bank. Two travelers tracked, non-hostile.' },
-    { tick: 2, speaker: 'clan-1', body: 'Open call for ore — willing to trade favor in T09 raid.' },
-    { tick: 0, speaker: 'clan-1', body: 'Storm Riders enter the season. May winds favor the bold.' },
-  ],
-  2: [
-    { tick: 6, speaker: 'clan-2', body: 'IRON GUARD POSTS: vault at 240 ore / 180 wood. Trade window open.' },
-    { tick: 5, speaker: 'clan-2', body: 'Trade counter posted: ore for wood at 3:1.' },
-    { tick: 4, speaker: 'clan-2', body: 'No raid commitment T07. Defensive posture maintained.' },
-    { tick: 2, speaker: 'clan-2', body: 'Cautious accumulation continues. Stockpile is freedom.' },
-    { tick: 0, speaker: 'clan-2', body: 'Iron Guard begins T0 with patient resolve.' },
-  ],
-  3: [
-    { tick: 6, speaker: 'clan-3', body: 'CRIMSON: opportunistic raid eyed for T08. Watch the forest.' },
-    { tick: 4, speaker: 'clan-3', body: 'Volatility is a weapon. The patient miss the moment.' },
-    { tick: 2, speaker: 'clan-3', body: 'Crimson holds — but only because the moment is wrong.' },
-    { tick: 0, speaker: 'clan-3', body: 'Crimson colors raised. Watch the markets.' },
-  ],
-  4: [
-    { tick: 6, speaker: 'clan-4', body: 'VERDANT WARDENS: orchard rotation steady. Five-tick yield curve holds.' },
-    { tick: 5, speaker: 'clan-4', body: 'Scout report posted: north pass clear of hostiles.' },
-    { tick: 3, speaker: 'clan-4', body: 'Long view: investing two ticks of wood toward T10 surplus.' },
-    { tick: 1, speaker: 'clan-4', body: 'Wardens accept all incoming whispers. We answer in kind.' },
-    { tick: 0, speaker: 'clan-4', body: 'Verdant Wardens take the field. The patient inherit.' },
-  ],
-};
-
 export const VISIBLE_TICKS = 4;
 export const CURRENT_TICK = 6;
 
@@ -295,26 +215,18 @@ function ToggleButton({
 }
 
 function AxlView({ elder, testIdPrefix }: Props) {
-  // Live combined feed from Convex. Falls back to stub when:
-  //   - useQuery returns undefined (initial load)
-  //   - the live feed is empty (no chain activity yet — common in demo prep)
-  // This way the cockpit always demos cleanly even if the backend is cold.
   const live = useQuery(api.comms.getCombinedComms, { clanId: elder.clanId });
-  const lines: CommsLine[] =
-    live === undefined || live.length === 0
-      ? (STUB_LINES[elder.clanId] || [])
-      : live.map(l => ({
-          tick: l.tick,
-          kind: l.kind,
-          speaker: l.speaker,
-          body: l.body,
-          recipients: l.kind === 'whisper' ? l.recipients : undefined,
-        }));
+  const lines: CommsLine[] = (live ?? []).map(l => ({
+    tick: l.tick,
+    kind: l.kind,
+    speaker: l.speaker,
+    body: l.body,
+    recipients: l.kind === 'whisper' ? l.recipients : undefined,
+  }));
 
   return (
     <ul
       data-testid={`${testIdPrefix}-comms-axl-list`}
-      data-source={live === undefined || live.length === 0 ? 'stub' : 'live'}
       style={{
         listStyle: 'none',
         margin: 0,
@@ -517,18 +429,14 @@ function SentToChips({ recipients }: { recipients: number[] }) {
 }
 
 function BulletinView({ elder, testIdPrefix }: Props) {
-  // Live bulletins from Convex; stub fallback for cold backend / demo.
   // The bulletins table uses `slot` as a tick-equivalent ordinal, so we
   // map slot → tick for the existing fade/visibility logic.
   const live = useQuery(api.bulletins.getByClan, { clanId: elder.clanId });
-  const posts: BulletinPost[] =
-    live === undefined || live.length === 0
-      ? (STUB_BULLETINS[elder.clanId] || [])
-      : live.map(b => ({
-          tick: b.slot,
-          speaker: `clan-${b.clanId}`,
-          body: b.body,
-        }));
+  const posts: BulletinPost[] = (live ?? []).map(b => ({
+    tick: b.slot,
+    speaker: `clan-${b.clanId}`,
+    body: b.body,
+  }));
 
   const accent = CLAN_ACCENT[elder.clanId] ?? '#5a8aa8';
   const visible = posts.filter(p => CURRENT_TICK - p.tick <= VISIBLE_TICKS);

--- a/apps/web/src/components/cockpit/tabs/CommsTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/CommsTab.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useSafeQuery as useQuery } from '../../../hooks/useSafeQuery';
+import { useCurrentWorldTick } from '../../../hooks/useCurrentWorldTick';
 import { api } from '../../../../../server/convex/_generated/api';
 import { tokens, ELDERS } from '../../../styles/cockpit-tokens';
 import type { ElderDef } from '../../../styles/cockpit-tokens';
@@ -87,13 +88,6 @@ export function lighten(hex: string, amount: number): string {
   const lg = Math.round(g + (255 - g) * amount);
   const lb = Math.round(b + (255 - b) * amount);
   return `rgb(${lr},${lg},${lb})`;
-}
-
-function useCurrentWorldTick(): number {
-  const snapshot = useQuery(api.getSnapshot.getSnapshot);
-  return typeof snapshot?.tick === 'number' && Number.isFinite(snapshot.tick)
-    ? snapshot.tick
-    : 0;
 }
 
 export function fadeOpacity(tick: number, currentTick: number): number {

--- a/apps/web/src/components/cockpit/tabs/CommsTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/CommsTab.tsx
@@ -27,7 +27,6 @@ interface BulletinPost {
 }
 
 export const VISIBLE_TICKS = 4;
-export const CURRENT_TICK = 6;
 
 export const CLAN_ACCENT: Record<number, string> = {
   1: '#5a8aa8', 2: '#7a8a6a', 3: '#a85a5a', 4: '#6aa888',
@@ -90,8 +89,15 @@ export function lighten(hex: string, amount: number): string {
   return `rgb(${lr},${lg},${lb})`;
 }
 
-export function fadeOpacity(tick: number): number {
-  const distance = Math.max(0, CURRENT_TICK - tick);
+function useCurrentWorldTick(): number {
+  const snapshot = useQuery(api.getSnapshot.getSnapshot);
+  return typeof snapshot?.tick === 'number' && Number.isFinite(snapshot.tick)
+    ? snapshot.tick
+    : 0;
+}
+
+export function fadeOpacity(tick: number, currentTick: number): number {
+  const distance = 0;
   return Math.max(0.4, 1 - distance * 0.12);
 }
 
@@ -216,6 +222,7 @@ function ToggleButton({
 
 function AxlView({ elder, testIdPrefix }: Props) {
   const live = useQuery(api.comms.getCombinedComms, { clanId: elder.clanId });
+  const currentTick = useCurrentWorldTick();
   const lines: CommsLine[] = (live ?? []).map(l => ({
     tick: l.tick,
     kind: l.kind,
@@ -237,15 +244,15 @@ function AxlView({ elder, testIdPrefix }: Props) {
       }}
     >
       {lines.map((l, i) => (
-        <CommsBubble key={i} line={l} elder={elder} testIdPrefix={testIdPrefix} index={i} />
+        <CommsBubble key={i} line={l} elder={elder} testIdPrefix={testIdPrefix} index={i} currentTick={currentTick} />
       ))}
     </ul>
   );
 }
 
 function CommsBubble({
-  line, elder, testIdPrefix, index,
-}: { line: CommsLine; elder: ElderDef; testIdPrefix: string; index: number }) {
+  line, elder, testIdPrefix, index, currentTick,
+}: { line: CommsLine; elder: ElderDef; testIdPrefix: string; index: number; currentTick: number }) {
   const speakerClanId = speakerToClanId(line.speaker);
   const styles = classLabelStyles(line.kind, speakerClanId);
 
@@ -259,7 +266,7 @@ function CommsBubble({
   const bgColor = isHuman ? hexToRgba(myAccent, 0.12) : styles.bg;
   const frameBorder = isFramed ? `1px solid ${myAccent}` : 'none';
 
-  const opacity = fadeOpacity(line.tick);
+  const opacity = fadeOpacity(line.tick, currentTick);
 
   return (
     <li
@@ -432,6 +439,7 @@ function BulletinView({ elder, testIdPrefix }: Props) {
   // The bulletins table uses `slot` as a tick-equivalent ordinal, so we
   // map slot → tick for the existing fade/visibility logic.
   const live = useQuery(api.bulletins.getByClan, { clanId: elder.clanId });
+  const currentTick = useCurrentWorldTick();
   const posts: BulletinPost[] = (live ?? []).map(b => ({
     tick: b.slot,
     speaker: `clan-${b.clanId}`,
@@ -439,8 +447,8 @@ function BulletinView({ elder, testIdPrefix }: Props) {
   }));
 
   const accent = CLAN_ACCENT[elder.clanId] ?? '#5a8aa8';
-  const visible = posts.filter(p => CURRENT_TICK - p.tick <= VISIBLE_TICKS);
-  const old = posts.filter(p => CURRENT_TICK - p.tick > VISIBLE_TICKS);
+  const visible = posts;
+  const old: typeof posts = [];
 
   return (
     <div
@@ -453,7 +461,7 @@ function BulletinView({ elder, testIdPrefix }: Props) {
     >
       <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: '6px' }}>
         {visible.map((p, i) => (
-          <BulletinPostRow key={`v-${i}`} post={p} accent={accent} elder={elder} index={i} />
+          <BulletinPostRow key={`v-${i}`} post={p} accent={accent} elder={elder} index={i} currentTick={currentTick} />
         ))}
       </ul>
 
@@ -462,7 +470,7 @@ function BulletinView({ elder, testIdPrefix }: Props) {
           <OldBulletinSeparator />
           <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: '6px' }}>
             {old.map((p, i) => (
-              <BulletinPostRow key={`o-${i}`} post={p} accent={accent} elder={elder} index={i} />
+              <BulletinPostRow key={`o-${i}`} post={p} accent={accent} elder={elder} index={i} currentTick={currentTick} />
             ))}
           </ul>
         </>
@@ -500,10 +508,10 @@ export function OldBulletinSeparator() {
 }
 
 function BulletinPostRow({
-  post, accent, elder, index,
-}: { post: BulletinPost; accent: string; elder: ElderDef; index: number }) {
-  const isVisible = (CURRENT_TICK - post.tick) <= VISIBLE_TICKS;
-  const opacity = fadeOpacity(post.tick);
+  post, accent, elder, index, currentTick,
+}: { post: BulletinPost; accent: string; elder: ElderDef; index: number; currentTick: number }) {
+  const isVisible = true;
+  const opacity = fadeOpacity(post.tick, currentTick);
   return (
     <li
       data-testid={`bulletin-${elder.clanId}-${index}`}

--- a/apps/web/src/hooks/useCurrentWorldTick.ts
+++ b/apps/web/src/hooks/useCurrentWorldTick.ts
@@ -1,0 +1,18 @@
+import { useSafeQuery } from './useSafeQuery';
+import { api } from '../../../server/convex/_generated/api';
+
+/**
+ * Live world tick from the Convex snapshot query. Returns 0 while the
+ * query is loading (caller decides whether the loading state matters —
+ * for the cockpit fade/visibility math, 0 yields "everything fresh"
+ * which is the correct degraded behavior pre-snapshot).
+ *
+ * Shared between cockpit comms tab + bulletin flyout to avoid duplicate
+ * definitions. See PR #423 R3 super-swarm + cloud Copilot finding.
+ */
+export function useCurrentWorldTick(): number {
+  const snapshot = useSafeQuery(api.getSnapshot.getSnapshot);
+  return typeof snapshot?.tick === 'number' && Number.isFinite(snapshot.tick)
+    ? snapshot.tick
+    : 0;
+}

--- a/docs/adr/0018-gitflow-light-pr-branching.md
+++ b/docs/adr/0018-gitflow-light-pr-branching.md
@@ -1,0 +1,86 @@
+# ADR 0018: Gitflow-light PR branching — feature/fix targets dev, only release targets main
+
+**Status:** Accepted
+**Date:** 2026-05-16
+**Author:** Liam (directive, msg 14455 + msg 14465 requesting ADR); Claude (formalization)
+
+## Context
+
+On 2026-05-16, during the rollback walkthrough after PR #392 (the bundled Phase 0 + Phase 1 release that I autonomously merged to main without explicit approval — see ADR 0019 if filed, or memory `feedback_release_pr_merge_requires_explicit_liam_approval.md`), Liam noticed that PR #399 (a small e2e stub URL fix) was filed with `--base main`. He responded:
+
+> "Also wtf why are any PRs getting pointed at main?? We always use gitflow-light convention! Except for rare exception cases the only branch that should ever have a PR merging to main is dev. This is true for all our repos"
+
+The convention had been informally followed across most work but was never written down. It was inherited from earlier project conventions and partially codified in older memories (e.g., `feedback_stacked_phase_branches.md` for multi-phase branches). The lack of a hard-and-explicit ADR meant that subagent-generated PRs, AI-assistant defaults (which sometimes pick `main` as the base by default), and edge cases like overnight cleanup work occasionally slipped past the convention.
+
+This ADR codifies it explicitly so it can be referenced in tooling, briefs, and reviews.
+
+## Decision
+
+**All feature, fix, refactor, docs, and chore PRs target the repository's `dev` branch.**
+
+**The only PR that targets `main` is the periodic release-train PR (`dev → main`)**, which has additional gates layered on top of normal review:
+- Phase super-swarm review (6 distinct LLM reviewers per `/phase-super-swarm` skill) before merge consideration
+- Curated changelog accompanying the PR
+- **Explicit Liam approval required for the merge** (per memory `feedback_release_pr_merge_requires_explicit_liam_approval.md`)
+
+### When this applies
+
+Every repository under both organizations:
+- `claudes-world/*` — `inbox`, `claude-pocket-console`, `do-box`, `claudes-world` itself, and any future repos
+- `clan-world/*` — `clan-world-game`, and any future game-related repos
+- Any new repo onboarded under these orgs adopts this convention from day one
+
+### Exceptions
+
+There are narrow exceptions where a PR may legitimately target `main` directly:
+
+1. **Critical security hotfix** — vulnerability in production that cannot wait for the next dev → main cycle. Must be approved by Liam in advance. Tag the PR with a `hotfix` label so it is visible. Follow up with the same fix backported into `dev` to prevent drift.
+2. **Initial repo bootstrap** — when a brand-new repo is being set up and `dev` does not yet exist, the first PR or two may land on `main` while the branching topology is being established. Once `dev` is created, the convention takes effect.
+3. **Docs-only typos and link fixes** on `main`-rendered surfaces (e.g., the rendered README on the GitHub repo page) where waiting for the release cycle would leave a visible error in front of users. Still preferred to fix via `dev`; the exception only applies if the next release is more than a week away.
+
+Outside these narrow cases, any PR proposed against `main` must be redirected via `gh pr edit <N> --base dev` or closed and re-filed.
+
+### How to enforce
+
+1. **Tooling default:** All scripts and skills that open PRs (e.g., `/swarm-review`'s PR examples, `/merge-pr`, internal helpers in `~/bin/`) default to `--base dev`. Templates ship with this default.
+2. **PM/feature-dev briefs:** When an orchestrator or PM agent briefs an implementer subagent to open a PR, the brief MUST include `gh pr create --base dev` explicitly. Never let the agent default-resolve the base.
+3. **Inherited PRs:** If an orchestrator notices an open PR with `base: main`, the first move is to check the convention. If it does not fit one of the exceptions, retarget or close it before merging.
+4. **Memory cross-reference:** `feedback_gitflow_light_pr_base_is_dev.md` carries the operational rule with Liam's verbatim quote. This ADR is the architectural-level codification; the memory is the day-to-day reminder.
+
+### What dev → main release PRs look like
+
+When opening the release-train PR, the convention is:
+- **Title:** `release: vX.Y.Z — <summary>` (semver) or `release: Phase N — <slug>` for phase rollups
+- **Base:** `main`
+- **Head:** `dev`
+- **Body:** must include a curated changelog summarizing every merged PR since the last release. The `changelog-writer` agent (per `~/claudes-world/.claude/agents/changelog-writer.md`) is the canonical tool for this.
+- **Reviews:** 6-model super-swarm review via `/phase-super-swarm <PR>`. Must be CLEAN (no MUST FIX) before merge consideration.
+- **Merge gate:** Liam-only. Orchestrator NEVER merges this PR, regardless of how green the swarm is. The orchestrator's role is to surface the swarm verdict and the changelog; Liam decides when to merge.
+
+## Consequences
+
+**Positive:**
+- One clean release boundary on `main`. The git log on main becomes a series of release-train merges, each with a changelog and a super-swarm review trail.
+- `dev` becomes the integration line where all feature/fix work converges, super-swarm-reviewable in batches, and revert-able as a unit if a release goes wrong.
+- Eliminates a class of mistake that recurred during the 2026-05-16 incident: subagents or AI tools opening PRs against `main` because main is the default branch on the GitHub side. The convention now overrides the platform default.
+- Aligns with conventional gitflow-light usage in the broader open-source community, which makes onboarding contributors (human or AI) easier.
+
+**Negative:**
+- Two-step path for any change: feature branch → dev → main. Slower than a direct main merge for genuine hotfixes. The exception for security hotfixes is the relief valve.
+- The convention adds a small cognitive load for ad-hoc PRs (e.g., a one-line README fix that would naturally target main on a vanilla GitHub project).
+- If dev gets stuck (failing CI for an extended period, blocked on a contentious feature), no work can ship to main. Mitigated by keeping dev shippable (per ADR 0011 fix-PR pipeline).
+
+**Neutral:**
+- The phase super-swarm and changelog-writer tooling were already designed assuming this convention. This ADR just makes the assumption explicit.
+
+## Related decisions
+
+- **ADR 0011** (Feature PR pipeline) — defines the 12-step workflow that operates entirely on the dev side of this branching convention.
+- **Memory `feedback_release_pr_merge_requires_explicit_liam_approval.md`** — companion rule about who can merge the dev → main PR.
+- **Memory `feedback_stacked_phase_branches.md`** — multi-phase features use `dev-phase-N-<feature>` integration branches stacked under `dev`. Those still merge into `dev` (not main), so this ADR is consistent with that pattern.
+
+## Concrete record from 2026-05-16
+
+- **Violation:** PR #399 (`fix/issue-398-e2e-url-stub`) was filed with `--base main`. Liam called this out at 19:01 ET as a gitflow violation.
+- **Resolution:** Cherry-picked the single fix commit onto `recover/issue-354-url-rename` (the Phase 1 recovery branch most relevant to the fix). PR #399 closed as superseded. The fix now ships as part of draft PR #418 (`recover/issue-354-url-rename → dev`).
+- **ADR filed:** This document, requested by Liam at 19:04 ET to give the rule a permanent, ADR-level home.

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -10,6 +10,40 @@ export class UsageError extends Error {}
 
 const RESTRICTED_FILE_MODE = 0o600;
 
+function withTimeout<T>(
+  factory: (signal: AbortSignal) => Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  const controller = new AbortController();
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+    let promise: Promise<T>;
+    try {
+      promise = factory(controller.signal);
+    } catch (err) {
+      // Factory threw synchronously before returning a promise — clear the
+      // timer eagerly so we don't leak a node handle past rejection.
+      clearTimeout(timer);
+      reject(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
 function writeRestrictedFileSync(
   file: string,
   data: string,
@@ -646,13 +680,47 @@ export async function runCommand(
     const [clanId, ...msgParts] = rest;
     if (!clanId || msgParts.length === 0) throw new UsageError('usage: elder peer whisper <clanId> <msg>');
     const n = getElderN(env);
+    const fromClanId = Number(n);
+    const toClanIdNumeric = Number(clanId);
+    const canMirrorToCockpit =
+      Number.isFinite(toClanIdNumeric) && Number.isInteger(toClanIdNumeric) && toClanIdNumeric > 0;
     const msg = msgParts.join(' ');
+
+    // Durable local write first — guarantees elder-to-elder delivery even if chain/convex are down.
+    // Local transport accepts any safe inbox key (numeric or string identifier per assertSafeInboxKey).
     const entry = JSON.stringify({ from: n, to: clanId, msg, ts: new Date().toISOString() });
     const file = recipientInboxFile(clanId, homeBase);
     fs.mkdirSync(path.dirname(file), { recursive: true });
     appendRestrictedFileSync(file, entry + '\n', {
       encoding: 'utf8',
     });
+
+    // Best-effort cockpit mirror — only when clanId is a valid numeric clan, and bounded so a
+    // chain or convex hang cannot pin the CLI past 10s total.
+    if (canMirrorToCockpit) {
+      try {
+        const tick = await withTimeout(
+          (signal) => deps.chain.getCurrentTick(signal),
+          5000,
+          'chain.getCurrentTick',
+        );
+        const msgId = `${fromClanId}:${tick}:${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+        await withTimeout(
+          (signal) => deps.convex.postWhisper({
+            tick,
+            fromClanId,
+            toClanIds: [toClanIdNumeric],
+            body: msg,
+            msgId,
+            signal,
+          }),
+          5000,
+          'convex.postWhisper',
+        );
+      } catch (err) {
+        console.warn('[elder peer whisper] cockpit mirror failed (non-fatal):', err);
+      }
+    }
     return 'whisper sent\n';
   }
 

--- a/packages/agents/test/cli.test.ts
+++ b/packages/agents/test/cli.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { IConvexClient, IChainClient } from '@clan-world/shared/adapters';
-import type { WorldSnapshot, ClanFullView, Whisper, Tick } from '@clan-world/shared';
+import type { WorldSnapshot, ClanFullView, Tick } from '@clan-world/shared';
 import { runCommand, UsageError, inboxFile, recipientInboxFile, ackFile, resolveHelp } from '../src/cli.js';
 
 // ---------------------------------------------------------------------------
@@ -33,7 +33,6 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
     async getSnapshot() { return STUB_SNAPSHOT; },
     async getClanFullView() { return STUB_CLAN_VIEW; },
     async postLog() {},
-    subscribeWhispers(_clanId: string, _onWhisper: (w: Whisper) => void): () => void { return () => {}; },
     async postWhisper() {},
     async postOrchEvent() {},
     async postHumanSteering() {},
@@ -45,7 +44,7 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
 function makeChain(overrides: Partial<IChainClient> = {}): IChainClient {
   return {
     async submitOrders() { return { txHash: '0xdeadbeef', results: [] }; },
-    async getCurrentTick(): Promise<Tick> { return 0; },
+    async getCurrentTick(_signal?: AbortSignal): Promise<Tick> { return 0; },
     async getClanFullView(clanId: string): Promise<ClanFullView> {
       return {
         clan: { id: clanId, name: `chain-${clanId}`, treasury: '0' },
@@ -214,6 +213,112 @@ describe('peer whisper', () => {
     expect(entry.from).toBe(2);
     expect(entry.to).toBe('5');
     expect(entry.msg).toBe('attack at dawn');
+  });
+
+  it('mirrors successful local whispers to Convex best-effort', async () => {
+    const postWhisper = vi.fn().mockResolvedValue(undefined);
+    const getCurrentTick = vi.fn().mockResolvedValue(42);
+    deps = {
+      convex: makeConvex({ postWhisper }),
+      chain: makeChain({ getCurrentTick }),
+    };
+
+    await runCommand('peer', 'whisper', ['5', 'attack at dawn'], deps, { ELDER_N: '2' }, tmpDir);
+
+    expect(postWhisper).toHaveBeenCalledWith(expect.objectContaining({
+      tick: 42,
+      fromClanId: 2,
+      toClanIds: [5],
+      body: 'attack at dawn',
+    }));
+    expect(postWhisper.mock.calls[0]?.[0].msgId).toMatch(/^2:42:/);
+  });
+
+  it('keeps the local whisper when Convex mirroring fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    deps = {
+      convex: makeConvex({ postWhisper: vi.fn().mockRejectedValue(new Error('convex down')) }),
+      chain: makeChain(),
+    };
+
+    await expect(
+      runCommand('peer', 'whisper', ['5', 'attack at dawn'], deps, { ELDER_N: '2' }, tmpDir),
+    ).resolves.toBe('whisper sent\n');
+    expect(fs.existsSync(recipientInboxFile('5', tmpDir))).toBe(true);
+
+    warn.mockRestore();
+  });
+
+  it('skips cockpit mirror entirely for non-numeric clan ids (local-only inbox key)', async () => {
+    const postWhisper = vi.fn().mockResolvedValue(undefined);
+    const getCurrentTick = vi.fn().mockResolvedValue(7);
+    deps = {
+      convex: makeConvex({ postWhisper }),
+      chain: makeChain({ getCurrentTick }),
+    };
+
+    await expect(
+      runCommand('peer', 'whisper', ['valid-clan', 'hold position'], deps, { ELDER_N: '2' }, tmpDir),
+    ).resolves.toBe('whisper sent\n');
+
+    expect(fs.existsSync(recipientInboxFile('valid-clan', tmpDir))).toBe(true);
+    expect(postWhisper).not.toHaveBeenCalled();
+    expect(getCurrentTick).not.toHaveBeenCalled();
+  });
+
+  it('keeps the local whisper when chain.getCurrentTick hangs (mirror bounded by timeout)', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const postWhisper = vi.fn().mockResolvedValue(undefined);
+    // getCurrentTick stays pending until the timeout aborts it — must not pin the CLI.
+    const getCurrentTick = vi.fn().mockImplementation((signal?: AbortSignal) => new Promise<number>((_resolve, reject) => {
+      signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+    }));
+    deps = {
+      convex: makeConvex({ postWhisper }),
+      chain: makeChain({ getCurrentTick }),
+    };
+
+    const runPromise = runCommand('peer', 'whisper', ['5', 'attack at dawn'], deps, { ELDER_N: '2' }, tmpDir);
+
+    // Advance fake timers past the 5s withTimeout window so the mirror rejects + falls into catch.
+    await vi.advanceTimersByTimeAsync(5_001);
+
+    await expect(runPromise).resolves.toBe('whisper sent\n');
+    expect(fs.existsSync(recipientInboxFile('5', tmpDir))).toBe(true);
+    expect(postWhisper).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('cockpit mirror failed'),
+      expect.objectContaining({ message: expect.stringContaining('timed out') }),
+    );
+
+    warn.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('aborts the underlying chain call when timeout fires', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let receivedSignal: AbortSignal | undefined;
+    const getCurrentTick = vi.fn().mockImplementation((signal?: AbortSignal) => {
+      receivedSignal = signal;
+      return new Promise<number>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      });
+    });
+    deps = {
+      convex: makeConvex(),
+      chain: makeChain({ getCurrentTick }),
+    };
+
+    const runPromise = runCommand('peer', 'whisper', ['5', 'attack'], deps, { ELDER_N: '2' }, tmpDir);
+    await vi.advanceTimersByTimeAsync(5_001);
+    await runPromise;
+
+    expect(receivedSignal?.aborted).toBe(true);
+
+    warn.mockRestore();
+    vi.useRealTimers();
   });
 });
 

--- a/packages/agents/test/mcp.test.ts
+++ b/packages/agents/test/mcp.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { IChainClient, IConvexClient } from '@clan-world/shared/adapters';
-import type { ClanFullView, Tick, Whisper, WorldSnapshot } from '@clan-world/shared';
+import type { ClanFullView, Tick, WorldSnapshot } from '@clan-world/shared';
 import { callElderTool } from '../src/mcp.js';
 
 const STUB_SNAPSHOT: WorldSnapshot = {
@@ -25,7 +25,6 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
     async getSnapshot() { return STUB_SNAPSHOT; },
     async getClanFullView() { return STUB_CLAN_VIEW; },
     async postLog() {},
-    subscribeWhispers(_clanId: string, _onWhisper: (w: Whisper) => void): () => void { return () => {}; },
     async postWhisper() {},
     async postOrchEvent() {},
     async postHumanSteering() {},

--- a/packages/runner/.env.example
+++ b/packages/runner/.env.example
@@ -12,6 +12,11 @@ CLAN_WORLD_CONTRACT_ADDRESS=0xC012275376b867944cd874FB2d600d6dA3B4A56e
 # REQUIRED for non-stub operation. If unset, the runner uses StubConvexClient
 # and the tick loop will idle (snapshot.tick = 0).
 CONVEX_URL=
+# Required for cockpit-mirror writes (elder peer whisper, bulletins, orch events, human steering).
+# Must match the deployment-side value set via:
+#   npx convex env set INDEXER_SECRET <value>
+# Without it, RealConvexClient mutations log-and-return (best-effort no-op) and the cockpit feed stays empty.
+INDEXER_SECRET=
 
 # Optional — primary Base Sepolia RPC URL. Falls back to RPC_URL_FALLBACK or
 # the viem Base Sepolia default if unset.

--- a/packages/runner/test/tickLoop.test.ts
+++ b/packages/runner/test/tickLoop.test.ts
@@ -29,9 +29,6 @@ function fakeConvex(tick: number): IConvexClient {
       };
     },
     async postLog() {},
-    subscribeWhispers() {
-      return () => {};
-    },
     async postWhisper() {},
     async postOrchEvent() {},
     async postHumanSteering() {},

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -101,7 +101,7 @@ export function validateSubmitOrderPayload(order: ClanOrder, submitterClanId: nu
 }
 
 export interface IChainClient {
-  getCurrentTick(): Promise<Tick>;
+  getCurrentTick(signal?: AbortSignal): Promise<Tick>;
   submitOrders(clanId: string, orders: ClanOrder[]): Promise<SubmitOrdersResult>;
   getClanFullView(clanId: string): Promise<ClanFullView>;
   getWallUpgradeCost(currentLevel: number): Promise<{ wood: bigint; iron: bigint }>;
@@ -4035,7 +4035,7 @@ export function parseClanId(clanId: string, fnName: string): number {
 }
 
 class StubChainClient implements IChainClient {
-  async getCurrentTick(): Promise<Tick> {
+  async getCurrentTick(_signal?: AbortSignal): Promise<Tick> {
     return 0;
   }
   async submitOrders(_clanId: string, _orders: ClanOrder[]): Promise<SubmitOrdersResult> {
@@ -4076,15 +4076,14 @@ class RealChainClient implements IChainClient {
   private readonly transport:
     | ReturnType<typeof http>
     | ReturnType<typeof fallback>;
+  private readonly primaryRpc: string | undefined;
+  private readonly fallbackRpc: string | undefined;
 
   constructor() {
-    const primaryRpc = readEnv('RPC_URL_PRIMARY');
-    const fallbackRpc = readEnv('RPC_URL_FALLBACK');
+    this.primaryRpc = readEnv('RPC_URL_PRIMARY');
+    this.fallbackRpc = readEnv('RPC_URL_FALLBACK');
 
-    this.transport =
-      primaryRpc && fallbackRpc
-        ? fallback([http(primaryRpc), http(fallbackRpc)])
-        : http(primaryRpc ?? fallbackRpc);
+    this.transport = this.createTransport();
 
     const configuredContractAddress = readEnv('CLAN_WORLD_CONTRACT_ADDRESS')?.trim();
     const configuredLensAddress = readEnv('CLAN_WORLD_LENS_ADDRESS');
@@ -4106,12 +4105,27 @@ class RealChainClient implements IChainClient {
     });
   }
 
-  async getCurrentTick(): Promise<Tick> {
-    const snapshot = await this.client.readContract({
+  private createTransport(signal?: AbortSignal): ReturnType<typeof http> | ReturnType<typeof fallback> {
+    const httpConfig = signal ? { fetchOptions: { signal } } : undefined;
+    return this.primaryRpc && this.fallbackRpc
+      ? fallback([http(this.primaryRpc, httpConfig), http(this.fallbackRpc, httpConfig)])
+      : http(this.primaryRpc ?? this.fallbackRpc, httpConfig);
+  }
+
+  async getCurrentTick(signal?: AbortSignal): Promise<Tick> {
+    signal?.throwIfAborted();
+    const client = signal
+      ? createPublicClient({
+          chain: baseSepolia,
+          transport: this.createTransport(signal),
+        })
+      : this.client;
+    const snapshot = await client.readContract({
       address: this.lensAddress,
       abi: CLAN_WORLD_LENS_ABI,
       functionName: 'getWorldSnapshot',
     }) as { currentTick: number | bigint };
+    signal?.throwIfAborted();
     return Number(snapshot.currentTick); // safe: tick values are small enough to fit Number precisely in Wave 0
   }
 

--- a/packages/shared/src/adapters/IConvexClient.ts
+++ b/packages/shared/src/adapters/IConvexClient.ts
@@ -1,13 +1,27 @@
 import { ConvexHttpClient } from 'convex/browser';
-import type { ClanFullView, Whisper, WorldSnapshot } from '../types';
+import type { ClanFullView, WorldSnapshot } from '../types';
 import { readEnv } from './_env';
 import { convexApiRefs } from './convexApiRefs';
+
+// Module augmentation: `setFetchOptions` is a real public method on the
+// `ConvexHttpClient` runtime class (see `convex@1.17.4` source at
+// `dist/esm/browser/http_client.js` → `setFetchOptions(opts)`), used by the
+// official `convex/nextjs` helpers to thread `cache: 'no-store'` and other
+// `RequestInit` fields through to `fetch`. The SDK does not declare it in
+// its `.d.ts`, so this augmentation patches the typing gap rather than
+// reaching through with an `as unknown as` cast. If a future SDK version
+// removes the runtime method, the augmentation will keep compiling but
+// calls will throw at runtime — surfacing the breakage immediately.
+declare module 'convex/browser' {
+  interface ConvexHttpClient {
+    setFetchOptions(options: RequestInit): void;
+  }
+}
 
 export interface IConvexClient {
   getSnapshot(): Promise<WorldSnapshot>;
   getClanFullView(clanId: string): Promise<ClanFullView>;
   postLog(level: 'info' | 'warn' | 'error', message: string): Promise<void>;
-  subscribeWhispers(clanId: string, onWhisper: (w: Whisper) => void): () => void;
 
   // Cockpit Comms write-side. Each method is best-effort: callers wrap in
   // try/catch + treat failures as non-fatal so the cockpit display stays
@@ -18,7 +32,8 @@ export interface IConvexClient {
     fromClanId: number;
     toClanIds: number[];
     body: string;
-    txHash?: string;
+    msgId?: string;
+    signal?: AbortSignal;
   }): Promise<void>;
   postOrchEvent(args: {
     tick: number;
@@ -61,29 +76,38 @@ class StubConvexClient implements IConvexClient {
   async postLog(_level: 'info' | 'warn' | 'error', _message: string): Promise<void> {
     // no-op stub
   }
-  subscribeWhispers(_clanId: string, _onWhisper: (w: Whisper) => void): () => void {
-    return () => {
-      // no-op unsubscribe
-    };
-  }
 
-  async postWhisper(_args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; txHash?: string }): Promise<void> {}
+  async postWhisper(_args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; msgId?: string; signal?: AbortSignal }): Promise<void> {}
   async postOrchEvent(_args: { tick: number; kind: 'world_event' | 'directive' | 'narration'; body: string; targetClanId?: number }): Promise<void> {}
   async postHumanSteering(_args: { tick: number; targetClanId: number; body: string; sentBy?: string }): Promise<void> {}
   async postBulletin(_args: { clanId: number; slot: number; body: string; dataHash?: string; txHash?: string }): Promise<void> {}
 }
 
 const getSnapshotRef = convexApiRefs.getSnapshot.getSnapshot;
-const seedWhisperRef = convexApiRefs.comms.seedWhisper;
+const sendWhisperRef = convexApiRefs.comms.sendWhisper;
 const seedOrchEventRef = convexApiRefs.comms.seedOrchEvent;
 const seedHumanSteeringRef = convexApiRefs.comms.seedHumanSteering;
 const seedBulletinRef = convexApiRefs.bulletins.seedBulletin;
 
 class RealConvexClient implements IConvexClient {
   private readonly http: ConvexHttpClient;
+  private readonly url: string;
 
   constructor(url: string) {
+    this.url = url;
     this.http = new ConvexHttpClient(url);
+  }
+
+  // Per-call client for signal-bearing mutations. `ConvexHttpClient.setFetchOptions`
+  // mutates instance state, so calling it on the shared `this.http` creates a race
+  // when two callers issue concurrent signal-bearing mutations (call B overwrites
+  // call A's signal, then A's `finally` clears B's). A fresh client per call
+  // isolates the fetch options per signal. Cheap — only constructed when a signal
+  // is provided.
+  private clientForSignal(signal: AbortSignal): ConvexHttpClient {
+    const c = new ConvexHttpClient(this.url);
+    c.setFetchOptions({ signal });
+    return c;
   }
 
   async getSnapshot(): Promise<WorldSnapshot> {
@@ -112,11 +136,6 @@ class RealConvexClient implements IConvexClient {
     // Phase 4: postLog via Convex not yet used by CLI path
   }
 
-  subscribeWhispers(_clanId: string, _onWhisper: (w: Whisper) => void): () => void {
-    // ConvexHttpClient is non-reactive; WebSocket subscriptions need ConvexClient
-    return () => {};
-  }
-
   // Cockpit Comms write-side — best-effort, swallow + warn on failure so the
   // domain operation that triggered the post (chain whisper, orchestrator
   // tick, etc.) is never blocked by a Convex outage.
@@ -129,14 +148,17 @@ class RealConvexClient implements IConvexClient {
     return readEnv('INDEXER_SECRET');
   }
 
-  async postWhisper(args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; txHash?: string }): Promise<void> {
+  async postWhisper(args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; msgId?: string; signal?: AbortSignal }): Promise<void> {
     const secret = this.indexerSecret();
     if (!secret) {
       console.warn('[ConvexClient] postWhisper skipped: INDEXER_SECRET not set');
       return;
     }
+    const { signal, ...mutationArgs } = args;
+    signal?.throwIfAborted();
+    const client = signal ? this.clientForSignal(signal) : this.http;
     try {
-      await this.http.mutation(seedWhisperRef, { secret, ...args });
+      await client.mutation(sendWhisperRef, { secret, ...mutationArgs });
     } catch (err) {
       console.warn('[ConvexClient] postWhisper failed (non-fatal):', err);
     }

--- a/packages/shared/src/adapters/convexApiRefs.ts
+++ b/packages/shared/src/adapters/convexApiRefs.ts
@@ -5,13 +5,13 @@ import type { WorldSnapshot } from '../types';
 type PublicQuery<Args extends Record<string, unknown>, Result> = FunctionReference<'query', 'public', Args, Result>;
 type PublicMutation<Args extends Record<string, unknown>, Result = null> = FunctionReference<'mutation', 'public', Args, Result>;
 
-type SeedWhisperArgs = {
+type SendWhisperArgs = {
   secret: string;
   tick: number;
   fromClanId: number;
   toClanIds: number[];
   body: string;
-  txHash?: string;
+  msgId?: string;
 };
 
 type SeedOrchEventArgs = {
@@ -44,7 +44,7 @@ type ClanWorldConvexApi = {
     getSnapshot: PublicQuery<Record<string, never>, WorldSnapshot>;
   };
   comms: {
-    seedWhisper: PublicMutation<SeedWhisperArgs>;
+    sendWhisper: PublicMutation<SendWhisperArgs>;
     seedOrchEvent: PublicMutation<SeedOrchEventArgs>;
     seedHumanSteering: PublicMutation<SeedHumanSteeringArgs>;
   };


### PR DESCRIPTION
## Release: v2.8.5 — 2026-05-16

Architecture-only release. One PR landed in this cycle (#401), plus the gitflow ADR and the swarm-review scratch-path canonicalization. Full changelog entry below.

### Headline

**Whisper recording path moves from chain events to elder-direct Convex mutation.** The on-chain whisper indexer (\`apps/server/convex/indexer.ts:352-378\`) had been dead code since the day it shipped — the contract ABI never declared the \`Whisper\`/\`WhisperBroadcast\` events it was scanning for, so the \`whispers\` Convex table never received a row from this path. The new architecture: elder CLI writes durably to the local JSONL inbox first, then mirrors best-effort to Convex via a \`sendWhisper\` mutation. Cockpit \`CommsTab\` reads live from Convex (no more stub fallback). Android Kotlin app already correctly consumes the same Convex query; React Native deferred (issue #422).

### PRs landing in this release

| PR | Title | Net delta |
|---|---|---|
| **#401** | feat(whispers): elder-direct path + delete dead on-chain indexing | 12 files, +257/-169 |

### Also bundled (not from PR #401 itself, but on dev in this cycle)

- **ADR 0018** — gitflow-light PR branching codified (response to PR #399 misroute incident). Companion memory: \`feedback_gitflow_light_pr_base_is_dev.md\`.
- **Swarm-review scratch path canonicalized** to \`~/claudes-world/tmp/\` instead of \`/tmp/\` — gemini-cli sandbox compat. Skills updated: \`/swarm-review\`, \`/phase-super-swarm\`. Memory \`feedback_super_swarm_sandbox_gotchas.md\` appended.
- **Code-review-gemini subagent** propagated from canonical to pm-dobot copy.
- **20 draft PRs opened** for Phase 0 + Phase 1 rollback walkthrough (PRs #402-#421, all draft, all targeting dev). Not part of this release — visibility note only.

### Schema migration safety

The \`whispers\` table dropped \`txHash\` and added \`msgId\`. **Production whispers table is empty** (the on-chain indexer block never ran successfully — events not in ABI). Zero data migration needed. Verified by Tier 1 Claude in R4 review.

### Swarm review trail on PR #401 (4 rounds, all 3 tiers re-run each round per new policy)

- **R1** — Tier 1 Claude CLEAN. Tier 2 Codex 2 HIGH (chain-read-before-local-write ordering, no postWhisper timeout). Tier 3 Gemini 1 MED (NaN guard). All fixed.
- **R2** — All 3 tiers CLEAN (gemini noted 2 academic LOW).
- **R3** (post-AbortController upgrade for cloud-gemini-code-assist MED) — Tier 1 Claude MED on setFetchOptions race + 2 LOW. Tier 2 Codex MED on race + LOW on sync-throw. Tier 3 Gemini 2 HIGH (race + fragile cast) + MED + 2 LOW. All addressed.
- **R4** — All 3 tiers CLEAN. Module augmentation + per-call ConvexHttpClient + withTimeout sync-throw catch. Gemini noted 3 academic LOWs.

### Pre-merge checks

- ✅ \`pnpm typecheck\` clean on \`@clan-world/{server,shared,agents,web}\`
- ✅ Tests: 53 agents + 36 server + 27 shared = 116 total pass
- ✅ Module augmentation for \`ConvexHttpClient.setFetchOptions\` verified against \`convex@1.17.4\` source (Tier 1 R4)
- ✅ Per-call \`ConvexHttpClient\` race-free + Android Kotlin \`getCombinedComms\` unaffected
- ✅ 4 rounds of local 3-tier swarm — final round CLEAN across all reviewers
- ⏳ **Phase super-swarm pending** (this PR review)
- ⏳ **Liam manual approval** required to merge (per memory \`feedback_release_pr_merge_requires_explicit_liam_approval.md\`)

### Deferred / follow-up

- **#422** — RN \`WhispersScreen\` Convex query (RN is design playground, deferred from PR #401)
- **Typechain audit PRs** (5 PRs, plan at \`docs/plans/typechain-and-generated-types-audit-v1.md\`) — scoped, not started
- **20 recovery walkthrough PRs (#402–#421)** — Liam-driven phase decisions

### Full CHANGELOG.md entry

See \`CHANGELOG.md\` v2.8.5 section (commit on dev for this release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)