### PR TITLE
fix(ci): harden typechain-ci — check:abi parity + multi-pattern grep + build smoke (#439)

### DIFF
--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -25,10 +25,14 @@ jobs:
         with:
           version: stable
       - run: pnpm install --frozen-lockfile
+      - name: Verify committed ABI JSON matches forge artifacts
+        run: pnpm --filter @clan-world/contracts run check:abi
       # codegen:check reads the ABI JSON and exits non-zero if the committed
       # output in packages/contract-types/src/ is stale — no files are written.
       - name: Check @clan-world/contract-types output is current
         run: pnpm --filter @clan-world/contract-types run codegen:check
+      - name: Build smoke — @clan-world/contract-types compiles cleanly
+        run: pnpm --filter @clan-world/contract-types run build
 
   convex-types-freshness:
     name: Convex generated types are current
@@ -54,7 +58,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Grep for as-Abi casts
         run: |
-          if grep -rEn "as[[:space:]]+Abi\b" \
+          # Catches single-line raw casts (`as Abi`) and double-casts (`as unknown as Abi`); multiline and alias bypasses are out of scope follow-ups if found.
+          if grep -rEn "as[[:space:]]+(unknown[[:space:]]+as[[:space:]]+)?Abi\b" \
             --include="*.ts" \
             --include="*.tsx" \
             --exclude-dir="_generated" \

--- a/turbo.json
+++ b/turbo.json
@@ -26,9 +26,7 @@
         "src/adapters/IChainClient.ts",
         "src/generated/constants.ts",
         "src/generated/enums.ts",
-        "convex/_generated/**",
-        "src/IClanWorld.ts",
-        "src/IClanWorldLens.ts"
+        "convex/_generated/**"
       ]
     },
     "dev": {


### PR DESCRIPTION
Closes #439.

Cross-model SHOULD-FIX from PR #432 super-swarm — 4 distinct gaps flagged by codex 5.3 + 5.4 + 5.5 + opus 4.6.

## Changes

`.github/workflows/typechain-ci.yml`:
1. **NEW** `check:abi` parity step runs BEFORE `codegen:check` — closes the Solidity → committed JSON drift gap (codex 5.5 MEDIUM)
2. **NEW** `@clan-world/contract-types` build smoke step — catches package-level type errors / broken root re-exports (codex 5.4 LOW)
3. **EXPANDED** grep regex `as[[:space:]]+(unknown[[:space:]]+as[[:space:]]+)?Abi\b` now catches `as unknown as Abi` double-casts (codex 5.3 MEDIUM 3); comment notes multiline + alias bypasses as out-of-scope follow-ups

`turbo.json`:
4. Removed dead `codegen.outputs` entries `src/IClanWorld.ts` and `src/IClanWorldLens.ts` — paths resolved relative to each package and never matched anything (opus 4.6 LOW)

## Verification

Codex 5-stage workflow:
- Stage 1 plan validated against repo
- Stage 2 implement: surgical 7-line addition + 2-line deletion
- Stage 3 critique returned `CLEAN - ready to commit` with file-by-file confirmation

Orch-direct dispatch via Bash (not subagent) per memory `feedback_subagent_codex_wrapper_monitor_antipattern.md` — the original subagent dispatch hung in codex stdin-read mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)