### PR TITLE
feat(web): remove stale as-any casts for season/winter snapshot fields (#PR4)

### DIFF
--- a/apps/web/src/TopHud.tsx
+++ b/apps/web/src/TopHud.tsx
@@ -72,17 +72,13 @@ export function TopHud({ liveTick }: { liveTick: number }) {
   }, []);
 
   const { seasonStartTick, seasonEndTick, winterActive, winterStartsAtTick } = useMemo(() => {
-    // Try to read real season data from full worldSnapshot via getSnapshot.
-    // The lightweight getSnapshot query only returns tick + tickEpoch + clans + regions —
-    // season fields come from a broader snapshot query if exposed.
-    // Cast as any to access optional fields the TS type doesn't expose yet.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const s = snapshot as any;
+    // getSnapshot derives season fields from tick via deriveSeasonState() — all four
+    // fields are present in the return type.
     return {
-      seasonStartTick: typeof s?.seasonStartTick === 'number' ? s.seasonStartTick : null,
-      seasonEndTick: typeof s?.seasonEndTick === 'number' ? s.seasonEndTick : null,
-      winterActive: s?.winterActive === true,
-      winterStartsAtTick: typeof s?.winterStartsAtTick === 'number' ? s.winterStartsAtTick : null,
+      seasonStartTick: typeof snapshot?.seasonStartTick === 'number' ? snapshot.seasonStartTick : null,
+      seasonEndTick: typeof snapshot?.seasonEndTick === 'number' ? snapshot.seasonEndTick : null,
+      winterActive: snapshot?.winterActive === true,
+      winterStartsAtTick: typeof snapshot?.winterStartsAtTick === 'number' ? snapshot.winterStartsAtTick : null,
     };
   }, [snapshot]);
 

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -2123,8 +2123,7 @@ export function WorldMap() {
                 currentApp.stage.addChild(snow.container);
                 winterSnowRef.current = snow;
               }
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const winterActive = (snapshotRef.current as any)?.winterActive === true;
+              const winterActive = snapshotRef.current?.winterActive === true;
               winterSnowRef.current.setActive(winterActive);
             }
           };
@@ -3775,10 +3774,9 @@ export function WorldMap() {
       REGION_KEY_BY_CHAIN_ID,
     );
 
-    // TODO(backend): worldPaused is not currently in worldSnapshot schema.
-    // Plumb through apps/server/convex/getSnapshot.ts when adding pause support.
-    // Until then, this branch is dormant and animations advance during pause.
-    const worldPaused = ((snap as any)?.worldPaused ?? false) === true;
+    // TODO(backend): worldPaused is not yet returned by getSnapshot. Wire up when
+    // pause support lands in the schema; until then animations advance during pause.
+    const worldPaused = false;
 
     // Hide everything by default, then enable per-phase.
     hideBanditAnimSprites();
@@ -5008,8 +5006,7 @@ export function WorldMap() {
   // particle overlay's active state. The underlying snapshot type doesn't yet
   // expose the season fields (matches the cast TopHud does — same getSnapshot
   // query, same broader-schema-pending caveat), so we read via `any`.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const winterActive = (snapshot as any)?.winterActive === true;
+  const winterActive = snapshot?.winterActive === true;
   useEffect(() => {
     if (!pixiReady) return;
     const snow = winterSnowRef.current;


### PR DESCRIPTION
## Summary

`getSnapshot` returns `seasonStartTick`, `seasonEndTick`, `winterActive`, and `winterStartsAtTick` via `deriveSeasonState()` (added ~sprint ago). The `as any` casts in TopHud.tsx and WorldMap.tsx were written before these fields were plumbed through and were never cleaned up.

- **TopHud.tsx:80** — Remove `const s = snapshot as any;`, access fields directly on `snapshot`
- **WorldMap.tsx:2127** — `(snapshotRef.current as any)?.winterActive` → `snapshotRef.current?.winterActive`
- **WorldMap.tsx:5012** — `(snapshot as any)?.winterActive` → `snapshot?.winterActive`
- **WorldMap.tsx:3781** — `(snap as any)?.worldPaused ?? false` → `false` (field not in schema, branch documented as dormant, TODO updated)

## Deferred: mobile D-11 (`clanData.ts:25` SnapshotClan)
`apps/mobile` explicitly avoids importing from `@clan-world/server` (see `convexApi.ts` comment: transitive type errors). Requires a slim `mobile-api.d.ts` re-export. Tracked for slice 2.

## Test plan

- [x] `pnpm --filter @clan-world/web typecheck` — clean
- [ ] 3-tier swarm review
- [ ] Orchestrator super-swarm

Part of typechain migration: `docs/plans/typechain-and-generated-types-audit-v1.md`
PR 1 (#427) ✓ | PR 2 (#428) ✓ | PR 3 (#429) ✓ | **PR 4 (this)** | PR 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)