### PR TITLE
fix(scripts): derive eventNames from canonical ABI (D-12, META)

### DIFF
--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -2773,6 +2773,37 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "event",
+    "name": "BlueprintTransferred",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "ClanColdShortage",
     "inputs": [
       {
@@ -2842,6 +2873,37 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "event",
+    "name": "ClanOwnershipTransferred",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwnerNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "ClanSettled",
     "inputs": [
       {
@@ -2852,6 +2914,81 @@ export const CLAN_WORLD_ABI = [
       },
       {
         "name": "settledToTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanColdDeath",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "csId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanKilledByBandit",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanRevived",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "atTick",
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"
@@ -2917,56 +3054,6 @@ export const CLAN_WORLD_ABI = [
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ClansmanColdDeath",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "csId",
-        "type": "uint32",
-        "indexed": false,
-        "internalType": "uint32"
-      },
-      {
-        "name": "tick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ClansmanKilledByBandit",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "banditId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
       }
     ],
     "anonymous": false
@@ -3569,6 +3656,61 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "event",
+    "name": "ResourcesInjected",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "wood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "gold",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprint",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "ResourcesWithdrawn",
     "inputs": [
       {
@@ -3778,37 +3920,6 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "event",
-    "name": "ClanOwnershipTransferred",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "oldOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "newOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "newOwnerNonce",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
     "name": "VaultResourceTransferred",
     "inputs": [
       {
@@ -3984,28 +4095,41 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "event",
-    "name": "BlueprintTransferred",
+    "name": "WorldPaused",
     "inputs": [
       {
-        "name": "fromClanId",
-        "type": "uint32",
+        "name": "tick",
+        "type": "uint64",
         "indexed": true,
-        "internalType": "uint32"
+        "internalType": "uint64"
       },
       {
-        "name": "toClanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
+        "name": "pausedAtTs",
+        "type": "uint64",
         "indexed": false,
-        "internalType": "uint256"
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WorldUnpaused",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
       {
-        "name": "atTick",
+        "name": "durationSeconds",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "nextHeartbeatAtTs",
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"

--- a/scripts/gen-chainclient-abi.mjs
+++ b/scripts/gen-chainclient-abi.mjs
@@ -39,55 +39,6 @@ const functionNames = [
   'transferClanOwnership',
 ];
 
-const eventNames = [
-  'BanditAttackResolved',
-  'BanditDefeated',
-  'BanditEscaped',
-  'BanditMoved',
-  'BanditSpawned',
-  'BanditStateChanged',
-  'BanditTargetDied',
-  'BaseLevelChanged',
-  'BlueprintAwarded',
-  'BlueprintEarned',
-  'ClanColdShortage',
-  'ClanDied',
-  'ClanEliminated',
-  'ClanSettled',
-  'ClanSpawned',
-  'ClanStarvationChanged',
-  'ClansmanColdDeath',
-  'ClansmanKilledByBandit',
-  'GoldTransferred',
-  'ImmediateMarketActionExecuted',
-  'LootDistributed',
-  'LootDistributedToDefender',
-  'MarketActionFailed',
-  'MissionAssigned',
-  'MissionCompleted',
-  'MissionInterrupted',
-  'MonumentLevelChanged',
-  'PoolsSeeded',
-  'ResourceBurned',
-  'ResourceMinted',
-  'ResourcesDeposited',
-  'ResourcesGathered',
-  'ResourcesWithdrawn',
-  'ScheduledMarketActionCommitted',
-  'ScheduledMarketActionExecuted',
-  'SeasonFinalized',
-  'TickAdvanced',
-  'ClanOwnershipTransferred',
-  'VaultResourceTransferred',
-  'WallDamagedByBandit',
-  'WallDegradedByCold',
-  'WallLevelChanged',
-  'WinterEnded',
-  'WinterStarted',
-  'WorkerArrived',
-  'BlueprintTransferred',
-];
-
 function readCanonicalAbi() {
   const parsed = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
   const abi = Array.isArray(parsed) ? parsed : parsed.abi;
@@ -95,6 +46,22 @@ function readCanonicalAbi() {
     throw new Error(`${artifactPath} must contain an ABI array or an "abi" array`);
   }
   return abi;
+}
+
+function eventNameSort(left, right) {
+  return left.localeCompare(right);
+}
+
+function readEventNames(abi) {
+  return abi
+    .filter((entry) => entry.type === 'event')
+    .map((entry) => {
+      if (typeof entry.name !== 'string' || entry.name.length === 0) {
+        throw new Error(`Found event without a name in ${artifactPath}`);
+      }
+      return entry.name;
+    })
+    .sort(eventNameSort);
 }
 
 function generatedBlock() {
@@ -106,6 +73,7 @@ function generatedBlock() {
     }
     return fragment;
   });
+  const eventNames = readEventNames(abi);
   const eventFragments = eventNames.map((name) => {
     const fragment = abi.find((entry) => entry.type === 'event' && entry.name === name);
     if (!fragment) {


### PR DESCRIPTION
Closes #454.

Eliminates the hand-maintained `eventNames` array in `scripts/gen-chainclient-abi.mjs`. The list is now derived from the canonical ABI JSON the generator reads, then sorted alphabetically for deterministic generated output.

**Verification of regenerated output vs committed:** derived ABI has 50 events vs the old hand-rolled 46. The generated typed client now includes four canonical ABI events that were missing from the hand-maintained list:

- `ClansmanRevived` — emitted by admin recovery revive flows; canonical ABI event was missing from generated client coverage.
- `ResourcesInjected` — emitted by admin resource injection; canonical ABI event was missing from generated client coverage.
- `WorldPaused` — emitted by world pause controls; canonical ABI event was missing from generated client coverage.
- `WorldUnpaused` — emitted by world pause controls; canonical ABI event was missing from generated client coverage.

No hand-rolled events were absent from the canonical ABI. Existing events are the same set, with ordering normalized alphabetically in the generated ABI block.

Validation:

- `pnpm gen:chainclient-abi` regenerated `packages/shared/src/adapters/IChainClient.ts`.
- `pnpm test:chainclient-abi` passed.
- `pnpm test:abi-parity` passed.
- `pnpm --filter @clan-world/shared typecheck` passed.
- `CLAN_WORLD_MAP_URL=http://localhost:5173 CLAN_WORLD_TERMINAL_BASE_URL=http://localhost:5174 pnpm exec turbo run test --env-mode=loose` passed: 11/11 Turbo tasks, including 500 Foundry contract tests.

Note: root `pnpm typecheck` is blocked by existing `@clan-world/seeker` React type incompatibilities (`ConvexProvider`, `SafeAreaView`, `Svg`, `LinearGradient`, `WebView` cannot be used as JSX components). This is unrelated to the generator/client ABI change; the touched shared package typecheck is clean.
