### PR TITLE
release: v2.9.1 — typechain hardening + season-freeze fix + worldPaused plumbing

### DIFF
--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -25,10 +25,14 @@ jobs:
         with:
           version: stable
       - run: pnpm install --frozen-lockfile
+      - name: Verify committed ABI JSON matches forge artifacts
+        run: pnpm --filter @clan-world/contracts run check:abi
       # codegen:check reads the ABI JSON and exits non-zero if the committed
       # output in packages/contract-types/src/ is stale — no files are written.
       - name: Check @clan-world/contract-types output is current
         run: pnpm --filter @clan-world/contract-types run codegen:check
+      - name: Build smoke — @clan-world/contract-types compiles cleanly
+        run: pnpm --filter @clan-world/contract-types run build
 
   convex-types-freshness:
     name: Convex generated types are current
@@ -54,7 +58,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Grep for as-Abi casts
         run: |
-          if grep -rEn "as[[:space:]]+Abi\b" \
+          # Catches single-line raw casts (`as Abi`) and double-casts (`as unknown as Abi`); multiline and alias bypasses are out of scope follow-ups if found.
+          if grep -rEn "as[[:space:]]+(unknown[[:space:]]+as[[:space:]]+)?Abi\b" \
             --include="*.ts" \
             --include="*.tsx" \
             --exclude-dir="_generated" \

--- a/apps/server/convex/getSnapshot.test.ts
+++ b/apps/server/convex/getSnapshot.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   deriveSeasonState,
+  normalizePausedAtTs,
+  resolvePauseStateForSnap,
   resolveSeasonStateForSnap,
   type PersistedSnapshotSeasonFields,
 } from "./getSnapshot";
@@ -142,5 +144,27 @@ describe("deriveSeasonState (empty-state fallback)", () => {
     expect(result.winterActive).toBe(false);
     expect(result.winterStartsAtTick).toBe(WINTER_START + 110);
     expect(result.winterEndsAtTick).toBe(WINTER_START + 110 + WINTER_DUR);
+  });
+});
+
+describe("normalizePausedAtTs", () => {
+  it("paused row: preserves a positive pausedAtTs", () => {
+    expect(resolvePauseStateForSnap({ worldPaused: true, pausedAtTs: 12345 })).toEqual({
+      worldPaused: true,
+      pausedAtTs: 12345,
+    });
+  });
+
+  it("unpaused row: normalizes missing or non-positive pausedAtTs to null", () => {
+    expect(resolvePauseStateForSnap({ worldPaused: false, pausedAtTs: undefined })).toEqual({
+      worldPaused: false,
+      pausedAtTs: null,
+    });
+    expect(resolvePauseStateForSnap({ worldPaused: false, pausedAtTs: 0 })).toEqual({
+      worldPaused: false,
+      pausedAtTs: null,
+    });
+    expect(normalizePausedAtTs(undefined)).toBeNull();
+    expect(normalizePausedAtTs(0)).toBeNull();
   });
 });

