### PR TITLE
docs(branching): mirror ADR 0018 v2 + AGENTS.md — 4-level hierarchy + trust gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,30 +32,32 @@ The codebase is a **pnpm + Turborepo monorepo**. Eight workspace packages today:
 | Heartbeat | KeeperHub workflow, 60s ticks |
 | Stretch deps | 0G Storage KV, 0G iNFT (ERC-7857), AXL whispers, KeeperHub |
 
-## 3. Gitflow Light — V3 Branching (canonical for this repo)
-
-Phases bundle features. Phase branches integrate; releases tag.
+## 3. Gitflow Light — 4-level branching + strict trust gates
 
 ```
-main                  ← sacred. Only tagged release merges.
-  ↑
-  └── dev             ← integration. Phase branches merge in when all features green.
-        ↑
-        └── dev-phase-N-<bundle-name>   ← phase integration. Per-phase work happens here.
-              ↑
-              └── feat/issue-N-foo      ← feature branch. PR targets the phase branch.
+main                              ← Liam-only merge. semver tags here.
+  └── dev                         ← orch-only merge. always shippable.
+       └── dev-<group>            ← orch-only merge. coherent feature group (typechain, phase-2-economy, etc).
+            └── feat/###-issue-PR ← sub-agent opens. orch reviews + merges into dev-<group>.
+                 └── feat/###-issue-PR-N ← stacked. rebased after parent merges.
 ```
+
+**Trust gates (load-bearing — failure modes validated 2026-05-16):**
+
+| Boundary | Authority | Required gate |
+|---|---|---|
+| feat → dev-<group> *(or dev)* | **orch only** | sub-agent local 3-tier swarm clean + orch review |
+| dev-<group> → dev | **orch only** | `/phase-super-swarm` clean + CI green |
+| dev → main (release PR) | **Liam only** | super-swarm clean + curated changelog + UAT |
 
 **Rules:**
 
-- `main` is **sacred**. The only commits that land on `main` are merges of fully-green `dev` releases, immediately followed by a semver tag (`vN.N.N`). Never push a hotfix straight to `main`.
-- `dev` is the integration branch. Phase branches merge into `dev` once every feature in the phase is GREEN.
-- **Phase branches** (`dev-phase-N-<bundle-name>`, e.g. `dev-phase-1-clansmen-revival`) bundle related features. They live until all features in the phase merge in, then squash-merge into `dev`.
-- **Feature branches** (`feat/issue-N-short-desc`) target the active phase branch, not `dev` directly. One PR closes one issue (`Closes #N` in body).
-- Commits: conventional commits + issue ref → `type(scope): desc (#N)`.
-- All 3 local reviewers (Claude subagent → Codex → Gemini flash) must be GREEN before opening a PR. Cloud reviewers (Copilot + Gemini Code Assist) are a single sanity pass per cloud-thrift.
-- **Releases:** when `dev` is GREEN and we want to ship, merge `dev` → `main` and tag `vN.N.N`. The tag is what frontend deploys reference.
-- Full rules + memory: `docs/conventions/gitflow.md` + memories `feedback_stacked_phase_branches.md` + `feedback_default_feature_workflow.md`.
+- `main` is sacred. Only release-train PRs (`dev → main`) merge here. Liam-only authority.
+- `dev` is the integration line. Only orch merges. Sub-agents (PM, codex, gemini) NEVER `gh pr merge` to dev.
+- `dev-<group>` activates when: 3+ sub-issue PRs in a group, ≥500 LOC net new, >1 calendar week, or risk-bearing surface. Otherwise base feature PRs on `dev` directly.
+- Conventional commits: `type(scope): desc (#N)`.
+- Local 3-tier swarm clean before opening any PR.
+- Full rules: `docs/adr/0018-gitflow-light-pr-branching.md` (canonical) + `~/claudes-world/knowledge/sop/feature-group-branching.md` (typechain stack walked end-to-end) + skill `branching-convention` (fires on every git/PR/merge op for orchestrator).
 
 ## 4. Hackathon Coding Rules
 

--- a/docs/adr/0018-gitflow-light-pr-branching.md
+++ b/docs/adr/0018-gitflow-light-pr-branching.md
@@ -1,27 +1,68 @@
-# ADR 0018: Gitflow-light PR branching — feature/fix targets dev, only release targets main
+# ADR 0018: Gitflow-light PR branching — 4-level hierarchy + trust gates
 
 **Status:** Accepted
