### PR TITLE
fix(web): EventTicker formatters for v2.10 newly-surfaced events (#463)

### DIFF
--- a/apps/web/src/EventTicker.test.ts
+++ b/apps/web/src/EventTicker.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+import { formatChainEvent, type ChainEventForTicker } from './EventTicker';
+
+const event = (input: ChainEventForTicker): ChainEventForTicker => input;
+
+test.describe('EventTicker chain event formatters', () => {
+  test('formats WorldPaused as a global event', () => {
+    const entry = formatChainEvent(event({
+      eventName: 'WorldPaused',
+      args: { tick: 12 },
+    }));
+
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toBe('World paused at tick 12');
+    expect(entry?.text).not.toContain('Clan');
+  });
+
+  test('formats WorldUnpaused as a global event', () => {
+    const entry = formatChainEvent(event({
+      eventName: 'WorldUnpaused',
+      args: {},
+      tick: 13,
+    }));
+
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toBe('World unpaused at tick 13');
+    expect(entry?.text).not.toContain('Clan');
+  });
+
+  test('formats ClansmanRevived with clan name and clansman id', () => {
+    const entry = formatChainEvent(event({
+      eventName: 'ClansmanRevived',
+      args: {},
+      clanId: 2,
+      clansmanId: 7,
+    }));
+
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toBe('Clan Iron Guard revived clansman #7');
+  });
+});

--- a/apps/web/src/EventTicker.tsx
+++ b/apps/web/src/EventTicker.tsx
@@ -4,7 +4,9 @@ import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { api } from '../../server/convex/_generated/api';
 import type { Doc } from '../../server/convex/_generated/dataModel';
 import { useAgentLogs } from './useAgentLogs';
-import { DEMO_MODE } from './config/env';
+import { ELDERS } from './styles/cockpit-tokens';
+
+const DEMO_MODE = import.meta.env?.VITE_CLANWORLD_DEMO_MODE === 'true';
 
 // --- Region + action label tables (mirrors WorldMap.tsx) ---
 
@@ -58,9 +60,14 @@ function slotColor(clanId: number): string {
   return CLAN_SLOT_COLORS[(clanId - 1) % CLAN_SLOT_COLORS.length] ?? '#cccccc';
 }
 
+function clanDisplayName(clanId: number): string {
+  return ELDERS.find((elder) => elder.clanId === clanId)?.name ?? String(clanId);
+}
+
 // ---- Chain event → ticker string -----------------------------------------------
 
 type ChainEvent = Doc<'chainEvents'>;
+export type ChainEventForTicker = Pick<ChainEvent, 'eventName' | 'args' | 'tick' | 'clanId' | 'clansmanId'>;
 
 function safeNum(v: unknown, fallback = 0): number {
   if (typeof v === 'number') return Number.isFinite(v) ? v : fallback;
@@ -84,11 +91,12 @@ function resourceAmount(v: unknown): string {
   return human.toFixed(2).replace(/0+$/, '').replace(/\\.$/, '');
 }
 
-function formatChainEvent(ev: ChainEvent): TickerEntry | null {
+export function formatChainEvent(ev: ChainEventForTicker): TickerEntry | null {
   const args = (ev.args ?? {}) as Record<string, unknown>;
   const clanId = ev.clanId ?? safeNum(args.clanId, 0);
   const clanLabel = clanId > 0 ? `Clan ${clanId}` : 'Unknown';
   const clanColor = clanId > 0 ? slotColor(clanId) : '#aaa';
+  const tick = ev.tick ?? safeNum(args.tick ?? args.atTick ?? args.openedTick, 0);
   const regionId = safeNum(args.region, 0) || safeNum(args.toRegion, 0);
   const regionName = REGION_NAMES[regionId] ?? `Region ${regionId}`;
 
@@ -173,6 +181,18 @@ function formatChainEvent(ev: ChainEvent): TickerEntry | null {
     }
     case 'ClansmanKilledByBandit':
       return { text: `${clanLabel} lost a clansman to bandits`, clanColor: '#b23a48' };
+    case 'ClansmanRevived': {
+      const clansmanId = ev.clansmanId ?? safeNum(args.clansmanId, 0);
+      return {
+        text: `Clan ${clanDisplayName(clanId)} revived clansman #${clansmanId}`,
+        clanColor,
+        highlight: true,
+      };
+    }
+    case 'WorldPaused':
+      return { text: `World paused at tick ${tick}`, clanColor: '#d4a24c', highlight: true };
+    case 'WorldUnpaused':
+      return { text: `World unpaused at tick ${tick}`, clanColor: '#d4a24c', highlight: true };
     case 'BlueprintEarned':
       return { text: `${clanLabel} earned a blueprint!`, clanColor: '#d4a24c', highlight: true };
     case 'BuildingUpgraded': {


### PR DESCRIPTION
Closes #463. Adds EventTicker formatters for the 3 chain events surfaced by v2.10 D-12 META that were previously formatting to null: `WorldPaused`, `WorldUnpaused` (global admin events), and `ClansmanRevived` (clan-attributed). Test fixtures mirror existing patterns. `ResourcesInjected` already has full vault projection so doesn't need ticker formatting beyond its existing path.