### PR TITLE
v2.10: typechain completion — D-7/D-11/D-12 (META)/D-13

### DIFF
--- a/apps/mobile/src/clanData.ts
+++ b/apps/mobile/src/clanData.ts
@@ -15,6 +15,7 @@ import type {
   Movement,
   Strategy,
 } from './data';
+import type { Doc } from '../../server/convex/_generated/dataModel';
 import { ARCHETYPE_GLYPHS } from './data';
 import type { ForgedInft } from './storage';
 
@@ -22,23 +23,26 @@ import type { ForgedInft } from './storage';
  * Live Convex clan slice from `worldSnapshot.clans[i]`. Subset of fields we
  * actually need for slice 1 — the snapshot has more.
  */
-export type SnapshotClan = {
-  id: string;
-  name: string;
-  treasury: string;
-  goldBalance?: string;
-  blueprintBalance?: string;
-  vaultWood?: string;
-  vaultIron?: string;
-  vaultWheat?: string;
-  vaultFish?: string;
-  baseRegion?: number;
-  baseLevel?: number;
-  wallLevel?: number;
-  monumentLevel?: number;
-  livingClansmen?: number;
-  owner?: string;
-};
+type ConvexSnapshotClan = Doc<'worldSnapshot'>['clans'][number];
+
+export type SnapshotClan = Pick<
+  ConvexSnapshotClan,
+  | 'id'
+  | 'name'
+  | 'treasury'
+  | 'goldBalance'
+  | 'blueprintBalance'
+  | 'vaultWood'
+  | 'vaultIron'
+  | 'vaultWheat'
+  | 'vaultFish'
+  | 'baseRegion'
+  | 'baseLevel'
+  | 'wallLevel'
+  | 'monumentLevel'
+  | 'livingClansmen'
+  | 'owner'
+>;
 
 /** Subset of the worldSnapshot we read for the Hero. */
 export type SnapshotForHero = {

--- a/apps/mobile/src/data.ts
+++ b/apps/mobile/src/data.ts
@@ -1,6 +1,8 @@
 // Mock data for the Clan World shell. Mirrors data.jsx from the design bundle.
 // When integrations land, swap these for live queries against the backend.
 
+import type { Doc } from '../../server/convex/_generated/dataModel';
+
 export type ResourceKey = 'gold' | 'wood' | 'iron' | 'wheat' | 'fish' | 'blueprint';
 
 export type ArchetypeKey =
@@ -239,6 +241,16 @@ export const BAZAAR_INFTS: Inft[] = [
 
 export type WhisperKind = 'live' | 'danger' | 'warn' | 'info';
 
+// schema-source: Doc<"whispers">
+export type WhisperFromConvex = Doc<'whispers'>;
+export type _ConvexWhisper = WhisperFromConvex;
+
+// Mobile whispers are display fixtures, not persisted rows. The backing schema
+// stores tick/fromClanId/toClanIds/body/msgId/timestamp, while this UI layer
+// keeps hand-rolled presentation fields:
+// id/day group the mock list, kind/icon drive styling, title/snippet/t are
+// derived copy for cards, and unread is local UI state. There are currently no
+// same-named fields shared with Doc<"whispers">, so no schema type conflicts.
 export type Whisper = {
   id: string;
   day: 'today' | 'yesterday' | 'wed-6-may';

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -7,7 +7,6 @@ import {
 import { internal } from "./_generated/api";
 import {
   iClanWorldAbi,
-  iClanWorldLensAbi,
   isClanWorldEventName,
 } from "@clan-world/contract-types";
 import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
@@ -41,19 +40,16 @@ const DEFAULT_CONFIRMATION_DEPTH = 5;
 const MAX_LOG_BLOCK_RANGE = 9n;
 const DEFAULT_COLD_START_LOOKBACK = 100n;
 type ReadContractMutability = "view" | "pure";
-type LensFunctionName = ContractFunctionName<
-  typeof iClanWorldLensAbi,
-  ReadContractMutability
->;
 type ClanWorldFunctionName = ContractFunctionName<
   typeof iClanWorldAbi,
   ReadContractMutability
 >;
-const GET_WORLD_SNAPSHOT = "getWorldSnapshot" satisfies LensFunctionName;
-const GET_MARKET_STATE = "getMarketState" satisfies LensFunctionName;
-const GET_ACTIVE_BANDIT_VIEW = "getActiveBanditView" satisfies LensFunctionName;
+const GET_WORLD_SNAPSHOT = "getWorldSnapshot" satisfies ClanWorldFunctionName;
+const GET_MARKET_STATE = "getMarketState" satisfies ClanWorldFunctionName;
+const GET_ACTIVE_BANDIT_VIEW =
+  "getActiveBanditView" satisfies ClanWorldFunctionName;
 const GET_CLAN_IDS = "getClanIds" satisfies ClanWorldFunctionName;
-const GET_CLAN_FULL_VIEW = "getClanFullView" satisfies LensFunctionName;
+const GET_CLAN_FULL_VIEW = "getClanFullView" satisfies ClanWorldFunctionName;
 const LEGACY_REGIONS = [
   { id: "forest", name: "Forest", ownerClanId: null },
   { id: "mountains", name: "Mountains", ownerClanId: null },

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -7,6 +7,7 @@ import {
 import { internal } from "./_generated/api";
 import {
   iClanWorldAbi,
+  iClanWorldLensAbi,
   isClanWorldEventName,
 } from "@clan-world/contract-types";
 import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
@@ -15,6 +16,7 @@ import {
   createPublicClient,
   http,
   parseEventLogs,
+  type ContractFunctionName,
   type Hex,
   type Log,
   type ParseEventLogsReturnType,
@@ -38,6 +40,20 @@ const DEFAULT_CONFIRMATION_DEPTH = 5;
 // a non-PAYG RPC (e.g. demo deployment).
 const MAX_LOG_BLOCK_RANGE = 9n;
 const DEFAULT_COLD_START_LOOKBACK = 100n;
+type ReadContractMutability = "view" | "pure";
+type LensFunctionName = ContractFunctionName<
+  typeof iClanWorldLensAbi,
+  ReadContractMutability
+>;
+type ClanWorldFunctionName = ContractFunctionName<
+  typeof iClanWorldAbi,
+  ReadContractMutability
+>;
+const GET_WORLD_SNAPSHOT = "getWorldSnapshot" satisfies LensFunctionName;
+const GET_MARKET_STATE = "getMarketState" satisfies LensFunctionName;
+const GET_ACTIVE_BANDIT_VIEW = "getActiveBanditView" satisfies LensFunctionName;
+const GET_CLAN_IDS = "getClanIds" satisfies ClanWorldFunctionName;
+const GET_CLAN_FULL_VIEW = "getClanFullView" satisfies LensFunctionName;
 const LEGACY_REGIONS = [
   { id: "forest", name: "Forest", ownerClanId: null },
   { id: "mountains", name: "Mountains", ownerClanId: null },
@@ -662,31 +678,20 @@ export const refreshSnapshot = internalAction({
       args.blockNumber === undefined ? undefined : BigInt(args.blockNumber);
     const blockNumber =
       args.blockNumber ?? Number(await client.getBlockNumber());
+    const readArgs = <TFunctionName extends ClanWorldFunctionName>(
+      fn: TFunctionName,
+    ) => ({
+      address,
+      abi: iClanWorldAbi,
+      ["functionName"]: fn,
+      blockNumber: pinnedBlockNumber,
+    });
 
     const [worldRaw, market, bandit] = await Promise.all([
+      client.readContract(readArgs(GET_WORLD_SNAPSHOT)).catch(() => undefined),
+      client.readContract(readArgs(GET_MARKET_STATE)).catch(() => undefined),
       client
-        .readContract({
-          address,
-          abi: iClanWorldAbi,
-          functionName: "getWorldSnapshot",
-          blockNumber: pinnedBlockNumber,
-        })
-        .catch(() => undefined),
-      client
-        .readContract({
-          address,
-          abi: iClanWorldAbi,
-          functionName: "getMarketState",
-          blockNumber: pinnedBlockNumber,
-        })
-        .catch(() => undefined),
-      client
-        .readContract({
-          address,
-          abi: iClanWorldAbi,
-          functionName: "getActiveBanditView",
-          blockNumber: pinnedBlockNumber,
-        })
+        .readContract(readArgs(GET_ACTIVE_BANDIT_VIEW))
         .catch(() => undefined),
     ]);
 
@@ -699,12 +704,7 @@ export const refreshSnapshot = internalAction({
     }
 
     const clanIdsRaw = await client
-      .readContract({
-        address,
-        abi: iClanWorldAbi,
-        functionName: "getClanIds",
-        blockNumber: pinnedBlockNumber,
-      })
+      .readContract(readArgs(GET_CLAN_IDS))
       .catch(() => undefined);
     const clanIds =
       Array.isArray(clanIdsRaw) && clanIdsRaw.length > 0
@@ -715,11 +715,8 @@ export const refreshSnapshot = internalAction({
       clanIds.map(async (clanId) => {
         return client
           .readContract({
-            address,
-            abi: iClanWorldAbi,
-            functionName: "getClanFullView",
+            ...readArgs(GET_CLAN_FULL_VIEW),
             args: [clanId],
-            blockNumber: pinnedBlockNumber,
           })
           .then((view: unknown) => bigintSafe(view) as Record<string, unknown>)
           .catch(() => undefined);

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -2773,6 +2773,37 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "event",
+    "name": "BlueprintTransferred",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "ClanColdShortage",
     "inputs": [
       {
@@ -2842,6 +2873,37 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "event",
+    "name": "ClanOwnershipTransferred",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "oldOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwnerNonce",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "ClanSettled",
     "inputs": [
       {
@@ -2852,6 +2914,81 @@ export const CLAN_WORLD_ABI = [
       },
       {
         "name": "settledToTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanColdDeath",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "csId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanKilledByBandit",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClansmanRevived",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "atTick",
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"
@@ -2917,56 +3054,6 @@ export const CLAN_WORLD_ABI = [
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ClansmanColdDeath",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "csId",
-        "type": "uint32",
-        "indexed": false,
-        "internalType": "uint32"
-      },
-      {
-        "name": "tick",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "ClansmanKilledByBandit",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "banditId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
       }
     ],
     "anonymous": false
@@ -3569,6 +3656,61 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "event",
+    "name": "ResourcesInjected",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "wood",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "fish",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "gold",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprint",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "atTick",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "ResourcesWithdrawn",
     "inputs": [
       {
@@ -3778,37 +3920,6 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "event",
-    "name": "ClanOwnershipTransferred",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "oldOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "newOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "newOwnerNonce",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
     "name": "VaultResourceTransferred",
     "inputs": [
       {
@@ -3984,28 +4095,41 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "event",
-    "name": "BlueprintTransferred",
+    "name": "WorldPaused",
     "inputs": [
       {
-        "name": "fromClanId",
-        "type": "uint32",
+        "name": "tick",
+        "type": "uint64",
         "indexed": true,
-        "internalType": "uint32"
+        "internalType": "uint64"
       },
       {
-        "name": "toClanId",
-        "type": "uint32",
-        "indexed": true,
-        "internalType": "uint32"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
+        "name": "pausedAtTs",
+        "type": "uint64",
         "indexed": false,
-        "internalType": "uint256"
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WorldUnpaused",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
       },
       {
-        "name": "atTick",
+        "name": "durationSeconds",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "nextHeartbeatAtTs",
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -130,257 +130,54 @@ export const baseSepolia = defineChain({
 export const CLAN_WORLD_ABI = [
   {
     "type": "function",
-    "name": "heartbeat",
+    "name": "finalizeSeason",
     "inputs": [],
     "outputs": [],
     "stateMutability": "nonpayable"
   },
   {
     "type": "function",
-    "name": "getWorldState",
+    "name": "getActionDuration",
+    "inputs": [
+      {
+        "name": "action",
+        "type": "uint8",
+        "internalType": "enum ActionType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getActiveBanditView",
     "inputs": [],
     "outputs": [
       {
         "name": "",
         "type": "tuple",
-        "internalType": "struct WorldState",
+        "internalType": "struct ActiveBanditView",
         "components": [
           {
-            "name": "currentTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonStartTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonEndTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonFinalized",
+            "name": "exists",
             "type": "bool",
             "internalType": "bool"
           },
           {
-            "name": "currentSeasonNumber",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "nextHeartbeatAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "nextHeartbeatAtTs",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "nextBanditSpawnEligibleTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "currentBanditSpawnChanceBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "currentTickSeed",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "activeBanditId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "winterActive",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "winterStartsAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "winterEndsAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "nextCommitSequence",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "worldPaused",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "pausedAtTs",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getClan",
-    "inputs": [
-      {
-        "name": "clanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Clan",
-        "components": [
-          {
-            "name": "clanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "iftTokenId",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "owner",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "clanState",
-            "type": "uint8",
-            "internalType": "enum ClanState"
-          },
-          {
-            "name": "baseRegion",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "baseLevel",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "wallLevel",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "monumentLevel",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "livingClansmen",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "lastSettledTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "starvationStartsAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "coldDamage",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "ownerNonce",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "goldBalance",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "blueprintBalance",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "vaultWood",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "vaultIron",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "vaultWheat",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "vaultFish",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getClansman",
-    "inputs": [
-      {
-        "name": "clansmanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct Clansman",
-        "components": [
-          {
-            "name": "clansmanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "clanId",
+            "name": "banditId",
             "type": "uint32",
             "internalType": "uint32"
           },
           {
             "name": "state",
             "type": "uint8",
-            "internalType": "enum ClansmanState"
+            "internalType": "enum BanditState"
           },
           {
             "name": "currentRegion",
@@ -388,14 +185,34 @@ export const CLAN_WORLD_ABI = [
             "internalType": "uint8"
           },
           {
-            "name": "cooldownEndsAtTs",
+            "name": "attackAttemptsMade",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "maxAttemptsRemaining",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "stateEnteredTick",
             "type": "uint64",
             "internalType": "uint64"
           },
           {
-            "name": "lastMissionNonce",
+            "name": "nextActionTick",
             "type": "uint64",
             "internalType": "uint64"
+          },
+          {
+            "name": "tier",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackPower",
+            "type": "uint16",
+            "internalType": "uint16"
           },
           {
             "name": "carryWood",
@@ -416,8 +233,37 @@ export const CLAN_WORLD_ABI = [
             "name": "carryFish",
             "type": "uint256",
             "internalType": "uint256"
+          },
+          {
+            "name": "projectedTargetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "projectedTargetLootValue",
+            "type": "uint256",
+            "internalType": "uint256"
           }
         ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getActiveDefenders",
+    "inputs": [
+      {
+        "name": "targetClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clansmanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
       }
     ],
     "stateMutability": "view"
@@ -562,6 +408,130 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "function",
+    "name": "getBandit",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct BanditTroop",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "region",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum BanditState"
+          },
+          {
+            "name": "targetClanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "tickEnteredState",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "strength",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "tier",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "attackAttemptsMade",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryGold",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBanditsInRegion",
+    "inputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBanditTargetPreview",
+    "inputs": [
+      {
+        "name": "banditId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "previewClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getBanditTroop",
     "inputs": [
       {
@@ -648,73 +618,36 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "function",
-    "name": "getScheduledMarketActionsForTick",
+    "name": "getBaseUpgradeCost",
     "inputs": [
       {
-        "name": "tick",
-        "type": "uint64",
-        "internalType": "uint64"
+        "name": "currentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
       }
     ],
     "outputs": [
       {
-        "name": "",
-        "type": "tuple[]",
-        "internalType": "struct ScheduledMarketAction[]",
-        "components": [
-          {
-            "name": "executeAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "commitSequence",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "missionNonce",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "clanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "clansmanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "action",
-            "type": "uint8",
-            "internalType": "enum ActionType"
-          },
-          {
-            "name": "marketToken",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "marketAmount",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "maxGoldIn",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
-    "stateMutability": "view"
+    "stateMutability": "pure"
   },
   {
     "type": "function",
-    "name": "getDerivedClanState",
+    "name": "getClan",
     "inputs": [
       {
         "name": "clanId",
@@ -726,124 +659,102 @@ export const CLAN_WORLD_ABI = [
       {
         "name": "",
         "type": "tuple",
-        "internalType": "struct DerivedClanState",
+        "internalType": "struct Clan",
         "components": [
           {
-            "name": "clan",
-            "type": "tuple",
-            "internalType": "struct Clan",
-            "components": [
-              {
-                "name": "clanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "iftTokenId",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "owner",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "clanState",
-                "type": "uint8",
-                "internalType": "enum ClanState"
-              },
-              {
-                "name": "baseRegion",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "baseLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "wallLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "monumentLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "livingClansmen",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "lastSettledTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "starvationStartsAtTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "coldDamage",
-                "type": "uint16",
-                "internalType": "uint16"
-              },
-              {
-                "name": "ownerNonce",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "goldBalance",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "blueprintBalance",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "vaultWood",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "vaultIron",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "vaultWheat",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "vaultFish",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
           },
           {
-            "name": "isStarving",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "lootValue",
+            "name": "iftTokenId",
             "type": "uint256",
             "internalType": "uint256"
           },
           {
-            "name": "derivedAtTick",
+            "name": "owner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "clanState",
+            "type": "uint8",
+            "internalType": "enum ClanState"
+          },
+          {
+            "name": "baseRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "baseLevel",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "wallLevel",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "monumentLevel",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "livingClansmen",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "lastSettledTick",
             "type": "uint64",
             "internalType": "uint64"
+          },
+          {
+            "name": "starvationStartsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "coldDamage",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "ownerNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "goldBalance",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "blueprintBalance",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vaultFish",
+            "type": "uint256",
+            "internalType": "uint256"
           }
         ]
       }
@@ -852,339 +763,19 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "function",
-    "name": "getDerivedClansmanState",
+    "name": "getClanClansmanIds",
     "inputs": [
       {
-        "name": "clansmanId",
+        "name": "clanId",
         "type": "uint32",
         "internalType": "uint32"
       }
     ],
     "outputs": [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct DerivedClansmanState",
-        "components": [
-          {
-            "name": "clansman",
-            "type": "tuple",
-            "internalType": "struct Clansman",
-            "components": [
-              {
-                "name": "clansmanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "clanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "state",
-                "type": "uint8",
-                "internalType": "enum ClansmanState"
-              },
-              {
-                "name": "currentRegion",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "cooldownEndsAtTs",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "lastMissionNonce",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "carryWood",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "carryIron",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "carryWheat",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "carryFish",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          },
-          {
-            "name": "activeMission",
-            "type": "tuple",
-            "internalType": "struct Mission",
-            "components": [
-              {
-                "name": "active",
-                "type": "bool",
-                "internalType": "bool"
-              },
-              {
-                "name": "nonce",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "submittedAtTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "executesAtTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "settlesAtTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "clansmanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "startRegion",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "targetRegion",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "action",
-                "type": "uint8",
-                "internalType": "enum ActionType"
-              },
-              {
-                "name": "startTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "arrivalTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "actionStartTick",
-                "type": "uint64",
-                "internalType": "uint64"
-              },
-              {
-                "name": "missionSeed",
-                "type": "bytes32",
-                "internalType": "bytes32"
-              },
-              {
-                "name": "marketMode",
-                "type": "uint8",
-                "internalType": "enum MarketExecutionMode"
-              },
-              {
-                "name": "targetClanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "marketToken",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "marketAmount",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "maxGoldIn",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "withdrawResources",
-                "type": "tuple",
-                "internalType": "struct WithdrawResourcesData",
-                "components": [
-                  {
-                    "name": "wood",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "iron",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "wheat",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  },
-                  {
-                    "name": "fish",
-                    "type": "uint256",
-                    "internalType": "uint256"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "name": "effectiveRegion",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "derivedAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          }
-        ]
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "getWorldSnapshot",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct WorldSnapshot",
-        "components": [
-          {
-            "name": "currentTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonStartTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonEndTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "seasonFinalized",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "currentSeasonNumber",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "nextHeartbeatAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "worldPaused",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "pausedAtTs",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "winterActive",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "winterStartsAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "winterEndsAtTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "activeBanditId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "currentTickSeed",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "leaderboard",
-            "type": "tuple[]",
-            "internalType": "struct LeaderboardEntry[]",
-            "components": [
-              {
-                "name": "clanId",
-                "type": "uint32",
-                "internalType": "uint32"
-              },
-              {
-                "name": "owner",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "monumentLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "baseLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "wallLevel",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "livingClansmen",
-                "type": "uint8",
-                "internalType": "uint8"
-              },
-              {
-                "name": "state",
-                "type": "uint8",
-                "internalType": "enum ClanState"
-              },
-              {
-                "name": "lootValue",
-                "type": "uint256",
-                "internalType": "uint256"
-              }
-            ]
-          }
-        ]
+        "name": "clansmanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
       }
     ],
     "stateMutability": "view"
@@ -1729,6 +1320,507 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "function",
+    "name": "getClanIds",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "clanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClanScore",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "score",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "monumentReachedAtTick",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "monumentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClansman",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct Clansman",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum ClansmanState"
+          },
+          {
+            "name": "currentRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "cooldownEndsAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "lastMissionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "carryWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "carryFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClansmanDefendingRegion",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDefendingClans",
+    "inputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clanIds",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDerivedClansmanState",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DerivedClansmanState",
+        "components": [
+          {
+            "name": "clansman",
+            "type": "tuple",
+            "internalType": "struct Clansman",
+            "components": [
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum ClansmanState"
+              },
+              {
+                "name": "currentRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "cooldownEndsAtTs",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "lastMissionNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "carryWood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryIron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "carryFish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "activeMission",
+            "type": "tuple",
+            "internalType": "struct Mission",
+            "components": [
+              {
+                "name": "active",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "nonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "submittedAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "executesAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "settlesAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "clansmanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "startRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "targetRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "action",
+                "type": "uint8",
+                "internalType": "enum ActionType"
+              },
+              {
+                "name": "startTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "arrivalTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "actionStartTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "missionSeed",
+                "type": "bytes32",
+                "internalType": "bytes32"
+              },
+              {
+                "name": "marketMode",
+                "type": "uint8",
+                "internalType": "enum MarketExecutionMode"
+              },
+              {
+                "name": "targetClanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "marketToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "marketAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxGoldIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "withdrawResources",
+                "type": "tuple",
+                "internalType": "struct WithdrawResourcesData",
+                "components": [
+                  {
+                    "name": "wood",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "iron",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "wheat",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "fish",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "effectiveRegion",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "derivedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDerivedClanState",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DerivedClanState",
+        "components": [
+          {
+            "name": "clan",
+            "type": "tuple",
+            "internalType": "struct Clan",
+            "components": [
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "iftTokenId",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "clanState",
+                "type": "uint8",
+                "internalType": "enum ClanState"
+              },
+              {
+                "name": "baseRegion",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "baseLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "wallLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "monumentLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "livingClansmen",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "lastSettledTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "starvationStartsAtTick",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "coldDamage",
+                "type": "uint16",
+                "internalType": "uint16"
+              },
+              {
+                "name": "ownerNonce",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "goldBalance",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "blueprintBalance",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultWood",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultIron",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultWheat",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "vaultFish",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "isStarving",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "lootValue",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "derivedAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getMarketState",
     "inputs": [],
     "outputs": [
@@ -1961,151 +2053,61 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "function",
-    "name": "getActiveBanditView",
-    "inputs": [],
+    "name": "getMissionTiming",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
     "outputs": [
       {
-        "name": "",
-        "type": "tuple",
-        "internalType": "struct ActiveBanditView",
-        "components": [
-          {
-            "name": "exists",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "banditId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "state",
-            "type": "uint8",
-            "internalType": "enum BanditState"
-          },
-          {
-            "name": "currentRegion",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "attackAttemptsMade",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "maxAttemptsRemaining",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "stateEnteredTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "nextActionTick",
-            "type": "uint64",
-            "internalType": "uint64"
-          },
-          {
-            "name": "tier",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "attackPower",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "carryWood",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryIron",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryWheat",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "carryFish",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "projectedTargetClanId",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "projectedTargetLootValue",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
+        "name": "submitted",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "executes",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "settles",
+        "type": "uint64",
+        "internalType": "uint64"
       }
     ],
     "stateMutability": "view"
   },
   {
     "type": "function",
-    "name": "getWallUpgradeCost",
+    "name": "getMonumentLevelReachedAt",
     "inputs": [
       {
-        "name": "currentLevel",
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "level",
         "type": "uint8",
         "internalType": "uint8"
       }
     ],
     "outputs": [
       {
-        "name": "wood",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "iron",
-        "type": "uint256",
-        "internalType": "uint256"
+        "name": "reachedAtTick",
+        "type": "uint64",
+        "internalType": "uint64"
       }
     ],
-    "stateMutability": "pure"
-  },
-  {
-    "type": "function",
-    "name": "getBaseUpgradeCost",
-    "inputs": [
-      {
-        "name": "currentLevel",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "wood",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "iron",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
-      {
-        "name": "wheat",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "pure"
+    "stateMutability": "view"
   },
   {
     "type": "function",
@@ -2143,29 +2145,43 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "function",
-    "name": "getClanScore",
+    "name": "getPool",
     "inputs": [
       {
-        "name": "clanId",
-        "type": "uint32",
-        "internalType": "uint32"
+        "name": "resourceType",
+        "type": "uint8",
+        "internalType": "uint8"
       }
     ],
     "outputs": [
       {
-        "name": "score",
-        "type": "uint256",
-        "internalType": "uint256"
-      },
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPrice",
+    "inputs": [
       {
-        "name": "monumentReachedAtTick",
-        "type": "uint64",
-        "internalType": "uint64"
-      },
-      {
-        "name": "monumentLevel",
+        "name": "resourceType",
         "type": "uint8",
         "internalType": "uint8"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "stateMutability": "view"
@@ -2187,6 +2203,859 @@ export const CLAN_WORLD_ABI = [
       }
     ],
     "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRegionPopulation",
+    "inputs": [
+      {
+        "name": "region",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct RegionOccupant[]",
+        "components": [
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum ClansmanState"
+          },
+          {
+            "name": "currentAction",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "missionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getResourceToken",
+    "inputs": [
+      {
+        "name": "resourceType",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getScheduledMarketActionsForTick",
+    "inputs": [
+      {
+        "name": "tick",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct ScheduledMarketAction[]",
+        "components": [
+          {
+            "name": "executeAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "commitSequence",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "missionNonce",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "clanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "clansmanId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "action",
+            "type": "uint8",
+            "internalType": "enum ActionType"
+          },
+          {
+            "name": "marketToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "marketAmount",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxGoldIn",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTravelTicks",
+    "inputs": [
+      {
+        "name": "fromRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "toRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getTreasuryState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct TreasuryState",
+        "components": [
+          {
+            "name": "treasuryOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "prizePotGold",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "poolsSeeded",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "woodToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "wheatToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "fishToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "ironToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "goldToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "blueprintToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "woodGoldPool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "wheatGoldPool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "fishGoldPool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "ironGoldPool",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWallUpgradeCost",
+    "inputs": [
+      {
+        "name": "currentLevel",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getWheatPlots",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "west",
+        "type": "tuple",
+        "internalType": "struct WheatPlot",
+        "components": [
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum WheatPlotState"
+          },
+          {
+            "name": "region",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "remainingWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "regrowUntilTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "east",
+        "type": "tuple",
+        "internalType": "struct WheatPlot",
+        "components": [
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum WheatPlotState"
+          },
+          {
+            "name": "region",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "remainingWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "regrowUntilTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWorldSnapshot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct WorldSnapshot",
+        "components": [
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonStartTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonEndTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonFinalized",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "currentSeasonNumber",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextHeartbeatAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterActive",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "winterStartsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterEndsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "activeBanditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "currentTickSeed",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "leaderboard",
+            "type": "tuple[]",
+            "internalType": "struct LeaderboardEntry[]",
+            "components": [
+              {
+                "name": "clanId",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "monumentLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "baseLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "wallLevel",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "livingClansmen",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "state",
+                "type": "uint8",
+                "internalType": "enum ClanState"
+              },
+              {
+                "name": "lootValue",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWorldState",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct WorldState",
+        "components": [
+          {
+            "name": "currentTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonStartTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonEndTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "seasonFinalized",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "currentSeasonNumber",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextHeartbeatAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextHeartbeatAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextBanditSpawnEligibleTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "currentBanditSpawnChanceBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "currentTickSeed",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "activeBanditId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "winterActive",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "winterStartsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "winterEndsAtTick",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextCommitSequence",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "worldPaused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "pausedAtTs",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "heartbeat",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "initTreasury",
+    "inputs": [
+      {
+        "name": "tokens",
+        "type": "address[6]",
+        "internalType": "address[6]"
+      },
+      {
+        "name": "pools",
+        "type": "address[4]",
+        "internalType": "address[4]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "injectClanResources",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "wood",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "iron",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "wheat",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "fish",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "blueprint",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isWinter",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isWorldPaused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mintClan",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "iftTokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pauseWorld",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "quoteLootValueRaw",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lootValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteLootValueSettled",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lootValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteTravel",
+    "inputs": [
+      {
+        "name": "srcRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "dstRegion",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "travelTicks",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "path",
+        "type": "bytes8",
+        "internalType": "bytes8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "reviveClansman",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "reviveDeadClansmen",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "seedPools",
+    "inputs": [
+      {
+        "name": "cfg",
+        "type": "tuple",
+        "internalType": "struct PoolSeedConfig",
+        "components": [
+          {
+            "name": "woodSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "wheatSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "fishSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ironSeed",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForWood",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForWheat",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForFish",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "goldSeedForIron",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleClan",
+    "inputs": [
+      {
+        "name": "clanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleClansman",
+    "inputs": [
+      {
+        "name": "clansmanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
@@ -2305,57 +3174,6 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "function",
-    "name": "transferGold",
-    "inputs": [
-      {
-        "name": "fromClanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "toClanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "transferVaultResource",
-    "inputs": [
-      {
-        "name": "fromClanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "toClanId",
-        "type": "uint32",
-        "internalType": "uint32"
-      },
-      {
-        "name": "resource",
-        "type": "uint8",
-        "internalType": "enum ResourceType"
-      },
-      {
-        "name": "amount",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "transferBlueprint",
     "inputs": [
       {
@@ -2440,6 +3258,64 @@ export const CLAN_WORLD_ABI = [
         "internalType": "address"
       }
     ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferGold",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferVaultResource",
+    "inputs": [
+      {
+        "name": "fromClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "toClanId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "resource",
+        "type": "uint8",
+        "internalType": "enum ResourceType"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpauseWorld",
+    "inputs": [],
     "outputs": [],
     "stateMutability": "nonpayable"
   },

--- a/scripts/gen-chainclient-abi.mjs
+++ b/scripts/gen-chainclient-abi.mjs
@@ -39,55 +39,6 @@ const functionNames = [
   'transferClanOwnership',
 ];
 
-const eventNames = [
-  'BanditAttackResolved',
-  'BanditDefeated',
-  'BanditEscaped',
-  'BanditMoved',
-  'BanditSpawned',
-  'BanditStateChanged',
-  'BanditTargetDied',
-  'BaseLevelChanged',
-  'BlueprintAwarded',
-  'BlueprintEarned',
-  'ClanColdShortage',
-  'ClanDied',
-  'ClanEliminated',
-  'ClanSettled',
-  'ClanSpawned',
-  'ClanStarvationChanged',
-  'ClansmanColdDeath',
-  'ClansmanKilledByBandit',
-  'GoldTransferred',
-  'ImmediateMarketActionExecuted',
-  'LootDistributed',
-  'LootDistributedToDefender',
-  'MarketActionFailed',
-  'MissionAssigned',
-  'MissionCompleted',
-  'MissionInterrupted',
-  'MonumentLevelChanged',
-  'PoolsSeeded',
-  'ResourceBurned',
-  'ResourceMinted',
-  'ResourcesDeposited',
-  'ResourcesGathered',
-  'ResourcesWithdrawn',
-  'ScheduledMarketActionCommitted',
-  'ScheduledMarketActionExecuted',
-  'SeasonFinalized',
-  'TickAdvanced',
-  'ClanOwnershipTransferred',
-  'VaultResourceTransferred',
-  'WallDamagedByBandit',
-  'WallDegradedByCold',
-  'WallLevelChanged',
-  'WinterEnded',
-  'WinterStarted',
-  'WorkerArrived',
-  'BlueprintTransferred',
-];
-
 function readCanonicalAbi() {
   const parsed = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
   const abi = Array.isArray(parsed) ? parsed : parsed.abi;
@@ -95,6 +46,22 @@ function readCanonicalAbi() {
     throw new Error(`${artifactPath} must contain an ABI array or an "abi" array`);
   }
   return abi;
+}
+
+function eventNameSort(left, right) {
+  return left.localeCompare(right);
+}
+
+function readEventNames(abi) {
+  return abi
+    .filter((entry) => entry.type === 'event')
+    .map((entry) => {
+      if (typeof entry.name !== 'string' || entry.name.length === 0) {
+        throw new Error(`Found event without a name in ${artifactPath}`);
+      }
+      return entry.name;
+    })
+    .sort(eventNameSort);
 }
 
 function generatedBlock() {
@@ -106,6 +73,7 @@ function generatedBlock() {
     }
     return fragment;
   });
+  const eventNames = readEventNames(abi);
   const eventFragments = eventNames.map((name) => {
     const fragment = abi.find((entry) => entry.type === 'event' && entry.name === name);
     if (!fragment) {

--- a/scripts/gen-chainclient-abi.mjs
+++ b/scripts/gen-chainclient-abi.mjs
@@ -12,33 +12,6 @@ const targetPath = path.join(repoRoot, 'packages/shared/src/adapters/IChainClien
 const startMarker = '// BEGIN GENERATED CLAN_WORLD_ABI';
 const endMarker = '// END GENERATED CLAN_WORLD_ABI';
 
-const functionNames = [
-  'heartbeat',
-  'getWorldState',
-  'getClan',
-  'getClansman',
-  'getActiveMission',
-  'getBanditTroop',
-  'getScheduledMarketActionsForTick',
-  'getDerivedClanState',
-  'getDerivedClansmanState',
-  'getWorldSnapshot',
-  'getClanFullView',
-  'getMarketState',
-  'getActiveBanditView',
-  'getWallUpgradeCost',
-  'getBaseUpgradeCost',
-  'getMonumentUpgradeCost',
-  'getClanScore',
-  'getRankings',
-  'submitClanOrders',
-  'transferGold',
-  'transferVaultResource',
-  'transferBlueprint',
-  'transferBundle',
-  'transferClanOwnership',
-];
-
 function readCanonicalAbi() {
   const parsed = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
   const abi = Array.isArray(parsed) ? parsed : parsed.abi;
@@ -50,6 +23,18 @@ function readCanonicalAbi() {
 
 function eventNameSort(left, right) {
   return left.localeCompare(right);
+}
+
+function readFunctionNames(abi) {
+  return abi
+    .filter((entry) => entry.type === 'function')
+    .map((entry) => {
+      if (typeof entry.name !== 'string' || entry.name.length === 0) {
+        throw new Error(`Found function without a name in ${artifactPath}`);
+      }
+      return entry.name;
+    })
+    .sort(eventNameSort);
 }
 
 function readEventNames(abi) {
@@ -66,6 +51,7 @@ function readEventNames(abi) {
 
 function generatedBlock() {
   const abi = readCanonicalAbi();
+  const functionNames = readFunctionNames(abi);
   const functionFragments = functionNames.map((name) => {
     const fragment = abi.find((entry) => entry.type === 'function' && entry.name === name);
     if (!fragment) {


### PR DESCRIPTION
# v2.10 — Typechain completion

Closes the remaining 4 typechain drift findings from `docs/plans/typechain-and-generated-types-audit-v1.md`. After v2.9.0 shipped 9 of 13 fixes, this PR closes D-7, D-11, D-12 (the meta-bug), and D-13.

## Findings closed

| ID | Sev | Issue | PR | Scope |
|---|---|---|---|---|
| D-7 | MED | [#452](https://github.com/clan-world/clan-world-game/issues/452) | [#458](https://github.com/clan-world/clan-world-game/pull/458) | 5 raw `functionName` string literals in `apps/server/convex/indexer.ts` → typed `ContractFunctionName` inference (lens + main ABI) |
| D-11 | MED | [#453](https://github.com/clan-world/clan-world-game/issues/453) | [#457](https://github.com/clan-world/clan-world-game/pull/457) | Hand-rolled `SnapshotClan` in `apps/mobile/src/clanData.ts` → `Pick<Doc<"worldSnapshot">["clans"][number], ...>` |
| D-12 | MED (META) | [#454](https://github.com/clan-world/clan-world-game/issues/454) | [#459](https://github.com/clan-world/clan-world-game/pull/459) | Hand-maintained 45-entry `eventNames` in `scripts/gen-chainclient-abi.mjs` → derived from canonical ABI at generation time |
| D-13 | LOW | [#455](https://github.com/clan-world/clan-world-game/issues/455) | [#456](https://github.com/clan-world/clan-world-game/pull/456) | UI-layer `Whisper` in `apps/mobile/src/data.ts` kept hand-rolled (option b) with `WhisperFromConvex = Doc<"whispers">` alias for future reference |

## Real bug surfaced by the META fix (D-12)

The hand-rolled `eventNames` array had **46 entries**; the canonical ABI has **50 events**. The generated typed chainclient was **silently missing 4 events**:

- `ClansmanRevived` — admin recovery flow
- `ResourcesInjected` — admin resource injection
- `WorldPaused` — world pause control (added in v2.9.0 typechain migration)
- `WorldUnpaused` — world pause control (added in v2.9.0 typechain migration)

Downstream consumers using `eventNames` for event-log parsing would have silently dropped these. v2.10 includes them in the generated artifacts (committed alongside the generator change). No hand-rolled events were absent from the canonical ABI — the delta is one-direction (additions), no removals.

## Verification table

| Surface | Verification | Result |
|---|---|---|
| Server typecheck (D-7) | `pnpm --filter @clan-world/server typecheck` | ✓ clean |
| Server tests (D-7) | `pnpm --filter @clan-world/server test` | ✓ 53/53 pass |
| Mobile derived types (D-11/D-13) | grep + per-file typecheck | ✓ derives present, no casts |
| ChainClient ABI parity (D-12) | `pnpm test:chainclient-abi` + `pnpm test:abi-parity` | ✓ pass |
| Foundry contracts (D-12) | `pnpm exec turbo run test --env-mode=loose` | ✓ 500/500 pass |
| No new `as any` / `@ts-ignore` | per-PR diff grep | ✓ zero |
| CI on each sub-PR | Typechain CI + Contracts + ChainClient ABI Drift | ✓ all green |

## Branching shape (per ADR 0018)

```
feat/issue-452-* ┐
feat/issue-453-* ├─→ dev-typechain-completion ─→ dev ─→ main (v2.10 tag)
feat/issue-454-* ┤
feat/issue-455-* ┘
```

Sub-PRs each squash-merged into `dev-typechain-completion`. This PR collapses the integration branch into `dev`. The v2.10 release PR (`dev → main`) opens after super-swarm clean.

## Next steps after merge

1. Open `v2.10` release PR `dev → main` (Liam-only merge per ADR 0018)
2. Tag `v2.10` after Liam merges
3. Write v2.10 release notes (highlight D-12 META bug fix prominently)
