### PR TITLE
fix(server,web): plumb worldPaused through getSnapshot — typed runtime fallback (#438)

### DIFF
--- a/apps/server/convex/getSnapshot.ts
+++ b/apps/server/convex/getSnapshot.ts
@@ -59,6 +59,8 @@ export const getSnapshot = query({
         clans: [],
         activeBanditId: undefined,
         bandit: null,
+        worldPaused: false,
+        pausedAtTs: null,
         ...deriveSeasonState(0),
       };
     }
@@ -98,6 +100,8 @@ export const getSnapshot = query({
       clans: snap.clans,
       activeBanditId,
       bandit,
+      worldPaused: snap.worldPaused === true,
+      pausedAtTs: typeof snap.pausedAtTs === "number" ? snap.pausedAtTs : null,
       ...deriveSeasonState(snap.tick),
     };
   },

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -563,6 +563,8 @@ export const commitSnapshot = internalMutation({
       winterActive: asBool(world.winterActive),
       winterStartsAtTick: asNumber(world.winterStartsAtTick),
       winterEndsAtTick: asNumber(world.winterEndsAtTick),
+      worldPaused: asBool(world.worldPaused),
+      pausedAtTs: asNumber(world.pausedAtTs),
       nextHeartbeatAtTick: asNumber(world.nextHeartbeatAtTick),
       regions: LEGACY_REGIONS,
       clans: legacyClans,

--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -13,6 +13,8 @@ export default defineSchema({
     winterActive: v.optional(v.boolean()),
     winterStartsAtTick: v.optional(v.number()),
     winterEndsAtTick: v.optional(v.number()),
+    worldPaused: v.optional(v.boolean()),
+    pausedAtTs: v.optional(v.number()),
     nextHeartbeatAtTick: v.optional(v.number()),
     regions: v.array(
       v.object({

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -3773,9 +3773,7 @@ export function WorldMap() {
       REGION_KEY_BY_CHAIN_ID,
     );
 
-    // TODO(backend): worldPaused is not yet returned by getSnapshot. Wire up when
-    // pause support lands in the schema; until then animations advance during pause.
-    const worldPaused = false;
+    const worldPaused = snap?.worldPaused === true;
 
     // Hide everything by default, then enable per-phase.
     hideBanditAnimSprites();


### PR DESCRIPTION
## Summary

Plumbs `worldPaused` (and `pausedAtTs`) from chain → Convex → frontend so the
typechain-migration's hardcoded `const worldPaused = false` becomes a typed
runtime value driven by the actual chain state.

Closes #438.

## Per-file changes

1. **`apps/server/convex/schema.ts`** — extend the `worldSnapshot` table with
   two new optional fields:
   ```ts
   worldPaused: v.optional(v.boolean()),
   pausedAtTs: v.optional(v.number()),
   ```
   Optional because old pre-migration rows won't have them.

2. **`apps/server/convex/indexer.ts`** — persist both fields from the chain
   `getWorldSnapshot()` tuple using the existing `asBool` / `asNumber`
   helpers, identical pattern to `winterActive` / `nextHeartbeatAtTick`.

3. **`apps/server/convex/getSnapshot.ts`** — surface both fields in the
   query return shape, in BOTH the empty-snapshot branch (defaults
   `false` / `null`) and the populated branch (defensive narrows
   `snap.worldPaused === true` and `typeof snap.pausedAtTs === "number"
   ? snap.pausedAtTs : null` against pre-migration rows).

4. **`apps/web/src/WorldMap.tsx`** — replace lines 3776-3778
   (hardcoded `false` + TODO) with
   `const worldPaused = snap?.worldPaused === true;` — matches the
   established `winterActive` idiom at line 2125. Convex's return-type
   inference now wires the typed access automatically.

## Out of scope / deferred

None for this PR. The chain contract already exposes `worldPaused` /
`pausedAtTs` in `getWorldSnapshot()` (see
`packages/contract-types/src/IClanWorld.ts:2447-2455`), and the indexer
already decodes the named tuple — so both fields persist as soon as this
PR merges. No further indexer work needed.

The frontend currently only consumes `worldPaused` in the bandit-animation
phase (lines 3788, 3825) to freeze sprite jitter while paused. Other UI
pause behavior (overlays, banners) is out of scope and a future feature.

## Verification

```bash
pnpm --filter @clan-world/server typecheck   # ✓
pnpm --filter @clan-world/shared typecheck   # ✓
pnpm --filter @clan-world/web typecheck      # ✓
rg -n "as any|as unknown as" apps/server/convex/getSnapshot.ts \
    apps/server/convex/indexer.ts apps/server/convex/schema.ts \
    apps/web/src/WorldMap.tsx                # zero new casts
```

## Local 3-tier swarm verdict

(Posted as separate comment after PR open.)

## Notes

- Followup to the v2.9.0 typechain migration (PRs #427-#431, #433 merged
  to dev). PR #432 (dev→main release) is currently open; this PR will
  land on dev and auto-update the release PR.
- Source: codex 5.3 MEDIUM 4 + codex 5.4 MEDIUM from PR #432 super-swarm.
