### PR TITLE
fix(shared): migrate test as-Abi cast + extend grep gate to test dir

### DIFF
--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -60,7 +60,9 @@ jobs:
             --exclude-dir="_generated" \
             --exclude-dir="node_modules" \
             --exclude-dir="dev-ui" \
-            apps/ packages/shared/src/ packages/shared/test/ packages/runner/src/ packages/agents/src/ 2>/dev/null; then
+            apps/ packages/shared/src/ packages/shared/test/ \
+            packages/runner/src/ packages/runner/test/ \
+            packages/agents/src/ packages/agents/test/ 2>/dev/null; then
             echo "::error::Found raw 'as Abi' cast(s). Import the generated iClanWorldAbi / iClanWorldLensAbi from @clan-world/contract-types instead."
             exit 1
           fi

--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -60,7 +60,7 @@ jobs:
             --exclude-dir="_generated" \
             --exclude-dir="node_modules" \
             --exclude-dir="dev-ui" \
-            apps/ packages/shared/src/ packages/runner/src/ packages/agents/src/ 2>/dev/null; then
+            apps/ packages/shared/src/ packages/shared/test/ packages/runner/src/ packages/agents/src/ 2>/dev/null; then
             echo "::error::Found raw 'as Abi' cast(s). Import the generated iClanWorldAbi / iClanWorldLensAbi from @clan-world/contract-types instead."
             exit 1
           fi

--- a/packages/shared/test/clanWorldAbi.test.ts
+++ b/packages/shared/test/clanWorldAbi.test.ts
@@ -4,6 +4,9 @@ import { decodeFunctionResult, encodeAbiParameters, getAbiItem, type Abi, type A
 import { CLAN_WORLD_ABI } from '../src/adapters/IChainClient';
 
 const ZERO_BYTES32 = `0x${'00'.repeat(32)}` as `0x${string}`;
+// Widening annotation (not cast) — `satisfies Abi` preserves the deep literal union
+// and causes TypeScript instantiation-depth errors inside getAbiItem. The structural
+// assignment is type-checked by the compiler; if any ABI entry were malformed, tsc fails.
 const abi: Abi = iClanWorldAbi;
 
 const getFunctionOutputs = (name: string) => (getAbiItem({ abi, name }) as AbiFunction).outputs;

--- a/packages/shared/test/clanWorldAbi.test.ts
+++ b/packages/shared/test/clanWorldAbi.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import canonicalAbi from '@clan-world/contracts/abi/IClanWorld.json' with { type: 'json' };
+import { iClanWorldAbi } from '@clan-world/contract-types';
 import { decodeFunctionResult, encodeAbiParameters, getAbiItem, type Abi, type AbiFunction } from 'viem';
 import { CLAN_WORLD_ABI } from '../src/adapters/IChainClient';
 
 const ZERO_BYTES32 = `0x${'00'.repeat(32)}` as `0x${string}`;
-const abi = canonicalAbi.abi as Abi;
+const abi: Abi = iClanWorldAbi;
 
 const getFunctionOutputs = (name: string) => (getAbiItem({ abi, name }) as AbiFunction).outputs;
 const worldStateOutputs = getFunctionOutputs('getWorldState');


### PR DESCRIPTION
## Summary

Follow-up to #431 per orchestrator LOW finding.

- **`packages/shared/test/clanWorldAbi.test.ts:7`** — Remove `canonicalAbi.abi as Abi` (raw JSON import + cast). Import `iClanWorldAbi` from `@clan-world/contract-types` and use explicit type annotation `const abi: Abi = iClanWorldAbi`. Note: `satisfies Abi` was tried first but keeps the literal as-const union type, which causes TypeScript's instantiation depth limit when passed to `getAbiItem`. Explicit annotation widens to `Abi` without a cast operator.

- **`.github/workflows/typechain-ci.yml`** — Add `packages/shared/test/` to the `no-as-abi-casts` grep scope so test re-introductions are caught by CI.

## Test plan

- [x] `pnpm --filter @clan-world/shared typecheck` — clean
- [x] `pnpm --filter @clan-world/shared test` — 27/27 pass
- [x] Grep gate verified: exit 0 with `packages/shared/test/` in scope
- [ ] 3-tier swarm review
- [ ] Orchestrator super-swarm + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)