### PR TITLE
fix(server): use persisted season fields from worldSnapshot, not derived from tick (#435)

### DIFF
--- a/apps/server/convex/getSnapshot.test.ts
+++ b/apps/server/convex/getSnapshot.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveSeasonState,
+  resolveSeasonStateForSnap,
+  type PersistedSnapshotSeasonFields,
+} from "./getSnapshot";
+
+// Constants from packages/shared/src/generated/constants.ts (mirrors chain).
+const SEASON_LEN = 360;
+const WINTER_START = 110;
+const WINTER_DUR = 10;
+
+describe("resolveSeasonStateForSnap (issue #435 regression)", () => {
+  it("season-freeze window: tick === seasonEndTick && !seasonFinalized returns persisted OLD season, NOT derived next season", () => {
+    // Regression for the bug filed as issue #435 from PR #432 super-swarm.
+    // At tick === SEASON_DURATION_TICKS the contract holds
+    // `currentSeasonNumber = 1`, `seasonStartTick = 0`, `seasonEndTick = 360`
+    // until `finalizeSeason()` is invoked. The pre-fix resolver derived
+    // season 2 from `Math.floor(tick / SEASON_LEN)` and overwrote the
+    // persisted values, surfacing the NEXT season in HUD/winter UI one
+    // tick early. See:
+    //   - packages/contracts/src/ClanWorld.sol:3188-3199
+    //   - packages/contracts/test/HeartbeatOrdering.t.sol:447-452
+    const snap: PersistedSnapshotSeasonFields = {
+      tick: SEASON_LEN,
+      currentSeasonNumber: 1,
+      seasonStartTick: 0,
+      seasonEndTick: SEASON_LEN,
+      winterActive: false,
+      winterStartsAtTick: WINTER_START,
+      winterEndsAtTick: WINTER_START + WINTER_DUR,
+    };
+
+    const result = resolveSeasonStateForSnap(snap);
+
+    // Persisted OLD season values win — this is the freeze-window assertion.
+    expect(result.currentSeasonNumber).toBe(1);
+    expect(result.seasonStartTick).toBe(0);
+    expect(result.seasonEndTick).toBe(SEASON_LEN);
+    // Anti-assertion: the buggy derived values must NOT leak through.
+    expect(result.currentSeasonNumber).not.toBe(2);
+    expect(result.seasonStartTick).not.toBe(SEASON_LEN);
+    expect(result.seasonEndTick).not.toBe(SEASON_LEN * 2);
+    // Winter fields pass through from persisted row.
+    expect(result.winterActive).toBe(false);
+    expect(result.winterStartsAtTick).toBe(WINTER_START);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + WINTER_DUR);
+  });
+
+  it("mid-season: returns persisted season/winter fields exactly", () => {
+    const snap: PersistedSnapshotSeasonFields = {
+      tick: 100,
+      currentSeasonNumber: 1,
+      seasonStartTick: 0,
+      seasonEndTick: SEASON_LEN,
+      winterActive: false,
+      winterStartsAtTick: WINTER_START,
+      winterEndsAtTick: WINTER_START + WINTER_DUR,
+    };
+
+    const result = resolveSeasonStateForSnap(snap);
+
+    expect(result.currentSeasonNumber).toBe(1);
+    expect(result.seasonStartTick).toBe(0);
+    expect(result.seasonEndTick).toBe(SEASON_LEN);
+    expect(result.winterActive).toBe(false);
+    expect(result.winterStartsAtTick).toBe(WINTER_START);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + WINTER_DUR);
+  });
+
+  it("legacy row with missing optional season fields: falls back to derive per-field", () => {
+    // Pre-Phase-4.4 rows did not persist these fields. The resolver must
+    // still return sensible derived values for those specific missing
+    // fields without disturbing whatever is persisted.
+    const snap: PersistedSnapshotSeasonFields = {
+      tick: 50,
+      // No optional season/winter fields persisted (legacy row).
+    };
+
+    const result = resolveSeasonStateForSnap(snap);
+
+    // All six fields come from deriveSeasonState(50).
+    expect(result.currentSeasonNumber).toBe(1);
+    expect(result.seasonStartTick).toBe(0);
+    expect(result.seasonEndTick).toBe(SEASON_LEN);
+    expect(result.winterActive).toBe(false);
+    expect(result.winterStartsAtTick).toBe(WINTER_START);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + WINTER_DUR);
+  });
+
+  it("partial legacy row: persisted fields win, missing fields fall back to derive", () => {
+    // Mixed case — persisted seasonStartTick + seasonEndTick but no
+    // currentSeasonNumber or winter fields. The resolver must NOT
+    // recompute the persisted fields, but MUST derive the missing ones.
+    const snap: PersistedSnapshotSeasonFields = {
+      tick: SEASON_LEN,
+      seasonStartTick: 0,
+      seasonEndTick: SEASON_LEN,
+      // No currentSeasonNumber → derive returns 2 here, freeze unaware
+      // since the row predates the persisted-currentSeasonNumber field.
+      // This is acceptable: legacy rows pay the legacy cost. Current
+      // rows always persist all six fields, so this case is rare.
+    };
+
+    const result = resolveSeasonStateForSnap(snap);
+
+    expect(result.seasonStartTick).toBe(0);
+    expect(result.seasonEndTick).toBe(SEASON_LEN);
+    // Derived for missing field.
+    expect(result.currentSeasonNumber).toBe(2);
+    expect(result.winterActive).toBe(false);
+  });
+});
+
+describe("deriveSeasonState (empty-state fallback)", () => {
+  it("tick 0: season 1, no winter active yet", () => {
+    const result = deriveSeasonState(0);
+
+    expect(result.currentSeasonNumber).toBe(1);
+    expect(result.seasonStartTick).toBe(0);
+    expect(result.seasonEndTick).toBe(SEASON_LEN);
+    expect(result.winterActive).toBe(false);
+    // Pre-WINTER_START_TICK, the next winter starts at WINTER_START.
+    expect(result.winterStartsAtTick).toBe(WINTER_START);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + WINTER_DUR);
+  });
+
+  it("tick inside first winter window: winterActive=true", () => {
+    // WINTER_START=110, WINTER_DUR=10 → ticks 110..119 are first winter.
+    const result = deriveSeasonState(WINTER_START + 5);
+
+    expect(result.winterActive).toBe(true);
+    expect(result.winterStartsAtTick).toBe(WINTER_START);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + WINTER_DUR);
+  });
+
+  it("tick just past first winter: winterActive=false, next winter pre-computed", () => {
+    // WINTER_PERIOD=110, so next winter starts at WINTER_START + 110 = 220.
+    const result = deriveSeasonState(WINTER_START + WINTER_DUR + 1);
+
+    expect(result.winterActive).toBe(false);
+    expect(result.winterStartsAtTick).toBe(WINTER_START + 110);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + 110 + WINTER_DUR);
+  });
+});