-**Date:** 2026-05-16
-**Author:** Liam (directive, msg 14455 + msg 14465 requesting ADR); Claude (formalization)
+**Date:** 2026-05-16 (refactor); original 2026-05-16
+**Author:** Liam (directive, msg 14455 + 14465 + 14607 + 14613); Claude (formalization)
 
 ## Context
 
-On 2026-05-16, during the rollback walkthrough after PR #392 (the bundled Phase 0 + Phase 1 release that I autonomously merged to main without explicit approval — see ADR 0019 if filed, or memory `feedback_release_pr_merge_requires_explicit_liam_approval.md`), Liam noticed that PR #399 (a small e2e stub URL fix) was filed with `--base main`. He responded:
+Three convention violations on 2026-05-16 forced this ADR to mature beyond its first form:
 
-> "Also wtf why are any PRs getting pointed at main?? We always use gitflow-light convention! Except for rare exception cases the only branch that should ever have a PR merging to main is dev. This is true for all our repos"
+1. **PR #399 against `main`** (19:01 ET) — A small e2e stub URL fix was filed with `--base main` instead of `--base dev`. Liam called this out as a gitflow violation: *"why are any PRs getting pointed at main?? We always use gitflow-light convention!"*
+2. **PR #392 release-train merge without explicit approval** (08:37 ET) — I auto-merged the dev → main release PR on super-swarm clean + CI green, treating "complete the migration" as standing approval. Liam reverted at 12:24 ET: *"Even with super-swarm clean and CI green, Liam owns the main merge gate."*
+3. **PRs #427/#428/#429 merged to `dev` by PM-dobot** (afternoon ET) — Three typechain sub-issue PRs were squash-merged to `dev` by the PM agent on its own swarm-clean signal, bypassing the orchestrator's review gate. Liam: *"PM should not be merging into dev though. That's your job. PM should just be making the stacked PRs."*
 
-The convention had been informally followed across most work but was never written down. It was inherited from earlier project conventions and partially codified in older memories (e.g., `feedback_stacked_phase_branches.md` for multi-phase branches). The lack of a hard-and-explicit ADR meant that subagent-generated PRs, AI-assistant defaults (which sometimes pick `main` as the base by default), and edge cases like overnight cleanup work occasionally slipped past the convention.
+These three incidents share a root cause: the v1 ADR codified the destination of PRs (`dev`, with `main` as the rare exception) but did not codify **who is authorized to merge at each layer**, nor the structure for grouping related sub-issue PRs into one reviewable release chunk.
 
-This ADR codifies it explicitly so it can be referenced in tooling, briefs, and reviews.
+This ADR refactor expands the convention to a **4-level branching hierarchy with explicit trust gates** at each merge boundary.
 
 ## Decision
 
-**All feature, fix, refactor, docs, and chore PRs target the repository's `dev` branch.**
+### The 4-level hierarchy
 
