### PR TITLE
fix(release): v2.9.1 R2 super-swarm findings — TopHud seasonNumber + pausedAtTs + currentTickFloat + types

### DIFF
--- a/apps/server/convex/getSnapshot.test.ts
+++ b/apps/server/convex/getSnapshot.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   deriveSeasonState,
+  normalizePausedAtTs,
+  resolvePauseStateForSnap,
   resolveSeasonStateForSnap,
   type PersistedSnapshotSeasonFields,
 } from "./getSnapshot";
@@ -142,5 +144,27 @@ describe("deriveSeasonState (empty-state fallback)", () => {
     expect(result.winterActive).toBe(false);
     expect(result.winterStartsAtTick).toBe(WINTER_START + 110);
     expect(result.winterEndsAtTick).toBe(WINTER_START + 110 + WINTER_DUR);
+  });
+});
+
+describe("normalizePausedAtTs", () => {
+  it("paused row: preserves a positive pausedAtTs", () => {
+    expect(resolvePauseStateForSnap({ worldPaused: true, pausedAtTs: 12345 })).toEqual({
+      worldPaused: true,
+      pausedAtTs: 12345,
+    });
+  });
+
+  it("unpaused row: normalizes missing or non-positive pausedAtTs to null", () => {
+    expect(resolvePauseStateForSnap({ worldPaused: false, pausedAtTs: undefined })).toEqual({
+      worldPaused: false,
+      pausedAtTs: null,
+    });
+    expect(resolvePauseStateForSnap({ worldPaused: false, pausedAtTs: 0 })).toEqual({
+      worldPaused: false,
+      pausedAtTs: null,
+    });
+    expect(normalizePausedAtTs(undefined)).toBeNull();
+    expect(normalizePausedAtTs(0)).toBeNull();
   });
 });

--- a/apps/server/convex/getSnapshot.ts
+++ b/apps/server/convex/getSnapshot.ts
@@ -125,6 +125,22 @@ export function resolveSeasonStateForSnap(
   };
 }
 
