### PR TITLE
refactor(cockpit): extract useCurrentWorldTick to shared hook

### DIFF
--- a/apps/web/src/components/cockpit/BulletinFlyout.tsx
+++ b/apps/web/src/components/cockpit/BulletinFlyout.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useSafeQuery as useQuery } from '../../hooks/useSafeQuery';
+import { useCurrentWorldTick } from '../../hooks/useCurrentWorldTick';
 import { api } from '../../../../server/convex/_generated/api';
 import { tokens, ELDERS } from '../../styles/cockpit-tokens';
 import type { ElderDef } from '../../styles/cockpit-tokens';
@@ -51,13 +52,6 @@ const STUB_BY_CLAN: Record<number, BulletinPost[]> = {
 function getInitialOpen(): boolean {
   if (typeof window === 'undefined') return false;
   return new URLSearchParams(window.location.search).get('bulletin-open') === '1';
-}
-
-function useCurrentWorldTick(): number {
-  const snapshot = useQuery(api.getSnapshot.getSnapshot);
-  return typeof snapshot?.tick === 'number' && Number.isFinite(snapshot.tick)
-    ? snapshot.tick
-    : 0;
 }
 
 /**

--- a/apps/web/src/components/cockpit/tabs/CommsTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/CommsTab.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useSafeQuery as useQuery } from '../../../hooks/useSafeQuery';
+import { useCurrentWorldTick } from '../../../hooks/useCurrentWorldTick';
 import { api } from '../../../../../server/convex/_generated/api';
 import { tokens, ELDERS } from '../../../styles/cockpit-tokens';
 import type { ElderDef } from '../../../styles/cockpit-tokens';
@@ -87,13 +88,6 @@ export function lighten(hex: string, amount: number): string {
   const lg = Math.round(g + (255 - g) * amount);
   const lb = Math.round(b + (255 - b) * amount);
   return `rgb(${lr},${lg},${lb})`;
-}
-
-function useCurrentWorldTick(): number {
-  const snapshot = useQuery(api.getSnapshot.getSnapshot);
-  return typeof snapshot?.tick === 'number' && Number.isFinite(snapshot.tick)
-    ? snapshot.tick
-    : 0;
 }
 
 export function fadeOpacity(tick: number, currentTick: number): number {

--- a/apps/web/src/hooks/useCurrentWorldTick.ts
+++ b/apps/web/src/hooks/useCurrentWorldTick.ts
@@ -1,0 +1,18 @@
+import { useSafeQuery } from './useSafeQuery';
+import { api } from '../../../server/convex/_generated/api';
+
+/**
+ * Live world tick from the Convex snapshot query. Returns 0 while the
+ * query is loading (caller decides whether the loading state matters —
+ * for the cockpit fade/visibility math, 0 yields "everything fresh"
+ * which is the correct degraded behavior pre-snapshot).
+ *
+ * Shared between cockpit comms tab + bulletin flyout to avoid duplicate
+ * definitions. See PR #423 R3 super-swarm + cloud Copilot finding.
+ */
+export function useCurrentWorldTick(): number {
+  const snapshot = useSafeQuery(api.getSnapshot.getSnapshot);
+  return typeof snapshot?.tick === 'number' && Number.isFinite(snapshot.tick)
+    ? snapshot.tick
+    : 0;
+}


### PR DESCRIPTION
Addresses cloud Copilot LOW + opus 4.7 R3 L2 + gemini R2 LOW on PR #423 — duplicate `useCurrentWorldTick` hook in BulletinFlyout.tsx + CommsTab.tsx. Extracted to `apps/web/src/hooks/useCurrentWorldTick.ts` (uses existing `useSafeQuery` wrapper, no behavior change). Pure DRY refactor, -14/+2 LOC. Web typecheck clean.

Auto-update PR #423 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)