--- a/apps/server/convex/getSnapshot.test.ts
+++ b/apps/server/convex/getSnapshot.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveSeasonState,
+  resolveSeasonStateForSnap,
+  type PersistedSnapshotSeasonFields,
+} from "./getSnapshot";
+
+// Constants from packages/shared/src/generated/constants.ts (mirrors chain).
+const SEASON_LEN = 360;
+const WINTER_START = 110;
+const WINTER_DUR = 10;
+
+describe("resolveSeasonStateForSnap (issue #435 regression)", () => {
+  it("season-freeze window: tick === seasonEndTick && !seasonFinalized returns persisted OLD season, NOT derived next season", () => {
+    // Regression for the bug filed as issue #435 from PR #432 super-swarm.
+    // At tick === SEASON_DURATION_TICKS the contract holds
+    // `currentSeasonNumber = 1`, `seasonStartTick = 0`, `seasonEndTick = 360`
+    // until `finalizeSeason()` is invoked. The pre-fix resolver derived
+    // season 2 from `Math.floor(tick / SEASON_LEN)` and overwrote the
+    // persisted values, surfacing the NEXT season in HUD/winter UI one
+    // tick early. See:
+    //   - packages/contracts/src/ClanWorld.sol:3188-3199
+    //   - packages/contracts/test/HeartbeatOrdering.t.sol:447-452
+    const snap: PersistedSnapshotSeasonFields = {
+      tick: SEASON_LEN,
+      currentSeasonNumber: 1,
+      seasonStartTick: 0,
+      seasonEndTick: SEASON_LEN,
+      seasonFinalized: false,
+      winterActive: false,
+      winterStartsAtTick: WINTER_START,
+      winterEndsAtTick: WINTER_START + WINTER_DUR,
+    };
+
+    const result = resolveSeasonStateForSnap(snap);
+
+    // Persisted OLD season values win — this is the freeze-window assertion.
+    expect(result.currentSeasonNumber).toBe(1);
+    expect(result.seasonStartTick).toBe(0);
+    expect(result.seasonEndTick).toBe(SEASON_LEN);
+    // Anti-assertion: the buggy derived values must NOT leak through.
+    expect(result.currentSeasonNumber).not.toBe(2);
+    expect(result.seasonStartTick).not.toBe(SEASON_LEN);
+    expect(result.seasonEndTick).not.toBe(SEASON_LEN * 2);
+    // Winter fields pass through from persisted row.
+    expect(result.winterActive).toBe(false);
+    expect(result.winterStartsAtTick).toBe(WINTER_START);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + WINTER_DUR);
+  });
+
+  it("mid-season: returns persisted season/winter fields exactly", () => {
+    const snap: PersistedSnapshotSeasonFields = {
+      tick: 100,
+      currentSeasonNumber: 1,
+      seasonStartTick: 0,
+      seasonEndTick: SEASON_LEN,
+      winterActive: false,
+      winterStartsAtTick: WINTER_START,
+      winterEndsAtTick: WINTER_START + WINTER_DUR,
+    };
+
+    const result = resolveSeasonStateForSnap(snap);
+
+    expect(result.currentSeasonNumber).toBe(1);
+    expect(result.seasonStartTick).toBe(0);
+    expect(result.seasonEndTick).toBe(SEASON_LEN);
+    expect(result.winterActive).toBe(false);
+    expect(result.winterStartsAtTick).toBe(WINTER_START);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + WINTER_DUR);
+  });
+
+  it("legacy row with missing optional season fields: falls back to derive per-field", () => {
+    // Pre-Phase-4.4 rows did not persist these fields. The resolver must
+    // still return sensible derived values for those specific missing
+    // fields without disturbing whatever is persisted.
+    const snap: PersistedSnapshotSeasonFields = {
+      tick: 50,
+      // No optional season/winter fields persisted (legacy row).
+    };
+
+    const result = resolveSeasonStateForSnap(snap);
+
+    // All six fields come from deriveSeasonState(50).
+    expect(result.currentSeasonNumber).toBe(1);
+    expect(result.seasonStartTick).toBe(0);
+    expect(result.seasonEndTick).toBe(SEASON_LEN);
+    expect(result.winterActive).toBe(false);
+    expect(result.winterStartsAtTick).toBe(WINTER_START);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + WINTER_DUR);
+  });
+
+  it("partial legacy row: persisted fields win, missing fields fall back to derive", () => {
+    // Mixed case — persisted seasonStartTick + seasonEndTick but no
+    // currentSeasonNumber or winter fields. The resolver must NOT
+    // recompute the persisted fields, but MUST derive the missing ones.
+    const snap: PersistedSnapshotSeasonFields = {
+      tick: SEASON_LEN,
+      seasonStartTick: 0,
+      seasonEndTick: SEASON_LEN,
+      // No currentSeasonNumber → derive returns 2 here, freeze unaware
+      // since the row predates the persisted-currentSeasonNumber field.
+      // This is acceptable: legacy rows pay the legacy cost. Current
+      // rows always persist all six fields, so this case is rare.
+    };
+
+    const result = resolveSeasonStateForSnap(snap);
+
+    expect(result.seasonStartTick).toBe(0);
+    expect(result.seasonEndTick).toBe(SEASON_LEN);
+    // Derived for missing field.
+    expect(result.currentSeasonNumber).toBe(2);
+    expect(result.winterActive).toBe(false);
+  });
+});
+
+describe("deriveSeasonState (empty-state fallback)", () => {
+  it("tick 0: season 1, no winter active yet", () => {
+    const result = deriveSeasonState(0);
+
+    expect(result.currentSeasonNumber).toBe(1);
+    expect(result.seasonStartTick).toBe(0);
+    expect(result.seasonEndTick).toBe(SEASON_LEN);
+    expect(result.winterActive).toBe(false);
+    // Pre-WINTER_START_TICK, the next winter starts at WINTER_START.
+    expect(result.winterStartsAtTick).toBe(WINTER_START);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + WINTER_DUR);
+  });
+
+  it("tick inside first winter window: winterActive=true", () => {
+    // WINTER_START=110, WINTER_DUR=10 → ticks 110..119 are first winter.
+    const result = deriveSeasonState(WINTER_START + 5);
+
+    expect(result.winterActive).toBe(true);
+    expect(result.winterStartsAtTick).toBe(WINTER_START);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + WINTER_DUR);
+  });
+
+  it("tick just past first winter: winterActive=false, next winter pre-computed", () => {
+    // WINTER_PERIOD=110, so next winter starts at WINTER_START + 110 = 220.
+    const result = deriveSeasonState(WINTER_START + WINTER_DUR + 1);
+
+    expect(result.winterActive).toBe(false);
+    expect(result.winterStartsAtTick).toBe(WINTER_START + 110);
+    expect(result.winterEndsAtTick).toBe(WINTER_START + 110 + WINTER_DUR);
+  });
+});

--- a/apps/server/convex/getSnapshot.ts
+++ b/apps/server/convex/getSnapshot.ts
@@ -13,27 +13,45 @@ const WINTER_START = Number(WINTER_START_TICK);
 const WINTER_DUR = Number(WINTER_DURATION_TICKS);
 const WINTER_PERIOD = Number(WINTER_PERIOD_TICKS);
 
