### PR TITLE
feat(contract-types): PR1 — add @clan-world/contract-types generated literal ABI types

### DIFF
--- a/packages/contract-types/index.ts
+++ b/packages/contract-types/index.ts
@@ -1,0 +1,2 @@
+export * from './src/IClanWorld.js';
+export * from './src/IClanWorldLens.js';

--- a/packages/contract-types/package.json
+++ b/packages/contract-types/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@clan-world/contract-types",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Generated TypeScript literal-type ABIs for ClanWorld contracts",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "codegen": "node scripts/generate.mjs",
+    "codegen:check": "node scripts/generate.mjs --check",
+    "build": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@clan-world/contracts": "workspace:*"
+  }
+}

--- a/packages/contract-types/scripts/generate.mjs
+++ b/packages/contract-types/scripts/generate.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * generate.mjs — generates packages/contract-types/src/*.ts from committed ABI JSON.
+ * Source: packages/contracts/abi/*.json
+ * Run: node scripts/generate.mjs
+ * Check: node scripts/generate.mjs --check
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(__dirname, '..');
+const repoRoot = resolve(pkgRoot, '../..');
+const check = process.argv.includes('--check');
+const errors = [];
+
+function readAbi(name) {
+  const path = resolve(repoRoot, 'packages/contracts/abi', `${name}.json`);
+  const raw = JSON.parse(readFileSync(path, 'utf8'));
+  // abi files may be plain arrays or { abi: [...] } objects
+  return Array.isArray(raw) ? raw : raw.abi;
+}
+
+function generateFile(varName, abi) {
+  const lines = [
+    '// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen',
+    `export const ${varName} = ${JSON.stringify(abi, null, 2)} as const;`,
+    '',
+    `export type ${varName.charAt(0).toUpperCase() + varName.slice(1)}Type = typeof ${varName};`,
+    '',
+    '// Derived event name union',
+    `export type ${varName.charAt(0).toUpperCase() + varName.slice(1)}EventName = (typeof ${varName})[number] extends infer T`,
+    "  ? T extends { type: 'event'; name: string }",
+    "    ? T['name']",
+    '    : never',
+    '  : never;',
+    '',
+    '// Derived function name union',
+    `export type ${varName.charAt(0).toUpperCase() + varName.slice(1)}FunctionName = (typeof ${varName})[number] extends infer T`,
+    "  ? T extends { type: 'function'; name: string }",
+    "    ? T['name']",
+    '    : never',
+    '  : never;',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+const contracts = [
+  { abiFile: 'IClanWorld', varName: 'iClanWorldAbi', outFile: 'IClanWorld.ts' },
+  { abiFile: 'IClanWorldLens', varName: 'iClanWorldLensAbi', outFile: 'IClanWorldLens.ts' },
+];
+
+for (const { abiFile, varName, outFile } of contracts) {
+  const abi = readAbi(abiFile);
+  const content = generateFile(varName, abi);
+  const outPath = resolve(pkgRoot, 'src', outFile);
+
+  if (check) {
+    if (!existsSync(outPath)) {
+      errors.push(`MISSING: ${outPath} — run codegen`);
+      continue;
+    }
+    const existing = readFileSync(outPath, 'utf8');
+    if (existing !== content) {
+      errors.push(`STALE: ${outPath} — run codegen`);
+    }
+  } else {
+    writeFileSync(outPath, content, 'utf8');
+    console.log(`wrote ${outFile}`);
+  }
+}
+
+if (check) {
+  if (errors.length > 0) {
+    for (const e of errors) console.error(e);
+    process.exit(1);
+  }
+  console.log('contract-types: up to date');
+}

--- a/packages/contract-types/src/IClanWorld.ts
+++ b/packages/contract-types/src/IClanWorld.ts
@@ -1,0 +1,4904 @@
+// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
+export const iClanWorldAbi = [
+  {
+    "type": "function",
+    "name": "finalizeSeason",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getActionDuration",
+    "inputs": [
+      {
+        "name": "action",
+        "type": "uint8",
+        "internalType": "enum ActionType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getActiveBanditView",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ActiveBanditView",
+        "components": [
+          {
+            "name": "exists",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "banditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum BanditState"
+          },
+          {
+            "name": "currentRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackAttemptsMade",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "maxAttemptsRemaining",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "stateEnteredTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextActionTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "tier",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackPower",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "projectedTargetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "projectedTargetLootValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getActiveDefenders",
+    "inputs": [
+      {
+        "name": "targetClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clansmanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getActiveMission",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Mission",
+        "components": [
+          {
+            "name": "active",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "nonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "submittedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "executesAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "settlesAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "startRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "targetRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "action",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "startTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "arrivalTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "actionStartTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "missionSeed",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "marketMode",
+            "type": "uint8",
+            "internalType": "enum MarketExecutionMode"
+          },
+          {
+            "name": "targetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "marketToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "marketAmount",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxGoldIn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "withdrawResources",
+            "type": "tuple",
+            "internalType": "struct WithdrawResourcesData",
+            "components": [
+              {
+                "name": "wood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "iron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "wheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "fish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBandit",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct BanditTroop",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "region",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum BanditState"
+          },
+          {
+            "name": "targetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "tickEnteredState",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "strength",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "tier",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackAttemptsMade",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryGold",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBanditTargetPreview",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "previewClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBanditTroop",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct BanditTroop",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "region",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum BanditState"
+          },
+          {
+            "name": "targetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "tickEnteredState",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "strength",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "tier",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackAttemptsMade",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryGold",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBanditsInRegion",
+    "inputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBaseUpgradeCost",
+    "inputs": [
+      {
+        "name": "currentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getClan",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Clan",
+        "components": [
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "iftTokenId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "owner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "clanState",
+            "type": "uint8",
+            "internalType": "enum ClanState"
+          },
+          {
+            "name": "baseRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "baseLevel",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "wallLevel",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "monumentLevel",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "livingClansmen",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "lastSettledTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "starvationStartsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "coldDamage",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "ownerNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "goldBalance",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "blueprintBalance",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanClansmanIds",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clansmanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanFullView",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ClanFullView",
+        "components": [
+          {
+            "name": "clan",
+            "type": "tuple",
+            "internalType": "struct DerivedClanState",
+            "components": [
+              {
+                "name": "clan",
+                "type": "tuple",
+                "internalType": "struct Clan",
+                "components": [
+                  {
+                    "name": "clanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "iftTokenId",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "owner",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "clanState",
+                    "type": "uint8",
+                    "internalType": "enum ClanState"
+                  },
+                  {
+                    "name": "baseRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "baseLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "wallLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "monumentLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "livingClansmen",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "lastSettledTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "starvationStartsAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "coldDamage",
+                    "type": "uint16",
+                    "internalType": "uint16"
+                  },
+                  {
+                    "name": "ownerNonce",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "goldBalance",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "blueprintBalance",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultWood",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultIron",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultWheat",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultFish",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "isStarving",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "lootValue",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "derivedAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "clansmen",
+            "type": "tuple[]",
+            "internalType": "struct ClansmanFullView[]",
+            "components": [
+              {
+                "name": "clansman",
+                "type": "tuple",
+                "internalType": "struct DerivedClansmanState",
+                "components": [
+                  {
+                    "name": "clansman",
+                    "type": "tuple",
+                    "internalType": "struct Clansman",
+                    "components": [
+                      {
+                        "name": "clansmanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "clanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "state",
+                        "type": "uint8",
+                        "internalType": "enum ClansmanState"
+                      },
+                      {
+                        "name": "currentRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "cooldownEndsAtTs",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "lastMissionNonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "carryWood",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryIron",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryWheat",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryFish",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "activeMission",
+                    "type": "tuple",
+                    "internalType": "struct Mission",
+                    "components": [
+                      {
+                        "name": "active",
+                        "type": "bool",
+                        "internalType": "bool"
+                      },
+                      {
+                        "name": "nonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "submittedAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "executesAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "settlesAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "clansmanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "startRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "targetRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "action",
+                        "type": "uint8",
+                        "internalType": "enum ActionType"
+                      },
+                      {
+                        "name": "startTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "arrivalTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "actionStartTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "missionSeed",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                      },
+                      {
+                        "name": "marketMode",
+                        "type": "uint8",
+                        "internalType": "enum MarketExecutionMode"
+                      },
+                      {
+                        "name": "targetClanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "marketToken",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "marketAmount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "maxGoldIn",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "withdrawResources",
+                        "type": "tuple",
+                        "internalType": "struct WithdrawResourcesData",
+                        "components": [
+                          {
+                            "name": "wood",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "iron",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "wheat",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "fish",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "effectiveRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "derivedAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  }
+                ]
+              },
+              {
+                "name": "activeMission",
+                "type": "tuple",
+                "internalType": "struct Mission",
+                "components": [
+                  {
+                    "name": "active",
+                    "type": "bool",
+                    "internalType": "bool"
+                  },
+                  {
+                    "name": "nonce",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "submittedAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "executesAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "settlesAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "clansmanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "startRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "targetRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "action",
+                    "type": "uint8",
+                    "internalType": "enum ActionType"
+                  },
+                  {
+                    "name": "startTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "arrivalTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "actionStartTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "missionSeed",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "marketMode",
+                    "type": "uint8",
+                    "internalType": "enum MarketExecutionMode"
+                  },
+                  {
+                    "name": "targetClanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "marketToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "marketAmount",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "maxGoldIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "withdrawResources",
+                    "type": "tuple",
+                    "internalType": "struct WithdrawResourcesData",
+                    "components": [
+                      {
+                        "name": "wood",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "iron",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "wheat",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "fish",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "westPlot",
+            "type": "tuple",
+            "internalType": "struct WheatPlot",
+            "components": [
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum WheatPlotState"
+              },
+              {
+                "name": "region",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "remainingWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "regrowUntilTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "eastPlot",
+            "type": "tuple",
+            "internalType": "struct WheatPlot",
+            "components": [
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum WheatPlotState"
+              },
+              {
+                "name": "region",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "remainingWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "regrowUntilTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "incomingDefenderIds",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          },
+          {
+            "name": "thisClanDefendingBaseId",
+            "type": "uint32",
+            "internalType": "uint32"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanIds",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "clanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanScore",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "score",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "monumentReachedAtTick",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "monumentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClansman",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Clansman",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum ClansmanState"
+          },
+          {
+            "name": "currentRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "cooldownEndsAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "lastMissionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClansmanDefendingRegion",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDefendingClans",
+    "inputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDerivedClanState",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DerivedClanState",
+        "components": [
+          {
+            "name": "clan",
+            "type": "tuple",
+            "internalType": "struct Clan",
+            "components": [
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "iftTokenId",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "clanState",
+                "type": "uint8",
+                "internalType": "enum ClanState"
+              },
+              {
+                "name": "baseRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "baseLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "wallLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "monumentLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "livingClansmen",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "lastSettledTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "starvationStartsAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "coldDamage",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "ownerNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "goldBalance",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "blueprintBalance",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultWood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultIron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultFish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "isStarving",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "lootValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "derivedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDerivedClansmanState",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DerivedClansmanState",
+        "components": [
+          {
+            "name": "clansman",
+            "type": "tuple",
+            "internalType": "struct Clansman",
+            "components": [
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum ClansmanState"
+              },
+              {
+                "name": "currentRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "cooldownEndsAtTs",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "lastMissionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "carryWood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryIron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryFish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "activeMission",
+            "type": "tuple",
+            "internalType": "struct Mission",
+            "components": [
+              {
+                "name": "active",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "nonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "submittedAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "executesAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "settlesAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "startRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "targetRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "startTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "arrivalTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "actionStartTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionSeed",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "marketMode",
+                "type": "uint8",
+                "internalType": "enum MarketExecutionMode"
+              },
+              {
+                "name": "targetClanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "withdrawResources",
+                "type": "tuple",
+                "internalType": "struct WithdrawResourcesData",
+                "components": [
+                  {
+                    "name": "wood",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "iron",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "wheat",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "fish",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "effectiveRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "derivedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMarketState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct MarketState",
+        "components": [
+          {
+            "name": "wood",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "wheat",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "fish",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "iron",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "currentTickQueue",
+            "type": "tuple[]",
+            "internalType": "struct ScheduledMarketAction[]",
+            "components": [
+              {
+                "name": "executeAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "commitSequence",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "nextTickQueue",
+            "type": "tuple[]",
+            "internalType": "struct ScheduledMarketAction[]",
+            "components": [
+              {
+                "name": "executeAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "commitSequence",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMissionTiming",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "submitted",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "executes",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "settles",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMonumentLevelReachedAt",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "level",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "reachedAtTick",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMonumentUpgradeCost",
+    "inputs": [
+      {
+        "name": "currentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprint",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getPool",
+    "inputs": [
+      {
+        "name": "resourceType",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPrice",
+    "inputs": [
+      {
+        "name": "resourceType",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRankings",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "clanIdsRanked",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "scores",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRegionPopulation",
+    "inputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct RegionOccupant[]",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum ClansmanState"
+          },
+          {
+            "name": "currentAction",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "missionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getResourceToken",
+    "inputs": [
+      {
+        "name": "resourceType",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getScheduledMarketActionsForTick",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct ScheduledMarketAction[]",
+        "components": [
+          {
+            "name": "executeAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "commitSequence",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "missionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "action",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "marketToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "marketAmount",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxGoldIn",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTravelTicks",
+    "inputs": [
+      {
+        "name": "fromRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "toRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getTreasuryState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct TreasuryState",
+        "components": [
+          {
+            "name": "treasuryOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "prizePotGold",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "poolsSeeded",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "woodToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "wheatToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "fishToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "ironToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "goldToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "blueprintToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "woodGoldPool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "wheatGoldPool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "fishGoldPool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "ironGoldPool",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWallUpgradeCost",
+    "inputs": [
+      {
+        "name": "currentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getWheatPlots",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "west",
+        "type": "tuple",
+        "internalType": "struct WheatPlot",
+        "components": [
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum WheatPlotState"
+          },
+          {
+            "name": "region",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "remainingWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "regrowUntilTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "east",
+        "type": "tuple",
+        "internalType": "struct WheatPlot",
+        "components": [
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum WheatPlotState"
+          },
+          {
+            "name": "region",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "remainingWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "regrowUntilTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWorldSnapshot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct WorldSnapshot",
+        "components": [
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonStartTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonEndTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonFinalized",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "currentSeasonNumber",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextHeartbeatAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterActive",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "winterStartsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterEndsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "activeBanditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "currentTickSeed",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "leaderboard",
+            "type": "tuple[]",
+            "internalType": "struct LeaderboardEntry[]",
+            "components": [
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "monumentLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "baseLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "wallLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "livingClansmen",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum ClanState"
+              },
+              {
+                "name": "lootValue",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWorldState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct WorldState",
+        "components": [
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonStartTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonEndTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonFinalized",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "currentSeasonNumber",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextHeartbeatAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextHeartbeatAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextBanditSpawnEligibleTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "currentBanditSpawnChanceBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "currentTickSeed",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "activeBanditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "winterActive",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "winterStartsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterEndsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextCommitSequence",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "heartbeat",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "initTreasury",
+    "inputs": [
+      {
+        "name": "tokens",
+        "type": "address[6]",
+        "internalType": "address[6]"
+      },
+      {
+        "name": "pools",
+        "type": "address[4]",
+        "internalType": "address[4]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "injectClanResources",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "fish",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprint",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isWinter",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isWorldPaused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mintClan",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "iftTokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pauseWorld",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "quoteLootValueRaw",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lootValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteLootValueSettled",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lootValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteTravel",
+    "inputs": [
+      {
+        "name": "srcRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "dstRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "travelTicks",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "path",
+        "type": "bytes8",
+        "internalType": "bytes8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "reviveClansman",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "reviveDeadClansmen",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "seedPools",
+    "inputs": [
+      {
+        "name": "cfg",
+        "type": "tuple",
+        "internalType": "struct PoolSeedConfig",
+        "components": [
+          {
+            "name": "woodSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "wheatSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "fishSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ironSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleClan",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleClansman",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "submitClanOrders",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "orders",
+        "type": "tuple[]",
+        "internalType": "struct ClanOrder[]",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "gotoRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "action",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "targetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "marketToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "marketAmount",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxGoldIn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "withdrawResources",
+            "type": "tuple",
+            "internalType": "struct WithdrawResourcesData",
+            "components": [
+              {
+                "name": "wood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "iron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "wheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "fish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct OrderResult[]",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enum StatusCode"
+          },
+          {
+            "name": "cooldownEndsAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "missionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "marketMode",
+            "type": "uint8",
+            "internalType": "enum MarketExecutionMode"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferBlueprint",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferBundle",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "gold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprint",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "fish",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferClanOwnership",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferGold",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferVaultResource",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "resource",
+        "type": "uint8",
+        "internalType": "enum ResourceType"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpauseWorld",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "BanditAttackResolved",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "targetClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "defended",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      },
+      {
+        "name": "attackPower",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "totalDefense",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "wallLevelAfter",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "stolenWood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "stolenIron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "stolenWheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "stolenFish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditDefeated",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "targetClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditEscaped",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditMoved",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "fromRegion",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "toRegion",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditSpawned",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "region",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "tier",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "attackPower",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditStateChanged",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldState",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum BanditState"
+      },
+      {
+        "name": "newState",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum BanditState"
+      },
+      {
+        "name": "region",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditTargetDied",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "deadClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BaseLevelChanged",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "newLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BlueprintAwarded",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BlueprintEarned",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BlueprintTransferred",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanColdShortage",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "woodShort",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanDied",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "reason",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanEliminated",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanOwnershipTransferred",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwnerNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanSettled",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "settledToTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanSpawned",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "iftTokenId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "baseRegion",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanStarvationChanged",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "isStarving",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanColdDeath",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "csId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanKilledByBandit",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanRevived",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "GoldTransferred",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ImmediateMarketActionExecuted",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "resourceIn",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "resourceOut",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "LootDistributed",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clanIdsRewarded",
+        "type": "uint32[]",
+        "indexed": false,
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "perClanWood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "perClanWheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "perClanFish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "perClanIron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "perClanGold",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "burnedWood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "burnedWheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "burnedFish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "burnedIron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "burnedGold",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "LootDistributedToDefender",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "wood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MarketActionFailed",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "mode",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum MarketExecutionMode"
+      },
+      {
+        "name": "reason",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum StatusCode"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MissionAssigned",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "missionNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "startRegion",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "targetRegion",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "startTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "arrivalTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MissionCompleted",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "missionNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MissionInterrupted",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldMissionNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "newMissionNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MonumentLevelChanged",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "newLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PoolsSeeded",
+    "inputs": [
+      {
+        "name": "woodGoldPool",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "wheatGoldPool",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "fishGoldPool",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "ironGoldPool",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourceBurned",
+    "inputs": [
+      {
+        "name": "resourceType",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "uint8"
+      },
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourceMinted",
+    "inputs": [
+      {
+        "name": "resourceType",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "uint8"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourcesDeposited",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "woodDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "ironDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheatDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fishDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourcesGathered",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "woodGained",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "ironGained",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheatGained",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fishGained",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "goldBonus",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourcesInjected",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "wood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "gold",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprint",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourcesWithdrawn",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "woodDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "ironDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheatDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fishDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ScheduledMarketActionCommitted",
+    "inputs": [
+      {
+        "name": "executeAtTick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "commitSequence",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "marketToken",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "marketAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxGoldIn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ScheduledMarketActionExecuted",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "resourceIn",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "resourceOut",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "settledAtTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SeasonFinalized",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "rankedClanIds",
+        "type": "uint32[]",
+        "indexed": false,
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "scores",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TickAdvanced",
+    "inputs": [
+      {
+        "name": "closedTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "openedTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "tickSeed",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "VaultResourceTransferred",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "resource",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ResourceType"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WallDamagedByBandit",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "newLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WallDegradedByCold",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "newWallLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WallLevelChanged",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "newLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WinterEnded",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WinterStarted",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WorkerArrived",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "region",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WorldPaused",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "pausedAtTs",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WorldUnpaused",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "durationSeconds",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "nextHeartbeatAtTs",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  }
+] as const;
+
+export type IClanWorldAbiType = typeof iClanWorldAbi;
+
+// Derived event name union
+export type IClanWorldAbiEventName = (typeof iClanWorldAbi)[number] extends infer T
+  ? T extends { type: 'event'; name: string }
+    ? T['name']
+    : never
+  : never;
+
+// Derived function name union
+export type IClanWorldAbiFunctionName = (typeof iClanWorldAbi)[number] extends infer T
+  ? T extends { type: 'function'; name: string }
+    ? T['name']
+    : never
+  : never;

--- a/packages/contract-types/src/IClanWorldLens.ts
+++ b/packages/contract-types/src/IClanWorldLens.ts
@@ -1,0 +1,1553 @@
+// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
+export const iClanWorldLensAbi = [
+  {
+    "type": "function",
+    "name": "getActiveBanditView",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ActiveBanditView",
+        "components": [
+          {
+            "name": "exists",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "banditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum BanditState"
+          },
+          {
+            "name": "currentRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackAttemptsMade",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "maxAttemptsRemaining",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "stateEnteredTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextActionTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "tier",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackPower",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "projectedTargetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "projectedTargetLootValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBanditTargetPreview",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "previewClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanFullView",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ClanFullView",
+        "components": [
+          {
+            "name": "clan",
+            "type": "tuple",
+            "internalType": "struct DerivedClanState",
+            "components": [
+              {
+                "name": "clan",
+                "type": "tuple",
+                "internalType": "struct Clan",
+                "components": [
+                  {
+                    "name": "clanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "iftTokenId",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "owner",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "clanState",
+                    "type": "uint8",
+                    "internalType": "enum ClanState"
+                  },
+                  {
+                    "name": "baseRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "baseLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "wallLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "monumentLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "livingClansmen",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "lastSettledTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "starvationStartsAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "coldDamage",
+                    "type": "uint16",
+                    "internalType": "uint16"
+                  },
+                  {
+                    "name": "ownerNonce",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "goldBalance",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "blueprintBalance",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultWood",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultIron",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultWheat",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultFish",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "isStarving",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "lootValue",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "derivedAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "clansmen",
+            "type": "tuple[]",
+            "internalType": "struct ClansmanFullView[]",
+            "components": [
+              {
+                "name": "clansman",
+                "type": "tuple",
+                "internalType": "struct DerivedClansmanState",
+                "components": [
+                  {
+                    "name": "clansman",
+                    "type": "tuple",
+                    "internalType": "struct Clansman",
+                    "components": [
+                      {
+                        "name": "clansmanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "clanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "state",
+                        "type": "uint8",
+                        "internalType": "enum ClansmanState"
+                      },
+                      {
+                        "name": "currentRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "cooldownEndsAtTs",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "lastMissionNonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "carryWood",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryIron",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryWheat",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryFish",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "activeMission",
+                    "type": "tuple",
+                    "internalType": "struct Mission",
+                    "components": [
+                      {
+                        "name": "active",
+                        "type": "bool",
+                        "internalType": "bool"
+                      },
+                      {
+                        "name": "nonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "submittedAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "executesAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "settlesAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "clansmanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "startRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "targetRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "action",
+                        "type": "uint8",
+                        "internalType": "enum ActionType"
+                      },
+                      {
+                        "name": "startTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "arrivalTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "actionStartTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "missionSeed",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                      },
+                      {
+                        "name": "marketMode",
+                        "type": "uint8",
+                        "internalType": "enum MarketExecutionMode"
+                      },
+                      {
+                        "name": "targetClanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "marketToken",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "marketAmount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "maxGoldIn",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "withdrawResources",
+                        "type": "tuple",
+                        "internalType": "struct WithdrawResourcesData",
+                        "components": [
+                          {
+                            "name": "wood",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "iron",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "wheat",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "fish",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "effectiveRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "derivedAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  }
+                ]
+              },
+              {
+                "name": "activeMission",
+                "type": "tuple",
+                "internalType": "struct Mission",
+                "components": [
+                  {
+                    "name": "active",
+                    "type": "bool",
+                    "internalType": "bool"
+                  },
+                  {
+                    "name": "nonce",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "submittedAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "executesAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "settlesAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "clansmanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "startRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "targetRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "action",
+                    "type": "uint8",
+                    "internalType": "enum ActionType"
+                  },
+                  {
+                    "name": "startTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "arrivalTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "actionStartTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "missionSeed",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "marketMode",
+                    "type": "uint8",
+                    "internalType": "enum MarketExecutionMode"
+                  },
+                  {
+                    "name": "targetClanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "marketToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "marketAmount",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "maxGoldIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "withdrawResources",
+                    "type": "tuple",
+                    "internalType": "struct WithdrawResourcesData",
+                    "components": [
+                      {
+                        "name": "wood",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "iron",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "wheat",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "fish",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "westPlot",
+            "type": "tuple",
+            "internalType": "struct WheatPlot",
+            "components": [
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum WheatPlotState"
+              },
+              {
+                "name": "region",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "remainingWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "regrowUntilTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "eastPlot",
+            "type": "tuple",
+            "internalType": "struct WheatPlot",
+            "components": [
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum WheatPlotState"
+              },
+              {
+                "name": "region",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "remainingWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "regrowUntilTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "incomingDefenderIds",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          },
+          {
+            "name": "thisClanDefendingBaseId",
+            "type": "uint32",
+            "internalType": "uint32"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanScore",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "score",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "monumentReachedAtTick",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "monumentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDerivedClanState",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DerivedClanState",
+        "components": [
+          {
+            "name": "clan",
+            "type": "tuple",
+            "internalType": "struct Clan",
+            "components": [
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "iftTokenId",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "clanState",
+                "type": "uint8",
+                "internalType": "enum ClanState"
+              },
+              {
+                "name": "baseRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "baseLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "wallLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "monumentLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "livingClansmen",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "lastSettledTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "starvationStartsAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "coldDamage",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "ownerNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "goldBalance",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "blueprintBalance",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultWood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultIron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultFish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "isStarving",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "lootValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "derivedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDerivedClansmanState",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DerivedClansmanState",
+        "components": [
+          {
+            "name": "clansman",
+            "type": "tuple",
+            "internalType": "struct Clansman",
+            "components": [
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum ClansmanState"
+              },
+              {
+                "name": "currentRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "cooldownEndsAtTs",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "lastMissionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "carryWood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryIron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryFish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "activeMission",
+            "type": "tuple",
+            "internalType": "struct Mission",
+            "components": [
+              {
+                "name": "active",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "nonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "submittedAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "executesAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "settlesAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "startRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "targetRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "startTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "arrivalTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "actionStartTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionSeed",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "marketMode",
+                "type": "uint8",
+                "internalType": "enum MarketExecutionMode"
+              },
+              {
+                "name": "targetClanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "withdrawResources",
+                "type": "tuple",
+                "internalType": "struct WithdrawResourcesData",
+                "components": [
+                  {
+                    "name": "wood",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "iron",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "wheat",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "fish",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "effectiveRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "derivedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMarketState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct MarketState",
+        "components": [
+          {
+            "name": "wood",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "wheat",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "fish",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "iron",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "currentTickQueue",
+            "type": "tuple[]",
+            "internalType": "struct ScheduledMarketAction[]",
+            "components": [
+              {
+                "name": "executeAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "commitSequence",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "nextTickQueue",
+            "type": "tuple[]",
+            "internalType": "struct ScheduledMarketAction[]",
+            "components": [
+              {
+                "name": "executeAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "commitSequence",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRankings",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "clanIdsRanked",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "scores",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRegionPopulation",
+    "inputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct RegionOccupant[]",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum ClansmanState"
+          },
+          {
+            "name": "currentAction",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "missionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWorldSnapshot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct WorldSnapshot",
+        "components": [
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonStartTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonEndTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonFinalized",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "currentSeasonNumber",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextHeartbeatAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterActive",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "winterStartsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterEndsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "activeBanditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "currentTickSeed",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "leaderboard",
+            "type": "tuple[]",
+            "internalType": "struct LeaderboardEntry[]",
+            "components": [
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "monumentLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "baseLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "wallLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "livingClansmen",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum ClanState"
+              },
+              {
+                "name": "lootValue",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteLootValueRaw",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lootValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteLootValueSettled",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lootValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteTravel",
+    "inputs": [
+      {
+        "name": "srcRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "dstRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "travelTicks",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "path",
+        "type": "bytes8",
+        "internalType": "bytes8"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "world",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IClanWorld"
+      }
+    ],
+    "stateMutability": "view"
+  }
+] as const;
+
+export type IClanWorldLensAbiType = typeof iClanWorldLensAbi;
+
+// Derived event name union
+export type IClanWorldLensAbiEventName = (typeof iClanWorldLensAbi)[number] extends infer T
+  ? T extends { type: 'event'; name: string }
+    ? T['name']
+    : never
+  : never;
+
+// Derived function name union
+export type IClanWorldLensAbiFunctionName = (typeof iClanWorldLensAbi)[number] extends infer T
+  ? T extends { type: 'function'; name: string }
+    ? T['name']
+    : never
+  : never;

--- a/packages/contract-types/tsconfig.json
+++ b/packages/contract-types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "composite": false,
+    "noEmit": true
+  },
+  "include": ["index.ts", "src/**/*.ts"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -26,7 +26,9 @@
         "src/adapters/IChainClient.ts",
         "src/generated/constants.ts",
         "src/generated/enums.ts",
