### PR TITLE
fix(server): pause-plumbing edge cases — pausedAtTs invariant + same-tick anchor refresh (#448, #449)

### DIFF
--- a/apps/server/convex/getSnapshot.test.ts
+++ b/apps/server/convex/getSnapshot.test.ts
@@ -167,4 +167,18 @@ describe("normalizePausedAtTs", () => {
     expect(normalizePausedAtTs(undefined)).toBeNull();
     expect(normalizePausedAtTs(0)).toBeNull();
   });
+
+  it("paused row: normalizes zero pausedAtTs to null", () => {
+    expect(resolvePauseStateForSnap({ worldPaused: true, pausedAtTs: 0 })).toEqual({
+      worldPaused: true,
+      pausedAtTs: null,
+    });
+  });
+
+  it("unpaused row: hides stale positive pausedAtTs", () => {
+    expect(resolvePauseStateForSnap({ worldPaused: false, pausedAtTs: 12345 })).toEqual({
+      worldPaused: false,
+      pausedAtTs: null,
+    });
+  });
 });

--- a/apps/server/convex/getSnapshot.ts
+++ b/apps/server/convex/getSnapshot.ts
@@ -137,7 +137,7 @@ export function resolvePauseStateForSnap(snap: {
 }): { worldPaused: boolean; pausedAtTs: number | null } {
   return {
     worldPaused: snap.worldPaused === true,
-    pausedAtTs: normalizePausedAtTs(snap.pausedAtTs),
+    pausedAtTs: snap.worldPaused === true ? normalizePausedAtTs(snap.pausedAtTs) : null,
   };
 }
 

--- a/apps/server/convex/indexer.test.ts
+++ b/apps/server/convex/indexer.test.ts
@@ -68,6 +68,22 @@ function createDb(tables: Record<string, any[]> = {}) {
   };
 }
 