--- a/apps/server/convex/getSnapshot.test.ts
+++ b/apps/server/convex/getSnapshot.test.ts
@@ -26,6 +26,7 @@ describe("resolveSeasonStateForSnap (issue #435 regression)", () => {
       currentSeasonNumber: 1,
       seasonStartTick: 0,
       seasonEndTick: SEASON_LEN,
+      seasonFinalized: false,
       winterActive: false,
       winterStartsAtTick: WINTER_START,
       winterEndsAtTick: WINTER_START + WINTER_DUR,

--- a/apps/server/convex/getSnapshot.ts
+++ b/apps/server/convex/getSnapshot.ts
@@ -13,27 +13,45 @@ const WINTER_START = Number(WINTER_START_TICK);
 const WINTER_DUR = Number(WINTER_DURATION_TICKS);
 const WINTER_PERIOD = Number(WINTER_PERIOD_TICKS);
 
-/**
- * Derive season + winter state from `tick` per `LibSeason.sol`. Pure
- * computation — no chain or DB read required. Surfaces the four fields the
- * `<TopHud>` component reads (`seasonStartTick`, `seasonEndTick`,
- * `winterActive`, `winterStartsAtTick`) so the live HUD reflects on-chain
- * state without a separate facet view.
- */
-function deriveSeasonState(tick: number): {
+export interface DerivedSeasonState {
+  currentSeasonNumber: number;
   seasonStartTick: number;
   seasonEndTick: number;
   winterActive: boolean;
-  winterStartsAtTick: number | null;
-} {
+  winterStartsAtTick: number;
+  winterEndsAtTick: number;
+}
+
+/**
+ * Derive season + winter state from `tick` using LibSeason-style math.
+ *
+ * IMPORTANT: this helper is ONLY for the empty-state fallback (no
+ * `worldSnapshot` row yet) and as per-field fallback for legacy rows where
+ * a specific optional season/winter field was not persisted (pre-Phase-4.4
+ * indexer rows). For any row written by the current indexer the persisted
+ * chain values are authoritative — see `_worldStateView` in
+ * `packages/contracts/src/ClanWorld.sol`, which holds the OLD season fields
+ * on storage until `finalizeSeason()` runs. Overriding persisted values
+ * with this derivation flipped season N → N+1 one tick early (the freeze
+ * window between `tick === seasonEndTick` and `finalizeSeason()`).
+ *
+ * Returns the same six season/winter fields the indexer persists, with
+ * deterministic values for every `tick >= 0`.
+ */
+export function deriveSeasonState(tick: number): DerivedSeasonState {
   const seasonStartTick = Math.floor(tick / SEASON_LEN) * SEASON_LEN;
   const seasonEndTick = seasonStartTick + SEASON_LEN;
+  // 1-based season number, matching contract `_world.currentSeasonNumber`
+  // (initialised to 1 in ClanWorld constructor + ClanWorldStub).
+  const currentSeasonNumber = Math.floor(tick / SEASON_LEN) + 1;
 
   // Winter cycles after WINTER_START. Mirrors LibSeason.isWinterActive():
   // active when `(tick - WINTER_START) % WINTER_PERIOD < WINTER_DURATION`,
-  // and only after the first window has opened.
+  // and only after the first window has opened. `winterEndsAtTick` mirrors
+  // contract `_winterWindowForTick`: it is always `startsAtTick +
+  // WINTER_DURATION_TICKS`, regardless of active/inactive.
   let winterActive = false;
-  let winterStartsAtTick: number | null = null;
+  let winterStartsAtTick: number;
   if (tick >= WINTER_START) {
     const elapsed = tick - WINTER_START;
     const cycleIndex = Math.floor(elapsed / WINTER_PERIOD);
@@ -44,8 +62,54 @@ function deriveSeasonState(tick: number): {
   } else {
     winterStartsAtTick = WINTER_START;
   }
+  const winterEndsAtTick = winterStartsAtTick + WINTER_DUR;
 
-  return { seasonStartTick, seasonEndTick, winterActive, winterStartsAtTick };
+  return {
+    currentSeasonNumber,
+    seasonStartTick,
+    seasonEndTick,
+    winterActive,
+    winterStartsAtTick,
+    winterEndsAtTick,
+  };
+}
+
+/**
+ * Persisted-fields subset of `worldSnapshot` that this resolver reads.
+ * Mirrors the optional season/winter fields written by `indexer.ts`. Keep
+ * this in lockstep with `apps/server/convex/schema.ts:worldSnapshot`.
+ */
+export interface PersistedSnapshotSeasonFields {
+  tick: number;
+  currentSeasonNumber?: number;
+  seasonStartTick?: number;
+  seasonEndTick?: number;
+  winterActive?: boolean;
+  winterStartsAtTick?: number;
+  winterEndsAtTick?: number;
+}
+
+/**
+ * Resolve the six season/winter fields for a `worldSnapshot` row, with
+ * persisted chain values winning over a per-field fallback to
+ * `deriveSeasonState(snap.tick)` only when the field is `undefined` (legacy
+ * pre-Phase-4.4 rows). This is the regression seam for issue #435.
+ *
+ * Exported so unit tests can exercise the freeze-window behaviour without
+ * touching Convex's `query()` wrapper.
+ */
+export function resolveSeasonStateForSnap(
+  snap: PersistedSnapshotSeasonFields,
+): DerivedSeasonState {
+  const derived = deriveSeasonState(snap.tick);
+  return {
+    currentSeasonNumber: snap.currentSeasonNumber ?? derived.currentSeasonNumber,
+    seasonStartTick: snap.seasonStartTick ?? derived.seasonStartTick,
+    seasonEndTick: snap.seasonEndTick ?? derived.seasonEndTick,
+    winterActive: snap.winterActive ?? derived.winterActive,
+    winterStartsAtTick: snap.winterStartsAtTick ?? derived.winterStartsAtTick,
+    winterEndsAtTick: snap.winterEndsAtTick ?? derived.winterEndsAtTick,
+  };
 }
 
 export const getSnapshot = query({
@@ -102,7 +166,7 @@ export const getSnapshot = query({
       bandit,
       worldPaused: snap.worldPaused === true,
       pausedAtTs: typeof snap.pausedAtTs === "number" ? snap.pausedAtTs : null,
-      ...deriveSeasonState(snap.tick),
+      ...resolveSeasonStateForSnap(snap),
     };
   },
 });

--- a/apps/server/convex/getSnapshot.ts
+++ b/apps/server/convex/getSnapshot.ts
@@ -84,6 +84,7 @@ export interface PersistedSnapshotSeasonFields {
   currentSeasonNumber?: number;
   seasonStartTick?: number;
   seasonEndTick?: number;
+  seasonFinalized?: boolean;
   winterActive?: boolean;
   winterStartsAtTick?: number;
   winterEndsAtTick?: number;
@@ -103,12 +104,24 @@ export function resolveSeasonStateForSnap(
 ): DerivedSeasonState {
   const derived = deriveSeasonState(snap.tick);
   return {
-    currentSeasonNumber: snap.currentSeasonNumber ?? derived.currentSeasonNumber,
-    seasonStartTick: snap.seasonStartTick ?? derived.seasonStartTick,
-    seasonEndTick: snap.seasonEndTick ?? derived.seasonEndTick,
-    winterActive: snap.winterActive ?? derived.winterActive,
-    winterStartsAtTick: snap.winterStartsAtTick ?? derived.winterStartsAtTick,
-    winterEndsAtTick: snap.winterEndsAtTick ?? derived.winterEndsAtTick,
+    currentSeasonNumber: snap.currentSeasonNumber !== undefined
+      ? snap.currentSeasonNumber
+      : derived.currentSeasonNumber,
+    seasonStartTick: snap.seasonStartTick !== undefined
+      ? snap.seasonStartTick
+      : derived.seasonStartTick,
+    seasonEndTick: snap.seasonEndTick !== undefined
+      ? snap.seasonEndTick
+      : derived.seasonEndTick,
+    winterActive: snap.winterActive !== undefined
+      ? snap.winterActive
+      : derived.winterActive,
+    winterStartsAtTick: snap.winterStartsAtTick !== undefined
+      ? snap.winterStartsAtTick
+      : derived.winterStartsAtTick,
+    winterEndsAtTick: snap.winterEndsAtTick !== undefined
+      ? snap.winterEndsAtTick
+      : derived.winterEndsAtTick,
   };
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -48,6 +48,19 @@ export interface WorldSnapshot {
   tickEpoch: TickEpoch;
   regions: Region[];
   clans: Clan[];
+  /**
+   * Season + winter timers surfaced from `worldSnapshot` (Phase 4.4+).
+   * All optional for backward compat with legacy rows that pre-date the
+   * persisted-fields migration. When `getSnapshot()` returns these, they
+   * are authoritative chain values from `_world.*` — see
+   * `apps/server/convex/getSnapshot.ts` and ClanWorld._worldStateView.
+   */
+  currentSeasonNumber?: number;
+  seasonStartTick?: number;
+  seasonEndTick?: number;
+  winterActive?: boolean;
+  winterStartsAtTick?: number;
+  winterEndsAtTick?: number;
 }
 
 export interface ClanFullView {


### PR DESCRIPTION
## Summary

Closes #435. Pre-existing bug surfaced by PR #432 super-swarm synthesis (Codex 5.4 HIGH). `getSnapshot()` recomputed `seasonStartTick`, `seasonEndTick`, `winterActive`, `winterStartsAtTick` from `tick` via a local `deriveSeasonState()`, overriding the authoritative chain values that the `worldSnapshot` row already persisted.

The contract holds `currentSeasonNumber`, `seasonStartTick`, `seasonEndTick` on the OLD season until `finalizeSeason()` runs — even when ``currentTick === seasonEndTick``. See ``packages/contracts/src/ClanWorld.sol:3188-3199`` and the HeartbeatOrdering test at ``packages/contracts/test/HeartbeatOrdering.t.sol:447-452``. The derive override flipped the HUD/winter UI to season N+1 one tick early during the freeze window.

## Changes

- **``getSnapshot.ts``**: new exported helpers ``deriveSeasonState``, ``resolveSeasonStateForSnap``, and ``PersistedSnapshotSeasonFields`` type. The resolver applies missing-field-only fallback: persisted chain values win; derive is the empty-state + legacy-row backstop. Now also exposes ``currentSeasonNumber`` and ``winterEndsAtTick`` (both already persisted by the indexer; previously discarded). Empty-state branch keeps ``deriveSeasonState(0)``.
- **``types.ts``**: extend ``WorldSnapshot`` with the 6 optional season/winter fields so typed adapter callers (``IConvexClient.getSnapshot``) see them.
- **``getSnapshot.test.ts``**: new regression suite covering freeze window, mid-season, empty state, legacy-row partial fallback, and ``deriveSeasonState`` edge cases. 7 test cases, all passing.

## Test plan

- [x] ``pnpm --filter @clan-world/server typecheck`` clean
- [x] ``pnpm --filter @clan-world/server test`` — 44/44 pass (7 new in ``getSnapshot.test.ts``)
- [x] ``pnpm --filter @clan-world/shared typecheck`` clean
- [x] ``pnpm --filter @clan-world/web typecheck`` clean
- [x] No ``as any`` / type escape hatches

## Bug shape verified by new test

At ``tick === SEASON_DURATION_TICKS`` (=360), persisted ``currentSeasonNumber=1``, ``seasonStartTick=0``, ``seasonEndTick=360`` with ``seasonFinalized=false``:
- **Pre-fix**: derived would return ``currentSeasonNumber=2``, ``seasonStartTick=360``, ``seasonEndTick=720`` — WRONG during freeze window.
- **Post-fix**: returns persisted ``1``, ``0``, ``360``. The anti-assertion in the freeze-window test catches any regression to the derive-override behaviour.

## Scope kept tight

- Did NOT pass through ``nextHeartbeatAtTick`` or ``seasonFinalized`` (out of issue scope; can follow up if useful).
- Did NOT touch ``apps/web/src/TopHud.tsx`` stale derivation of ``seasonNumber`` from ``liveTick`` (separate frontend issue; server fix is independent).
- Carries the upstream merge from PR #440 (``worldPaused``/``pausedAtTs``) cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)