-/**
- * Derive season + winter state from `tick` per `LibSeason.sol`. Pure
- * computation — no chain or DB read required. Surfaces the four fields the
- * `<TopHud>` component reads (`seasonStartTick`, `seasonEndTick`,
- * `winterActive`, `winterStartsAtTick`) so the live HUD reflects on-chain
- * state without a separate facet view.
- */
-function deriveSeasonState(tick: number): {
+export interface DerivedSeasonState {
+  currentSeasonNumber: number;
   seasonStartTick: number;
   seasonEndTick: number;
   winterActive: boolean;
-  winterStartsAtTick: number | null;
-} {
+  winterStartsAtTick: number;
+  winterEndsAtTick: number;
+}
+
+/**
+ * Derive season + winter state from `tick` using LibSeason-style math.
+ *
+ * IMPORTANT: this helper is ONLY for the empty-state fallback (no
+ * `worldSnapshot` row yet) and as per-field fallback for legacy rows where
+ * a specific optional season/winter field was not persisted (pre-Phase-4.4
+ * indexer rows). For any row written by the current indexer the persisted
+ * chain values are authoritative — see `_worldStateView` in
+ * `packages/contracts/src/ClanWorld.sol`, which holds the OLD season fields
+ * on storage until `finalizeSeason()` runs. Overriding persisted values
+ * with this derivation flipped season N → N+1 one tick early (the freeze
+ * window between `tick === seasonEndTick` and `finalizeSeason()`).
+ *
+ * Returns the same six season/winter fields the indexer persists, with
+ * deterministic values for every `tick >= 0`.
+ */
+export function deriveSeasonState(tick: number): DerivedSeasonState {
   const seasonStartTick = Math.floor(tick / SEASON_LEN) * SEASON_LEN;
   const seasonEndTick = seasonStartTick + SEASON_LEN;
+  // 1-based season number, matching contract `_world.currentSeasonNumber`
+  // (initialised to 1 in ClanWorld constructor + ClanWorldStub).
+  const currentSeasonNumber = Math.floor(tick / SEASON_LEN) + 1;
 
   // Winter cycles after WINTER_START. Mirrors LibSeason.isWinterActive():
   // active when `(tick - WINTER_START) % WINTER_PERIOD < WINTER_DURATION`,
-  // and only after the first window has opened.
+  // and only after the first window has opened. `winterEndsAtTick` mirrors
+  // contract `_winterWindowForTick`: it is always `startsAtTick +
+  // WINTER_DURATION_TICKS`, regardless of active/inactive.
   let winterActive = false;
-  let winterStartsAtTick: number | null = null;
+  let winterStartsAtTick: number;
   if (tick >= WINTER_START) {
     const elapsed = tick - WINTER_START;
     const cycleIndex = Math.floor(elapsed / WINTER_PERIOD);
@@ -44,8 +62,67 @@ function deriveSeasonState(tick: number): {
   } else {
     winterStartsAtTick = WINTER_START;
   }
+  const winterEndsAtTick = winterStartsAtTick + WINTER_DUR;
 
-  return { seasonStartTick, seasonEndTick, winterActive, winterStartsAtTick };
+  return {
+    currentSeasonNumber,
+    seasonStartTick,
+    seasonEndTick,
+    winterActive,
+    winterStartsAtTick,
+    winterEndsAtTick,
+  };
+}
+
+/**
+ * Persisted-fields subset of `worldSnapshot` that this resolver reads.
+ * Mirrors the optional season/winter fields written by `indexer.ts`. Keep
+ * this in lockstep with `apps/server/convex/schema.ts:worldSnapshot`.
+ */
+export interface PersistedSnapshotSeasonFields {
+  tick: number;
+  currentSeasonNumber?: number;
+  seasonStartTick?: number;
+  seasonEndTick?: number;
+  seasonFinalized?: boolean;
+  winterActive?: boolean;
+  winterStartsAtTick?: number;
+  winterEndsAtTick?: number;
+}
+
+/**
+ * Resolve the six season/winter fields for a `worldSnapshot` row, with
+ * persisted chain values winning over a per-field fallback to
+ * `deriveSeasonState(snap.tick)` only when the field is `undefined` (legacy
+ * pre-Phase-4.4 rows). This is the regression seam for issue #435.
+ *
+ * Exported so unit tests can exercise the freeze-window behaviour without
+ * touching Convex's `query()` wrapper.
+ */
+export function resolveSeasonStateForSnap(
+  snap: PersistedSnapshotSeasonFields,
+): DerivedSeasonState {
+  const derived = deriveSeasonState(snap.tick);
+  return {
+    currentSeasonNumber: snap.currentSeasonNumber !== undefined
+      ? snap.currentSeasonNumber
+      : derived.currentSeasonNumber,
+    seasonStartTick: snap.seasonStartTick !== undefined
+      ? snap.seasonStartTick
+      : derived.seasonStartTick,
+    seasonEndTick: snap.seasonEndTick !== undefined
+      ? snap.seasonEndTick
+      : derived.seasonEndTick,
+    winterActive: snap.winterActive !== undefined
+      ? snap.winterActive
+      : derived.winterActive,
+    winterStartsAtTick: snap.winterStartsAtTick !== undefined
+      ? snap.winterStartsAtTick
+      : derived.winterStartsAtTick,
+    winterEndsAtTick: snap.winterEndsAtTick !== undefined
+      ? snap.winterEndsAtTick
+      : derived.winterEndsAtTick,
+  };
 }
 
 export const getSnapshot = query({
@@ -102,7 +179,7 @@ export const getSnapshot = query({
       bandit,
       worldPaused: snap.worldPaused === true,
       pausedAtTs: typeof snap.pausedAtTs === "number" ? snap.pausedAtTs : null,
-      ...deriveSeasonState(snap.tick),
+      ...resolveSeasonStateForSnap(snap),
     };
   },
 });

--- a/apps/server/convex/getSnapshot.ts
+++ b/apps/server/convex/getSnapshot.ts
@@ -125,6 +125,22 @@ export function resolveSeasonStateForSnap(
   };
 }
 
+export function normalizePausedAtTs(pausedAtTs: unknown): number | null {
+  return typeof pausedAtTs === "number" && Number.isFinite(pausedAtTs) && pausedAtTs > 0
+    ? pausedAtTs
+    : null;
+}
+
+export function resolvePauseStateForSnap(snap: {
+  worldPaused?: unknown;
+  pausedAtTs?: unknown;
+}): { worldPaused: boolean; pausedAtTs: number | null } {
+  return {
+    worldPaused: snap.worldPaused === true,
+    pausedAtTs: normalizePausedAtTs(snap.pausedAtTs),
+  };
+}
+
 export const getSnapshot = query({
   handler: async (ctx) => {
     const snap = await ctx.db.query("worldSnapshot").order("desc").first();
@@ -177,8 +193,7 @@ export const getSnapshot = query({
       clans: snap.clans,
       activeBanditId,
       bandit,
-      worldPaused: snap.worldPaused === true,
-      pausedAtTs: typeof snap.pausedAtTs === "number" ? snap.pausedAtTs : null,
+      ...resolvePauseStateForSnap(snap),
       ...resolveSeasonStateForSnap(snap),
     };
   },

--- a/apps/server/convex/getSnapshot.ts
+++ b/apps/server/convex/getSnapshot.ts
@@ -59,6 +59,8 @@ export const getSnapshot = query({
         clans: [],
         activeBanditId: undefined,
         bandit: null,
+        worldPaused: false,
+        pausedAtTs: null,
         ...deriveSeasonState(0),
       };
     }
@@ -98,6 +100,8 @@ export const getSnapshot = query({
       clans: snap.clans,
       activeBanditId,
       bandit,
+      worldPaused: snap.worldPaused === true,
+      pausedAtTs: typeof snap.pausedAtTs === "number" ? snap.pausedAtTs : null,
       ...deriveSeasonState(snap.tick),
     };
   },

--- a/apps/server/convex/indexer.test.ts
+++ b/apps/server/convex/indexer.test.ts
@@ -316,6 +316,55 @@ describe("ingestEvents checkpoint isolation", () => {
   });
 });
 
+describe("ingestEvents allowlist", () => {
+  it("skips unknown event names with structured warning and rejected counter", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { db, tables } = createDb({
+        eventCheckpoint: [
+          { _id: "eventCheckpoint:0", _creationTime: 0, lastBlock: 100 },
+        ],
+      });
+
+      const goodEvent = {
+        eventName: "TickAdvanced",
+        args: { closedTick: "1", openedTick: "2", tickSeed: "0x1234" },
+        transactionHash,
+        blockNumber: 105,
+        logIndex: 0,
+      };
+      const badEvent = {
+        eventName: "FakeEvent",
+        args: { foo: "bar" },
+        transactionHash,
+        blockNumber: 105,
+        logIndex: 1,
+      };
+
+      const result = await (ingestEvents as any)._handler(
+        { db },
+        {
+          events: [goodEvent, badEvent],
+          blockNumber: 105,
+          txHash: transactionHash,
+          advanceCheckpoint: false,
+        },
+      );
+
+      expect(result.inserted).toBe(1);
+      expect(result.rejected).toBe(1);
+      expect(tables.chainEvents).toHaveLength(1);
+      expect(tables.chainEvents?.[0]?.eventName).toBe("TickAdvanced");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("FakeEvent"),
+        expect.objectContaining({ eventName: "FakeEvent" }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
 describe("legacy snapshot backfill", () => {
   it("commitSnapshot writes non-empty legacy clans from clanView rows", async () => {
     const { db, tables } = createDb();

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -563,6 +563,8 @@ export const commitSnapshot = internalMutation({
       winterActive: asBool(world.winterActive),
       winterStartsAtTick: asNumber(world.winterStartsAtTick),
       winterEndsAtTick: asNumber(world.winterEndsAtTick),
+      worldPaused: asBool(world.worldPaused),
+      pausedAtTs: asNumber(world.pausedAtTs),
       nextHeartbeatAtTick: asNumber(world.nextHeartbeatAtTick),
       regions: LEGACY_REGIONS,
       clans: legacyClans,

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -587,6 +587,12 @@ export const commitSnapshot = internalMutation({
       previousWorldSnapshot?.tick === tick
         ? previousWorldSnapshot.tickEpochStartedAt
         : Math.floor(now / 1000);
+    const worldPaused = asBool(world.worldPaused);
+    const rawPausedAtTs = asNumber(world.pausedAtTs, Number.NaN);
+    const pausedAtTs =
+      Number.isFinite(rawPausedAtTs) && (rawPausedAtTs > 0 || worldPaused)
+        ? rawPausedAtTs
+        : undefined;
     const worldSnapshot = {
       tick,
       tickEpochStartedAt,
@@ -597,8 +603,8 @@ export const commitSnapshot = internalMutation({
       winterActive: asBool(world.winterActive),
       winterStartsAtTick: asNumber(world.winterStartsAtTick),
       winterEndsAtTick: asNumber(world.winterEndsAtTick),
-      worldPaused: asBool(world.worldPaused),
-      pausedAtTs: asNumber(world.pausedAtTs),
+      worldPaused,
+      pausedAtTs,
       nextHeartbeatAtTick: asNumber(world.nextHeartbeatAtTick),
       regions: LEGACY_REGIONS,
       clans: legacyClans,

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -5,7 +5,10 @@ import {
   internalQuery,
 } from "./_generated/server";
 import { internal } from "./_generated/api";
-import { iClanWorldAbi } from "@clan-world/contract-types";
+import {
+  iClanWorldAbi,
+  isClanWorldEventName,
+} from "@clan-world/contract-types";
 import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
 import {
   defineChain,
@@ -298,12 +301,42 @@ export const ingestEvents = internalMutation({
       return {
         inserted: 0,
         skipped: args.events.length,
+        // Keep the response shape stable for callers that inspect ingest stats.
+        rejected: 0,
         resetLocked: true,
       };
     }
 
     let inserted = 0;
-    for (const raw of args.events as ParsedIndexerEvent[]) {
+    let rejected = 0;
+    for (const raw of args.events) {
+      if (!isClanWorldEventName(raw.eventName)) {
+        console.warn(
+          `[indexer] rejecting unknown eventName "${String(raw.eventName)}"`,
+          {
+            eventName: raw.eventName,
+            txHash: raw.transactionHash ?? args.txHash,
+            logIndex: raw.logIndex,
+            blockNumber: raw.blockNumber ?? args.blockNumber,
+          },
+        );
+        rejected++;
+        continue;
+      }
+
+      const event: ParsedIndexerEvent = {
+        eventName: raw.eventName,
+        args: raw.args,
+        address: raw.address,
+        blockHash: raw.blockHash,
+        blockNumber:
+          typeof raw.blockNumber === "string"
+            ? Number(raw.blockNumber)
+            : raw.blockNumber,
+        transactionHash: raw.transactionHash,
+        transactionIndex: raw.transactionIndex,
+        logIndex: raw.logIndex,
+      };
       const logIndex = raw.logIndex ?? 0;
       const txHash = raw.transactionHash ?? args.txHash;
       if (!txHash) continue;
@@ -320,27 +353,28 @@ export const ingestEvents = internalMutation({
         txHash,
         logIndex,
         blockNumber,
-        eventName: raw.eventName,
-        args: bigintSafe(raw.args),
+        eventName: event.eventName,
+        args: bigintSafe(event.args),
         decodedAt: Date.now(),
-        blockHash: raw.blockHash ?? undefined,
-        transactionIndex: raw.transactionIndex ?? undefined,
+        blockHash: event.blockHash ?? undefined,
+        transactionIndex: event.transactionIndex ?? undefined,
         tick:
-          eventNumber(raw, "tick") ??
-          eventNumber(raw, "atTick") ??
-          eventNumber(raw, "openedTick"),
-        clanId: eventNumber(raw, "clanId") ?? eventNumber(raw, "targetClanId"),
-        clansmanId: eventNumber(raw, "clansmanId"),
-        banditId: eventNumber(raw, "banditId"),
+          eventNumber(event, "tick") ??
+          eventNumber(event, "atTick") ??
+          eventNumber(event, "openedTick"),
+        clanId:
+          eventNumber(event, "clanId") ?? eventNumber(event, "targetClanId"),
+        clansmanId: eventNumber(event, "clansmanId"),
+        banditId: eventNumber(event, "banditId"),
         source: "real-indexer",
       });
       inserted++;
 
-      if (raw.eventName === "TickAdvanced") {
+      if (event.eventName === "TickAdvanced") {
         await ctx.db.insert("tickHistory", {
-          closedTick: asNumber(raw.args.closedTick),
-          openedTick: asNumber(raw.args.openedTick),
-          tickSeed: asString(raw.args.tickSeed),
+          closedTick: asNumber(event.args.closedTick),
+          openedTick: asNumber(event.args.openedTick),
+          tickSeed: asString(event.args.tickSeed),
           blockNumber,
           txHash,
           firedAtTs: args.firedAtTs,
@@ -348,7 +382,7 @@ export const ingestEvents = internalMutation({
         });
       }
 
-      const pricePoint = pricePointFromEvent(raw, blockNumber);
+      const pricePoint = pricePointFromEvent(event, blockNumber);
       if (pricePoint) await ctx.db.insert("pricePoint", pricePoint);
     }
 
@@ -368,7 +402,7 @@ export const ingestEvents = internalMutation({
       }
     }
 
-    return { inserted };
+    return { inserted, rejected };
   },
 });
 

--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -13,6 +13,8 @@ export default defineSchema({
     winterActive: v.optional(v.boolean()),
     winterStartsAtTick: v.optional(v.number()),
     winterEndsAtTick: v.optional(v.number()),
+    worldPaused: v.optional(v.boolean()),
+    pausedAtTs: v.optional(v.number()),
     nextHeartbeatAtTick: v.optional(v.number()),
     regions: v.array(
       v.object({

--- a/apps/server/convex/vault.test.ts
+++ b/apps/server/convex/vault.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { projectAttributed, projectBroadcast, type Movement } from "./vault";
-import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
+import {
+  isClanWorldEventName,
+  type IClanWorldAbiEventName,
+} from "@clan-world/contract-types";
 
 const WEI = "1000000000000000000"; // 1e18
 const wei = (n: number) => `${n}${"0".repeat(18)}`;
@@ -216,5 +219,25 @@ describe("projectBroadcast", () => {
       out,
     );
     expect(out).toEqual([]);
+  });
+});
+
+describe("isClanWorldEventName", () => {
+  it("accepts canonical ABI event names", () => {
+    expect(isClanWorldEventName("TickAdvanced")).toBe(true);
+    expect(isClanWorldEventName("ResourcesGathered")).toBe(true);
+    expect(isClanWorldEventName("GoldTransferred")).toBe(true);
+  });
+
+  it("rejects unknown names", () => {
+    expect(isClanWorldEventName("FakeEvent")).toBe(false);
+    expect(isClanWorldEventName("")).toBe(false);
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(isClanWorldEventName(undefined)).toBe(false);
+    expect(isClanWorldEventName(null)).toBe(false);
+    expect(isClanWorldEventName(123)).toBe(false);
+    expect(isClanWorldEventName({})).toBe(false);
   });
 });

--- a/apps/server/convex/vault.ts
+++ b/apps/server/convex/vault.ts
@@ -1,6 +1,9 @@
 import { query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
-import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
+import {
+  isClanWorldEventName,
+  type IClanWorldAbiEventName,
+} from "@clan-world/contract-types";
 
 /**
  * Vault movement feed for a single clan.
@@ -262,10 +265,17 @@ export const getVaultMovements = query({
       void before;
     };
     for (const e of attributed) {
+      if (!isClanWorldEventName(e.eventName)) {
+        console.warn(
+          `[vault] skipping unknown chainEvent eventName "${String(e.eventName)}"`,
+          { eventName: e.eventName, txHash: e.txHash, logIndex: e.logIndex, tick: e.tick },
+        );
+        continue;
+      }
       collect(
         {
-          // Safe: unknown names fall through to `default: return` in projectAttributed.
-          eventName: e.eventName as IClanWorldAbiEventName,
+          // Allowlist-guarded — unknown event names were skipped + logged above.
+          eventName: e.eventName,
           args: (e.args ?? {}) as Record<string, unknown>,
           tick: e.tick,
           decodedAt: e.decodedAt,
@@ -281,10 +291,17 @@ export const getVaultMovements = query({
       );
     }
     for (const e of broadcast) {
+      if (!isClanWorldEventName(e.eventName)) {
+        console.warn(
+          `[vault] skipping unknown chainEvent eventName "${String(e.eventName)}"`,
+          { eventName: e.eventName, txHash: e.txHash, logIndex: e.logIndex, tick: e.tick },
+        );
+        continue;
+      }
       collect(
         {
-          // Safe: unknown names fall through to `default: return` in projectBroadcast.
-          eventName: e.eventName as IClanWorldAbiEventName,
+          // Allowlist-guarded — unknown event names were skipped + logged above.
+          eventName: e.eventName,
           args: (e.args ?? {}) as Record<string, unknown>,
           tick: e.tick,
           decodedAt: e.decodedAt,

--- a/apps/web/src/TopHud.tsx
+++ b/apps/web/src/TopHud.tsx
@@ -71,10 +71,11 @@ export function TopHud({ liveTick }: { liveTick: number }) {
     return () => window.clearInterval(id);
   }, []);
 
-  const { seasonStartTick, seasonEndTick, winterActive, winterStartsAtTick } = useMemo(() => {
-    // getSnapshot derives season fields from tick via deriveSeasonState() — all four
-    // fields are present in the return type.
+  const { currentSeasonNumber, seasonStartTick, seasonEndTick, winterActive, winterStartsAtTick } = useMemo(() => {
+    // getSnapshot returns persisted chain season fields when present and
+    // derives only legacy missing fields server-side.
     return {
+      currentSeasonNumber: typeof snapshot?.currentSeasonNumber === 'number' ? snapshot.currentSeasonNumber : null,
       seasonStartTick: typeof snapshot?.seasonStartTick === 'number' ? snapshot.seasonStartTick : null,
       seasonEndTick: typeof snapshot?.seasonEndTick === 'number' ? snapshot.seasonEndTick : null,
       winterActive: snapshot?.winterActive === true,
@@ -92,11 +93,9 @@ export function TopHud({ liveTick }: { liveTick: number }) {
   }, [liveTick, seasonStartTick, seasonEndTick]);
 
   const seasonNumber = useMemo(() => {
-    if (seasonStartTick !== null && seasonEndTick !== null) {
-      return Math.floor(liveTick / TICKS_PER_SEASON) + 1;
-    }
+    if (currentSeasonNumber !== null) return currentSeasonNumber;
     return Math.floor(liveTick / TICKS_PER_SEASON) + 1;
-  }, [liveTick, seasonStartTick, seasonEndTick]);
+  }, [currentSeasonNumber, liveTick]);
 
   // Winter approaching warning: within 20 ticks
   const winterWarning = useMemo(() => {

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -3028,6 +3028,9 @@ export function WorldMap() {
   function currentTickFloat() {
     const snap = snapshotRef.current;
     const tick = typeof snap?.tick === 'number' && Number.isFinite(snap.tick) ? snap.tick : liveTickRef.current;
+    if (snap?.worldPaused === true) {
+      return tick;
+    }
     const epoch = snap?.tickEpoch;
     if (!epoch || typeof epoch.startedAt !== 'number' || typeof epoch.durationMs !== 'number' || epoch.durationMs <= 0) {
       return tick;

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -3773,9 +3773,7 @@ export function WorldMap() {
       REGION_KEY_BY_CHAIN_ID,
     );
 
-    // TODO(backend): worldPaused is not yet returned by getSnapshot. Wire up when
-    // pause support lands in the schema; until then animations advance during pause.
-    const worldPaused = false;
+    const worldPaused = snap?.worldPaused === true;
 
     // Hide everything by default, then enable per-phase.
     hideBanditAnimSprites();

--- a/packages/contract-types/index.ts
+++ b/packages/contract-types/index.ts
@@ -1,2 +1,3 @@
-export * from './src/IClanWorld.js';
-export * from './src/IClanWorldLens.js';
+export * from "./src/IClanWorld.js";
+export * from "./src/IClanWorldLens.js";
+export * from "./src/eventNames.js";

--- a/packages/contract-types/package.json
+++ b/packages/contract-types/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "description": "Generated TypeScript literal-type ABIs for ClanWorld contracts",
   "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
   "exports": {
     ".": "./index.ts"
   },

--- a/packages/contract-types/package.json
+++ b/packages/contract-types/package.json
@@ -12,9 +12,12 @@
   "scripts": {
     "codegen": "node scripts/generate.mjs",
     "codegen:check": "node scripts/generate.mjs --check",
-    "build": "tsc --noEmit"
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run test/*.test.ts"
   },
   "devDependencies": {
-    "@clan-world/contracts": "workspace:*"
+    "@clan-world/contracts": "workspace:*",
+    "vitest": "3.2.4"
   }
 }

--- a/packages/contract-types/src/eventNames.ts
+++ b/packages/contract-types/src/eventNames.ts
@@ -1,0 +1,24 @@
+import { iClanWorldAbi, type IClanWorldAbiEventName } from "./IClanWorld.js";
+
+// Allowlist derived once at module load from the generated ABI const.
+// `iClanWorldAbi` is `as const`, so the literal-union IClanWorldAbiEventName
+// is the compile-time source of truth; this Set is its runtime mirror.
+export const IClanWorldAbiEventNames: ReadonlySet<IClanWorldAbiEventName> =
+  new Set(
+    iClanWorldAbi
+      .filter(
+        (item): item is typeof item & { type: "event"; name: string } =>
+          item.type === "event" &&
+          typeof (item as { name?: unknown }).name === "string",
+      )
+      .map((item) => item.name as IClanWorldAbiEventName),
+  );
+
+export function isClanWorldEventName(
+  name: unknown,
+): name is IClanWorldAbiEventName {
+  return (
+    typeof name === "string" &&
+    (IClanWorldAbiEventNames as ReadonlySet<string>).has(name)
+  );
+}

--- a/packages/contract-types/test/eventNames.test.ts
+++ b/packages/contract-types/test/eventNames.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  IClanWorldAbiEventNames,
+  isClanWorldEventName,
+  iClanWorldAbi,
+} from "../index.js";
+
+describe("IClanWorldAbiEventNames", () => {
+  it("size equals number of event entries in the ABI", () => {
+    const expectedCount = iClanWorldAbi.filter(
+      (item) => item.type === "event",
+    ).length;
+    expect(IClanWorldAbiEventNames.size).toBe(expectedCount);
+    expect(expectedCount).toBeGreaterThan(0);
+  });
+
+  it("contains representative event names", () => {
+    expect(IClanWorldAbiEventNames.has("TickAdvanced")).toBe(true);
+    expect(IClanWorldAbiEventNames.has("ResourcesGathered")).toBe(true);
+  });
+});
+
+describe("isClanWorldEventName", () => {
+  it("returns true for canonical event names", () => {
+    expect(isClanWorldEventName("TickAdvanced")).toBe(true);
+    expect(isClanWorldEventName("ResourcesDeposited")).toBe(true);
+  });
+
+  it("returns false for unknown names", () => {
+    expect(isClanWorldEventName("NotAnEvent")).toBe(false);
+    expect(isClanWorldEventName("")).toBe(false);
+  });
+
+  it("returns false for non-string inputs", () => {
+    expect(isClanWorldEventName(undefined)).toBe(false);
+    expect(isClanWorldEventName(null)).toBe(false);
+    expect(isClanWorldEventName(42)).toBe(false);
+    expect(isClanWorldEventName({ name: "TickAdvanced" })).toBe(false);
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -61,6 +61,8 @@ export interface WorldSnapshot {
   winterActive?: boolean;
   winterStartsAtTick?: number;
   winterEndsAtTick?: number;
+  worldPaused?: boolean;
+  pausedAtTs?: number | null;
 }
 
 export interface ClanFullView {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -48,6 +48,19 @@ export interface WorldSnapshot {
   tickEpoch: TickEpoch;
   regions: Region[];
   clans: Clan[];
+  /**
+   * Season + winter timers surfaced from `worldSnapshot` (Phase 4.4+).
+   * All optional for backward compat with legacy rows that pre-date the
+   * persisted-fields migration. When `getSnapshot()` returns these, they
+   * are authoritative chain values from `_world.*` — see
+   * `apps/server/convex/getSnapshot.ts` and ClanWorld._worldStateView.
+   */
+  currentSeasonNumber?: number;
+  seasonStartTick?: number;
+  seasonEndTick?: number;
+  winterActive?: boolean;
+  winterStartsAtTick?: number;
+  winterEndsAtTick?: number;
 }
 
 export interface ClanFullView {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       '@clan-world/contracts':
         specifier: workspace:*
         version: link:../contracts
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2)
 
   packages/contracts: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -26,9 +26,7 @@
         "src/adapters/IChainClient.ts",
         "src/generated/constants.ts",
         "src/generated/enums.ts",
-        "convex/_generated/**",
-        "src/IClanWorld.ts",
-        "src/IClanWorldLens.ts"
+        "convex/_generated/**"
       ]
     },
     "dev": {


### PR DESCRIPTION
## Release v2.9.1 — Typechain hardening + season-freeze fix + worldPaused plumbing

Bundle of 5 fix PRs addressing the cross-model SHOULD-FIX findings + the pre-existing HIGH from PR #432 super-swarm synthesis. All issues filed + closed in the same session as v2.9.0 shipped (2026-05-16 afternoon).

## What ships

| # | PR | Fix | Source finding |
|---|---|---|---|
| #438 | #440 | Plumb `worldPaused` + `pausedAtTs` through getSnapshot → typed runtime fallback in WorldMap (drops hardcoded `false`) | super-swarm S1 cross-model (codex 5.3 + 5.4) |
| #439 | #442 | Harden typechain-ci: `check:abi` parity step + grep regex catches `as unknown as Abi` + contract-types build smoke + turbo.json dead-input removal | super-swarm S2 cross-model (4 of 4 codex variants) |
| #435 | #444 | Preserve persisted season fields from `worldSnapshot` at freeze boundary — drop `deriveSeasonState(snap.tick)` override + new freeze-window regression test | super-swarm HIGH (codex 5.4, pre-existing in v2.8.5) |
| #436 | #441 | Runtime event-name allowlist + `isClanWorldEventName` type guard — close ingest/vault type escape hatch + reject + rejected counter | super-swarm MEDIUM (codex 5.3) |
| #437 | #443 | `@clan-world/contract-types` package.json — add `main` + `types` fields aligning with `@clan-world/shared` sibling convention | super-swarm LOW (codex 5.3) |

## Why these matter

The five fixes collectively close every cross-model finding from the v2.9.0 super-swarm that was scoped as a *real* improvement vs. a single-reviewer opinion:

- **#435** is the only release-relevant HIGH from the super-swarm. Pre-existing bug exposed by v2.9.0's removal of `(snapshot as any)` casts. At the season-freeze boundary the frontend would show next-season fields one tick too early. Fix uses persisted worldSnapshot values (which the contract holds intentionally during freeze).
- **#436** closes the last runtime escape hatch from the typechain migration. Indexer no longer casts arbitrary strings to `IClanWorldAbiEventName`; type guard rejects + logs + counts unknown names.
- **#438** keeps the typechain-migration's no-`as any` guarantee while restoring runtime-correct pause handling.
- **#439** strengthens the CI gates the typechain workflow was supposed to provide — closes Solidity↔JSON drift, multi-pattern cast grep, package build smoke.
- **#437** is a small docs/exports alignment for tooling compatibility.

## Verified before release

- Each sub-PR ran the local 3-tier swarm to clean (or orch-direct codex 5-stage critique on the 3 PRs where the subagent dispatch wrapper hung — see `feedback_subagent_codex_wrapper_monitor_antipattern` memory)
- All CI green at squash-merge time
- `pnpm typecheck` clean across all workspaces
- Test counts: server 44/44 passing (+7 vs v2.9.0 — coverage added)
- No new `as any` / `as unknown as Abi` introduced anywhere (the new CI grep gate is itself enforced)

## Final gate

This PR runs `/phase-super-swarm` (6-model lineup) for cross-model verification before merge. The super-swarm-orchestrator subagent was patched earlier this session (commit `31136ba`) to use the file-pointer dispatch pattern instead of the cat-stdin anti-pattern that caused 2 of 6 silent failures on v2.9.0's super-swarm.

Merge requires explicit Liam approval per ADR 0018.

## Tag plan

On merge: tag `v2.9.1` from the resulting `main` commit. Previous release: `v2.9.0` (typechain migration, 2026-05-16 ~17:23 ET).

## Open follow-ups (not in this release)

None substantive. The agents reported some interesting process notes in their PR bodies — codex subagent dispatch hangs in stdin-read mode 3 of 5 times, working fallback is orch-direct Bash with `echo | codex exec` stdin pipe. Memory entry pending.
