### PR TITLE
feat(indexer): PR2 — delete dead Whisper code + migrate indexer/heartbeat to literal ABI

### DIFF
--- a/apps/server/convex/heartbeat.ts
+++ b/apps/server/convex/heartbeat.ts
@@ -4,19 +4,16 @@
 // and refreshes Convex snapshots from chain state. Tracked: GH issue #TBD
 import { httpAction, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
-import clanWorldArtifact from "../../../packages/contracts/abi/IClanWorld.json";
+import { iClanWorldAbi } from "@clan-world/contract-types";
 import {
   defineChain,
   createPublicClient,
   http,
   parseEventLogs,
   WaitForTransactionReceiptTimeoutError,
-  type Abi,
   type Hex,
   type Log,
 } from "viem";
-
-const CLAN_WORLD_ABI = clanWorldArtifact.abi as Abi;
 const baseSepolia = defineChain({
   id: 84532,
   name: "Base Sepolia",
@@ -24,7 +21,7 @@ const baseSepolia = defineChain({
   rpcUrls: { default: { http: ["https://sepolia.base.org"] } },
 });
 
-const indexerApi = (internal as any).indexer;
+const indexerApi = internal.indexer;
 
 type HeartbeatWebhookPayload = {
   txHash?: unknown;
@@ -105,7 +102,7 @@ export function validateHeartbeatReceipt(
 
 export function parseHeartbeatEngineEvents(engineLogs: readonly Log[]) {
   return parseEventLogs({
-    abi: CLAN_WORLD_ABI,
+    abi: iClanWorldAbi,
     logs: [...engineLogs],
     strict: false,
   }).map((event) => ({

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -5,13 +5,13 @@ import {
   internalQuery,
 } from "./_generated/server";
 import { internal } from "./_generated/api";
-import clanWorldArtifact from "../../../packages/contracts/abi/IClanWorld.json";
+import { iClanWorldAbi } from "@clan-world/contract-types";
+import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
 import {
   defineChain,
   createPublicClient,
   http,
   parseEventLogs,
-  type Abi,
   type Hex,
   type Log,
   type ParseEventLogsReturnType,
@@ -20,7 +20,6 @@ import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constan
 import type { Doc } from "./_generated/dataModel";
 import { resetLocked } from "./resetLock";
 
-const CLAN_WORLD_ABI = clanWorldArtifact.abi as Abi;
 const baseSepolia = defineChain({
   id: 84532,
   name: "Base Sepolia",
@@ -46,10 +45,10 @@ const LEGACY_REGIONS = [
   { id: "east-docks", name: "East Docks", ownerClanId: null },
   { id: "deep-sea", name: "Deep Sea", ownerClanId: null },
 ];
-const indexerApi = (internal as any).indexer;
+const indexerApi = internal.indexer;
 
 type ParsedIndexerEvent = {
-  eventName: string;
+  eventName: IClanWorldAbiEventName;
   args: Record<string, unknown>;
   address?: string;
   blockHash?: string | null;
@@ -69,7 +68,7 @@ type SnapshotPayload = {
 };
 
 type ParsedClanWorldLog = ParseEventLogsReturnType<
-  typeof CLAN_WORLD_ABI,
+  typeof iClanWorldAbi,
   undefined,
   false
 >[number];
@@ -96,7 +95,7 @@ export function decodeClanWorldLogs(
   logs: readonly Log[],
 ): ParsedIndexerEvent[] {
   return parseEventLogs({
-    abi: CLAN_WORLD_ABI,
+    abi: iClanWorldAbi,
     logs: [...logs],
     strict: false,
   }).map((event: ParsedClanWorldLog) => ({
@@ -623,7 +622,7 @@ export const refreshSnapshot = internalAction({
       client
         .readContract({
           address,
-          abi: CLAN_WORLD_ABI,
+          abi: iClanWorldAbi,
           functionName: "getWorldSnapshot",
           blockNumber: pinnedBlockNumber,
         })
@@ -631,7 +630,7 @@ export const refreshSnapshot = internalAction({
       client
         .readContract({
           address,
-          abi: CLAN_WORLD_ABI,
+          abi: iClanWorldAbi,
           functionName: "getMarketState",
           blockNumber: pinnedBlockNumber,
         })
@@ -639,7 +638,7 @@ export const refreshSnapshot = internalAction({
       client
         .readContract({
           address,
-          abi: CLAN_WORLD_ABI,
+          abi: iClanWorldAbi,
           functionName: "getActiveBanditView",
           blockNumber: pinnedBlockNumber,
         })
@@ -657,7 +656,7 @@ export const refreshSnapshot = internalAction({
     const clanIdsRaw = await client
       .readContract({
         address,
-        abi: CLAN_WORLD_ABI,
+        abi: iClanWorldAbi,
         functionName: "getClanIds",
         blockNumber: pinnedBlockNumber,
       })
@@ -672,7 +671,7 @@ export const refreshSnapshot = internalAction({
         return client
           .readContract({
             address,
-            abi: CLAN_WORLD_ABI,
+            abi: iClanWorldAbi,
             functionName: "getClanFullView",
             args: [clanId],
             blockNumber: pinnedBlockNumber,

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,6 +13,7 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@clan-world/contract-types": "workspace:*",
     "@clan-world/shared": "workspace:*",
     "convex": "1.17.4",
     "viem": "2.48.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
 
   apps/server:
     dependencies:
+      '@clan-world/contract-types':
+        specifier: workspace:*
+        version: link:../../packages/contract-types
       '@clan-world/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -326,6 +329,12 @@ importers:
       vitest:
         specifier: ^3.2.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2)
+
+  packages/contract-types:
+    devDependencies:
+      '@clan-world/contracts':
+        specifier: workspace:*
+        version: link:../contracts
 
   packages/contracts: {}
 


### PR DESCRIPTION
## Summary

Implements PR 2 of 5 in the typechain migration series. This is the hot-path PR — migrates the Convex indexer and heartbeat handler from the untyped JSON artifact import to the generated \`iClanWorldAbi\` constant from \`@clan-world/contract-types\`.

## Drift findings closed

- **D-1**: \`clanWorldArtifact.abi as Abi\` cast in \`indexer.ts\` — replaced with \`iClanWorldAbi\` (literal \`as const\`, no cast needed)
- **D-2**: \`clanWorldArtifact.abi as Abi\` cast in \`heartbeat.ts\` — same replacement
- **D-4**: \`(internal as any).indexer\` in \`indexer.ts\` — removed \`as any\` cast; generated API types already correct
- **D-6**: \`(internal as any).indexer\` in \`heartbeat.ts\` — same fix
- **D-7**: \`ParsedIndexerEvent.eventName: string\` — narrowed to \`IClanWorldAbiEventName\` union from generated types

## Whisper/WhisperBroadcast verification

Neither \`Whisper\` nor \`WhisperBroadcast\` appears in the generated \`IClanWorldAbiEventName\` union (verified in \`packages/contract-types/src/IClanWorld.ts\`). No dead Whisper block was found in this branch — it was either never present or pre-cleaned before this PR.

## Changes

| File | Changes |
|---|---|
| \`apps/server/convex/indexer.ts\` | Replace JSON import + \`as Abi\` cast; fix \`as any\`; narrow \`eventName\` type |
| \`apps/server/convex/heartbeat.ts\` | Replace JSON import + \`as Abi\` cast; fix \`as any\` |
| \`apps/server/package.json\` | Add \`@clan-world/contract-types: workspace:*\` dependency |
| \`pnpm-lock.yaml\` | Updated to reflect new workspace dep |

## Test results

```
Test Files  7 passed (7)
     Tests  36 passed (36)
  Duration  1.30s
```

## TypeScript typecheck

```
pnpm --filter @clan-world/server typecheck  → clean (0 errors)
```

## Risk note

Per plan §4 PR 2: the `whispers` table in production should be verified empty before deploying, as it was associated with the dead Whisper event handling path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)