+type CommitSnapshotTestHandler = (
+  ctx: { db: ReturnType<typeof createDb>["db"] },
+  args: {
+    snapshot: {
+      blockNumber: number;
+      txHash?: string;
+      world: Record<string, unknown>;
+      clans: unknown[];
+    };
+  },
+) => Promise<{ tick?: number; clans?: number; skipped?: string }>;
+
+const runCommitSnapshot = (
+  commitSnapshot as unknown as { _handler: CommitSnapshotTestHandler }
+)._handler;
+
 function eventAbi(name: string) {
   const event = CLAN_WORLD_ABI.find(
     (item) => item.type === "event" && item.name === name,
@@ -369,7 +385,7 @@ describe("legacy snapshot backfill", () => {
   it("commitSnapshot writes non-empty legacy clans from clanView rows", async () => {
     const { db, tables } = createDb();
 
-    await (commitSnapshot as any)._handler(
+    await runCommitSnapshot(
       { db },
       {
         snapshot: {
@@ -425,7 +441,7 @@ describe("legacy snapshot backfill", () => {
     const now = vi.spyOn(Date, "now");
     now.mockReturnValue(1_000_000);
 
-    await (commitSnapshot as any)._handler(
+    await runCommitSnapshot(
       { db },
       {
         snapshot: {
@@ -437,7 +453,7 @@ describe("legacy snapshot backfill", () => {
     );
 
     now.mockReturnValue(1_015_000);
-    await (commitSnapshot as any)._handler(
+    await runCommitSnapshot(
       { db },
       {
         snapshot: {
@@ -453,7 +469,7 @@ describe("legacy snapshot backfill", () => {
     expect(sameTickSnapshot.tickEpochDurationMs).toBe(60_000);
 
     now.mockReturnValue(1_060_000);
-    await (commitSnapshot as any)._handler(
+    await runCommitSnapshot(
       { db },
       {
         snapshot: {
@@ -467,6 +483,41 @@ describe("legacy snapshot backfill", () => {
     const advancedTickSnapshot = tables.worldSnapshot?.[0];
     expect(advancedTickSnapshot.tickEpochStartedAt).toBe(1_060);
     expect(advancedTickSnapshot.tickEpochDurationMs).toBe(60_000);
+
+    now.mockRestore();
+  });
+
+  it("refreshes tick epoch start when same-tick snapshot unpauses", async () => {
+    const { db, tables } = createDb({
+      worldSnapshot: [
+        {
+          _id: "worldSnapshot:0",
+          _creationTime: 0,
+          tick: 12,
+          tickEpochStartedAt: 1_000,
+          tickEpochDurationMs: 60_000,
+          worldPaused: true,
+          pausedAtTs: 1_000,
+          clans: [],
+        },
+      ],
+    });
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(1_015_000);
+
+    await runCommitSnapshot(
+      { db },
+      {
+        snapshot: {
+          blockNumber: 100,
+          world: { currentTick: 12, worldPaused: false },
+          clans: [],
+        },
+      },
+    );
+
+    expect(tables.worldSnapshot?.[0]?.tickEpochStartedAt).toBe(1_015);
+    expect(tables.worldSnapshot?.[0]?.worldPaused).toBe(false);
 
     now.mockRestore();
   });
@@ -486,7 +537,7 @@ describe("legacy snapshot backfill", () => {
       ],
     });
 
-    const result = await (commitSnapshot as any)._handler(
+    const result = await runCommitSnapshot(
       { db },
       {
         snapshot: {

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -583,11 +583,14 @@ export const commitSnapshot = internalMutation({
     const legacyClans = legacyClansFromClanViews(
       latestClanViews.filter(isPresent),
     );
+    const worldPaused = asBool(world.worldPaused);
+    const sameTickAsPrevious = previousWorldSnapshot?.tick === tick;
+    const wasPausedNowUnpaused =
+      previousWorldSnapshot?.worldPaused === true && !worldPaused;
     const tickEpochStartedAt =
-      previousWorldSnapshot?.tick === tick
+      previousWorldSnapshot && sameTickAsPrevious && !wasPausedNowUnpaused
         ? previousWorldSnapshot.tickEpochStartedAt
         : Math.floor(now / 1000);
-    const worldPaused = asBool(world.worldPaused);
     const rawPausedAtTs = asNumber(world.pausedAtTs, Number.NaN);
     const pausedAtTs =
       Number.isFinite(rawPausedAtTs) && (rawPausedAtTs > 0 || worldPaused)


### PR DESCRIPTION
Bundle of the two pause-plumbing edge cases v2.9.1 R2 super-swarm flagged as latent. Both touch the same server surface (getSnapshot.ts + indexer.ts) — cohesive scope.

Closes #448. Closes #449.

## Two fixes

### #449 — `pausedAtTs ↔ worldPaused` invariant gap (cross-model: opus 4.7 + gemini)

`apps/server/convex/getSnapshot.ts` — one-line read-side defense in `resolvePauseStateForSnap`:
```ts
pausedAtTs: snap.worldPaused === true ? normalizePausedAtTs(snap.pausedAtTs) : null,
```
Enforces "pausedAtTs is non-null iff worldPaused is true" regardless of any write-side drift.

### #448 — pause→unpause same-tick stale anchor (codex 5.4)

`apps/server/convex/indexer.ts` — `commitSnapshot` now detects pause→unpause transitions and refreshes `tickEpochStartedAt` instead of preserving the pre-pause anchor:
```ts
const sameTickAsPrevious = previousWorldSnapshot?.tick === tick;
const wasPausedNowUnpaused = previousWorldSnapshot?.worldPaused === true && !worldPaused;
const tickEpochStartedAt =
  sameTickAsPrevious && !wasPausedNowUnpaused
    ? previousWorldSnapshot.tickEpochStartedAt
    : Math.floor(now / 1000);
```
Existing same-tick preservation is intact for non-pause refreshes (covered by existing tests).

## Verification

- `pnpm --filter @clan-world/server test` — **53/53 pass** (+3 new vs v2.9.1)
- `pnpm typecheck` clean across `@clan-world/{server, web, shared}`
- Codex 5-stage workflow (orch-direct Bash stdin pipe); Stage 3 critique returned CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)