### PR TITLE
feat(ci): typechain-ci — ABI freshness, Convex types freshness, no-as-Abi gate (#PR5)

### DIFF
--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           version: stable
       - run: pnpm install --frozen-lockfile
+      # codegen:check reads the ABI JSON and exits non-zero if the committed
+      # output in packages/contract-types/src/ is stale — no files are written.
       - name: Check @clan-world/contract-types output is current
         run: pnpm --filter @clan-world/contract-types run codegen:check
-      - name: Verify no staged diff in generated files
-        run: git diff --exit-code packages/contract-types/src/
 
   convex-types-freshness:
     name: Convex generated types are current
@@ -44,7 +44,7 @@ jobs:
       - name: Regenerate Convex types
         working-directory: apps/server
         run: pnpm run codegen
-      - name: Verify no staged diff in _generated
+      - name: Verify no working-tree changes in _generated
         run: git diff --exit-code apps/server/convex/_generated/
 
   no-as-abi-casts:
@@ -54,8 +54,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Grep for as-Abi casts
         run: |
-          if grep -rn "as Abi" \
+          if grep -rEn "as[[:space:]]+Abi\b" \
             --include="*.ts" \
+            --include="*.tsx" \
             --exclude-dir="_generated" \
             --exclude-dir="node_modules" \
             --exclude-dir="dev-ui" \

--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -1,0 +1,66 @@
+name: Typechain CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+      - main
+
+jobs:
+  contract-types-freshness:
+    name: Contract types are current
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+      - run: pnpm install --frozen-lockfile
+      - name: Check @clan-world/contract-types output is current
+        run: pnpm --filter @clan-world/contract-types run codegen:check
+      - name: Verify no staged diff in generated files
+        run: git diff --exit-code packages/contract-types/src/
+
+  convex-types-freshness:
+    name: Convex generated types are current
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Regenerate Convex types
+        working-directory: apps/server
+        run: pnpm run codegen
+      - name: Verify no staged diff in _generated
+        run: git diff --exit-code apps/server/convex/_generated/
+
+  no-as-abi-casts:
+    name: No raw as-Abi casts in source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Grep for as-Abi casts
+        run: |
+          if grep -rn "as Abi" \
+            --include="*.ts" \
+            --exclude-dir="_generated" \
+            --exclude-dir="node_modules" \
+            --exclude-dir="dev-ui" \
+            apps/ packages/shared/src/ packages/runner/src/ packages/agents/src/ 2>/dev/null; then
+            echo "::error::Found raw 'as Abi' cast(s). Import the generated iClanWorldAbi / iClanWorldLensAbi from @clan-world/contract-types instead."
+            exit 1
+          fi
+          echo "No raw as-Abi casts found."

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -2115,9 +2115,8 @@ export function WorldMap() {
             } else {
               // User just turned reduced-motion OFF. Lazily build the handle
               // if init skipped it (reducedMotion was true at startup), then
-              // restore the snapshot-driven active state. The (snapshot as any)
-              // cast mirrors the dedicated useEffect downstream — same broader
-              // snapshot-schema-pending caveat.
+              // restore the snapshot-driven active state. winterActive is typed
+              // in the getSnapshot return type via deriveSeasonState().
               if (!winterSnowRef.current) {
                 const snow = createWinterSnow(currentApp, { particleCount: 100 });
                 currentApp.stage.addChild(snow.container);
@@ -5003,9 +5002,8 @@ export function WorldMap() {
   }, [liveTick, pixiReady, liveBandit]);
 
   // Winter snowfall: subscribe to `worldSnapshot.winterActive` and drive the
-  // particle overlay's active state. The underlying snapshot type doesn't yet
-  // expose the season fields (matches the cast TopHud does — same getSnapshot
-  // query, same broader-schema-pending caveat), so we read via `any`.
+  // particle overlay's active state. Season fields are derived in getSnapshot
+  // via deriveSeasonState() and present in the return type.
   const winterActive = snapshot?.winterActive === true;
   useEffect(() => {
     if (!pixiReady) return;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,6 +23,7 @@
     "vitest": "^3.2.0"
   },
   "dependencies": {
+    "@clan-world/contract-types": "workspace:*",
     "@clan-world/contracts": "workspace:*",
     "convex": "1.17.4",
     "viem": "^2.48.4"

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import clanWorldLensAbi from '@clan-world/contracts/abi/IClanWorldLens.json' with { type: 'json' };
+import { iClanWorldLensAbi } from '@clan-world/contract-types';
 import {
   type Abi,
   createPublicClient,
@@ -15,7 +15,7 @@ import type { ClanFullView, ClanOrder, Tick } from '../types';
 import { ActionType } from '../generated/enums';
 import { readEnv } from './_env';
 
-const CLAN_WORLD_LENS_ABI = clanWorldLensAbi.abi as Abi;
+const CLAN_WORLD_LENS_ABI = iClanWorldLensAbi satisfies Abi;
 
 export interface SubmitOrderResult {
   clansmanId: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,9 @@ importers:
 
   packages/shared:
     dependencies:
+      '@clan-world/contract-types':
+        specifier: workspace:*
+        version: link:../contract-types
       '@clan-world/contracts':
         specifier: workspace:*
         version: link:../contracts


### PR DESCRIPTION
## Summary

Adds `.github/workflows/typechain-ci.yml` with three enforcement jobs:

| Job | What it checks |
|-----|---------------|
| `contract-types-freshness` | `@clan-world/contract-types codegen:check` + `git diff --exit-code packages/contract-types/src/` |
| `convex-types-freshness` | `pnpm run codegen` in apps/server + `git diff --exit-code apps/server/convex/_generated/` |
| `no-as-abi-casts` | grep blocks raw `as Abi` in `apps/` + `packages/shared/src/` (dev-ui excluded) |

Also in this PR:
- **`IChainClient.ts` (D-12)**: Last remaining `as Abi` cast. Import `iClanWorldLensAbi` from `@clan-world/contract-types`, use `satisfies Abi`. Add `@clan-world/contract-types` to `@clan-world/shared` deps.
- **WorldMap.tsx stale comments**: Two comments still referencing removed `as any` casts (Claude R1 F1/F2 on PR #430).

## Stacking note

This PR is stacked on `feat/pr4-web-as-any` (#430). After orchestrator merges PR 4 → dev, this branch will be rebased on dev and re-opened targeting dev.

## Test plan

- [x] `pnpm --filter @clan-world/shared typecheck` — clean
- [x] `pnpm --filter @clan-world/web typecheck` — clean
- [x] Grep gate verified: no `as Abi` in scope after IChainClient fix
- [ ] 3-tier swarm review
- [ ] Orchestrator super-swarm

Part of typechain migration: `docs/plans/typechain-and-generated-types-audit-v1.md`
PR 1 (#427) ✓ | PR 2 (#428) ✓ | PR 3 (#429) ✓ | PR 4 (#430) → orch | **PR 5 (this)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)