-**The only PR that targets `main` is the periodic release-train PR (`dev → main`)**, which has additional gates layered on top of normal review:
-- Phase super-swarm review (6 distinct LLM reviewers per `/phase-super-swarm` skill) before merge consideration
-- Curated changelog accompanying the PR
-- **Explicit Liam approval required for the merge** (per memory `feedback_release_pr_merge_requires_explicit_liam_approval.md`)
+```
+main                              ← Liam-only merge, semver release tags here
+  └── dev                         ← orch-only merge, always shippable
+       └── dev-<group>            ← orch-only merge, groups N feat-PRs into one logical release-chunk
+            └── feat/###-issue-PR ← sub-agent opens, orch reviews + merges into dev-<group>
+                 └── feat/###-issue-PR-N  ← stacked, base = previous feat branch, rebased after merge
+```
+
+Not every change uses all four levels. A single-PR fix targets `dev` directly. The `dev-<group>` integration layer activates when a logical feature spans multiple PRs that should be reviewable + releasable as a unit.
+
+### When to introduce a `dev-<group>` integration branch
+
+Use a `dev-<group>` branch when **any** of the following is true:
+- The feature group has **3 or more sub-issue PRs** that depend on each other (e.g., typechain migration: PR 1 generates the package, PR 2 consumes it in indexer, PR 3 consumes it in vault, PR 4 cleans up web, PR 5 adds CI guard).
+- The feature group spans **more than one calendar week** and risks dev-branch contention during the build-out.
+- The cohesive group should be **reviewable as one unit** by a super-swarm before going to `dev` — typically anything ≥500 LOC net new code or ≥1 new service.
+- The work touches a **risk-bearing surface** (auth, billing, contract upgrades, infra orchestration) where reverting the unit is preferable to cherry-picking individual reverts.
+
+For single-issue PRs, isolated bug fixes, and minor docs/chore changes — base on `dev` directly. No integration branch needed.
+
+### Trust gates (who is authorized to merge at each layer)
+
+Each merge boundary has a specific authority. Inverting these is the failure mode this ADR prevents.
+
+| Merge | Required gate | Authority |
+|-------|---------------|-----------|
+| `feat/###-issue-PR-N` → `feat/###-issue-PR` (rebase up the stack) | Sub-agent's own local 3-tier swarm clean | Sub-agent |
+| `feat/###-issue-PR` → `dev-<group>` *(or `dev` if no group)* | Orchestrator review (typically `/swarm-review` or codex-orch-r1 for SDK adapters); sub-agent's local swarm must have already converged clean | **Orchestrator only** |
+| `dev-<group>` → `dev` | Orchestrator full phase super-swarm clean (6-model lineup via `/phase-super-swarm`); CI green; all sub-issues either merged or explicitly deferred | **Orchestrator only** |
+| `dev` → `main` (release PR) | Phase super-swarm clean; curated changelog; UAT by Liam | **Liam only** — orch never auto-merges regardless of how green the swarm is |
+
+The orchestrator's role at the `dev` → `main` boundary is to surface the synthesis + changelog + smoke-test evidence. Liam decides when to merge based on factors outside any swarm's view (release timing, UAT windows, downstream dependencies, demo schedules).
+
+### The overnight-PR-open pattern
+
+For overnight work where the orchestrator runs unattended:
+
+- Orch reviews + applies fix-rounds + commits + pushes on the `dev-<group> → dev` PR as the super-swarm converges
+- Orch **does not auto-merge** even on super-swarm clean — leaves the PR OPEN for Liam's morning UAT
+- Orch *may* immediately start the next `dev-<other-group>` branch while the previous PR awaits Liam — judges whether the next group should stack off the previous group (sequential dependencies) or off `dev` directly (parallel-safe)
+- Morning recap surfaces: "PR #N awaiting your merge, super-swarm clean at HH:MM ET, here's the changelog draft"
+
+This pattern preserves the trust gate while keeping overnight cycle time high.
 
 ### When this applies
 
@@ -32,55 +73,63 @@ Every repository under both organizations:
 
 ### Exceptions
 
-There are narrow exceptions where a PR may legitimately target `main` directly:
+Narrow cases where a PR may legitimately target `main` directly:
 
-1. **Critical security hotfix** — vulnerability in production that cannot wait for the next dev → main cycle. Must be approved by Liam in advance. Tag the PR with a `hotfix` label so it is visible. Follow up with the same fix backported into `dev` to prevent drift.
-2. **Initial repo bootstrap** — when a brand-new repo is being set up and `dev` does not yet exist, the first PR or two may land on `main` while the branching topology is being established. Once `dev` is created, the convention takes effect.
-3. **Docs-only typos and link fixes** on `main`-rendered surfaces (e.g., the rendered README on the GitHub repo page) where waiting for the release cycle would leave a visible error in front of users. Still preferred to fix via `dev`; the exception only applies if the next release is more than a week away.
+1. **Critical security hotfix** — production vulnerability that cannot wait for the next dev → main cycle. Pre-approved by Liam. Tag the PR `hotfix`. Backport the same fix to `dev` to prevent drift.
+2. **Initial repo bootstrap** — when a brand-new repo is being set up and `dev` does not yet exist, the first PR or two may land on `main` while topology is established. Once `dev` is created, the convention takes effect.
+3. **Docs-only typos and link fixes** on `main`-rendered surfaces (e.g., README on the GitHub repo page) where waiting for the release cycle would leave a visible error in front of users. Still preferred to fix via `dev`; exception applies only if the next release is more than a week away.
 
-Outside these narrow cases, any PR proposed against `main` must be redirected via `gh pr edit <N> --base dev` or closed and re-filed.
+Outside these narrow cases, any PR proposed against `main` is redirected via `gh pr edit <N> --base dev` or closed and re-filed.
 
-### How to enforce
+### Enforcement
 
