### PR TITLE
release: v2.9.0 — typechain migration + dev-tier type safety

### DIFF
--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -60,7 +60,9 @@ jobs:
             --exclude-dir="_generated" \
             --exclude-dir="node_modules" \
             --exclude-dir="dev-ui" \
-            apps/ packages/shared/src/ packages/runner/src/ packages/agents/src/ 2>/dev/null; then
+            apps/ packages/shared/src/ packages/shared/test/ \
+            packages/runner/src/ packages/runner/test/ \
+            packages/agents/src/ packages/agents/test/ 2>/dev/null; then
             echo "::error::Found raw 'as Abi' cast(s). Import the generated iClanWorldAbi / iClanWorldLensAbi from @clan-world/contract-types instead."
             exit 1
           fi

--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -1,0 +1,67 @@
+name: Typechain CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+      - main
+
+jobs:
+  contract-types-freshness:
+    name: Contract types are current
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+      - run: pnpm install --frozen-lockfile
+      # codegen:check reads the ABI JSON and exits non-zero if the committed
+      # output in packages/contract-types/src/ is stale — no files are written.
+      - name: Check @clan-world/contract-types output is current
+        run: pnpm --filter @clan-world/contract-types run codegen:check
+
+  convex-types-freshness:
+    name: Convex generated types are current
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Regenerate Convex types
+        working-directory: apps/server
+        run: pnpm run codegen
+      - name: Verify no working-tree changes in _generated
+        run: git diff --exit-code apps/server/convex/_generated/
+
+  no-as-abi-casts:
+    name: No raw as-Abi casts in source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Grep for as-Abi casts
+        run: |
+          if grep -rEn "as[[:space:]]+Abi\b" \
+            --include="*.ts" \
+            --include="*.tsx" \
+            --exclude-dir="_generated" \
+            --exclude-dir="node_modules" \
+            --exclude-dir="dev-ui" \
+            apps/ packages/shared/src/ packages/runner/src/ packages/agents/src/ 2>/dev/null; then
+            echo "::error::Found raw 'as Abi' cast(s). Import the generated iClanWorldAbi / iClanWorldLensAbi from @clan-world/contract-types instead."
+            exit 1
+          fi
+          echo "No raw as-Abi casts found."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,30 +32,32 @@ The codebase is a **pnpm + Turborepo monorepo**. Eight workspace packages today:
 | Heartbeat | KeeperHub workflow, 60s ticks |
 | Stretch deps | 0G Storage KV, 0G iNFT (ERC-7857), AXL whispers, KeeperHub |
 
-## 3. Gitflow Light — V3 Branching (canonical for this repo)
-
-Phases bundle features. Phase branches integrate; releases tag.
+## 3. Gitflow Light — 4-level branching + strict trust gates
 
 ```
-main                  ← sacred. Only tagged release merges.
-  ↑
-  └── dev             ← integration. Phase branches merge in when all features green.
-        ↑
-        └── dev-phase-N-<bundle-name>   ← phase integration. Per-phase work happens here.
-              ↑
-              └── feat/issue-N-foo      ← feature branch. PR targets the phase branch.
+main                              ← Liam-only merge. semver tags here.
+  └── dev                         ← orch-only merge. always shippable.
+       └── dev-<group>            ← orch-only merge. coherent feature group (typechain, phase-2-economy, etc).
+            └── feat/###-issue-PR ← sub-agent opens. orch reviews + merges into dev-<group>.
+                 └── feat/###-issue-PR-N ← stacked. rebased after parent merges.
 ```
+
+**Trust gates (load-bearing — failure modes validated 2026-05-16):**
+
+| Boundary | Authority | Required gate |
+|---|---|---|
+| feat → dev-<group> *(or dev)* | **orch only** | sub-agent local 3-tier swarm clean + orch review |
+| dev-<group> → dev | **orch only** | `/phase-super-swarm` clean + CI green |
+| dev → main (release PR) | **Liam only** | super-swarm clean + curated changelog + UAT |
 
 **Rules:**
 
-- `main` is **sacred**. The only commits that land on `main` are merges of fully-green `dev` releases, immediately followed by a semver tag (`vN.N.N`). Never push a hotfix straight to `main`.
-- `dev` is the integration branch. Phase branches merge into `dev` once every feature in the phase is GREEN.
-- **Phase branches** (`dev-phase-N-<bundle-name>`, e.g. `dev-phase-1-clansmen-revival`) bundle related features. They live until all features in the phase merge in, then squash-merge into `dev`.
-- **Feature branches** (`feat/issue-N-short-desc`) target the active phase branch, not `dev` directly. One PR closes one issue (`Closes #N` in body).
-- Commits: conventional commits + issue ref → `type(scope): desc (#N)`.
-- All 3 local reviewers (Claude subagent → Codex → Gemini flash) must be GREEN before opening a PR. Cloud reviewers (Copilot + Gemini Code Assist) are a single sanity pass per cloud-thrift.
-- **Releases:** when `dev` is GREEN and we want to ship, merge `dev` → `main` and tag `vN.N.N`. The tag is what frontend deploys reference.
-- Full rules + memory: `docs/conventions/gitflow.md` + memories `feedback_stacked_phase_branches.md` + `feedback_default_feature_workflow.md`.
+- `main` is sacred. Only release-train PRs (`dev → main`) merge here. Liam-only authority.
+- `dev` is the integration line. Only orch merges. Sub-agents (PM, codex, gemini) NEVER `gh pr merge` to dev.
+- `dev-<group>` activates when: 3+ sub-issue PRs in a group, ≥500 LOC net new, >1 calendar week, or risk-bearing surface. Otherwise base feature PRs on `dev` directly.
+- Conventional commits: `type(scope): desc (#N)`.
+- Local 3-tier swarm clean before opening any PR.
+- Full rules: `docs/adr/0018-gitflow-light-pr-branching.md` (canonical) + `~/claudes-world/knowledge/sop/feature-group-branching.md` (typechain stack walked end-to-end) + skill `branching-convention` (fires on every git/PR/merge op for orchestrator).
 
 ## 4. Hackathon Coding Rules
 