-        "convex/_generated/**"
+        "convex/_generated/**",
+        "src/IClanWorld.ts",
+        "src/IClanWorldLens.ts"
       ]
     },
     "dev": {


### PR DESCRIPTION
## What this does

Adds `packages/contract-types/` — a new workspace package that generates TypeScript `as const` ABI literals from the committed ABI JSON files in `packages/contracts/abi/`.

This is PR 1 of 5 in the typechain migration. No external codegen tool (typechain/wagmi) — just a small `generate.mjs` script that reads the JSON and writes typed TS files.

### Generated types

Each generated file exports:
- `iClanWorldAbi` / `iClanWorldLensAbi` — the ABI as a TypeScript `as const` literal
- `IClanWorldAbiType` — the literal type of the ABI array
- `IClanWorldAbiEventName` — union of all event name strings (50 events)
- `IClanWorldAbiFunctionName` — union of all function name strings (58 functions)
- `IClanWorldLensAbiFunctionName` — union of all lens function names (14 functions)

Example:
```ts
import { type IClanWorldAbiEventName } from '@clan-world/contract-types';
// IClanWorldAbiEventName = "TickAdvanced" | "BanditSpawned" | "ClanDied" | ... (50 total)
```

## How to regenerate

```bash
pnpm --filter @clan-world/contract-types codegen
```

## How to check freshness (CI gate for PR 5)

```bash
pnpm --filter @clan-world/contract-types codegen:check
# exits 0 if up to date, 1 if stale/missing
```

## Turbo ordering

`packages/contract-types/package.json` declares `"@clan-world/contracts": "workspace:*"` as a devDependency. The root `turbo.json` `codegen` task already has `"dependsOn": ["^codegen"]`, so turbo runs `contracts` codegen (which produces the ABI JSON) before `contract-types` codegen. No other turbo config changes were needed beyond adding the new generated files to the global `outputs` array for caching.

## Verification

- `tsc --noEmit` on the package: clean (0 errors)
- `node scripts/generate.mjs --check` after codegen: exits 0
- `node scripts/generate.mjs --check` after tampering a file: exits 1 with `STALE:` message
- Idempotent: running codegen twice produces identical output

Closes #398