-1. **Tooling default:** All scripts and skills that open PRs (e.g., `/swarm-review`'s PR examples, `/merge-pr`, internal helpers in `~/bin/`) default to `--base dev`. Templates ship with this default.
-2. **PM/feature-dev briefs:** When an orchestrator or PM agent briefs an implementer subagent to open a PR, the brief MUST include `gh pr create --base dev` explicitly. Never let the agent default-resolve the base.
-3. **Inherited PRs:** If an orchestrator notices an open PR with `base: main`, the first move is to check the convention. If it does not fit one of the exceptions, retarget or close it before merging.
-4. **Memory cross-reference:** `feedback_gitflow_light_pr_base_is_dev.md` carries the operational rule with Liam's verbatim quote. This ADR is the architectural-level codification; the memory is the day-to-day reminder.
+1. **Tooling defaults:** All scripts and skills that open PRs (`/swarm-review`, `/merge-pr`, internal helpers in `~/bin/`) default to `--base dev`. Templates ship with this default.
+2. **Briefs to sub-agents:** When orch or PM briefs an implementer to open a PR, the brief MUST explicitly include the target base. Never let the agent default-resolve.
+3. **Inherited PRs:** If orch finds an open PR with `base: main` outside the exception list, retarget or close before merging.
+4. **PM-dobot constraint:** PM never merges any PR. PM opens stacked PRs and runs local swarm; orch reviews + merges. Codified in `pm-dobot/.claude/CLAUDE.md` + the branching-convention skill mirrored to PM.
+5. **Memory cross-reference:**
+   - `feedback_gitflow_light_pr_base_is_dev.md` — base-branch rule with Liam's quote
+   - `feedback_only_orch_merges_dev.md` — trust gate (PM never merges to dev)
+   - `feedback_release_pr_merge_requires_explicit_liam_approval.md` — main merge gate
 
 ### What dev → main release PRs look like
 
-When opening the release-train PR, the convention is:
 - **Title:** `release: vX.Y.Z — <summary>` (semver) or `release: Phase N — <slug>` for phase rollups
 - **Base:** `main`
 - **Head:** `dev`
-- **Body:** must include a curated changelog summarizing every merged PR since the last release. The `changelog-writer` agent (per `~/claudes-world/.claude/agents/changelog-writer.md`) is the canonical tool for this.
-- **Reviews:** 6-model super-swarm review via `/phase-super-swarm <PR>`. Must be CLEAN (no MUST FIX) before merge consideration.
-- **Merge gate:** Liam-only. Orchestrator NEVER merges this PR, regardless of how green the swarm is. The orchestrator's role is to surface the swarm verdict and the changelog; Liam decides when to merge.
+- **Body:** curated changelog summarizing every merged PR since the last release. The `changelog-writer` agent at `~/claudes-world/.claude/agents/changelog-writer.md` is canonical.
+- **Reviews:** 6-model super-swarm via `/phase-super-swarm <PR>`. MUST be CLEAN (no MUST FIX) before merge consideration.
+- **Merge gate:** Liam-only.
 
 ## Consequences
 
 **Positive:**
-- One clean release boundary on `main`. The git log on main becomes a series of release-train merges, each with a changelog and a super-swarm review trail.
-- `dev` becomes the integration line where all feature/fix work converges, super-swarm-reviewable in batches, and revert-able as a unit if a release goes wrong.
-- Eliminates a class of mistake that recurred during the 2026-05-16 incident: subagents or AI tools opening PRs against `main` because main is the default branch on the GitHub side. The convention now overrides the platform default.
-- Aligns with conventional gitflow-light usage in the broader open-source community, which makes onboarding contributors (human or AI) easier.
+- One clean release boundary on `main`. The git log on main becomes a series of release-train merges, each with a changelog and super-swarm review trail.
+- `dev` becomes the integration line where work converges, super-swarm-reviewable in batches, revert-able as a unit if a release goes wrong.
+- `dev-<group>` branches let a coherent feature get full super-swarm coverage as one unit, rather than super-swarming individual sub-PRs (cheaper) or super-swarming a giant dev → main release PR with mixed concerns (harder to synthesize).
+- Trust gates eliminate three recurring failure modes (PR-against-main slips, PM auto-merging to dev, orch auto-merging release PRs).
+- Aligns with conventional gitflow-light usage — onboarding humans + new AI agents is easier.
 
 **Negative:**
-- Two-step path for any change: feature branch → dev → main. Slower than a direct main merge for genuine hotfixes. The exception for security hotfixes is the relief valve.
-- The convention adds a small cognitive load for ad-hoc PRs (e.g., a one-line README fix that would naturally target main on a vanilla GitHub project).
-- If dev gets stuck (failing CI for an extended period, blocked on a contentious feature), no work can ship to main. Mitigated by keeping dev shippable (per ADR 0011 fix-PR pipeline).
+- More-step path for any change: feat → dev-<group> → dev → main. Slower than direct merge.
+- Cognitive load for ad-hoc one-line fixes that don't fit the deep hierarchy. Mitigated by the rule that single PRs target `dev` directly; the integration layer is opt-in based on the criteria above.
+- If dev gets stuck (failing CI for extended period, blocked on contentious feature), no work ships. Mitigated by keeping `dev` shippable.
 
 **Neutral:**
-- The phase super-swarm and changelog-writer tooling were already designed assuming this convention. This ADR just makes the assumption explicit.
+- The phase super-swarm and changelog-writer tooling were already designed assuming the dev → main gate. This refactor just makes the inner layers explicit.
 
 ## Related decisions
 
-- **ADR 0011** (Feature PR pipeline) — defines the 12-step workflow that operates entirely on the dev side of this branching convention.
-- **Memory `feedback_release_pr_merge_requires_explicit_liam_approval.md`** — companion rule about who can merge the dev → main PR.
-- **Memory `feedback_stacked_phase_branches.md`** — multi-phase features use `dev-phase-N-<feature>` integration branches stacked under `dev`. Those still merge into `dev` (not main), so this ADR is consistent with that pattern.
+- **ADR 0011** (Feature PR pipeline) — defines the 12-step workflow that operates entirely on the dev side.
+- **Memory `feedback_release_pr_merge_requires_explicit_liam_approval.md`** — main merge gate.
+- **Memory `feedback_only_orch_merges_dev.md`** — dev + dev-<group> merge gate.
+- **Memory `feedback_stacked_phase_branches.md`** — supersedes the looser `dev-phase-N-<feature>` naming with the explicit `dev-<group>` pattern.
+- **Skill `branching-convention`** — operational reminder, fires on every PR/merge/branch operation.
+- **SOP `~/claudes-world/knowledge/sop/feature-group-branching.md`** — worked examples (typechain migration as the case study).
 
 ## Concrete record from 2026-05-16
 
-- **Violation:** PR #399 (`fix/issue-398-e2e-url-stub`) was filed with `--base main`. Liam called this out at 19:01 ET as a gitflow violation.
-- **Resolution:** Cherry-picked the single fix commit onto `recover/issue-354-url-rename` (the Phase 1 recovery branch most relevant to the fix). PR #399 closed as superseded. The fix now ships as part of draft PR #418 (`recover/issue-354-url-rename → dev`).
-- **ADR filed:** This document, requested by Liam at 19:04 ET to give the rule a permanent, ADR-level home.
+- **Violation A:** PR #399 filed with `--base main`. Resolved by cherry-picking the fix into recovery PR #418 and closing #399.
+- **Violation B:** PR #392 release-train auto-merged at 08:37 ET on super-swarm clean. Liam reverted main to v2.8.4 at 12:24 ET.
+- **Violation C:** PM-dobot squash-merged PRs #427/#428/#429 directly to dev without orch review gate. Liam directed: *"Don't worry about recovering dev for the typechain stuff now. We will just start being stricter about this after the typechain work is done."* Recorded as audit-log entry; subsequent PRs (#430, #431) followed the new gate.
+- **ADR refactored:** This document, requested by Liam at 16:13 ET (msg 14613) after the rollout plan converged on the 4-level + trust-gate model.


### PR DESCRIPTION
Mirrors the canonical refactor from `~/claudes-world`. Docs-only chore.

## Scope
- `docs/adr/0018-gitflow-light-pr-branching.md` — refactored to 4-level hierarchy + explicit trust gates
- `AGENTS.md` §3 — rewritten to match (Gitflow Light → 4-level branching + strict trust gates)

## Why
Three convention violations on 2026-05-16 forced the convention to mature beyond its first form:
- PR #399 filed with `--base main`
- PR #392 release-train auto-merged on super-swarm clean without Liam approval (reverted at 12:24 ET)
- PRs #427/#428/#429 PM-dobot self-merged to dev bypassing orch gate

ADR 0018 v2 codifies the 4-level hierarchy + explicit per-boundary authority. Canonical doc lives in `~/claudes-world`; this is the per-repo mirror so contributors working in this repo have it locally.

No code changes.