### PR TITLE
fix(server,shared): runtime event-name allowlist — close ingest/vault type escape hatch (#436)

### DIFF
--- a/apps/server/convex/indexer.test.ts
+++ b/apps/server/convex/indexer.test.ts
@@ -316,6 +316,55 @@ describe("ingestEvents checkpoint isolation", () => {
   });
 });
 
+describe("ingestEvents allowlist", () => {
+  it("skips unknown event names with structured warning and rejected counter", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { db, tables } = createDb({
+        eventCheckpoint: [
+          { _id: "eventCheckpoint:0", _creationTime: 0, lastBlock: 100 },
+        ],
+      });
+
+      const goodEvent = {
+        eventName: "TickAdvanced",
+        args: { closedTick: "1", openedTick: "2", tickSeed: "0x1234" },
+        transactionHash,
+        blockNumber: 105,
+        logIndex: 0,
+      };
+      const badEvent = {
+        eventName: "FakeEvent",
+        args: { foo: "bar" },
+        transactionHash,
+        blockNumber: 105,
+        logIndex: 1,
+      };
+
+      const result = await (ingestEvents as any)._handler(
+        { db },
+        {
+          events: [goodEvent, badEvent],
+          blockNumber: 105,
+          txHash: transactionHash,
+          advanceCheckpoint: false,
+        },
+      );
+
+      expect(result.inserted).toBe(1);
+      expect(result.rejected).toBe(1);
+      expect(tables.chainEvents).toHaveLength(1);
+      expect(tables.chainEvents?.[0]?.eventName).toBe("TickAdvanced");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("FakeEvent"),
+        expect.objectContaining({ eventName: "FakeEvent" }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
 describe("legacy snapshot backfill", () => {
   it("commitSnapshot writes non-empty legacy clans from clanView rows", async () => {
     const { db, tables } = createDb();

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -5,7 +5,10 @@ import {
   internalQuery,
 } from "./_generated/server";
 import { internal } from "./_generated/api";
-import { iClanWorldAbi } from "@clan-world/contract-types";
+import {
+  iClanWorldAbi,
+  isClanWorldEventName,
+} from "@clan-world/contract-types";
 import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
 import {
   defineChain,
@@ -277,9 +280,7 @@ const indexerEventValidator = v.object({
   args: v.any(),
   address: v.optional(v.string()),
   blockHash: v.optional(v.union(v.string(), v.null())),
-  blockNumber: v.optional(
-    v.union(v.int64(), v.number(), v.string(), v.null()),
-  ),
+  blockNumber: v.optional(v.union(v.int64(), v.number(), v.string(), v.null())),
   transactionHash: v.optional(v.union(v.string(), v.null())),
   transactionIndex: v.optional(v.union(v.number(), v.null())),
   logIndex: v.optional(v.union(v.number(), v.null())),
@@ -298,12 +299,42 @@ export const ingestEvents = internalMutation({
       return {
         inserted: 0,
         skipped: args.events.length,
+        // Keep the response shape stable for callers that inspect ingest stats.
+        rejected: 0,
         resetLocked: true,
       };
     }
 
     let inserted = 0;
-    for (const raw of args.events as ParsedIndexerEvent[]) {
+    let rejected = 0;
+    for (const raw of args.events) {
+      if (!isClanWorldEventName(raw.eventName)) {
+        console.warn(
+          `[indexer] rejecting unknown eventName "${String(raw.eventName)}"`,
+          {
+            eventName: raw.eventName,
+            txHash: raw.transactionHash ?? args.txHash,
+            logIndex: raw.logIndex,
+            blockNumber: raw.blockNumber ?? args.blockNumber,
+          },
+        );
+        rejected++;
+        continue;
+      }
+
+      const event: ParsedIndexerEvent = {
+        eventName: raw.eventName,
+        args: raw.args,
+        address: raw.address,
+        blockHash: raw.blockHash,
+        blockNumber:
+          typeof raw.blockNumber === "string"
+            ? Number(raw.blockNumber)
+            : raw.blockNumber,
+        transactionHash: raw.transactionHash,
+        transactionIndex: raw.transactionIndex,
+        logIndex: raw.logIndex,
+      };
       const logIndex = raw.logIndex ?? 0;
       const txHash = raw.transactionHash ?? args.txHash;
       if (!txHash) continue;
@@ -320,27 +351,28 @@ export const ingestEvents = internalMutation({
         txHash,
         logIndex,
         blockNumber,
-        eventName: raw.eventName,
-        args: bigintSafe(raw.args),
+        eventName: event.eventName,
+        args: bigintSafe(event.args),
         decodedAt: Date.now(),
-        blockHash: raw.blockHash ?? undefined,
-        transactionIndex: raw.transactionIndex ?? undefined,
+        blockHash: event.blockHash ?? undefined,
+        transactionIndex: event.transactionIndex ?? undefined,
         tick:
-          eventNumber(raw, "tick") ??
-          eventNumber(raw, "atTick") ??
-          eventNumber(raw, "openedTick"),
-        clanId: eventNumber(raw, "clanId") ?? eventNumber(raw, "targetClanId"),
-        clansmanId: eventNumber(raw, "clansmanId"),
-        banditId: eventNumber(raw, "banditId"),
+          eventNumber(event, "tick") ??
+          eventNumber(event, "atTick") ??
+          eventNumber(event, "openedTick"),
+        clanId:
+          eventNumber(event, "clanId") ?? eventNumber(event, "targetClanId"),
+        clansmanId: eventNumber(event, "clansmanId"),
+        banditId: eventNumber(event, "banditId"),
         source: "real-indexer",
       });
       inserted++;
 
-      if (raw.eventName === "TickAdvanced") {
+      if (event.eventName === "TickAdvanced") {
         await ctx.db.insert("tickHistory", {
-          closedTick: asNumber(raw.args.closedTick),
-          openedTick: asNumber(raw.args.openedTick),
-          tickSeed: asString(raw.args.tickSeed),
+          closedTick: asNumber(event.args.closedTick),
+          openedTick: asNumber(event.args.openedTick),
+          tickSeed: asString(event.args.tickSeed),
           blockNumber,
           txHash,
           firedAtTs: args.firedAtTs,
@@ -348,7 +380,7 @@ export const ingestEvents = internalMutation({
         });
       }
 
-      const pricePoint = pricePointFromEvent(raw, blockNumber);
+      const pricePoint = pricePointFromEvent(event, blockNumber);
       if (pricePoint) await ctx.db.insert("pricePoint", pricePoint);
     }
 
@@ -368,7 +400,7 @@ export const ingestEvents = internalMutation({
       }
     }
 
-    return { inserted };
+    return { inserted, rejected };
   },
 });
 
@@ -649,9 +681,7 @@ export const refreshSnapshot = internalAction({
 
     const world = worldRaw as Record<string, unknown> | undefined;
     if (!world) {
-      console.warn(
-        "[indexer] getWorldSnapshot failed; skipping refresh",
-      );
+      console.warn("[indexer] getWorldSnapshot failed; skipping refresh");
       return { tick: 0, clans: 0 };
     }
 

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -280,7 +280,9 @@ const indexerEventValidator = v.object({
   args: v.any(),
   address: v.optional(v.string()),
   blockHash: v.optional(v.union(v.string(), v.null())),
-  blockNumber: v.optional(v.union(v.int64(), v.number(), v.string(), v.null())),
+  blockNumber: v.optional(
+    v.union(v.int64(), v.number(), v.string(), v.null()),
+  ),
   transactionHash: v.optional(v.union(v.string(), v.null())),
   transactionIndex: v.optional(v.union(v.number(), v.null())),
   logIndex: v.optional(v.union(v.number(), v.null())),
@@ -681,7 +683,9 @@ export const refreshSnapshot = internalAction({
 
     const world = worldRaw as Record<string, unknown> | undefined;
     if (!world) {
-      console.warn("[indexer] getWorldSnapshot failed; skipping refresh");
+      console.warn(
+        "[indexer] getWorldSnapshot failed; skipping refresh",
+      );
       return { tick: 0, clans: 0 };
     }
 

--- a/apps/server/convex/vault.test.ts
+++ b/apps/server/convex/vault.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { projectAttributed, projectBroadcast, type Movement } from "./vault";
-import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
+import {
+  isClanWorldEventName,
+  type IClanWorldAbiEventName,
+} from "@clan-world/contract-types";
 
 const WEI = "1000000000000000000"; // 1e18
 const wei = (n: number) => `${n}${"0".repeat(18)}`;
 
-const baseAttributed = (eventName: IClanWorldAbiEventName, args: Record<string, unknown>, tick = 5) => ({
+const baseAttributed = (
+  eventName: IClanWorldAbiEventName,
+  args: Record<string, unknown>,
+  tick = 5,
+) => ({
   eventName,
   args,
   tick,
@@ -13,7 +20,11 @@ const baseAttributed = (eventName: IClanWorldAbiEventName, args: Record<string, 
   clanId: 7,
 });
 
-const baseBroadcast = (eventName: IClanWorldAbiEventName, args: Record<string, unknown>, tick = 5) => ({
+const baseBroadcast = (
+  eventName: IClanWorldAbiEventName,
+  args: Record<string, unknown>,
+  tick = 5,
+) => ({
   eventName,
   args,
   tick,
@@ -35,31 +46,61 @@ describe("projectAttributed", () => {
       out,
     );
     // Filters zero-amount entries, keeps wood/wheat/gold gains
-    expect(out.map(m => `${m.type}:${m.amount}:${m.resource}`)).toEqual([
+    expect(out.map((m) => `${m.type}:${m.amount}:${m.resource}`)).toEqual([
       "gain:3:wood",
       "gain:2:wheat",
       "gain:1:gold",
     ]);
-    expect(out.every(m => m.tick === 5)).toBe(true);
-    expect(out.every(m => m.source === "gather" || m.source === "gather bonus")).toBe(true);
+    expect(out.every((m) => m.tick === 5)).toBe(true);
+    expect(
+      out.every((m) => m.source === "gather" || m.source === "gather bonus"),
+    ).toBe(true);
   });
 
   it("projects ResourcesDeposited as gains; ResourcesWithdrawn as spends", () => {
     const out: Movement[] = [];
-    projectAttributed(baseAttributed("ResourcesDeposited", { woodDelta: wei(5) }), 7, out);
-    projectAttributed(baseAttributed("ResourcesWithdrawn", { ironDelta: wei(2) }), 7, out);
+    projectAttributed(
+      baseAttributed("ResourcesDeposited", { woodDelta: wei(5) }),
+      7,
+      out,
+    );
+    projectAttributed(
+      baseAttributed("ResourcesWithdrawn", { ironDelta: wei(2) }),
+      7,
+      out,
+    );
     expect(out).toEqual([
-      expect.objectContaining({ type: "gain", amount: 5, resource: "wood", source: "deposit" }),
-      expect.objectContaining({ type: "spend", amount: 2, resource: "iron", source: "withdraw" }),
+      expect.objectContaining({
+        type: "gain",
+        amount: 5,
+        resource: "wood",
+        source: "deposit",
+      }),
+      expect.objectContaining({
+        type: "spend",
+        amount: 2,
+        resource: "iron",
+        source: "withdraw",
+      }),
     ]);
   });
 
   it("projects BlueprintAwarded / BlueprintEarned as blueprint gains", () => {
     const out: Movement[] = [];
-    projectAttributed(baseAttributed("BlueprintAwarded", { amount: wei(4) }), 7, out);
-    projectAttributed(baseAttributed("BlueprintEarned", { amount: wei(2) }), 7, out);
-    expect(out.map(m => m.amount)).toEqual([4, 2]);
-    expect(out.every(m => m.resource === "blueprint" && m.type === "gain")).toBe(true);
+    projectAttributed(
+      baseAttributed("BlueprintAwarded", { amount: wei(4) }),
+      7,
+      out,
+    );
+    projectAttributed(
+      baseAttributed("BlueprintEarned", { amount: wei(2) }),
+      7,
+      out,
+    );
+    expect(out.map((m) => m.amount)).toEqual([4, 2]);
+    expect(
+      out.every((m) => m.resource === "blueprint" && m.type === "gain"),
+    ).toBe(true);
   });
 
   it("projects BanditAttackResolved stolen amounts as spends", () => {
@@ -75,8 +116,18 @@ describe("projectAttributed", () => {
       out,
     );
     expect(out).toEqual([
-      expect.objectContaining({ type: "spend", amount: 3, resource: "wood", source: "bandit raid" }),
-      expect.objectContaining({ type: "spend", amount: 1, resource: "fish", source: "bandit raid" }),
+      expect.objectContaining({
+        type: "spend",
+        amount: 3,
+        resource: "wood",
+        source: "bandit raid",
+      }),
+      expect.objectContaining({
+        type: "spend",
+        amount: 1,
+        resource: "fish",
+        source: "bandit raid",
+      }),
     ]);
   });
 
@@ -94,8 +145,18 @@ describe("projectAttributed", () => {
       out,
     );
     expect(out).toEqual([
-      expect.objectContaining({ type: "spend", amount: 10, resource: "gold", source: "market trade" }),
-      expect.objectContaining({ type: "gain", amount: 5, resource: "wood", source: "market trade" }),
+      expect.objectContaining({
+        type: "spend",
+        amount: 10,
+        resource: "gold",
+        source: "market trade",
+      }),
+      expect.objectContaining({
+        type: "gain",
+        amount: 5,
+        resource: "wood",
+        source: "market trade",
+      }),
     ]);
 
     // Sell scheduled: spend wheat, gain gold; uses "market settle" label
@@ -110,10 +171,9 @@ describe("projectAttributed", () => {
       7,
       out,
     );
-    expect(out.map(m => `${m.type}:${m.amount}:${m.resource}:${m.source}`)).toEqual([
-      "spend:8:wheat:market settle",
-      "gain:11:gold:market settle",
-    ]);
+    expect(
+      out.map((m) => `${m.type}:${m.amount}:${m.resource}:${m.source}`),
+    ).toEqual(["spend:8:wheat:market settle", "gain:11:gold:market settle"]);
   });
 
   it("projects ResourcesInjected (admin recovery) as gains for all non-zero resources", () => {
@@ -130,7 +190,9 @@ describe("projectAttributed", () => {
       7,
       out,
     );
-    expect(out.map(m => `${m.type}:${m.amount}:${m.resource}:${m.source}`)).toEqual([
+    expect(
+      out.map((m) => `${m.type}:${m.amount}:${m.resource}:${m.source}`),
+    ).toEqual([
       "gain:5:wood:admin inject",
       "gain:3:wheat:admin inject",
       "gain:10:gold:admin inject",
@@ -139,7 +201,11 @@ describe("projectAttributed", () => {
 
   it("ignores ABI event names with no vault projection (e.g. TickAdvanced)", () => {
     const out: Movement[] = [];
-    projectAttributed(baseAttributed("TickAdvanced", { closedTick: 1 }), 7, out);
+    projectAttributed(
+      baseAttributed("TickAdvanced", { closedTick: 1 }),
+      7,
+      out,
+    );
     expect(out).toEqual([]);
   });
 });
@@ -149,43 +215,80 @@ describe("projectBroadcast", () => {
     const out: Movement[] = [];
     // Sender perspective: clanId === fromClanId
     projectBroadcast(
-      baseBroadcast("GoldTransferred", { fromClanId: 7, toClanId: 9, amount: wei(20) }),
+      baseBroadcast("GoldTransferred", {
+        fromClanId: 7,
+        toClanId: 9,
+        amount: wei(20),
+      }),
       7,
       out,
     );
     expect(out).toHaveLength(1);
-    expect(out[0]).toMatchObject({ type: "spend", amount: 20, resource: "gold", source: "transfer → clan 9" });
+    expect(out[0]).toMatchObject({
+      type: "spend",
+      amount: 20,
+      resource: "gold",
+      source: "transfer → clan 9",
+    });
 
     // Recipient perspective
     out.length = 0;
     projectBroadcast(
-      baseBroadcast("GoldTransferred", { fromClanId: 7, toClanId: 9, amount: wei(20) }),
+      baseBroadcast("GoldTransferred", {
+        fromClanId: 7,
+        toClanId: 9,
+        amount: wei(20),
+      }),
       9,
       out,
     );
     expect(out).toHaveLength(1);
-    expect(out[0]).toMatchObject({ type: "gain", amount: 20, resource: "gold", source: "transfer ← clan 7" });
+    expect(out[0]).toMatchObject({
+      type: "gain",
+      amount: 20,
+      resource: "gold",
+      source: "transfer ← clan 7",
+    });
   });
 
   it("projects VaultResourceTransferred with resource enum mapping", () => {
     const out: Movement[] = [];
     projectBroadcast(
       // resource id 2 = wheat
-      baseBroadcast("VaultResourceTransferred", { fromClanId: 1, toClanId: 9, resource: 2, amount: wei(7) }),
+      baseBroadcast("VaultResourceTransferred", {
+        fromClanId: 1,
+        toClanId: 9,
+        resource: 2,
+        amount: wei(7),
+      }),
       9,
       out,
     );
-    expect(out[0]).toMatchObject({ type: "gain", amount: 7, resource: "wheat", source: "transfer ← clan 1" });
+    expect(out[0]).toMatchObject({
+      type: "gain",
+      amount: 7,
+      resource: "wheat",
+      source: "transfer ← clan 1",
+    });
   });
 
   it("projects BlueprintTransferred (the missing-event finding from review)", () => {
     const out: Movement[] = [];
     projectBroadcast(
-      baseBroadcast("BlueprintTransferred", { fromClanId: 7, toClanId: 3, amount: wei(2) }),
+      baseBroadcast("BlueprintTransferred", {
+        fromClanId: 7,
+        toClanId: 3,
+        amount: wei(2),
+      }),
       7,
       out,
     );
-    expect(out[0]).toMatchObject({ type: "spend", amount: 2, resource: "blueprint", source: "transfer → clan 3" });
+    expect(out[0]).toMatchObject({
+      type: "spend",
+      amount: 2,
+      resource: "blueprint",
+      source: "transfer → clan 3",
+    });
   });
 
   it("projects LootDistributed only for clans in clanIdsRewarded", () => {
@@ -204,17 +307,47 @@ describe("projectBroadcast", () => {
 
     // Rewarded clan: emits gains for the non-zero per-resource fields
     projectBroadcast(baseBroadcast("LootDistributed", args), 5, out);
-    expect(out.map(m => `${m.amount}:${m.resource}`)).toEqual(["2:wood", "1:wheat", "4:gold"]);
-    expect(out.every(m => m.type === "gain" && m.source === "loot share")).toBe(true);
+    expect(out.map((m) => `${m.amount}:${m.resource}`)).toEqual([
+      "2:wood",
+      "1:wheat",
+      "4:gold",
+    ]);
+    expect(
+      out.every((m) => m.type === "gain" && m.source === "loot share"),
+    ).toBe(true);
   });
 
   it("ignores transfers where the clan is neither sender nor recipient", () => {
     const out: Movement[] = [];
     projectBroadcast(
-      baseBroadcast("GoldTransferred", { fromClanId: 1, toClanId: 2, amount: wei(20) }),
+      baseBroadcast("GoldTransferred", {
+        fromClanId: 1,
+        toClanId: 2,
+        amount: wei(20),
+      }),
       9,
       out,
     );
     expect(out).toEqual([]);
+  });
+});
+
+describe("isClanWorldEventName", () => {
+  it("accepts canonical ABI event names", () => {
+    expect(isClanWorldEventName("TickAdvanced")).toBe(true);
+    expect(isClanWorldEventName("ResourcesGathered")).toBe(true);
+    expect(isClanWorldEventName("GoldTransferred")).toBe(true);
+  });
+
+  it("rejects unknown names", () => {
+    expect(isClanWorldEventName("FakeEvent")).toBe(false);
+    expect(isClanWorldEventName("")).toBe(false);
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(isClanWorldEventName(undefined)).toBe(false);
+    expect(isClanWorldEventName(null)).toBe(false);
+    expect(isClanWorldEventName(123)).toBe(false);
+    expect(isClanWorldEventName({})).toBe(false);
   });
 });

--- a/apps/server/convex/vault.test.ts
+++ b/apps/server/convex/vault.test.ts
@@ -8,11 +8,7 @@ import {
 const WEI = "1000000000000000000"; // 1e18
 const wei = (n: number) => `${n}${"0".repeat(18)}`;
 
-const baseAttributed = (
-  eventName: IClanWorldAbiEventName,
-  args: Record<string, unknown>,
-  tick = 5,
-) => ({
+const baseAttributed = (eventName: IClanWorldAbiEventName, args: Record<string, unknown>, tick = 5) => ({
   eventName,
   args,
   tick,
@@ -20,11 +16,7 @@ const baseAttributed = (
   clanId: 7,
 });
 
-const baseBroadcast = (
-  eventName: IClanWorldAbiEventName,
-  args: Record<string, unknown>,
-  tick = 5,
-) => ({
+const baseBroadcast = (eventName: IClanWorldAbiEventName, args: Record<string, unknown>, tick = 5) => ({
   eventName,
   args,
   tick,
@@ -46,61 +38,31 @@ describe("projectAttributed", () => {
       out,
     );
     // Filters zero-amount entries, keeps wood/wheat/gold gains
-    expect(out.map((m) => `${m.type}:${m.amount}:${m.resource}`)).toEqual([
+    expect(out.map(m => `${m.type}:${m.amount}:${m.resource}`)).toEqual([
       "gain:3:wood",
       "gain:2:wheat",
       "gain:1:gold",
     ]);
-    expect(out.every((m) => m.tick === 5)).toBe(true);
-    expect(
-      out.every((m) => m.source === "gather" || m.source === "gather bonus"),
-    ).toBe(true);
+    expect(out.every(m => m.tick === 5)).toBe(true);
+    expect(out.every(m => m.source === "gather" || m.source === "gather bonus")).toBe(true);
   });
 
   it("projects ResourcesDeposited as gains; ResourcesWithdrawn as spends", () => {
     const out: Movement[] = [];
-    projectAttributed(
-      baseAttributed("ResourcesDeposited", { woodDelta: wei(5) }),
-      7,
-      out,
-    );
-    projectAttributed(
-      baseAttributed("ResourcesWithdrawn", { ironDelta: wei(2) }),
-      7,
-      out,
-    );
+    projectAttributed(baseAttributed("ResourcesDeposited", { woodDelta: wei(5) }), 7, out);
+    projectAttributed(baseAttributed("ResourcesWithdrawn", { ironDelta: wei(2) }), 7, out);
     expect(out).toEqual([
-      expect.objectContaining({
-        type: "gain",
-        amount: 5,
-        resource: "wood",
-        source: "deposit",
-      }),
-      expect.objectContaining({
-        type: "spend",
-        amount: 2,
-        resource: "iron",
-        source: "withdraw",
-      }),
+      expect.objectContaining({ type: "gain", amount: 5, resource: "wood", source: "deposit" }),
+      expect.objectContaining({ type: "spend", amount: 2, resource: "iron", source: "withdraw" }),
     ]);
   });
 
   it("projects BlueprintAwarded / BlueprintEarned as blueprint gains", () => {
     const out: Movement[] = [];
-    projectAttributed(
-      baseAttributed("BlueprintAwarded", { amount: wei(4) }),
-      7,
-      out,
-    );
-    projectAttributed(
-      baseAttributed("BlueprintEarned", { amount: wei(2) }),
-      7,
-      out,
-    );
-    expect(out.map((m) => m.amount)).toEqual([4, 2]);
-    expect(
-      out.every((m) => m.resource === "blueprint" && m.type === "gain"),
-    ).toBe(true);
+    projectAttributed(baseAttributed("BlueprintAwarded", { amount: wei(4) }), 7, out);
+    projectAttributed(baseAttributed("BlueprintEarned", { amount: wei(2) }), 7, out);
+    expect(out.map(m => m.amount)).toEqual([4, 2]);
+    expect(out.every(m => m.resource === "blueprint" && m.type === "gain")).toBe(true);
   });
 
   it("projects BanditAttackResolved stolen amounts as spends", () => {
@@ -116,18 +78,8 @@ describe("projectAttributed", () => {
       out,
     );
     expect(out).toEqual([
-      expect.objectContaining({
-        type: "spend",
-        amount: 3,
-        resource: "wood",
-        source: "bandit raid",
-      }),
-      expect.objectContaining({
-        type: "spend",
-        amount: 1,
-        resource: "fish",
-        source: "bandit raid",
-      }),
+      expect.objectContaining({ type: "spend", amount: 3, resource: "wood", source: "bandit raid" }),
+      expect.objectContaining({ type: "spend", amount: 1, resource: "fish", source: "bandit raid" }),
     ]);
   });
 
@@ -145,18 +97,8 @@ describe("projectAttributed", () => {
       out,
     );
     expect(out).toEqual([
-      expect.objectContaining({
-        type: "spend",
-        amount: 10,
-        resource: "gold",
-        source: "market trade",
-      }),
-      expect.objectContaining({
-        type: "gain",
-        amount: 5,
-        resource: "wood",
-        source: "market trade",
-      }),
+      expect.objectContaining({ type: "spend", amount: 10, resource: "gold", source: "market trade" }),
+      expect.objectContaining({ type: "gain", amount: 5, resource: "wood", source: "market trade" }),
     ]);
 
     // Sell scheduled: spend wheat, gain gold; uses "market settle" label
@@ -171,9 +113,10 @@ describe("projectAttributed", () => {
       7,
       out,
     );
-    expect(
-      out.map((m) => `${m.type}:${m.amount}:${m.resource}:${m.source}`),
-    ).toEqual(["spend:8:wheat:market settle", "gain:11:gold:market settle"]);
+    expect(out.map(m => `${m.type}:${m.amount}:${m.resource}:${m.source}`)).toEqual([
+      "spend:8:wheat:market settle",
+      "gain:11:gold:market settle",
+    ]);
   });
 
   it("projects ResourcesInjected (admin recovery) as gains for all non-zero resources", () => {
@@ -190,9 +133,7 @@ describe("projectAttributed", () => {
       7,
       out,
     );
-    expect(
-      out.map((m) => `${m.type}:${m.amount}:${m.resource}:${m.source}`),
-    ).toEqual([
+    expect(out.map(m => `${m.type}:${m.amount}:${m.resource}:${m.source}`)).toEqual([
       "gain:5:wood:admin inject",
       "gain:3:wheat:admin inject",
       "gain:10:gold:admin inject",
@@ -201,11 +142,7 @@ describe("projectAttributed", () => {
 
   it("ignores ABI event names with no vault projection (e.g. TickAdvanced)", () => {
     const out: Movement[] = [];
-    projectAttributed(
-      baseAttributed("TickAdvanced", { closedTick: 1 }),
-      7,
-      out,
-    );
+    projectAttributed(baseAttributed("TickAdvanced", { closedTick: 1 }), 7, out);
     expect(out).toEqual([]);
   });
 });
@@ -215,80 +152,43 @@ describe("projectBroadcast", () => {
     const out: Movement[] = [];
     // Sender perspective: clanId === fromClanId
     projectBroadcast(
-      baseBroadcast("GoldTransferred", {
-        fromClanId: 7,
-        toClanId: 9,
-        amount: wei(20),
-      }),
+      baseBroadcast("GoldTransferred", { fromClanId: 7, toClanId: 9, amount: wei(20) }),
       7,
       out,
     );
     expect(out).toHaveLength(1);
-    expect(out[0]).toMatchObject({
-      type: "spend",
-      amount: 20,
-      resource: "gold",
-      source: "transfer → clan 9",
-    });
+    expect(out[0]).toMatchObject({ type: "spend", amount: 20, resource: "gold", source: "transfer → clan 9" });
 
     // Recipient perspective
     out.length = 0;
     projectBroadcast(
-      baseBroadcast("GoldTransferred", {
-        fromClanId: 7,
-        toClanId: 9,
-        amount: wei(20),
-      }),
+      baseBroadcast("GoldTransferred", { fromClanId: 7, toClanId: 9, amount: wei(20) }),
       9,
       out,
     );
     expect(out).toHaveLength(1);
-    expect(out[0]).toMatchObject({
-      type: "gain",
-      amount: 20,
-      resource: "gold",
-      source: "transfer ← clan 7",
-    });
+    expect(out[0]).toMatchObject({ type: "gain", amount: 20, resource: "gold", source: "transfer ← clan 7" });
   });
 
   it("projects VaultResourceTransferred with resource enum mapping", () => {
     const out: Movement[] = [];
     projectBroadcast(
       // resource id 2 = wheat
-      baseBroadcast("VaultResourceTransferred", {
-        fromClanId: 1,
-        toClanId: 9,
-        resource: 2,
-        amount: wei(7),
-      }),
+      baseBroadcast("VaultResourceTransferred", { fromClanId: 1, toClanId: 9, resource: 2, amount: wei(7) }),
       9,
       out,
     );
-    expect(out[0]).toMatchObject({
-      type: "gain",
-      amount: 7,
-      resource: "wheat",
-      source: "transfer ← clan 1",
-    });
+    expect(out[0]).toMatchObject({ type: "gain", amount: 7, resource: "wheat", source: "transfer ← clan 1" });
   });
 
   it("projects BlueprintTransferred (the missing-event finding from review)", () => {
     const out: Movement[] = [];
     projectBroadcast(
-      baseBroadcast("BlueprintTransferred", {
-        fromClanId: 7,
-        toClanId: 3,
-        amount: wei(2),
-      }),
+      baseBroadcast("BlueprintTransferred", { fromClanId: 7, toClanId: 3, amount: wei(2) }),
       7,
       out,
     );
-    expect(out[0]).toMatchObject({
-      type: "spend",
-      amount: 2,
-      resource: "blueprint",
-      source: "transfer → clan 3",
-    });
+    expect(out[0]).toMatchObject({ type: "spend", amount: 2, resource: "blueprint", source: "transfer → clan 3" });
   });
 
   it("projects LootDistributed only for clans in clanIdsRewarded", () => {
@@ -307,24 +207,14 @@ describe("projectBroadcast", () => {
 
     // Rewarded clan: emits gains for the non-zero per-resource fields
     projectBroadcast(baseBroadcast("LootDistributed", args), 5, out);
-    expect(out.map((m) => `${m.amount}:${m.resource}`)).toEqual([
-      "2:wood",
-      "1:wheat",
-      "4:gold",
-    ]);
-    expect(
-      out.every((m) => m.type === "gain" && m.source === "loot share"),
-    ).toBe(true);
+    expect(out.map(m => `${m.amount}:${m.resource}`)).toEqual(["2:wood", "1:wheat", "4:gold"]);
+    expect(out.every(m => m.type === "gain" && m.source === "loot share")).toBe(true);
   });
 
   it("ignores transfers where the clan is neither sender nor recipient", () => {
     const out: Movement[] = [];
     projectBroadcast(
-      baseBroadcast("GoldTransferred", {
-        fromClanId: 1,
-        toClanId: 2,
-        amount: wei(20),
-      }),
+      baseBroadcast("GoldTransferred", { fromClanId: 1, toClanId: 2, amount: wei(20) }),
       9,
       out,
     );

--- a/apps/server/convex/vault.ts
+++ b/apps/server/convex/vault.ts
@@ -1,6 +1,9 @@
 import { query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
-import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
+import {
+  isClanWorldEventName,
+  type IClanWorldAbiEventName,
+} from "@clan-world/contract-types";
 
 /**
  * Vault movement feed for a single clan.
@@ -47,7 +50,8 @@ const GOLD_RESOURCE_ID = 4;
 function resourceName(index: unknown): string {
   const i = Number(index);
   if (Number.isFinite(i) && i === GOLD_RESOURCE_ID) return "gold";
-  if (Number.isFinite(i) && i >= 0 && i < RESOURCE_NAMES.length) return RESOURCE_NAMES[i] ?? "resource";
+  if (Number.isFinite(i) && i >= 0 && i < RESOURCE_NAMES.length)
+    return RESOURCE_NAMES[i] ?? "resource";
   return "resource";
 }
 
@@ -74,7 +78,13 @@ function pushDelta(
 }
 
 export function projectAttributed(
-  event: { eventName: IClanWorldAbiEventName; args: Record<string, unknown>; tick?: number; decodedAt: number; clanId?: number },
+  event: {
+    eventName: IClanWorldAbiEventName;
+    args: Record<string, unknown>;
+    tick?: number;
+    decodedAt: number;
+    clanId?: number;
+  },
   _clanId: number,
   out: Movement[],
 ) {
@@ -83,55 +93,279 @@ export function projectAttributed(
   const args = event.args ?? {};
   switch (event.eventName) {
     case "ResourcesGathered": {
-      pushDelta(out, tick, "gain", whole(args.woodGained), "wood", "gather", ts);
-      pushDelta(out, tick, "gain", whole(args.ironGained), "iron", "gather", ts);
-      pushDelta(out, tick, "gain", whole(args.wheatGained), "wheat", "gather", ts);
-      pushDelta(out, tick, "gain", whole(args.fishGained), "fish", "gather", ts);
-      pushDelta(out, tick, "gain", whole(args.goldBonus), "gold", "gather bonus", ts);
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.woodGained),
+        "wood",
+        "gather",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.ironGained),
+        "iron",
+        "gather",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.wheatGained),
+        "wheat",
+        "gather",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.fishGained),
+        "fish",
+        "gather",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.goldBonus),
+        "gold",
+        "gather bonus",
+        ts,
+      );
       return;
     }
     case "ResourcesDeposited": {
-      pushDelta(out, tick, "gain", whole(args.woodDelta), "wood", "deposit", ts);
-      pushDelta(out, tick, "gain", whole(args.ironDelta), "iron", "deposit", ts);
-      pushDelta(out, tick, "gain", whole(args.wheatDelta), "wheat", "deposit", ts);
-      pushDelta(out, tick, "gain", whole(args.fishDelta), "fish", "deposit", ts);
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.woodDelta),
+        "wood",
+        "deposit",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.ironDelta),
+        "iron",
+        "deposit",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.wheatDelta),
+        "wheat",
+        "deposit",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.fishDelta),
+        "fish",
+        "deposit",
+        ts,
+      );
       return;
     }
     case "ResourcesWithdrawn": {
       // Withdrawals leave the vault (clansman pulls inventory).
-      pushDelta(out, tick, "spend", whole(args.woodDelta), "wood", "withdraw", ts);
-      pushDelta(out, tick, "spend", whole(args.ironDelta), "iron", "withdraw", ts);
-      pushDelta(out, tick, "spend", whole(args.wheatDelta), "wheat", "withdraw", ts);
-      pushDelta(out, tick, "spend", whole(args.fishDelta), "fish", "withdraw", ts);
+      pushDelta(
+        out,
+        tick,
+        "spend",
+        whole(args.woodDelta),
+        "wood",
+        "withdraw",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "spend",
+        whole(args.ironDelta),
+        "iron",
+        "withdraw",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "spend",
+        whole(args.wheatDelta),
+        "wheat",
+        "withdraw",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "spend",
+        whole(args.fishDelta),
+        "fish",
+        "withdraw",
+        ts,
+      );
       return;
     }
     case "BlueprintAwarded":
     case "BlueprintEarned": {
-      pushDelta(out, tick, "gain", whole(args.amount), "blueprint", "bandit defeat", ts);
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.amount),
+        "blueprint",
+        "bandit defeat",
+        ts,
+      );
       return;
     }
     case "BanditAttackResolved": {
       // Defender-vault losses. defended=true with stolen=0 still shows as a no-op (filtered by amount<=0).
-      pushDelta(out, tick, "spend", whole(args.stolenWood), "wood", "bandit raid", ts);
-      pushDelta(out, tick, "spend", whole(args.stolenIron), "iron", "bandit raid", ts);
-      pushDelta(out, tick, "spend", whole(args.stolenWheat), "wheat", "bandit raid", ts);
-      pushDelta(out, tick, "spend", whole(args.stolenFish), "fish", "bandit raid", ts);
+      pushDelta(
+        out,
+        tick,
+        "spend",
+        whole(args.stolenWood),
+        "wood",
+        "bandit raid",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "spend",
+        whole(args.stolenIron),
+        "iron",
+        "bandit raid",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "spend",
+        whole(args.stolenWheat),
+        "wheat",
+        "bandit raid",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "spend",
+        whole(args.stolenFish),
+        "fish",
+        "bandit raid",
+        ts,
+      );
       return;
     }
     case "LootDistributedToDefender": {
-      pushDelta(out, tick, "gain", whole(args.wood), "wood", "defender loot", ts);
-      pushDelta(out, tick, "gain", whole(args.iron), "iron", "defender loot", ts);
-      pushDelta(out, tick, "gain", whole(args.wheat), "wheat", "defender loot", ts);
-      pushDelta(out, tick, "gain", whole(args.fish), "fish", "defender loot", ts);
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.wood),
+        "wood",
+        "defender loot",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.iron),
+        "iron",
+        "defender loot",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.wheat),
+        "wheat",
+        "defender loot",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.fish),
+        "fish",
+        "defender loot",
+        ts,
+      );
       return;
     }
     case "ResourcesInjected": {
-      pushDelta(out, tick, "gain", whole(args.wood), "wood", "admin inject", ts);
-      pushDelta(out, tick, "gain", whole(args.iron), "iron", "admin inject", ts);
-      pushDelta(out, tick, "gain", whole(args.wheat), "wheat", "admin inject", ts);
-      pushDelta(out, tick, "gain", whole(args.fish), "fish", "admin inject", ts);
-      pushDelta(out, tick, "gain", whole(args.gold), "gold", "admin inject", ts);
-      pushDelta(out, tick, "gain", whole(args.blueprint), "blueprint", "admin inject", ts);
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.wood),
+        "wood",
+        "admin inject",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.iron),
+        "iron",
+        "admin inject",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.wheat),
+        "wheat",
+        "admin inject",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.fish),
+        "fish",
+        "admin inject",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.gold),
+        "gold",
+        "admin inject",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.blueprint),
+        "blueprint",
+        "admin inject",
+        ts,
+      );
       return;
     }
     case "ImmediateMarketActionExecuted":
@@ -139,7 +373,10 @@ export function projectAttributed(
       // Market trade: the clan spends `amountIn` of `resourceIn` and receives
       // `amountOut` of `resourceOut`. resource id 4 == gold (per
       // RESOURCE_GOLD in contracts). Emit two deltas — one spend, one gain.
-      const label = event.eventName === "ImmediateMarketActionExecuted" ? "market trade" : "market settle";
+      const label =
+        event.eventName === "ImmediateMarketActionExecuted"
+          ? "market trade"
+          : "market settle";
       const resIn = resourceName(args.resourceIn);
       const resOut = resourceName(args.resourceOut);
       pushDelta(out, tick, "spend", whole(args.amountIn), resIn, label, ts);
@@ -152,7 +389,12 @@ export function projectAttributed(
 }
 
 export function projectBroadcast(
-  event: { eventName: IClanWorldAbiEventName; args: Record<string, unknown>; tick?: number; decodedAt: number },
+  event: {
+    eventName: IClanWorldAbiEventName;
+    args: Record<string, unknown>;
+    tick?: number;
+    decodedAt: number;
+  },
   clanId: number,
   out: Movement[],
 ) {
@@ -165,9 +407,25 @@ export function projectBroadcast(
       const to = Number(args.toClanId);
       const amount = whole(args.amount);
       if (Number.isFinite(from) && from === clanId)
-        pushDelta(out, tick, "spend", amount, "gold", `transfer → clan ${to}`, ts);
+        pushDelta(
+          out,
+          tick,
+          "spend",
+          amount,
+          "gold",
+          `transfer → clan ${to}`,
+          ts,
+        );
       if (Number.isFinite(to) && to === clanId)
-        pushDelta(out, tick, "gain", amount, "gold", `transfer ← clan ${from}`, ts);
+        pushDelta(
+          out,
+          tick,
+          "gain",
+          amount,
+          "gold",
+          `transfer ← clan ${from}`,
+          ts,
+        );
       return;
     }
     case "VaultResourceTransferred": {
@@ -178,17 +436,67 @@ export function projectBroadcast(
       if (Number.isFinite(from) && from === clanId)
         pushDelta(out, tick, "spend", amount, res, `transfer → clan ${to}`, ts);
       if (Number.isFinite(to) && to === clanId)
-        pushDelta(out, tick, "gain", amount, res, `transfer ← clan ${from}`, ts);
+        pushDelta(
+          out,
+          tick,
+          "gain",
+          amount,
+          res,
+          `transfer ← clan ${from}`,
+          ts,
+        );
       return;
     }
     case "LootDistributed": {
-      const rewarded = Array.isArray(args.clanIdsRewarded) ? args.clanIdsRewarded.map(Number) : [];
+      const rewarded = Array.isArray(args.clanIdsRewarded)
+        ? args.clanIdsRewarded.map(Number)
+        : [];
       if (!rewarded.includes(clanId)) return;
-      pushDelta(out, tick, "gain", whole(args.perClanWood), "wood", "loot share", ts);
-      pushDelta(out, tick, "gain", whole(args.perClanIron), "iron", "loot share", ts);
-      pushDelta(out, tick, "gain", whole(args.perClanWheat), "wheat", "loot share", ts);
-      pushDelta(out, tick, "gain", whole(args.perClanFish), "fish", "loot share", ts);
-      pushDelta(out, tick, "gain", whole(args.perClanGold), "gold", "loot share", ts);
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.perClanWood),
+        "wood",
+        "loot share",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.perClanIron),
+        "iron",
+        "loot share",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.perClanWheat),
+        "wheat",
+        "loot share",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.perClanFish),
+        "fish",
+        "loot share",
+        ts,
+      );
+      pushDelta(
+        out,
+        tick,
+        "gain",
+        whole(args.perClanGold),
+        "gold",
+        "loot share",
+        ts,
+      );
       return;
     }
     case "BlueprintTransferred": {
@@ -198,9 +506,25 @@ export function projectBroadcast(
       const to = Number(args.toClanId);
       const amount = whole(args.amount);
       if (Number.isFinite(from) && from === clanId)
-        pushDelta(out, tick, "spend", amount, "blueprint", `transfer → clan ${to}`, ts);
+        pushDelta(
+          out,
+          tick,
+          "spend",
+          amount,
+          "blueprint",
+          `transfer → clan ${to}`,
+          ts,
+        );
       if (Number.isFinite(to) && to === clanId)
-        pushDelta(out, tick, "gain", amount, "blueprint", `transfer ← clan ${from}`, ts);
+        pushDelta(
+          out,
+          tick,
+          "gain",
+          amount,
+          "blueprint",
+          `transfer ← clan ${from}`,
+          ts,
+        );
       return;
     }
     default:
@@ -220,7 +544,7 @@ export const getVaultMovements = query({
     // 1. Indexer-attributed events: row.clanId === clanId.
     const attributed = await ctx.db
       .query("chainEvents")
-      .withIndex("by_clan_tick", q => q.eq("clanId", clanId))
+      .withIndex("by_clan_tick", (q) => q.eq("clanId", clanId))
       .order("desc")
       .take(scanWindow);
 
@@ -235,10 +559,10 @@ export const getVaultMovements = query({
       "BlueprintTransferred",
     ];
     const broadcastBuckets = await Promise.all(
-      broadcastEventNames.map(name =>
+      broadcastEventNames.map((name) =>
         ctx.db
           .query("chainEvents")
-          .withIndex("by_event_block", q => q.eq("eventName", name))
+          .withIndex("by_event_block", (q) => q.eq("eventName", name))
           .order("desc")
           .take(scanWindow),
       ),
@@ -254,18 +578,35 @@ export const getVaultMovements = query({
       logIndex: number;
     };
     const movements: (Movement & { _src: string })[] = [];
-    const collect = (e: SourceEvent, project: (s: SourceEvent, c: number, out: Movement[]) => void) => {
+    const collect = (
+      e: SourceEvent,
+      project: (s: SourceEvent, c: number, out: Movement[]) => void,
+    ) => {
       const before = movements.length;
       const buf: Movement[] = [];
       project(e, clanId, buf);
-      for (const m of buf) movements.push({ ...m, _src: `${e.txHash}:${e.logIndex}` });
+      for (const m of buf)
+        movements.push({ ...m, _src: `${e.txHash}:${e.logIndex}` });
       void before;
     };
     for (const e of attributed) {
+      if (!isClanWorldEventName(e.eventName)) {
+        console.warn(
+          `[vault] skipping unknown chainEvent eventName "${String(e.eventName)}"`,
+          {
+            eventName: e.eventName,
+            txHash: e.txHash,
+            logIndex: e.logIndex,
+            tick: e.tick,
+          },
+        );
+        continue;
+      }
+
       collect(
         {
-          // Safe: unknown names fall through to `default: return` in projectAttributed.
-          eventName: e.eventName as IClanWorldAbiEventName,
+          // Allowlist-guarded — unknown event names were skipped + logged above.
+          eventName: e.eventName,
           args: (e.args ?? {}) as Record<string, unknown>,
           tick: e.tick,
           decodedAt: e.decodedAt,
@@ -274,17 +615,36 @@ export const getVaultMovements = query({
         },
         (src, cid, out) =>
           projectAttributed(
-            { eventName: src.eventName, args: src.args, tick: src.tick, decodedAt: src.decodedAt, clanId: e.clanId },
+            {
+              eventName: src.eventName,
+              args: src.args,
+              tick: src.tick,
+              decodedAt: src.decodedAt,
+              clanId: e.clanId,
+            },
             cid,
             out,
           ),
       );
     }
     for (const e of broadcast) {
+      if (!isClanWorldEventName(e.eventName)) {
+        console.warn(
+          `[vault] skipping unknown chainEvent eventName "${String(e.eventName)}"`,
+          {
+            eventName: e.eventName,
+            txHash: e.txHash,
+            logIndex: e.logIndex,
+            tick: e.tick,
+          },
+        );
+        continue;
+      }
+
       collect(
         {
-          // Safe: unknown names fall through to `default: return` in projectBroadcast.
-          eventName: e.eventName as IClanWorldAbiEventName,
+          // Allowlist-guarded — unknown event names were skipped + logged above.
+          eventName: e.eventName,
           args: (e.args ?? {}) as Record<string, unknown>,
           tick: e.tick,
           decodedAt: e.decodedAt,
@@ -293,7 +653,12 @@ export const getVaultMovements = query({
         },
         (src, cid, out) =>
           projectBroadcast(
-            { eventName: src.eventName, args: src.args, tick: src.tick, decodedAt: src.decodedAt },
+            {
+              eventName: src.eventName,
+              args: src.args,
+              tick: src.tick,
+              decodedAt: src.decodedAt,
+            },
             cid,
             out,
           ),

--- a/apps/server/convex/vault.ts
+++ b/apps/server/convex/vault.ts
@@ -50,8 +50,7 @@ const GOLD_RESOURCE_ID = 4;
 function resourceName(index: unknown): string {
   const i = Number(index);
   if (Number.isFinite(i) && i === GOLD_RESOURCE_ID) return "gold";
-  if (Number.isFinite(i) && i >= 0 && i < RESOURCE_NAMES.length)
-    return RESOURCE_NAMES[i] ?? "resource";
+  if (Number.isFinite(i) && i >= 0 && i < RESOURCE_NAMES.length) return RESOURCE_NAMES[i] ?? "resource";
   return "resource";
 }
 
@@ -78,13 +77,7 @@ function pushDelta(
 }
 
 export function projectAttributed(
-  event: {
-    eventName: IClanWorldAbiEventName;
-    args: Record<string, unknown>;
-    tick?: number;
-    decodedAt: number;
-    clanId?: number;
-  },
+  event: { eventName: IClanWorldAbiEventName; args: Record<string, unknown>; tick?: number; decodedAt: number; clanId?: number },
   _clanId: number,
   out: Movement[],
 ) {
@@ -93,279 +86,55 @@ export function projectAttributed(
   const args = event.args ?? {};
   switch (event.eventName) {
     case "ResourcesGathered": {
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.woodGained),
-        "wood",
-        "gather",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.ironGained),
-        "iron",
-        "gather",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.wheatGained),
-        "wheat",
-        "gather",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.fishGained),
-        "fish",
-        "gather",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.goldBonus),
-        "gold",
-        "gather bonus",
-        ts,
-      );
+      pushDelta(out, tick, "gain", whole(args.woodGained), "wood", "gather", ts);
+      pushDelta(out, tick, "gain", whole(args.ironGained), "iron", "gather", ts);
+      pushDelta(out, tick, "gain", whole(args.wheatGained), "wheat", "gather", ts);
+      pushDelta(out, tick, "gain", whole(args.fishGained), "fish", "gather", ts);
+      pushDelta(out, tick, "gain", whole(args.goldBonus), "gold", "gather bonus", ts);
       return;
     }
     case "ResourcesDeposited": {
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.woodDelta),
-        "wood",
-        "deposit",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.ironDelta),
-        "iron",
-        "deposit",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.wheatDelta),
-        "wheat",
-        "deposit",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.fishDelta),
-        "fish",
-        "deposit",
-        ts,
-      );
+      pushDelta(out, tick, "gain", whole(args.woodDelta), "wood", "deposit", ts);
+      pushDelta(out, tick, "gain", whole(args.ironDelta), "iron", "deposit", ts);
+      pushDelta(out, tick, "gain", whole(args.wheatDelta), "wheat", "deposit", ts);
+      pushDelta(out, tick, "gain", whole(args.fishDelta), "fish", "deposit", ts);
       return;
     }
     case "ResourcesWithdrawn": {
       // Withdrawals leave the vault (clansman pulls inventory).
-      pushDelta(
-        out,
-        tick,
-        "spend",
-        whole(args.woodDelta),
-        "wood",
-        "withdraw",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "spend",
-        whole(args.ironDelta),
-        "iron",
-        "withdraw",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "spend",
-        whole(args.wheatDelta),
-        "wheat",
-        "withdraw",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "spend",
-        whole(args.fishDelta),
-        "fish",
-        "withdraw",
-        ts,
-      );
+      pushDelta(out, tick, "spend", whole(args.woodDelta), "wood", "withdraw", ts);
+      pushDelta(out, tick, "spend", whole(args.ironDelta), "iron", "withdraw", ts);
+      pushDelta(out, tick, "spend", whole(args.wheatDelta), "wheat", "withdraw", ts);
+      pushDelta(out, tick, "spend", whole(args.fishDelta), "fish", "withdraw", ts);
       return;
     }
     case "BlueprintAwarded":
     case "BlueprintEarned": {
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.amount),
-        "blueprint",
-        "bandit defeat",
-        ts,
-      );
+      pushDelta(out, tick, "gain", whole(args.amount), "blueprint", "bandit defeat", ts);
       return;
     }
     case "BanditAttackResolved": {
       // Defender-vault losses. defended=true with stolen=0 still shows as a no-op (filtered by amount<=0).
-      pushDelta(
-        out,
-        tick,
-        "spend",
-        whole(args.stolenWood),
-        "wood",
-        "bandit raid",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "spend",
-        whole(args.stolenIron),
-        "iron",
-        "bandit raid",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "spend",
-        whole(args.stolenWheat),
-        "wheat",
-        "bandit raid",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "spend",
-        whole(args.stolenFish),
-        "fish",
-        "bandit raid",
-        ts,
-      );
+      pushDelta(out, tick, "spend", whole(args.stolenWood), "wood", "bandit raid", ts);
+      pushDelta(out, tick, "spend", whole(args.stolenIron), "iron", "bandit raid", ts);
+      pushDelta(out, tick, "spend", whole(args.stolenWheat), "wheat", "bandit raid", ts);
+      pushDelta(out, tick, "spend", whole(args.stolenFish), "fish", "bandit raid", ts);
       return;
     }
     case "LootDistributedToDefender": {
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.wood),
-        "wood",
-        "defender loot",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.iron),
-        "iron",
-        "defender loot",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.wheat),
-        "wheat",
-        "defender loot",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.fish),
-        "fish",
-        "defender loot",
-        ts,
-      );
+      pushDelta(out, tick, "gain", whole(args.wood), "wood", "defender loot", ts);
+      pushDelta(out, tick, "gain", whole(args.iron), "iron", "defender loot", ts);
+      pushDelta(out, tick, "gain", whole(args.wheat), "wheat", "defender loot", ts);
+      pushDelta(out, tick, "gain", whole(args.fish), "fish", "defender loot", ts);
       return;
     }
     case "ResourcesInjected": {
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.wood),
-        "wood",
-        "admin inject",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.iron),
-        "iron",
-        "admin inject",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.wheat),
-        "wheat",
-        "admin inject",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.fish),
-        "fish",
-        "admin inject",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.gold),
-        "gold",
-        "admin inject",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.blueprint),
-        "blueprint",
-        "admin inject",
-        ts,
-      );
+      pushDelta(out, tick, "gain", whole(args.wood), "wood", "admin inject", ts);
+      pushDelta(out, tick, "gain", whole(args.iron), "iron", "admin inject", ts);
+      pushDelta(out, tick, "gain", whole(args.wheat), "wheat", "admin inject", ts);
+      pushDelta(out, tick, "gain", whole(args.fish), "fish", "admin inject", ts);
+      pushDelta(out, tick, "gain", whole(args.gold), "gold", "admin inject", ts);
+      pushDelta(out, tick, "gain", whole(args.blueprint), "blueprint", "admin inject", ts);
       return;
     }
     case "ImmediateMarketActionExecuted":
@@ -373,10 +142,7 @@ export function projectAttributed(
       // Market trade: the clan spends `amountIn` of `resourceIn` and receives
       // `amountOut` of `resourceOut`. resource id 4 == gold (per
       // RESOURCE_GOLD in contracts). Emit two deltas — one spend, one gain.
-      const label =
-        event.eventName === "ImmediateMarketActionExecuted"
-          ? "market trade"
-          : "market settle";
+      const label = event.eventName === "ImmediateMarketActionExecuted" ? "market trade" : "market settle";
       const resIn = resourceName(args.resourceIn);
       const resOut = resourceName(args.resourceOut);
       pushDelta(out, tick, "spend", whole(args.amountIn), resIn, label, ts);
@@ -389,12 +155,7 @@ export function projectAttributed(
 }
 
 export function projectBroadcast(
-  event: {
-    eventName: IClanWorldAbiEventName;
-    args: Record<string, unknown>;
-    tick?: number;
-    decodedAt: number;
-  },
+  event: { eventName: IClanWorldAbiEventName; args: Record<string, unknown>; tick?: number; decodedAt: number },
   clanId: number,
   out: Movement[],
 ) {
@@ -407,25 +168,9 @@ export function projectBroadcast(
       const to = Number(args.toClanId);
       const amount = whole(args.amount);
       if (Number.isFinite(from) && from === clanId)
-        pushDelta(
-          out,
-          tick,
-          "spend",
-          amount,
-          "gold",
-          `transfer → clan ${to}`,
-          ts,
-        );
+        pushDelta(out, tick, "spend", amount, "gold", `transfer → clan ${to}`, ts);
       if (Number.isFinite(to) && to === clanId)
-        pushDelta(
-          out,
-          tick,
-          "gain",
-          amount,
-          "gold",
-          `transfer ← clan ${from}`,
-          ts,
-        );
+        pushDelta(out, tick, "gain", amount, "gold", `transfer ← clan ${from}`, ts);
       return;
     }
     case "VaultResourceTransferred": {
@@ -436,67 +181,17 @@ export function projectBroadcast(
       if (Number.isFinite(from) && from === clanId)
         pushDelta(out, tick, "spend", amount, res, `transfer → clan ${to}`, ts);
       if (Number.isFinite(to) && to === clanId)
-        pushDelta(
-          out,
-          tick,
-          "gain",
-          amount,
-          res,
-          `transfer ← clan ${from}`,
-          ts,
-        );
+        pushDelta(out, tick, "gain", amount, res, `transfer ← clan ${from}`, ts);
       return;
     }
     case "LootDistributed": {
-      const rewarded = Array.isArray(args.clanIdsRewarded)
-        ? args.clanIdsRewarded.map(Number)
-        : [];
+      const rewarded = Array.isArray(args.clanIdsRewarded) ? args.clanIdsRewarded.map(Number) : [];
       if (!rewarded.includes(clanId)) return;
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.perClanWood),
-        "wood",
-        "loot share",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.perClanIron),
-        "iron",
-        "loot share",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.perClanWheat),
-        "wheat",
-        "loot share",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.perClanFish),
-        "fish",
-        "loot share",
-        ts,
-      );
-      pushDelta(
-        out,
-        tick,
-        "gain",
-        whole(args.perClanGold),
-        "gold",
-        "loot share",
-        ts,
-      );
+      pushDelta(out, tick, "gain", whole(args.perClanWood), "wood", "loot share", ts);
+      pushDelta(out, tick, "gain", whole(args.perClanIron), "iron", "loot share", ts);
+      pushDelta(out, tick, "gain", whole(args.perClanWheat), "wheat", "loot share", ts);
+      pushDelta(out, tick, "gain", whole(args.perClanFish), "fish", "loot share", ts);
+      pushDelta(out, tick, "gain", whole(args.perClanGold), "gold", "loot share", ts);
       return;
     }
     case "BlueprintTransferred": {
@@ -506,25 +201,9 @@ export function projectBroadcast(
       const to = Number(args.toClanId);
       const amount = whole(args.amount);
       if (Number.isFinite(from) && from === clanId)
-        pushDelta(
-          out,
-          tick,
-          "spend",
-          amount,
-          "blueprint",
-          `transfer → clan ${to}`,
-          ts,
-        );
+        pushDelta(out, tick, "spend", amount, "blueprint", `transfer → clan ${to}`, ts);
       if (Number.isFinite(to) && to === clanId)
-        pushDelta(
-          out,
-          tick,
-          "gain",
-          amount,
-          "blueprint",
-          `transfer ← clan ${from}`,
-          ts,
-        );
+        pushDelta(out, tick, "gain", amount, "blueprint", `transfer ← clan ${from}`, ts);
       return;
     }
     default:
@@ -544,7 +223,7 @@ export const getVaultMovements = query({
     // 1. Indexer-attributed events: row.clanId === clanId.
     const attributed = await ctx.db
       .query("chainEvents")
-      .withIndex("by_clan_tick", (q) => q.eq("clanId", clanId))
+      .withIndex("by_clan_tick", q => q.eq("clanId", clanId))
       .order("desc")
       .take(scanWindow);
 
@@ -559,10 +238,10 @@ export const getVaultMovements = query({
       "BlueprintTransferred",
     ];
     const broadcastBuckets = await Promise.all(
-      broadcastEventNames.map((name) =>
+      broadcastEventNames.map(name =>
         ctx.db
           .query("chainEvents")
-          .withIndex("by_event_block", (q) => q.eq("eventName", name))
+          .withIndex("by_event_block", q => q.eq("eventName", name))
           .order("desc")
           .take(scanWindow),
       ),
@@ -578,31 +257,21 @@ export const getVaultMovements = query({
       logIndex: number;
     };
     const movements: (Movement & { _src: string })[] = [];
-    const collect = (
-      e: SourceEvent,
-      project: (s: SourceEvent, c: number, out: Movement[]) => void,
-    ) => {
+    const collect = (e: SourceEvent, project: (s: SourceEvent, c: number, out: Movement[]) => void) => {
       const before = movements.length;
       const buf: Movement[] = [];
       project(e, clanId, buf);
-      for (const m of buf)
-        movements.push({ ...m, _src: `${e.txHash}:${e.logIndex}` });
+      for (const m of buf) movements.push({ ...m, _src: `${e.txHash}:${e.logIndex}` });
       void before;
     };
     for (const e of attributed) {
       if (!isClanWorldEventName(e.eventName)) {
         console.warn(
           `[vault] skipping unknown chainEvent eventName "${String(e.eventName)}"`,
-          {
-            eventName: e.eventName,
-            txHash: e.txHash,
-            logIndex: e.logIndex,
-            tick: e.tick,
-          },
+          { eventName: e.eventName, txHash: e.txHash, logIndex: e.logIndex, tick: e.tick },
         );
         continue;
       }
-
       collect(
         {
           // Allowlist-guarded — unknown event names were skipped + logged above.
@@ -615,13 +284,7 @@ export const getVaultMovements = query({
         },
         (src, cid, out) =>
           projectAttributed(
-            {
-              eventName: src.eventName,
-              args: src.args,
-              tick: src.tick,
-              decodedAt: src.decodedAt,
-              clanId: e.clanId,
-            },
+            { eventName: src.eventName, args: src.args, tick: src.tick, decodedAt: src.decodedAt, clanId: e.clanId },
             cid,
             out,
           ),
@@ -631,16 +294,10 @@ export const getVaultMovements = query({
       if (!isClanWorldEventName(e.eventName)) {
         console.warn(
           `[vault] skipping unknown chainEvent eventName "${String(e.eventName)}"`,
-          {
-            eventName: e.eventName,
-            txHash: e.txHash,
-            logIndex: e.logIndex,
-            tick: e.tick,
-          },
+          { eventName: e.eventName, txHash: e.txHash, logIndex: e.logIndex, tick: e.tick },
         );
         continue;
       }
-
       collect(
         {
           // Allowlist-guarded — unknown event names were skipped + logged above.
@@ -653,12 +310,7 @@ export const getVaultMovements = query({
         },
         (src, cid, out) =>
           projectBroadcast(
-            {
-              eventName: src.eventName,
-              args: src.args,
-              tick: src.tick,
-              decodedAt: src.decodedAt,
-            },
+            { eventName: src.eventName, args: src.args, tick: src.tick, decodedAt: src.decodedAt },
             cid,
             out,
           ),

--- a/packages/contract-types/index.ts
+++ b/packages/contract-types/index.ts
@@ -1,2 +1,3 @@
-export * from './src/IClanWorld.js';
-export * from './src/IClanWorldLens.js';
+export * from "./src/IClanWorld.js";
+export * from "./src/IClanWorldLens.js";
+export * from "./src/eventNames.js";

--- a/packages/contract-types/package.json
+++ b/packages/contract-types/package.json
@@ -10,9 +10,12 @@
   "scripts": {
     "codegen": "node scripts/generate.mjs",
     "codegen:check": "node scripts/generate.mjs --check",
-    "build": "tsc --noEmit"
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run test/*.test.ts"
   },
   "devDependencies": {
-    "@clan-world/contracts": "workspace:*"
+    "@clan-world/contracts": "workspace:*",
+    "vitest": "3.2.4"
   }
 }

--- a/packages/contract-types/src/eventNames.ts
+++ b/packages/contract-types/src/eventNames.ts
@@ -1,0 +1,24 @@
+import { iClanWorldAbi, type IClanWorldAbiEventName } from "./IClanWorld.js";
+
+// Allowlist derived once at module load from the generated ABI const.
+// `iClanWorldAbi` is `as const`, so the literal-union IClanWorldAbiEventName
+// is the compile-time source of truth; this Set is its runtime mirror.
+export const IClanWorldAbiEventNames: ReadonlySet<IClanWorldAbiEventName> =
+  new Set(
+    iClanWorldAbi
+      .filter(
+        (item): item is typeof item & { type: "event"; name: string } =>
+          item.type === "event" &&
+          typeof (item as { name?: unknown }).name === "string",
+      )
+      .map((item) => item.name as IClanWorldAbiEventName),
+  );
+
+export function isClanWorldEventName(
+  name: unknown,
+): name is IClanWorldAbiEventName {
+  return (
+    typeof name === "string" &&
+    (IClanWorldAbiEventNames as ReadonlySet<string>).has(name)
+  );
+}

--- a/packages/contract-types/test/eventNames.test.ts
+++ b/packages/contract-types/test/eventNames.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  IClanWorldAbiEventNames,
+  isClanWorldEventName,
+  iClanWorldAbi,
+} from "../index.js";
+
+describe("IClanWorldAbiEventNames", () => {
+  it("size equals number of event entries in the ABI", () => {
+    const expectedCount = iClanWorldAbi.filter(
+      (item) => item.type === "event",
+    ).length;
+    expect(IClanWorldAbiEventNames.size).toBe(expectedCount);
+    expect(expectedCount).toBeGreaterThan(0);
+  });
+
+  it("contains representative event names", () => {
+    expect(IClanWorldAbiEventNames.has("TickAdvanced")).toBe(true);
+    expect(IClanWorldAbiEventNames.has("ResourcesGathered")).toBe(true);
+  });
+});
+
+describe("isClanWorldEventName", () => {
+  it("returns true for canonical event names", () => {
+    expect(isClanWorldEventName("TickAdvanced")).toBe(true);
+    expect(isClanWorldEventName("ResourcesDeposited")).toBe(true);
+  });
+
+  it("returns false for unknown names", () => {
+    expect(isClanWorldEventName("NotAnEvent")).toBe(false);
+    expect(isClanWorldEventName("")).toBe(false);
+  });
+
+  it("returns false for non-string inputs", () => {
+    expect(isClanWorldEventName(undefined)).toBe(false);
+    expect(isClanWorldEventName(null)).toBe(false);
+    expect(isClanWorldEventName(42)).toBe(false);
+    expect(isClanWorldEventName({ name: "TickAdvanced" })).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       '@clan-world/contracts':
         specifier: workspace:*
         version: link:../contracts
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2)
 
   packages/contracts: {}
 


### PR DESCRIPTION
Closes #436.

## Summary

The typechain migration delivered compile-time event-name safety inside `vault.ts` projection logic, but the **boundary casts** at ingest (`apps/server/convex/indexer.ts:306`) and DB-read (`apps/server/convex/vault.ts:268,287`) still allowed arbitrary strings to flow through while appearing type-safe. This PR closes that hole.

## Changes

- **New `packages/contract-types/src/eventNames.ts`** — exports
  - `IClanWorldAbiEventNames: ReadonlySet<IClanWorldAbiEventName>` — derived **once at module load** from the generated `iClanWorldAbi.events`
  - `isClanWorldEventName(name: unknown): name is IClanWorldAbiEventName` — type guard
- **`apps/server/convex/indexer.ts` `ingestEvents`** — skip + log unknown event names BEFORE Convex insert. Adds `rejected: number` to the return shape (resetLocked branch includes `rejected: 0` for stable shape). Removes the `as ParsedIndexerEvent[]` cast on the loop.
- **`apps/server/convex/vault.ts` `getVaultMovements`** — skip + log unknown event names in both `attributed` and `broadcast` projection loops. Removes both `as IClanWorldAbiEventName` casts.
- **Tests** — new `packages/contract-types/test/eventNames.test.ts` (5 tests on type guard + allowlist), 1 new test in `indexer.test.ts` for mixed batch ingest, 1 new `describe` in `vault.test.ts` for direct type-guard coverage.

## Design choice: skip + log (not throw)

Per the issue body's \"reject (or quarantine + log)\" option, the policy chosen is **skip + log**:
- Indexer is best-effort — a single unknown event name (legacy/typo/stale) should NOT abort the entire batch.
- Unknown names surface via `console.warn` with structured context (`eventName`, `txHash`, `logIndex`, `blockNumber`/`tick`) so operators can detect drift.
- `ingestEvents` returns a new `rejected: number` field so callers can observe non-zero drift counts.

## Verification

```
pnpm --filter @clan-world/contract-types build      # green
pnpm --filter @clan-world/contract-types test       # 5 new tests pass
pnpm --filter @clan-world/server typecheck          # green
pnpm --filter @clan-world/server test               # 41 tests pass (was 37)
```

Local 3-tier swarm: CLEAN (codex + gemini-3-flash + manual Claude reading-pass).

## Test plan

- [x] build green
- [x] typecheck green
- [x] tests green (4 new tests: 1 ingest, 3 type-guard direct, 5 in contract-types)
- [x] local swarm clean
- [ ] cloud review (Liam to trigger on UAT)