+export function normalizePausedAtTs(pausedAtTs: unknown): number | null {
+  return typeof pausedAtTs === "number" && Number.isFinite(pausedAtTs) && pausedAtTs > 0
+    ? pausedAtTs
+    : null;
+}
+
+export function resolvePauseStateForSnap(snap: {
+  worldPaused?: unknown;
+  pausedAtTs?: unknown;
+}): { worldPaused: boolean; pausedAtTs: number | null } {
+  return {
+    worldPaused: snap.worldPaused === true,
+    pausedAtTs: normalizePausedAtTs(snap.pausedAtTs),
+  };
+}
+
 export const getSnapshot = query({
   handler: async (ctx) => {
     const snap = await ctx.db.query("worldSnapshot").order("desc").first();
@@ -177,8 +193,7 @@ export const getSnapshot = query({
       clans: snap.clans,
       activeBanditId,
       bandit,
-      worldPaused: snap.worldPaused === true,
-      pausedAtTs: typeof snap.pausedAtTs === "number" ? snap.pausedAtTs : null,
+      ...resolvePauseStateForSnap(snap),
       ...resolveSeasonStateForSnap(snap),
     };
   },

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -587,6 +587,12 @@ export const commitSnapshot = internalMutation({
       previousWorldSnapshot?.tick === tick
         ? previousWorldSnapshot.tickEpochStartedAt
         : Math.floor(now / 1000);
+    const worldPaused = asBool(world.worldPaused);
+    const rawPausedAtTs = asNumber(world.pausedAtTs, Number.NaN);
+    const pausedAtTs =
+      Number.isFinite(rawPausedAtTs) && (rawPausedAtTs > 0 || worldPaused)
+        ? rawPausedAtTs
+        : undefined;
     const worldSnapshot = {
       tick,
       tickEpochStartedAt,
@@ -597,8 +603,8 @@ export const commitSnapshot = internalMutation({
       winterActive: asBool(world.winterActive),
       winterStartsAtTick: asNumber(world.winterStartsAtTick),
       winterEndsAtTick: asNumber(world.winterEndsAtTick),
-      worldPaused: asBool(world.worldPaused),
-      pausedAtTs: asNumber(world.pausedAtTs),
+      worldPaused,
+      pausedAtTs,
       nextHeartbeatAtTick: asNumber(world.nextHeartbeatAtTick),
       regions: LEGACY_REGIONS,
       clans: legacyClans,

--- a/apps/web/src/TopHud.tsx
+++ b/apps/web/src/TopHud.tsx
@@ -71,10 +71,11 @@ export function TopHud({ liveTick }: { liveTick: number }) {
     return () => window.clearInterval(id);
   }, []);
 
-  const { seasonStartTick, seasonEndTick, winterActive, winterStartsAtTick } = useMemo(() => {
-    // getSnapshot derives season fields from tick via deriveSeasonState() — all four
-    // fields are present in the return type.
+  const { currentSeasonNumber, seasonStartTick, seasonEndTick, winterActive, winterStartsAtTick } = useMemo(() => {
+    // getSnapshot returns persisted chain season fields when present and
+    // derives only legacy missing fields server-side.
     return {
+      currentSeasonNumber: typeof snapshot?.currentSeasonNumber === 'number' ? snapshot.currentSeasonNumber : null,
       seasonStartTick: typeof snapshot?.seasonStartTick === 'number' ? snapshot.seasonStartTick : null,
       seasonEndTick: typeof snapshot?.seasonEndTick === 'number' ? snapshot.seasonEndTick : null,
       winterActive: snapshot?.winterActive === true,
@@ -92,11 +93,9 @@ export function TopHud({ liveTick }: { liveTick: number }) {
   }, [liveTick, seasonStartTick, seasonEndTick]);
 
   const seasonNumber = useMemo(() => {
-    if (seasonStartTick !== null && seasonEndTick !== null) {
-      return Math.floor(liveTick / TICKS_PER_SEASON) + 1;
-    }
+    if (currentSeasonNumber !== null) return currentSeasonNumber;
     return Math.floor(liveTick / TICKS_PER_SEASON) + 1;
-  }, [liveTick, seasonStartTick, seasonEndTick]);
+  }, [currentSeasonNumber, liveTick]);
 
   // Winter approaching warning: within 20 ticks
   const winterWarning = useMemo(() => {

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -3028,6 +3028,9 @@ export function WorldMap() {
   function currentTickFloat() {
     const snap = snapshotRef.current;
     const tick = typeof snap?.tick === 'number' && Number.isFinite(snap.tick) ? snap.tick : liveTickRef.current;
+    if (snap?.worldPaused === true) {
+      return tick;
+    }
     const epoch = snap?.tickEpoch;
     if (!epoch || typeof epoch.startedAt !== 'number' || typeof epoch.durationMs !== 'number' || epoch.durationMs <= 0) {
       return tick;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -61,6 +61,8 @@ export interface WorldSnapshot {
   winterActive?: boolean;
   winterStartsAtTick?: number;
   winterEndsAtTick?: number;
+  worldPaused?: boolean;
+  pausedAtTs?: number | null;
 }
 
 export interface ClanFullView {


### PR DESCRIPTION
Cross-cutting fixes from PR #445 v2.9.1 super-swarm. **Codex 5.5 caught the HIGH that opus 4.6/4.7 + codex 5.3 missed** — verified against actual TopHud.tsx code, the freeze-window bug PR #444 fixed on the server was still live on the client.

Closes #446.

## Findings addressed

- **F1 HIGH** (codex 5.5): `TopHud.tsx:94-99` derived `seasonNumber` from `liveTick`, ignoring `snapshot.currentSeasonNumber` — same freeze-window bug, client-side. Fixed: prefer persisted value.
- **F2 MED** (codex 5.3): `pausedAtTs` coerced to 0 — `asNumber(undefined)===0` made unpaused indistinguishable from paused-at-epoch. Fixed: write only finite+positive at indexer, normalize on getSnapshot return.
- **F3 MED** (codex 5.4 + 5.5): `currentTickFloat()` advances from wall-clock during pause. Fixed: read snapshotRef inside; return integer tick when paused.
- **F4 MED** (codex 5.5): Shared `WorldSnapshot` type missing `worldPaused`/`pausedAtTs`. Fixed: added optional fields.
- **F5 LOW** (codex 5.3): Missing pause plumbing tests. Added 2 tests via exported `normalizePausedAtTs`.

## Verification

- 50/50 server tests passing (+6 vs v2.9.0)
- typecheck clean across @clan-world/{server, web, shared}
- No new `as any` / `as unknown as Abi`
- Local 5-stage codex CLEAN at stage 3 critique

## Cross-model disagreement note

Per memory `feedback_super_swarm_cross_model_disagreement_resolution`: opus 4.6 + 4.7 + codex 5.3 said CLEAN on F1; only codex 5.5 caught it. Verified against actual code — codex 5.5 was right. Both opus models can miss client-side state-derivation bugs that codex catches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)