### PR TITLE
fix(mobile): tighten UI-layer Whisper type (D-13, LOW)

### DIFF
--- a/apps/mobile/src/data.ts
+++ b/apps/mobile/src/data.ts
@@ -1,6 +1,8 @@
 // Mock data for the Clan World shell. Mirrors data.jsx from the design bundle.
 // When integrations land, swap these for live queries against the backend.
 
+import type { Doc } from '../../server/convex/_generated/dataModel';
+
 export type ResourceKey = 'gold' | 'wood' | 'iron' | 'wheat' | 'fish' | 'blueprint';
 
 export type ArchetypeKey =
@@ -239,6 +241,16 @@ export const BAZAAR_INFTS: Inft[] = [
 
 export type WhisperKind = 'live' | 'danger' | 'warn' | 'info';
 
+// schema-source: Doc<"whispers">
+export type WhisperFromConvex = Doc<'whispers'>;
+export type _ConvexWhisper = WhisperFromConvex;
+
+// Mobile whispers are display fixtures, not persisted rows. The backing schema
+// stores tick/fromClanId/toClanIds/body/msgId/timestamp, while this UI layer
+// keeps hand-rolled presentation fields:
+// id/day group the mock list, kind/icon drive styling, title/snippet/t are
+// derived copy for cards, and unread is local UI state. There are currently no
+// same-named fields shared with Doc<"whispers">, so no schema type conflicts.
 export type Whisper = {
   id: string;
   day: 'today' | 'yesterday' | 'wed-6-may';


### PR DESCRIPTION
Closes #455. Option (b): keeps the mobile Whisper type hand-rolled because the current data is a UI display fixture/projection with UI-only fields for grouping (day/id), styling (kind/icon), card copy (title/snippet/t), and local unread state rather than a persisted Convex whisper row. Added schema-source: Doc<"whispers"> plus WhisperFromConvex/_ConvexWhisper aliases as a reference point, and verified there are no same-named fields shared with the Convex whispers schema that could conflict. WhisperKind UI-styling union preserved.

Verification:
- pnpm install --frozen-lockfile
- pnpm typecheck 2>&1 | tail -40 (fails on existing mobile JSX component typing issues in Svg/Polygon/LinearGradient/WebView and workspace package-local node_modules warnings; no errors reported for apps/mobile/src/data.ts)
- pnpm --filter @clan-world/seeker exec tsc --noEmit --pretty false 2>&1 | tail -60 (same existing React JSX type skew; no data.ts errors)
- grep -B2 -A20 'type Whisper' apps/mobile/src/data.ts
- grep -B2 -A20 'whispers: defineTable' apps/server/convex/schema.ts