### PR TITLE
chore(contract-types): add main + types fields to package.json (#437)

### DIFF
--- a/packages/contract-types/package.json
+++ b/packages/contract-types/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "description": "Generated TypeScript literal-type ABIs for ClanWorld contracts",
   "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
   "exports": {
     ".": "./index.ts"
   },


### PR DESCRIPTION
Closes #437. Aligns `@clan-world/contract-types` with the sibling package convention (`@clan-world/shared` at `packages/shared/package.json:8-9`).

## Change

Single 2-line addition to `packages/contract-types/package.json`:

```json
"main": "./index.ts",
"types": "./index.ts",
```

## Why

The existing `exports` field already pointed to `./index.ts`. Adding `main` + `types` ensures non-TS-aware tools that read package.json (some bundlers, IDE plugins, dependency analyzers) resolve to the same entry as TS-aware consumers. Mirrors `@clan-world/shared` shape.

## Scope kept minimal

The `.js` suffixes in `index.ts` re-exports remain unchanged — they work fine under `moduleResolution: bundler`. Aligning to consistent `.ts`-without-suffix style is **deferred to a small follow-up after #441 (event-name allowlist) merges**, since #441 also touches `index.ts` and would conflict. That follow-up can land in v2.9.2 or be folded into v2.9.1's final pass.

## Verification

- `pnpm install --frozen-lockfile` clean
- `pnpm --filter @clan-world/contract-types build` clean  
- `pnpm typecheck` clean across `@clan-world/{server, web, shared}`

## Orch-direct dispatch note

The original subagent (a2835264c175db0de) hung in codex stdin-read mode without producing edits — same pattern as #439 and #435. Pattern matches memory `feedback_subagent_codex_wrapper_monitor_antipattern.md`. The orchestrator's stdin-pipe-foreground codex dispatch pattern (used on #439) is the working fallback. For #437, the change was small enough to apply inline as orch per the codex-implement skill's "<10 LOC mechanical" skip criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)