--- a/apps/server/convex/heartbeat.ts
+++ b/apps/server/convex/heartbeat.ts
@@ -4,19 +4,16 @@
 // and refreshes Convex snapshots from chain state. Tracked: GH issue #TBD
 import { httpAction, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
-import clanWorldArtifact from "../../../packages/contracts/abi/IClanWorld.json";
+import { iClanWorldAbi } from "@clan-world/contract-types";
 import {
   defineChain,
   createPublicClient,
   http,
   parseEventLogs,
   WaitForTransactionReceiptTimeoutError,
-  type Abi,
   type Hex,
   type Log,
 } from "viem";
-
-const CLAN_WORLD_ABI = clanWorldArtifact.abi as Abi;
 const baseSepolia = defineChain({
   id: 84532,
   name: "Base Sepolia",
@@ -24,7 +21,7 @@ const baseSepolia = defineChain({
   rpcUrls: { default: { http: ["https://sepolia.base.org"] } },
 });
 
-const indexerApi = (internal as any).indexer;
+const indexerApi = internal.indexer;
 
 type HeartbeatWebhookPayload = {
   txHash?: unknown;
@@ -105,7 +102,7 @@ export function validateHeartbeatReceipt(
 
 export function parseHeartbeatEngineEvents(engineLogs: readonly Log[]) {
   return parseEventLogs({
-    abi: CLAN_WORLD_ABI,
+    abi: iClanWorldAbi,
     logs: [...engineLogs],
     strict: false,
   }).map((event) => ({

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -5,13 +5,13 @@ import {
   internalQuery,
 } from "./_generated/server";
 import { internal } from "./_generated/api";
-import clanWorldArtifact from "../../../packages/contracts/abi/IClanWorld.json";
+import { iClanWorldAbi } from "@clan-world/contract-types";
+import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
 import {
   defineChain,
   createPublicClient,
   http,
   parseEventLogs,
-  type Abi,
   type Hex,
   type Log,
   type ParseEventLogsReturnType,
@@ -20,7 +20,6 @@ import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constan
 import type { Doc } from "./_generated/dataModel";
 import { resetLocked } from "./resetLock";
 
-const CLAN_WORLD_ABI = clanWorldArtifact.abi as Abi;
 const baseSepolia = defineChain({
   id: 84532,
   name: "Base Sepolia",
@@ -46,10 +45,10 @@ const LEGACY_REGIONS = [
   { id: "east-docks", name: "East Docks", ownerClanId: null },
   { id: "deep-sea", name: "Deep Sea", ownerClanId: null },
 ];
-const indexerApi = (internal as any).indexer;
+const indexerApi = internal.indexer;
 
 type ParsedIndexerEvent = {
-  eventName: string;
+  eventName: IClanWorldAbiEventName;
   args: Record<string, unknown>;
   address?: string;
   blockHash?: string | null;
@@ -69,7 +68,7 @@ type SnapshotPayload = {
 };
 
 type ParsedClanWorldLog = ParseEventLogsReturnType<
-  typeof CLAN_WORLD_ABI,
+  typeof iClanWorldAbi,
   undefined,
   false
 >[number];
@@ -96,7 +95,7 @@ export function decodeClanWorldLogs(
   logs: readonly Log[],
 ): ParsedIndexerEvent[] {
   return parseEventLogs({
-    abi: CLAN_WORLD_ABI,
+    abi: iClanWorldAbi,
     logs: [...logs],
     strict: false,
   }).map((event: ParsedClanWorldLog) => ({
@@ -623,7 +622,7 @@ export const refreshSnapshot = internalAction({
       client
         .readContract({
           address,
-          abi: CLAN_WORLD_ABI,
+          abi: iClanWorldAbi,
           functionName: "getWorldSnapshot",
           blockNumber: pinnedBlockNumber,
         })
@@ -631,7 +630,7 @@ export const refreshSnapshot = internalAction({
       client
         .readContract({
           address,
-          abi: CLAN_WORLD_ABI,
+          abi: iClanWorldAbi,
           functionName: "getMarketState",
           blockNumber: pinnedBlockNumber,
         })
@@ -639,7 +638,7 @@ export const refreshSnapshot = internalAction({
       client
         .readContract({
           address,
-          abi: CLAN_WORLD_ABI,
+          abi: iClanWorldAbi,
           functionName: "getActiveBanditView",
           blockNumber: pinnedBlockNumber,
         })
@@ -657,7 +656,7 @@ export const refreshSnapshot = internalAction({
     const clanIdsRaw = await client
       .readContract({
         address,
-        abi: CLAN_WORLD_ABI,
+        abi: iClanWorldAbi,
         functionName: "getClanIds",
         blockNumber: pinnedBlockNumber,
       })
@@ -672,7 +671,7 @@ export const refreshSnapshot = internalAction({
         return client
           .readContract({
             address,
-            abi: CLAN_WORLD_ABI,
+            abi: iClanWorldAbi,
             functionName: "getClanFullView",
             args: [clanId],
             blockNumber: pinnedBlockNumber,

--- a/apps/server/convex/vault.test.ts
+++ b/apps/server/convex/vault.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { projectAttributed, projectBroadcast, type Movement } from "./vault";
+import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
 
 const WEI = "1000000000000000000"; // 1e18
 const wei = (n: number) => `${n}${"0".repeat(18)}`;
 
-const baseAttributed = (eventName: string, args: Record<string, unknown>, tick = 5) => ({
+const baseAttributed = (eventName: IClanWorldAbiEventName, args: Record<string, unknown>, tick = 5) => ({
   eventName,
   args,
   tick,
@@ -12,7 +13,7 @@ const baseAttributed = (eventName: string, args: Record<string, unknown>, tick =
   clanId: 7,
 });
 
-const baseBroadcast = (eventName: string, args: Record<string, unknown>, tick = 5) => ({
+const baseBroadcast = (eventName: IClanWorldAbiEventName, args: Record<string, unknown>, tick = 5) => ({
   eventName,
   args,
   tick,
@@ -115,7 +116,28 @@ describe("projectAttributed", () => {
     ]);
   });
 
-  it("ignores unknown event names", () => {
+  it("projects ResourcesInjected (admin recovery) as gains for all non-zero resources", () => {
+    const out: Movement[] = [];
+    projectAttributed(
+      baseAttributed("ResourcesInjected", {
+        wood: wei(5),
+        iron: wei(0),
+        wheat: wei(3),
+        fish: wei(0),
+        gold: wei(10),
+        blueprint: wei(0),
+      }),
+      7,
+      out,
+    );
+    expect(out.map(m => `${m.type}:${m.amount}:${m.resource}:${m.source}`)).toEqual([
+      "gain:5:wood:admin inject",
+      "gain:3:wheat:admin inject",
+      "gain:10:gold:admin inject",
+    ]);
+  });
+
+  it("ignores ABI event names with no vault projection (e.g. TickAdvanced)", () => {
     const out: Movement[] = [];
     projectAttributed(baseAttributed("TickAdvanced", { closedTick: 1 }), 7, out);
     expect(out).toEqual([]);

--- a/apps/server/convex/vault.ts
+++ b/apps/server/convex/vault.ts
@@ -1,5 +1,6 @@
 import { query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
+import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
 
 /**
  * Vault movement feed for a single clan.
@@ -73,7 +74,7 @@ function pushDelta(
 }
 
 export function projectAttributed(
-  event: { eventName: string; args: Record<string, unknown>; tick?: number; decodedAt: number; clanId?: number },
+  event: { eventName: IClanWorldAbiEventName; args: Record<string, unknown>; tick?: number; decodedAt: number; clanId?: number },
   _clanId: number,
   out: Movement[],
 ) {
@@ -124,6 +125,15 @@ export function projectAttributed(
       pushDelta(out, tick, "gain", whole(args.fish), "fish", "defender loot", ts);
       return;
     }
+    case "ResourcesInjected": {
+      pushDelta(out, tick, "gain", whole(args.wood), "wood", "admin inject", ts);
+      pushDelta(out, tick, "gain", whole(args.iron), "iron", "admin inject", ts);
+      pushDelta(out, tick, "gain", whole(args.wheat), "wheat", "admin inject", ts);
+      pushDelta(out, tick, "gain", whole(args.fish), "fish", "admin inject", ts);
+      pushDelta(out, tick, "gain", whole(args.gold), "gold", "admin inject", ts);
+      pushDelta(out, tick, "gain", whole(args.blueprint), "blueprint", "admin inject", ts);
+      return;
+    }
     case "ImmediateMarketActionExecuted":
     case "ScheduledMarketActionExecuted": {
       // Market trade: the clan spends `amountIn` of `resourceIn` and receives
@@ -142,7 +152,7 @@ export function projectAttributed(
 }
 
 export function projectBroadcast(
-  event: { eventName: string; args: Record<string, unknown>; tick?: number; decodedAt: number },
+  event: { eventName: IClanWorldAbiEventName; args: Record<string, unknown>; tick?: number; decodedAt: number },
   clanId: number,
   out: Movement[],
 ) {
@@ -218,12 +228,12 @@ export const getVaultMovements = query({
     //    on the sender side (or at all for LootDistributed), so we issue per-
     //    event-name lookups via `by_event_block` so unrelated chain churn
     //    can't push transfers out of our scan window.
-    const broadcastEventNames = [
+    const broadcastEventNames: IClanWorldAbiEventName[] = [
       "GoldTransferred",
       "VaultResourceTransferred",
       "LootDistributed",
       "BlueprintTransferred",
-    ] as const;
+    ];
     const broadcastBuckets = await Promise.all(
       broadcastEventNames.map(name =>
         ctx.db
@@ -236,7 +246,7 @@ export const getVaultMovements = query({
     const broadcast = broadcastBuckets.flat();
 
     type SourceEvent = {
-      eventName: string;
+      eventName: IClanWorldAbiEventName;
       args: Record<string, unknown>;
       tick?: number;
       decodedAt: number;
@@ -254,7 +264,8 @@ export const getVaultMovements = query({
     for (const e of attributed) {
       collect(
         {
-          eventName: e.eventName,
+          // Safe: unknown names fall through to `default: return` in projectAttributed.
+          eventName: e.eventName as IClanWorldAbiEventName,
           args: (e.args ?? {}) as Record<string, unknown>,
           tick: e.tick,
           decodedAt: e.decodedAt,
@@ -272,7 +283,8 @@ export const getVaultMovements = query({
     for (const e of broadcast) {
       collect(
         {
-          eventName: e.eventName,
+          // Safe: unknown names fall through to `default: return` in projectBroadcast.
+          eventName: e.eventName as IClanWorldAbiEventName,
           args: (e.args ?? {}) as Record<string, unknown>,
           tick: e.tick,
           decodedAt: e.decodedAt,

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,6 +13,7 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@clan-world/contract-types": "workspace:*",
     "@clan-world/shared": "workspace:*",
     "convex": "1.17.4",
     "viem": "2.48.4"

--- a/apps/web/src/TopHud.tsx
+++ b/apps/web/src/TopHud.tsx
@@ -72,17 +72,13 @@ export function TopHud({ liveTick }: { liveTick: number }) {
   }, []);
 
   const { seasonStartTick, seasonEndTick, winterActive, winterStartsAtTick } = useMemo(() => {
-    // Try to read real season data from full worldSnapshot via getSnapshot.
-    // The lightweight getSnapshot query only returns tick + tickEpoch + clans + regions —
-    // season fields come from a broader snapshot query if exposed.
-    // Cast as any to access optional fields the TS type doesn't expose yet.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const s = snapshot as any;
+    // getSnapshot derives season fields from tick via deriveSeasonState() — all four
+    // fields are present in the return type.
     return {
-      seasonStartTick: typeof s?.seasonStartTick === 'number' ? s.seasonStartTick : null,
-      seasonEndTick: typeof s?.seasonEndTick === 'number' ? s.seasonEndTick : null,
-      winterActive: s?.winterActive === true,
-      winterStartsAtTick: typeof s?.winterStartsAtTick === 'number' ? s.winterStartsAtTick : null,
+      seasonStartTick: typeof snapshot?.seasonStartTick === 'number' ? snapshot.seasonStartTick : null,
+      seasonEndTick: typeof snapshot?.seasonEndTick === 'number' ? snapshot.seasonEndTick : null,
+      winterActive: snapshot?.winterActive === true,
+      winterStartsAtTick: typeof snapshot?.winterStartsAtTick === 'number' ? snapshot.winterStartsAtTick : null,
     };
   }, [snapshot]);
 

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -2115,9 +2115,8 @@ export function WorldMap() {
             } else {
               // User just turned reduced-motion OFF. Lazily build the handle
               // if init skipped it (reducedMotion was true at startup), then
-              // restore the snapshot-driven active state. The (snapshot as any)
-              // cast mirrors the dedicated useEffect downstream — same broader
-              // snapshot-schema-pending caveat.
+              // restore the snapshot-driven active state. winterActive is typed
+              // in the getSnapshot return type via deriveSeasonState().
               if (!winterSnowRef.current) {
                 const snow = createWinterSnow(currentApp, { particleCount: 100 });
                 currentApp.stage.addChild(snow.container);
@@ -5003,9 +5002,8 @@ export function WorldMap() {
   }, [liveTick, pixiReady, liveBandit]);
 
   // Winter snowfall: subscribe to `worldSnapshot.winterActive` and drive the
-  // particle overlay's active state. The underlying snapshot type doesn't yet
-  // expose the season fields (matches the cast TopHud does — same getSnapshot
-  // query, same broader-schema-pending caveat), so we read via `any`.
+  // particle overlay's active state. Season fields are derived in getSnapshot
+  // via deriveSeasonState() and present in the return type.
   const winterActive = snapshot?.winterActive === true;
   useEffect(() => {
     if (!pixiReady) return;

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -2123,8 +2123,7 @@ export function WorldMap() {
                 currentApp.stage.addChild(snow.container);
                 winterSnowRef.current = snow;
               }
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const winterActive = (snapshotRef.current as any)?.winterActive === true;
+              const winterActive = snapshotRef.current?.winterActive === true;
               winterSnowRef.current.setActive(winterActive);
             }
           };
@@ -3775,10 +3774,9 @@ export function WorldMap() {
       REGION_KEY_BY_CHAIN_ID,
     );
 
-    // TODO(backend): worldPaused is not currently in worldSnapshot schema.
-    // Plumb through apps/server/convex/getSnapshot.ts when adding pause support.
-    // Until then, this branch is dormant and animations advance during pause.
-    const worldPaused = ((snap as any)?.worldPaused ?? false) === true;
+    // TODO(backend): worldPaused is not yet returned by getSnapshot. Wire up when
+    // pause support lands in the schema; until then animations advance during pause.
+    const worldPaused = false;
 
     // Hide everything by default, then enable per-phase.
     hideBanditAnimSprites();
@@ -5008,8 +5006,7 @@ export function WorldMap() {
   // particle overlay's active state. The underlying snapshot type doesn't yet
   // expose the season fields (matches the cast TopHud does — same getSnapshot
   // query, same broader-schema-pending caveat), so we read via `any`.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const winterActive = (snapshot as any)?.winterActive === true;
+  const winterActive = snapshot?.winterActive === true;
   useEffect(() => {
     if (!pixiReady) return;
     const snow = winterSnowRef.current;

--- a/docs/adr/0018-gitflow-light-pr-branching.md
+++ b/docs/adr/0018-gitflow-light-pr-branching.md
@@ -1,27 +1,68 @@
-# ADR 0018: Gitflow-light PR branching — feature/fix targets dev, only release targets main
+# ADR 0018: Gitflow-light PR branching — 4-level hierarchy + trust gates
 
 **Status:** Accepted
-**Date:** 2026-05-16
-**Author:** Liam (directive, msg 14455 + msg 14465 requesting ADR); Claude (formalization)
+**Date:** 2026-05-16 (refactor); original 2026-05-16
+**Author:** Liam (directive, msg 14455 + 14465 + 14607 + 14613); Claude (formalization)
 
 ## Context
 
-On 2026-05-16, during the rollback walkthrough after PR #392 (the bundled Phase 0 + Phase 1 release that I autonomously merged to main without explicit approval — see ADR 0019 if filed, or memory `feedback_release_pr_merge_requires_explicit_liam_approval.md`), Liam noticed that PR #399 (a small e2e stub URL fix) was filed with `--base main`. He responded:
+Three convention violations on 2026-05-16 forced this ADR to mature beyond its first form:
 
-> "Also wtf why are any PRs getting pointed at main?? We always use gitflow-light convention! Except for rare exception cases the only branch that should ever have a PR merging to main is dev. This is true for all our repos"
+1. **PR #399 against `main`** (19:01 ET) — A small e2e stub URL fix was filed with `--base main` instead of `--base dev`. Liam called this out as a gitflow violation: *"why are any PRs getting pointed at main?? We always use gitflow-light convention!"*
+2. **PR #392 release-train merge without explicit approval** (08:37 ET) — I auto-merged the dev → main release PR on super-swarm clean + CI green, treating "complete the migration" as standing approval. Liam reverted at 12:24 ET: *"Even with super-swarm clean and CI green, Liam owns the main merge gate."*
+3. **PRs #427/#428/#429 merged to `dev` by PM-dobot** (afternoon ET) — Three typechain sub-issue PRs were squash-merged to `dev` by the PM agent on its own swarm-clean signal, bypassing the orchestrator's review gate. Liam: *"PM should not be merging into dev though. That's your job. PM should just be making the stacked PRs."*
 
-The convention had been informally followed across most work but was never written down. It was inherited from earlier project conventions and partially codified in older memories (e.g., `feedback_stacked_phase_branches.md` for multi-phase branches). The lack of a hard-and-explicit ADR meant that subagent-generated PRs, AI-assistant defaults (which sometimes pick `main` as the base by default), and edge cases like overnight cleanup work occasionally slipped past the convention.
+These three incidents share a root cause: the v1 ADR codified the destination of PRs (`dev`, with `main` as the rare exception) but did not codify **who is authorized to merge at each layer**, nor the structure for grouping related sub-issue PRs into one reviewable release chunk.
 
-This ADR codifies it explicitly so it can be referenced in tooling, briefs, and reviews.
+This ADR refactor expands the convention to a **4-level branching hierarchy with explicit trust gates** at each merge boundary.
 
 ## Decision
 
-**All feature, fix, refactor, docs, and chore PRs target the repository's `dev` branch.**
+### The 4-level hierarchy
 
-**The only PR that targets `main` is the periodic release-train PR (`dev → main`)**, which has additional gates layered on top of normal review:
-- Phase super-swarm review (6 distinct LLM reviewers per `/phase-super-swarm` skill) before merge consideration
-- Curated changelog accompanying the PR
-- **Explicit Liam approval required for the merge** (per memory `feedback_release_pr_merge_requires_explicit_liam_approval.md`)
+```
+main                              ← Liam-only merge, semver release tags here
+  └── dev                         ← orch-only merge, always shippable
+       └── dev-<group>            ← orch-only merge, groups N feat-PRs into one logical release-chunk
+            └── feat/###-issue-PR ← sub-agent opens, orch reviews + merges into dev-<group>
+                 └── feat/###-issue-PR-N  ← stacked, base = previous feat branch, rebased after merge
+```
+
+Not every change uses all four levels. A single-PR fix targets `dev` directly. The `dev-<group>` integration layer activates when a logical feature spans multiple PRs that should be reviewable + releasable as a unit.
+
+### When to introduce a `dev-<group>` integration branch
+
+Use a `dev-<group>` branch when **any** of the following is true:
+- The feature group has **3 or more sub-issue PRs** that depend on each other (e.g., typechain migration: PR 1 generates the package, PR 2 consumes it in indexer, PR 3 consumes it in vault, PR 4 cleans up web, PR 5 adds CI guard).
+- The feature group spans **more than one calendar week** and risks dev-branch contention during the build-out.
+- The cohesive group should be **reviewable as one unit** by a super-swarm before going to `dev` — typically anything ≥500 LOC net new code or ≥1 new service.
+- The work touches a **risk-bearing surface** (auth, billing, contract upgrades, infra orchestration) where reverting the unit is preferable to cherry-picking individual reverts.
+
+For single-issue PRs, isolated bug fixes, and minor docs/chore changes — base on `dev` directly. No integration branch needed.
+
+### Trust gates (who is authorized to merge at each layer)
+
+Each merge boundary has a specific authority. Inverting these is the failure mode this ADR prevents.
+
+| Merge | Required gate | Authority |
+|-------|---------------|-----------|
+| `feat/###-issue-PR-N` → `feat/###-issue-PR` (rebase up the stack) | Sub-agent's own local 3-tier swarm clean | Sub-agent |
+| `feat/###-issue-PR` → `dev-<group>` *(or `dev` if no group)* | Orchestrator review (typically `/swarm-review` or codex-orch-r1 for SDK adapters); sub-agent's local swarm must have already converged clean | **Orchestrator only** |
+| `dev-<group>` → `dev` | Orchestrator full phase super-swarm clean (6-model lineup via `/phase-super-swarm`); CI green; all sub-issues either merged or explicitly deferred | **Orchestrator only** |
+| `dev` → `main` (release PR) | Phase super-swarm clean; curated changelog; UAT by Liam | **Liam only** — orch never auto-merges regardless of how green the swarm is |
+
+The orchestrator's role at the `dev` → `main` boundary is to surface the synthesis + changelog + smoke-test evidence. Liam decides when to merge based on factors outside any swarm's view (release timing, UAT windows, downstream dependencies, demo schedules).
+
+### The overnight-PR-open pattern
+
+For overnight work where the orchestrator runs unattended:
+
+- Orch reviews + applies fix-rounds + commits + pushes on the `dev-<group> → dev` PR as the super-swarm converges
+- Orch **does not auto-merge** even on super-swarm clean — leaves the PR OPEN for Liam's morning UAT
+- Orch *may* immediately start the next `dev-<other-group>` branch while the previous PR awaits Liam — judges whether the next group should stack off the previous group (sequential dependencies) or off `dev` directly (parallel-safe)
+- Morning recap surfaces: "PR #N awaiting your merge, super-swarm clean at HH:MM ET, here's the changelog draft"
+
+This pattern preserves the trust gate while keeping overnight cycle time high.
 
 ### When this applies
 
@@ -32,55 +73,63 @@ Every repository under both organizations:
 
 ### Exceptions
 
-There are narrow exceptions where a PR may legitimately target `main` directly:
+Narrow cases where a PR may legitimately target `main` directly:
 
-1. **Critical security hotfix** — vulnerability in production that cannot wait for the next dev → main cycle. Must be approved by Liam in advance. Tag the PR with a `hotfix` label so it is visible. Follow up with the same fix backported into `dev` to prevent drift.
-2. **Initial repo bootstrap** — when a brand-new repo is being set up and `dev` does not yet exist, the first PR or two may land on `main` while the branching topology is being established. Once `dev` is created, the convention takes effect.
-3. **Docs-only typos and link fixes** on `main`-rendered surfaces (e.g., the rendered README on the GitHub repo page) where waiting for the release cycle would leave a visible error in front of users. Still preferred to fix via `dev`; the exception only applies if the next release is more than a week away.
+1. **Critical security hotfix** — production vulnerability that cannot wait for the next dev → main cycle. Pre-approved by Liam. Tag the PR `hotfix`. Backport the same fix to `dev` to prevent drift.
+2. **Initial repo bootstrap** — when a brand-new repo is being set up and `dev` does not yet exist, the first PR or two may land on `main` while topology is established. Once `dev` is created, the convention takes effect.
+3. **Docs-only typos and link fixes** on `main`-rendered surfaces (e.g., README on the GitHub repo page) where waiting for the release cycle would leave a visible error in front of users. Still preferred to fix via `dev`; exception applies only if the next release is more than a week away.
 
-Outside these narrow cases, any PR proposed against `main` must be redirected via `gh pr edit <N> --base dev` or closed and re-filed.
+Outside these narrow cases, any PR proposed against `main` is redirected via `gh pr edit <N> --base dev` or closed and re-filed.
 
-### How to enforce
+### Enforcement
 
-1. **Tooling default:** All scripts and skills that open PRs (e.g., `/swarm-review`'s PR examples, `/merge-pr`, internal helpers in `~/bin/`) default to `--base dev`. Templates ship with this default.
-2. **PM/feature-dev briefs:** When an orchestrator or PM agent briefs an implementer subagent to open a PR, the brief MUST include `gh pr create --base dev` explicitly. Never let the agent default-resolve the base.
-3. **Inherited PRs:** If an orchestrator notices an open PR with `base: main`, the first move is to check the convention. If it does not fit one of the exceptions, retarget or close it before merging.
-4. **Memory cross-reference:** `feedback_gitflow_light_pr_base_is_dev.md` carries the operational rule with Liam's verbatim quote. This ADR is the architectural-level codification; the memory is the day-to-day reminder.
+1. **Tooling defaults:** All scripts and skills that open PRs (`/swarm-review`, `/merge-pr`, internal helpers in `~/bin/`) default to `--base dev`. Templates ship with this default.
+2. **Briefs to sub-agents:** When orch or PM briefs an implementer to open a PR, the brief MUST explicitly include the target base. Never let the agent default-resolve.
+3. **Inherited PRs:** If orch finds an open PR with `base: main` outside the exception list, retarget or close before merging.
+4. **PM-dobot constraint:** PM never merges any PR. PM opens stacked PRs and runs local swarm; orch reviews + merges. Codified in `pm-dobot/.claude/CLAUDE.md` + the branching-convention skill mirrored to PM.
+5. **Memory cross-reference:**
+   - `feedback_gitflow_light_pr_base_is_dev.md` — base-branch rule with Liam's quote
+   - `feedback_only_orch_merges_dev.md` — trust gate (PM never merges to dev)
+   - `feedback_release_pr_merge_requires_explicit_liam_approval.md` — main merge gate
 
 ### What dev → main release PRs look like
 
-When opening the release-train PR, the convention is:
 - **Title:** `release: vX.Y.Z — <summary>` (semver) or `release: Phase N — <slug>` for phase rollups
 - **Base:** `main`
 - **Head:** `dev`
-- **Body:** must include a curated changelog summarizing every merged PR since the last release. The `changelog-writer` agent (per `~/claudes-world/.claude/agents/changelog-writer.md`) is the canonical tool for this.
-- **Reviews:** 6-model super-swarm review via `/phase-super-swarm <PR>`. Must be CLEAN (no MUST FIX) before merge consideration.
-- **Merge gate:** Liam-only. Orchestrator NEVER merges this PR, regardless of how green the swarm is. The orchestrator's role is to surface the swarm verdict and the changelog; Liam decides when to merge.
+- **Body:** curated changelog summarizing every merged PR since the last release. The `changelog-writer` agent at `~/claudes-world/.claude/agents/changelog-writer.md` is canonical.
+- **Reviews:** 6-model super-swarm via `/phase-super-swarm <PR>`. MUST be CLEAN (no MUST FIX) before merge consideration.
+- **Merge gate:** Liam-only.
 
 ## Consequences
 
 **Positive:**
-- One clean release boundary on `main`. The git log on main becomes a series of release-train merges, each with a changelog and a super-swarm review trail.
-- `dev` becomes the integration line where all feature/fix work converges, super-swarm-reviewable in batches, and revert-able as a unit if a release goes wrong.
-- Eliminates a class of mistake that recurred during the 2026-05-16 incident: subagents or AI tools opening PRs against `main` because main is the default branch on the GitHub side. The convention now overrides the platform default.
-- Aligns with conventional gitflow-light usage in the broader open-source community, which makes onboarding contributors (human or AI) easier.
+- One clean release boundary on `main`. The git log on main becomes a series of release-train merges, each with a changelog and super-swarm review trail.
+- `dev` becomes the integration line where work converges, super-swarm-reviewable in batches, revert-able as a unit if a release goes wrong.
+- `dev-<group>` branches let a coherent feature get full super-swarm coverage as one unit, rather than super-swarming individual sub-PRs (cheaper) or super-swarming a giant dev → main release PR with mixed concerns (harder to synthesize).
+- Trust gates eliminate three recurring failure modes (PR-against-main slips, PM auto-merging to dev, orch auto-merging release PRs).
+- Aligns with conventional gitflow-light usage — onboarding humans + new AI agents is easier.
 
 **Negative:**
-- Two-step path for any change: feature branch → dev → main. Slower than a direct main merge for genuine hotfixes. The exception for security hotfixes is the relief valve.
-- The convention adds a small cognitive load for ad-hoc PRs (e.g., a one-line README fix that would naturally target main on a vanilla GitHub project).
-- If dev gets stuck (failing CI for an extended period, blocked on a contentious feature), no work can ship to main. Mitigated by keeping dev shippable (per ADR 0011 fix-PR pipeline).
+- More-step path for any change: feat → dev-<group> → dev → main. Slower than direct merge.
+- Cognitive load for ad-hoc one-line fixes that don't fit the deep hierarchy. Mitigated by the rule that single PRs target `dev` directly; the integration layer is opt-in based on the criteria above.
+- If dev gets stuck (failing CI for extended period, blocked on contentious feature), no work ships. Mitigated by keeping `dev` shippable.
 
 **Neutral:**
-- The phase super-swarm and changelog-writer tooling were already designed assuming this convention. This ADR just makes the assumption explicit.
+- The phase super-swarm and changelog-writer tooling were already designed assuming the dev → main gate. This refactor just makes the inner layers explicit.
 
 ## Related decisions
 
-- **ADR 0011** (Feature PR pipeline) — defines the 12-step workflow that operates entirely on the dev side of this branching convention.
-- **Memory `feedback_release_pr_merge_requires_explicit_liam_approval.md`** — companion rule about who can merge the dev → main PR.
-- **Memory `feedback_stacked_phase_branches.md`** — multi-phase features use `dev-phase-N-<feature>` integration branches stacked under `dev`. Those still merge into `dev` (not main), so this ADR is consistent with that pattern.
+- **ADR 0011** (Feature PR pipeline) — defines the 12-step workflow that operates entirely on the dev side.
+- **Memory `feedback_release_pr_merge_requires_explicit_liam_approval.md`** — main merge gate.
+- **Memory `feedback_only_orch_merges_dev.md`** — dev + dev-<group> merge gate.
+- **Memory `feedback_stacked_phase_branches.md`** — supersedes the looser `dev-phase-N-<feature>` naming with the explicit `dev-<group>` pattern.
+- **Skill `branching-convention`** — operational reminder, fires on every PR/merge/branch operation.
+- **SOP `~/claudes-world/knowledge/sop/feature-group-branching.md`** — worked examples (typechain migration as the case study).
 
 ## Concrete record from 2026-05-16
 
-- **Violation:** PR #399 (`fix/issue-398-e2e-url-stub`) was filed with `--base main`. Liam called this out at 19:01 ET as a gitflow violation.
-- **Resolution:** Cherry-picked the single fix commit onto `recover/issue-354-url-rename` (the Phase 1 recovery branch most relevant to the fix). PR #399 closed as superseded. The fix now ships as part of draft PR #418 (`recover/issue-354-url-rename → dev`).
-- **ADR filed:** This document, requested by Liam at 19:04 ET to give the rule a permanent, ADR-level home.
+- **Violation A:** PR #399 filed with `--base main`. Resolved by cherry-picking the fix into recovery PR #418 and closing #399.
+- **Violation B:** PR #392 release-train auto-merged at 08:37 ET on super-swarm clean. Liam reverted main to v2.8.4 at 12:24 ET.
+- **Violation C:** PM-dobot squash-merged PRs #427/#428/#429 directly to dev without orch review gate. Liam directed: *"Don't worry about recovering dev for the typechain stuff now. We will just start being stricter about this after the typechain work is done."* Recorded as audit-log entry; subsequent PRs (#430, #431) followed the new gate.
+- **ADR refactored:** This document, requested by Liam at 16:13 ET (msg 14613) after the rollout plan converged on the 4-level + trust-gate model.

--- a/packages/contract-types/index.ts
+++ b/packages/contract-types/index.ts
@@ -1,0 +1,2 @@
+export * from './src/IClanWorld.js';
+export * from './src/IClanWorldLens.js';

--- a/packages/contract-types/package.json
+++ b/packages/contract-types/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@clan-world/contract-types",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Generated TypeScript literal-type ABIs for ClanWorld contracts",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "codegen": "node scripts/generate.mjs",
+    "codegen:check": "node scripts/generate.mjs --check",
+    "build": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@clan-world/contracts": "workspace:*"
+  }
+}

--- a/packages/contract-types/scripts/generate.mjs
+++ b/packages/contract-types/scripts/generate.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * generate.mjs — generates packages/contract-types/src/*.ts from committed ABI JSON.
+ * Source: packages/contracts/abi/*.json
+ * Run: node scripts/generate.mjs
+ * Check: node scripts/generate.mjs --check
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(__dirname, '..');
+const repoRoot = resolve(pkgRoot, '../..');
+const check = process.argv.includes('--check');
+const errors = [];
+
+function readAbi(name) {
+  const path = resolve(repoRoot, 'packages/contracts/abi', `${name}.json`);
+  const raw = JSON.parse(readFileSync(path, 'utf8'));
+  // abi files may be plain arrays or { abi: [...] } objects
+  return Array.isArray(raw) ? raw : raw.abi;
+}
+
+function generateFile(varName, abi) {
+  const lines = [
+    '// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen',
+    `export const ${varName} = ${JSON.stringify(abi, null, 2)} as const;`,
+    '',
+    `export type ${varName.charAt(0).toUpperCase() + varName.slice(1)}Type = typeof ${varName};`,
+    '',
+    '// Derived event name union',
+    `export type ${varName.charAt(0).toUpperCase() + varName.slice(1)}EventName = (typeof ${varName})[number] extends infer T`,
+    "  ? T extends { type: 'event'; name: string }",
+    "    ? T['name']",
+    '    : never',
+    '  : never;',
+    '',
+    '// Derived function name union',
+    `export type ${varName.charAt(0).toUpperCase() + varName.slice(1)}FunctionName = (typeof ${varName})[number] extends infer T`,
+    "  ? T extends { type: 'function'; name: string }",
+    "    ? T['name']",
+    '    : never',
+    '  : never;',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+const contracts = [
+  { abiFile: 'IClanWorld', varName: 'iClanWorldAbi', outFile: 'IClanWorld.ts' },
+  { abiFile: 'IClanWorldLens', varName: 'iClanWorldLensAbi', outFile: 'IClanWorldLens.ts' },
+];
+
+for (const { abiFile, varName, outFile } of contracts) {
+  const abi = readAbi(abiFile);
+  const content = generateFile(varName, abi);
+  const outPath = resolve(pkgRoot, 'src', outFile);
+
+  if (check) {
+    if (!existsSync(outPath)) {
+      errors.push(`MISSING: ${outPath} — run codegen`);
+      continue;
+    }
+    const existing = readFileSync(outPath, 'utf8');
+    if (existing !== content) {
+      errors.push(`STALE: ${outPath} — run codegen`);
+    }
+  } else {
+    writeFileSync(outPath, content, 'utf8');
+    console.log(`wrote ${outFile}`);
+  }
+}
+
+if (check) {
+  if (errors.length > 0) {
+    for (const e of errors) console.error(e);
+    process.exit(1);
+  }
+  console.log('contract-types: up to date');
+}

--- a/packages/contract-types/src/IClanWorld.ts
+++ b/packages/contract-types/src/IClanWorld.ts
@@ -1,0 +1,4904 @@
+// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
+export const iClanWorldAbi = [
+  {
+    "type": "function",
+    "name": "finalizeSeason",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getActionDuration",
+    "inputs": [
+      {
+        "name": "action",
+        "type": "uint8",
+        "internalType": "enum ActionType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getActiveBanditView",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ActiveBanditView",
+        "components": [
+          {
+            "name": "exists",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "banditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum BanditState"
+          },
+          {
+            "name": "currentRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackAttemptsMade",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "maxAttemptsRemaining",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "stateEnteredTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextActionTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "tier",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackPower",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "projectedTargetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "projectedTargetLootValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getActiveDefenders",
+    "inputs": [
+      {
+        "name": "targetClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clansmanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getActiveMission",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Mission",
+        "components": [
+          {
+            "name": "active",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "nonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "submittedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "executesAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "settlesAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "startRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "targetRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "action",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "startTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "arrivalTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "actionStartTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "missionSeed",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "marketMode",
+            "type": "uint8",
+            "internalType": "enum MarketExecutionMode"
+          },
+          {
+            "name": "targetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "marketToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "marketAmount",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxGoldIn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "withdrawResources",
+            "type": "tuple",
+            "internalType": "struct WithdrawResourcesData",
+            "components": [
+              {
+                "name": "wood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "iron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "wheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "fish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBandit",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct BanditTroop",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "region",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum BanditState"
+          },
+          {
+            "name": "targetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "tickEnteredState",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "strength",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "tier",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackAttemptsMade",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryGold",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBanditTargetPreview",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "previewClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBanditTroop",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct BanditTroop",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "region",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum BanditState"
+          },
+          {
+            "name": "targetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "tickEnteredState",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "strength",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "tier",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackAttemptsMade",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryGold",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBanditsInRegion",
+    "inputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBaseUpgradeCost",
+    "inputs": [
+      {
+        "name": "currentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getClan",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Clan",
+        "components": [
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "iftTokenId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "owner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "clanState",
+            "type": "uint8",
+            "internalType": "enum ClanState"
+          },
+          {
+            "name": "baseRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "baseLevel",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "wallLevel",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "monumentLevel",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "livingClansmen",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "lastSettledTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "starvationStartsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "coldDamage",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "ownerNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "goldBalance",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "blueprintBalance",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanClansmanIds",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clansmanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanFullView",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ClanFullView",
+        "components": [
+          {
+            "name": "clan",
+            "type": "tuple",
+            "internalType": "struct DerivedClanState",
+            "components": [
+              {
+                "name": "clan",
+                "type": "tuple",
+                "internalType": "struct Clan",
+                "components": [
+                  {
+                    "name": "clanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "iftTokenId",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "owner",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "clanState",
+                    "type": "uint8",
+                    "internalType": "enum ClanState"
+                  },
+                  {
+                    "name": "baseRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "baseLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "wallLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "monumentLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "livingClansmen",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "lastSettledTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "starvationStartsAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "coldDamage",
+                    "type": "uint16",
+                    "internalType": "uint16"
+                  },
+                  {
+                    "name": "ownerNonce",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "goldBalance",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "blueprintBalance",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultWood",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultIron",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultWheat",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultFish",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "isStarving",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "lootValue",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "derivedAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "clansmen",
+            "type": "tuple[]",
+            "internalType": "struct ClansmanFullView[]",
+            "components": [
+              {
+                "name": "clansman",
+                "type": "tuple",
+                "internalType": "struct DerivedClansmanState",
+                "components": [
+                  {
+                    "name": "clansman",
+                    "type": "tuple",
+                    "internalType": "struct Clansman",
+                    "components": [
+                      {
+                        "name": "clansmanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "clanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "state",
+                        "type": "uint8",
+                        "internalType": "enum ClansmanState"
+                      },
+                      {
+                        "name": "currentRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "cooldownEndsAtTs",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "lastMissionNonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "carryWood",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryIron",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryWheat",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryFish",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "activeMission",
+                    "type": "tuple",
+                    "internalType": "struct Mission",
+                    "components": [
+                      {
+                        "name": "active",
+                        "type": "bool",
+                        "internalType": "bool"
+                      },
+                      {
+                        "name": "nonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "submittedAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "executesAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "settlesAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "clansmanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "startRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "targetRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "action",
+                        "type": "uint8",
+                        "internalType": "enum ActionType"
+                      },
+                      {
+                        "name": "startTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "arrivalTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "actionStartTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "missionSeed",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                      },
+                      {
+                        "name": "marketMode",
+                        "type": "uint8",
+                        "internalType": "enum MarketExecutionMode"
+                      },
+                      {
+                        "name": "targetClanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "marketToken",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "marketAmount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "maxGoldIn",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "withdrawResources",
+                        "type": "tuple",
+                        "internalType": "struct WithdrawResourcesData",
+                        "components": [
+                          {
+                            "name": "wood",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "iron",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "wheat",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "fish",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "effectiveRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "derivedAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  }
+                ]
+              },
+              {
+                "name": "activeMission",
+                "type": "tuple",
+                "internalType": "struct Mission",
+                "components": [
+                  {
+                    "name": "active",
+                    "type": "bool",
+                    "internalType": "bool"
+                  },
+                  {
+                    "name": "nonce",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "submittedAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "executesAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "settlesAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "clansmanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "startRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "targetRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "action",
+                    "type": "uint8",
+                    "internalType": "enum ActionType"
+                  },
+                  {
+                    "name": "startTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "arrivalTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "actionStartTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "missionSeed",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "marketMode",
+                    "type": "uint8",
+                    "internalType": "enum MarketExecutionMode"
+                  },
+                  {
+                    "name": "targetClanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "marketToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "marketAmount",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "maxGoldIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "withdrawResources",
+                    "type": "tuple",
+                    "internalType": "struct WithdrawResourcesData",
+                    "components": [
+                      {
+                        "name": "wood",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "iron",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "wheat",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "fish",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "westPlot",
+            "type": "tuple",
+            "internalType": "struct WheatPlot",
+            "components": [
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum WheatPlotState"
+              },
+              {
+                "name": "region",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "remainingWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "regrowUntilTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "eastPlot",
+            "type": "tuple",
+            "internalType": "struct WheatPlot",
+            "components": [
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum WheatPlotState"
+              },
+              {
+                "name": "region",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "remainingWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "regrowUntilTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "incomingDefenderIds",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          },
+          {
+            "name": "thisClanDefendingBaseId",
+            "type": "uint32",
+            "internalType": "uint32"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanIds",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "clanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanScore",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "score",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "monumentReachedAtTick",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "monumentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClansman",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Clansman",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum ClansmanState"
+          },
+          {
+            "name": "currentRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "cooldownEndsAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "lastMissionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClansmanDefendingRegion",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDefendingClans",
+    "inputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDerivedClanState",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DerivedClanState",
+        "components": [
+          {
+            "name": "clan",
+            "type": "tuple",
+            "internalType": "struct Clan",
+            "components": [
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "iftTokenId",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "clanState",
+                "type": "uint8",
+                "internalType": "enum ClanState"
+              },
+              {
+                "name": "baseRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "baseLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "wallLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "monumentLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "livingClansmen",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "lastSettledTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "starvationStartsAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "coldDamage",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "ownerNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "goldBalance",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "blueprintBalance",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultWood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultIron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultFish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "isStarving",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "lootValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "derivedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDerivedClansmanState",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DerivedClansmanState",
+        "components": [
+          {
+            "name": "clansman",
+            "type": "tuple",
+            "internalType": "struct Clansman",
+            "components": [
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum ClansmanState"
+              },
+              {
+                "name": "currentRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "cooldownEndsAtTs",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "lastMissionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "carryWood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryIron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryFish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "activeMission",
+            "type": "tuple",
+            "internalType": "struct Mission",
+            "components": [
+              {
+                "name": "active",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "nonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "submittedAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "executesAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "settlesAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "startRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "targetRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "startTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "arrivalTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "actionStartTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionSeed",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "marketMode",
+                "type": "uint8",
+                "internalType": "enum MarketExecutionMode"
+              },
+              {
+                "name": "targetClanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "withdrawResources",
+                "type": "tuple",
+                "internalType": "struct WithdrawResourcesData",
+                "components": [
+                  {
+                    "name": "wood",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "iron",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "wheat",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "fish",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "effectiveRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "derivedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMarketState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct MarketState",
+        "components": [
+          {
+            "name": "wood",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "wheat",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "fish",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "iron",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "currentTickQueue",
+            "type": "tuple[]",
+            "internalType": "struct ScheduledMarketAction[]",
+            "components": [
+              {
+                "name": "executeAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "commitSequence",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "nextTickQueue",
+            "type": "tuple[]",
+            "internalType": "struct ScheduledMarketAction[]",
+            "components": [
+              {
+                "name": "executeAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "commitSequence",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMissionTiming",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "submitted",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "executes",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "settles",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMonumentLevelReachedAt",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "level",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "reachedAtTick",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMonumentUpgradeCost",
+    "inputs": [
+      {
+        "name": "currentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprint",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getPool",
+    "inputs": [
+      {
+        "name": "resourceType",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPrice",
+    "inputs": [
+      {
+        "name": "resourceType",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRankings",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "clanIdsRanked",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "scores",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRegionPopulation",
+    "inputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct RegionOccupant[]",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum ClansmanState"
+          },
+          {
+            "name": "currentAction",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "missionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getResourceToken",
+    "inputs": [
+      {
+        "name": "resourceType",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getScheduledMarketActionsForTick",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct ScheduledMarketAction[]",
+        "components": [
+          {
+            "name": "executeAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "commitSequence",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "missionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "action",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "marketToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "marketAmount",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxGoldIn",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTravelTicks",
+    "inputs": [
+      {
+        "name": "fromRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "toRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getTreasuryState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct TreasuryState",
+        "components": [
+          {
+            "name": "treasuryOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "prizePotGold",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "poolsSeeded",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "woodToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "wheatToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "fishToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "ironToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "goldToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "blueprintToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "woodGoldPool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "wheatGoldPool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "fishGoldPool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "ironGoldPool",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWallUpgradeCost",
+    "inputs": [
+      {
+        "name": "currentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getWheatPlots",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "west",
+        "type": "tuple",
+        "internalType": "struct WheatPlot",
+        "components": [
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum WheatPlotState"
+          },
+          {
+            "name": "region",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "remainingWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "regrowUntilTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "east",
+        "type": "tuple",
+        "internalType": "struct WheatPlot",
+        "components": [
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum WheatPlotState"
+          },
+          {
+            "name": "region",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "remainingWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "regrowUntilTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWorldSnapshot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct WorldSnapshot",
+        "components": [
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonStartTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonEndTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonFinalized",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "currentSeasonNumber",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextHeartbeatAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterActive",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "winterStartsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterEndsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "activeBanditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "currentTickSeed",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "leaderboard",
+            "type": "tuple[]",
+            "internalType": "struct LeaderboardEntry[]",
+            "components": [
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "monumentLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "baseLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "wallLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "livingClansmen",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum ClanState"
+              },
+              {
+                "name": "lootValue",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWorldState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct WorldState",
+        "components": [
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonStartTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonEndTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonFinalized",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "currentSeasonNumber",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextHeartbeatAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextHeartbeatAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextBanditSpawnEligibleTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "currentBanditSpawnChanceBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "currentTickSeed",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "activeBanditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "winterActive",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "winterStartsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterEndsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextCommitSequence",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "heartbeat",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "initTreasury",
+    "inputs": [
+      {
+        "name": "tokens",
+        "type": "address[6]",
+        "internalType": "address[6]"
+      },
+      {
+        "name": "pools",
+        "type": "address[4]",
+        "internalType": "address[4]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "injectClanResources",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "fish",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprint",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isWinter",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isWorldPaused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mintClan",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "iftTokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pauseWorld",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "quoteLootValueRaw",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lootValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteLootValueSettled",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lootValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteTravel",
+    "inputs": [
+      {
+        "name": "srcRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "dstRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "travelTicks",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "path",
+        "type": "bytes8",
+        "internalType": "bytes8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "reviveClansman",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "reviveDeadClansmen",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "seedPools",
+    "inputs": [
+      {
+        "name": "cfg",
+        "type": "tuple",
+        "internalType": "struct PoolSeedConfig",
+        "components": [
+          {
+            "name": "woodSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "wheatSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "fishSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ironSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleClan",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleClansman",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "submitClanOrders",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "orders",
+        "type": "tuple[]",
+        "internalType": "struct ClanOrder[]",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "gotoRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "action",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "targetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "marketToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "marketAmount",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxGoldIn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "withdrawResources",
+            "type": "tuple",
+            "internalType": "struct WithdrawResourcesData",
+            "components": [
+              {
+                "name": "wood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "iron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "wheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "fish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct OrderResult[]",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enum StatusCode"
+          },
+          {
+            "name": "cooldownEndsAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "missionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "marketMode",
+            "type": "uint8",
+            "internalType": "enum MarketExecutionMode"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferBlueprint",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferBundle",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "gold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprint",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "fish",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferClanOwnership",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferGold",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferVaultResource",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "resource",
+        "type": "uint8",
+        "internalType": "enum ResourceType"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpauseWorld",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "BanditAttackResolved",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "targetClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "defended",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      },
+      {
+        "name": "attackPower",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "totalDefense",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "wallLevelAfter",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "stolenWood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "stolenIron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "stolenWheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "stolenFish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditDefeated",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "targetClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditEscaped",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditMoved",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "fromRegion",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "toRegion",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditSpawned",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "region",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "tier",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "attackPower",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditStateChanged",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldState",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum BanditState"
+      },
+      {
+        "name": "newState",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum BanditState"
+      },
+      {
+        "name": "region",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BanditTargetDied",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "deadClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BaseLevelChanged",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "newLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BlueprintAwarded",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BlueprintEarned",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BlueprintTransferred",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanColdShortage",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "woodShort",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanDied",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "reason",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanEliminated",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanOwnershipTransferred",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwnerNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanSettled",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "settledToTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanSpawned",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "iftTokenId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "baseRegion",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClanStarvationChanged",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "isStarving",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanColdDeath",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "csId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanKilledByBandit",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanRevived",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "GoldTransferred",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ImmediateMarketActionExecuted",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "resourceIn",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "resourceOut",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "LootDistributed",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clanIdsRewarded",
+        "type": "uint32[]",
+        "indexed": false,
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "perClanWood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "perClanWheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "perClanFish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "perClanIron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "perClanGold",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "burnedWood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "burnedWheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "burnedFish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "burnedIron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "burnedGold",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "LootDistributedToDefender",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "wood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MarketActionFailed",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "mode",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum MarketExecutionMode"
+      },
+      {
+        "name": "reason",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum StatusCode"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MissionAssigned",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "missionNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "startRegion",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "targetRegion",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "startTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "arrivalTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MissionCompleted",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "missionNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MissionInterrupted",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldMissionNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "newMissionNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MonumentLevelChanged",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "newLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PoolsSeeded",
+    "inputs": [
+      {
+        "name": "woodGoldPool",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "wheatGoldPool",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "fishGoldPool",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "ironGoldPool",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourceBurned",
+    "inputs": [
+      {
+        "name": "resourceType",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "uint8"
+      },
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourceMinted",
+    "inputs": [
+      {
+        "name": "resourceType",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "uint8"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourcesDeposited",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "woodDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "ironDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheatDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fishDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourcesGathered",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "woodGained",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "ironGained",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheatGained",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fishGained",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "goldBonus",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourcesInjected",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "wood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "gold",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprint",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourcesWithdrawn",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "woodDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "ironDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheatDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fishDelta",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ScheduledMarketActionCommitted",
+    "inputs": [
+      {
+        "name": "executeAtTick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "commitSequence",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "marketToken",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "marketAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxGoldIn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ScheduledMarketActionExecuted",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "action",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ActionType"
+      },
+      {
+        "name": "resourceIn",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "resourceOut",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "settledAtTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SeasonFinalized",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "rankedClanIds",
+        "type": "uint32[]",
+        "indexed": false,
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "scores",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TickAdvanced",
+    "inputs": [
+      {
+        "name": "closedTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "openedTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "tickSeed",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "VaultResourceTransferred",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "resource",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum ResourceType"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WallDamagedByBandit",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "newLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WallDegradedByCold",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "newWallLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WallLevelChanged",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "newLevel",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WinterEnded",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WinterStarted",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WorkerArrived",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "region",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WorldPaused",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "pausedAtTs",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WorldUnpaused",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "durationSeconds",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "nextHeartbeatAtTs",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  }
+] as const;
+
+export type IClanWorldAbiType = typeof iClanWorldAbi;
+
+// Derived event name union
+export type IClanWorldAbiEventName = (typeof iClanWorldAbi)[number] extends infer T
+  ? T extends { type: 'event'; name: string }
+    ? T['name']
+    : never
+  : never;
+
+// Derived function name union
+export type IClanWorldAbiFunctionName = (typeof iClanWorldAbi)[number] extends infer T
+  ? T extends { type: 'function'; name: string }
+    ? T['name']
+    : never
+  : never;

--- a/packages/contract-types/src/IClanWorldLens.ts
+++ b/packages/contract-types/src/IClanWorldLens.ts
@@ -1,0 +1,1553 @@
+// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
+export const iClanWorldLensAbi = [
+  {
+    "type": "function",
+    "name": "getActiveBanditView",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ActiveBanditView",
+        "components": [
+          {
+            "name": "exists",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "banditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum BanditState"
+          },
+          {
+            "name": "currentRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackAttemptsMade",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "maxAttemptsRemaining",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "stateEnteredTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextActionTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "tier",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackPower",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "projectedTargetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "projectedTargetLootValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBanditTargetPreview",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "previewClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanFullView",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ClanFullView",
+        "components": [
+          {
+            "name": "clan",
+            "type": "tuple",
+            "internalType": "struct DerivedClanState",
+            "components": [
+              {
+                "name": "clan",
+                "type": "tuple",
+                "internalType": "struct Clan",
+                "components": [
+                  {
+                    "name": "clanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "iftTokenId",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "owner",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "clanState",
+                    "type": "uint8",
+                    "internalType": "enum ClanState"
+                  },
+                  {
+                    "name": "baseRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "baseLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "wallLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "monumentLevel",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "livingClansmen",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "lastSettledTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "starvationStartsAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "coldDamage",
+                    "type": "uint16",
+                    "internalType": "uint16"
+                  },
+                  {
+                    "name": "ownerNonce",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "goldBalance",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "blueprintBalance",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultWood",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultIron",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultWheat",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "vaultFish",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "isStarving",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "lootValue",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "derivedAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "clansmen",
+            "type": "tuple[]",
+            "internalType": "struct ClansmanFullView[]",
+            "components": [
+              {
+                "name": "clansman",
+                "type": "tuple",
+                "internalType": "struct DerivedClansmanState",
+                "components": [
+                  {
+                    "name": "clansman",
+                    "type": "tuple",
+                    "internalType": "struct Clansman",
+                    "components": [
+                      {
+                        "name": "clansmanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "clanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "state",
+                        "type": "uint8",
+                        "internalType": "enum ClansmanState"
+                      },
+                      {
+                        "name": "currentRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "cooldownEndsAtTs",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "lastMissionNonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "carryWood",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryIron",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryWheat",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "carryFish",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "activeMission",
+                    "type": "tuple",
+                    "internalType": "struct Mission",
+                    "components": [
+                      {
+                        "name": "active",
+                        "type": "bool",
+                        "internalType": "bool"
+                      },
+                      {
+                        "name": "nonce",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "submittedAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "executesAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "settlesAtTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "clansmanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "startRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "targetRegion",
+                        "type": "uint8",
+                        "internalType": "uint8"
+                      },
+                      {
+                        "name": "action",
+                        "type": "uint8",
+                        "internalType": "enum ActionType"
+                      },
+                      {
+                        "name": "startTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "arrivalTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "actionStartTick",
+                        "type": "uint64",
+                        "internalType": "uint64"
+                      },
+                      {
+                        "name": "missionSeed",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                      },
+                      {
+                        "name": "marketMode",
+                        "type": "uint8",
+                        "internalType": "enum MarketExecutionMode"
+                      },
+                      {
+                        "name": "targetClanId",
+                        "type": "uint32",
+                        "internalType": "uint32"
+                      },
+                      {
+                        "name": "marketToken",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "marketAmount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "maxGoldIn",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "withdrawResources",
+                        "type": "tuple",
+                        "internalType": "struct WithdrawResourcesData",
+                        "components": [
+                          {
+                            "name": "wood",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "iron",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "wheat",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          },
+                          {
+                            "name": "fish",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "effectiveRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "derivedAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  }
+                ]
+              },
+              {
+                "name": "activeMission",
+                "type": "tuple",
+                "internalType": "struct Mission",
+                "components": [
+                  {
+                    "name": "active",
+                    "type": "bool",
+                    "internalType": "bool"
+                  },
+                  {
+                    "name": "nonce",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "submittedAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "executesAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "settlesAtTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "clansmanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "startRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "targetRegion",
+                    "type": "uint8",
+                    "internalType": "uint8"
+                  },
+                  {
+                    "name": "action",
+                    "type": "uint8",
+                    "internalType": "enum ActionType"
+                  },
+                  {
+                    "name": "startTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "arrivalTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "actionStartTick",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "missionSeed",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "marketMode",
+                    "type": "uint8",
+                    "internalType": "enum MarketExecutionMode"
+                  },
+                  {
+                    "name": "targetClanId",
+                    "type": "uint32",
+                    "internalType": "uint32"
+                  },
+                  {
+                    "name": "marketToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "marketAmount",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "maxGoldIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "withdrawResources",
+                    "type": "tuple",
+                    "internalType": "struct WithdrawResourcesData",
+                    "components": [
+                      {
+                        "name": "wood",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "iron",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "wheat",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "fish",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "westPlot",
+            "type": "tuple",
+            "internalType": "struct WheatPlot",
+            "components": [
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum WheatPlotState"
+              },
+              {
+                "name": "region",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "remainingWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "regrowUntilTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "eastPlot",
+            "type": "tuple",
+            "internalType": "struct WheatPlot",
+            "components": [
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum WheatPlotState"
+              },
+              {
+                "name": "region",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "remainingWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "regrowUntilTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "incomingDefenderIds",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          },
+          {
+            "name": "thisClanDefendingBaseId",
+            "type": "uint32",
+            "internalType": "uint32"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanScore",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "score",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "monumentReachedAtTick",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "monumentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDerivedClanState",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DerivedClanState",
+        "components": [
+          {
+            "name": "clan",
+            "type": "tuple",
+            "internalType": "struct Clan",
+            "components": [
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "iftTokenId",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "clanState",
+                "type": "uint8",
+                "internalType": "enum ClanState"
+              },
+              {
+                "name": "baseRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "baseLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "wallLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "monumentLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "livingClansmen",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "lastSettledTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "starvationStartsAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "coldDamage",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "ownerNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "goldBalance",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "blueprintBalance",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultWood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultIron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultFish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "isStarving",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "lootValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "derivedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDerivedClansmanState",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DerivedClansmanState",
+        "components": [
+          {
+            "name": "clansman",
+            "type": "tuple",
+            "internalType": "struct Clansman",
+            "components": [
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum ClansmanState"
+              },
+              {
+                "name": "currentRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "cooldownEndsAtTs",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "lastMissionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "carryWood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryIron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryFish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "activeMission",
+            "type": "tuple",
+            "internalType": "struct Mission",
+            "components": [
+              {
+                "name": "active",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "nonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "submittedAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "executesAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "settlesAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "startRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "targetRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "startTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "arrivalTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "actionStartTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionSeed",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "marketMode",
+                "type": "uint8",
+                "internalType": "enum MarketExecutionMode"
+              },
+              {
+                "name": "targetClanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "withdrawResources",
+                "type": "tuple",
+                "internalType": "struct WithdrawResourcesData",
+                "components": [
+                  {
+                    "name": "wood",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "iron",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "wheat",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "fish",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "effectiveRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "derivedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMarketState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct MarketState",
+        "components": [
+          {
+            "name": "wood",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "wheat",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "fish",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "iron",
+            "type": "tuple",
+            "internalType": "struct PoolReserves",
+            "components": [
+              {
+                "name": "resourceToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "resourceReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "goldReserve",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "spotPriceGoldPerResource",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "currentTickQueue",
+            "type": "tuple[]",
+            "internalType": "struct ScheduledMarketAction[]",
+            "components": [
+              {
+                "name": "executeAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "commitSequence",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "nextTickQueue",
+            "type": "tuple[]",
+            "internalType": "struct ScheduledMarketAction[]",
+            "components": [
+              {
+                "name": "executeAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "commitSequence",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRankings",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "clanIdsRanked",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "scores",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRegionPopulation",
+    "inputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct RegionOccupant[]",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum ClansmanState"
+          },
+          {
+            "name": "currentAction",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "missionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWorldSnapshot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct WorldSnapshot",
+        "components": [
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonStartTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonEndTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonFinalized",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "currentSeasonNumber",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextHeartbeatAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterActive",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "winterStartsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterEndsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "activeBanditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "currentTickSeed",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "leaderboard",
+            "type": "tuple[]",
+            "internalType": "struct LeaderboardEntry[]",
+            "components": [
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "monumentLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "baseLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "wallLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "livingClansmen",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum ClanState"
+              },
+              {
+                "name": "lootValue",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteLootValueRaw",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lootValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteLootValueSettled",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lootValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteTravel",
+    "inputs": [
+      {
+        "name": "srcRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "dstRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "travelTicks",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "path",
+        "type": "bytes8",
+        "internalType": "bytes8"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "world",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IClanWorld"
+      }
+    ],
+    "stateMutability": "view"
+  }
+] as const;
+
+export type IClanWorldLensAbiType = typeof iClanWorldLensAbi;
+
+// Derived event name union
+export type IClanWorldLensAbiEventName = (typeof iClanWorldLensAbi)[number] extends infer T
+  ? T extends { type: 'event'; name: string }
+    ? T['name']
+    : never
+  : never;
+
+// Derived function name union
+export type IClanWorldLensAbiFunctionName = (typeof iClanWorldLensAbi)[number] extends infer T
+  ? T extends { type: 'function'; name: string }
+    ? T['name']
+    : never
+  : never;

--- a/packages/contract-types/tsconfig.json
+++ b/packages/contract-types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "composite": false,
+    "noEmit": true
+  },
+  "include": ["index.ts", "src/**/*.ts"]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,6 +23,7 @@
     "vitest": "^3.2.0"
   },
   "dependencies": {
+    "@clan-world/contract-types": "workspace:*",
     "@clan-world/contracts": "workspace:*",
     "convex": "1.17.4",
     "viem": "^2.48.4"

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import clanWorldLensAbi from '@clan-world/contracts/abi/IClanWorldLens.json' with { type: 'json' };
+import { iClanWorldLensAbi } from '@clan-world/contract-types';
 import {
   type Abi,
   createPublicClient,
@@ -15,7 +15,7 @@ import type { ClanFullView, ClanOrder, Tick } from '../types';
 import { ActionType } from '../generated/enums';
 import { readEnv } from './_env';
 
-const CLAN_WORLD_LENS_ABI = clanWorldLensAbi.abi as Abi;
+const CLAN_WORLD_LENS_ABI = iClanWorldLensAbi satisfies Abi;
 
 export interface SubmitOrderResult {
   clansmanId: number;

--- a/packages/shared/test/clanWorldAbi.test.ts
+++ b/packages/shared/test/clanWorldAbi.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import canonicalAbi from '@clan-world/contracts/abi/IClanWorld.json' with { type: 'json' };
+import { iClanWorldAbi } from '@clan-world/contract-types';
 import { decodeFunctionResult, encodeAbiParameters, getAbiItem, type Abi, type AbiFunction } from 'viem';
 import { CLAN_WORLD_ABI } from '../src/adapters/IChainClient';
 
 const ZERO_BYTES32 = `0x${'00'.repeat(32)}` as `0x${string}`;
-const abi = canonicalAbi.abi as Abi;
+// Widening annotation (not cast) — `satisfies Abi` preserves the deep literal union
+// and causes TypeScript instantiation-depth errors inside getAbiItem. The structural
+// assignment is type-checked by the compiler; if any ABI entry were malformed, tsc fails.
+const abi: Abi = iClanWorldAbi;
 
 const getFunctionOutputs = (name: string) => (getAbiItem({ abi, name }) as AbiFunction).outputs;
 const worldStateOutputs = getFunctionOutputs('getWorldState');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,9 @@ importers:
 
   packages/shared:
     dependencies:
+      '@clan-world/contract-types':
+        specifier: workspace:*
+        version: link:../contract-types
       '@clan-world/contracts':
         specifier: workspace:*
         version: link:../contracts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
 
   apps/server:
     dependencies:
+      '@clan-world/contract-types':
+        specifier: workspace:*
+        version: link:../../packages/contract-types
       '@clan-world/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -326,6 +329,12 @@ importers:
       vitest:
         specifier: ^3.2.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2)
+
+  packages/contract-types:
+    devDependencies:
+      '@clan-world/contracts':
+        specifier: workspace:*
+        version: link:../contracts
 
   packages/contracts: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -26,7 +26,9 @@
         "src/adapters/IChainClient.ts",
         "src/generated/constants.ts",
         "src/generated/enums.ts",
-        "convex/_generated/**"
+        "convex/_generated/**",
+        "src/IClanWorld.ts",
+        "src/IClanWorldLens.ts"
       ]
     },
     "dev": {


### PR DESCRIPTION
## Release v2.9.0 — Typechain migration + dev-tier type safety

This is the cumulative release of the **typechain + generated-types audit** project plan (`docs/plans/typechain-and-generated-types-audit-v1.md`). Five PRs land together, eliminating every raw `as Abi` cast and `JSON artifact .abi` import from runtime hot paths, replacing them with literal-typed `as const` ABI imports from the new `@clan-world/contract-types` workspace package.

## What ships

| # | PR | Surface | Net change |
|---|---|---|---|
| 1 | #427 | New workspace package `@clan-world/contract-types` — generates `as const` literal ABIs from `packages/contracts/abi/*.json` via `scripts/generate.mjs`. No external codegen tool. | +new package |
| 2 | #428 | Indexer + heartbeat handlers migrate from `clanWorldArtifact.abi as Abi` → `iClanWorldAbi` literal. Dead Whisper code removed from `apps/server/convex/indexer.ts`. | hot-path types |
| 3 | #429 | `vault.ts` event names narrowed `string` → `IClanWorldAbiEventName`. Compile-time guard against event-name typos. | back-end type narrowing |
| 4 | #430 | Web HUD (`TopHud.tsx`, `WorldMap.tsx`) stops `(snapshot as any)` field access — uses the typed `deriveSeasonState()` return shape directly. | front-end cleanup |
| 5 | #431 | New CI workflow `.github/workflows/typechain-ci.yml` with three jobs: (a) `contract-types` codegen freshness, (b) Convex `_generated/` freshness, (c) grep gate blocking new `as Abi` casts in `apps/`, `packages/shared/src/`, `packages/runner/src/`, `packages/agents/src/`. | regression guard |

## Why this matters

The previous state used untyped JSON ABI imports + `as Abi` casts in three runtime hot paths (indexer event decoding, heartbeat event decoding, IChainClient lens reads). Any silent ABI drift between `contracts/abi/*.json` and the imported event names was undetectable at compile time. PR #428 + #429 close those drift surfaces; PR #431 prevents regressions by failing CI on (a) stale generated types or (b) re-introduction of raw `as Abi` casts.

## Verified before release

- All 5 sub-PRs ran the local 3-tier swarm (Claude subagent + Codex CLI + Gemini flash) to clean
- PR #430 + #431 received explicit orchestrator-gate reviews on top of PM-level swarm
- CI green on each sub-PR at squash-merge time
- One LOW non-blocking finding (test-only `as Abi` cast in `packages/shared/test/clanWorldAbi.test.ts:7`) is deferred to a follow-up PR — does not affect runtime types

## Final gate

This PR runs `/phase-super-swarm` (6-model lineup: Codex 5.3/5.4/5.5 + Opus 4.6/4.7 + Gemini 3.1 Pro) for cross-model verification before merge. Merge requires explicit Liam approval per ADR 0018.

## Tag plan

On merge: tag `v2.9.0` from the resulting `main` commit. Previous release: `v2.8.5` (2026-05-16 PR #423 whisper elder-direct path).
