### PR TITLE
fix(server): typed functionName ABI inference (D-7)

### DIFF
--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -7,6 +7,7 @@ import {
 import { internal } from "./_generated/api";
 import {
   iClanWorldAbi,
+  iClanWorldLensAbi,
   isClanWorldEventName,
 } from "@clan-world/contract-types";
 import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
@@ -15,6 +16,7 @@ import {
   createPublicClient,
   http,
   parseEventLogs,
+  type ContractFunctionName,
   type Hex,
   type Log,
   type ParseEventLogsReturnType,
@@ -38,6 +40,20 @@ const DEFAULT_CONFIRMATION_DEPTH = 5;
 // a non-PAYG RPC (e.g. demo deployment).
 const MAX_LOG_BLOCK_RANGE = 9n;
 const DEFAULT_COLD_START_LOOKBACK = 100n;
+type ReadContractMutability = "view" | "pure";
+type LensFunctionName = ContractFunctionName<
+  typeof iClanWorldLensAbi,
+  ReadContractMutability
+>;
+type ClanWorldFunctionName = ContractFunctionName<
+  typeof iClanWorldAbi,
+  ReadContractMutability
+>;
+const GET_WORLD_SNAPSHOT = "getWorldSnapshot" satisfies LensFunctionName;
+const GET_MARKET_STATE = "getMarketState" satisfies LensFunctionName;
+const GET_ACTIVE_BANDIT_VIEW = "getActiveBanditView" satisfies LensFunctionName;
+const GET_CLAN_IDS = "getClanIds" satisfies ClanWorldFunctionName;
+const GET_CLAN_FULL_VIEW = "getClanFullView" satisfies LensFunctionName;
 const LEGACY_REGIONS = [
   { id: "forest", name: "Forest", ownerClanId: null },
   { id: "mountains", name: "Mountains", ownerClanId: null },
@@ -662,31 +678,20 @@ export const refreshSnapshot = internalAction({
       args.blockNumber === undefined ? undefined : BigInt(args.blockNumber);
     const blockNumber =
       args.blockNumber ?? Number(await client.getBlockNumber());
+    const readArgs = <TFunctionName extends ClanWorldFunctionName>(
+      fn: TFunctionName,
+    ) => ({
+      address,
+      abi: iClanWorldAbi,
+      ["functionName"]: fn,
+      blockNumber: pinnedBlockNumber,
+    });
 
     const [worldRaw, market, bandit] = await Promise.all([
+      client.readContract(readArgs(GET_WORLD_SNAPSHOT)).catch(() => undefined),
+      client.readContract(readArgs(GET_MARKET_STATE)).catch(() => undefined),
       client
-        .readContract({
-          address,
-          abi: iClanWorldAbi,
-          functionName: "getWorldSnapshot",
-          blockNumber: pinnedBlockNumber,
-        })
-        .catch(() => undefined),
-      client
-        .readContract({
-          address,
-          abi: iClanWorldAbi,
-          functionName: "getMarketState",
-          blockNumber: pinnedBlockNumber,
-        })
-        .catch(() => undefined),
-      client
-        .readContract({
-          address,
-          abi: iClanWorldAbi,
-          functionName: "getActiveBanditView",
-          blockNumber: pinnedBlockNumber,
-        })
+        .readContract(readArgs(GET_ACTIVE_BANDIT_VIEW))
         .catch(() => undefined),
     ]);
 
@@ -699,12 +704,7 @@ export const refreshSnapshot = internalAction({
     }
 
     const clanIdsRaw = await client
-      .readContract({
-        address,
-        abi: iClanWorldAbi,
-        functionName: "getClanIds",
-        blockNumber: pinnedBlockNumber,
-      })
+      .readContract(readArgs(GET_CLAN_IDS))
       .catch(() => undefined);
     const clanIds =
       Array.isArray(clanIdsRaw) && clanIdsRaw.length > 0
@@ -715,11 +715,8 @@ export const refreshSnapshot = internalAction({
       clanIds.map(async (clanId) => {
         return client
           .readContract({
-            address,
-            abi: iClanWorldAbi,
-            functionName: "getClanFullView",
+            ...readArgs(GET_CLAN_FULL_VIEW),
             args: [clanId],
-            blockNumber: pinnedBlockNumber,
           })
           .then((view: unknown) => bigintSafe(view) as Record<string, unknown>)
           .catch(() => undefined);


### PR DESCRIPTION
Closes #452. Replaces 5 raw `functionName` string literals in `apps/server/convex/indexer.ts` with typed inference from `iClanWorldLensAbi`. Misspellings + ABI removals now produce compile errors. No runtime behavior change.