### PR TITLE
fix(server, shared): consolidate baseSepolia chain declaration

### DIFF
--- a/apps/server/convex/heartbeat.ts
+++ b/apps/server/convex/heartbeat.ts
@@ -5,8 +5,8 @@
 import { httpAction, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { iClanWorldAbi } from "@clan-world/contract-types";
+import { baseSepolia } from "@clan-world/shared/adapters";
 import {
-  defineChain,
   createPublicClient,
   http,
   parseEventLogs,
@@ -14,12 +14,6 @@ import {
   type Hex,
   type Log,
 } from "viem";
-const baseSepolia = defineChain({
-  id: 84532,
-  name: "Base Sepolia",
-  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-  rpcUrls: { default: { http: ["https://sepolia.base.org"] } },
-});
 
 const indexerApi = internal.indexer;
 

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -12,7 +12,6 @@ import {
 } from "@clan-world/contract-types";
 import type { IClanWorldAbiEventName } from "@clan-world/contract-types";
 import {
-  defineChain,
   createPublicClient,
   http,
   parseEventLogs,
@@ -22,15 +21,9 @@ import {
   type ParseEventLogsReturnType,
 } from "viem";
 import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constants";
+import { baseSepolia } from "@clan-world/shared/adapters";
 import type { Doc } from "./_generated/dataModel";
 import { resetLocked } from "./resetLock";
-
-const baseSepolia = defineChain({
-  id: 84532,
-  name: "Base Sepolia",
-  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-  rpcUrls: { default: { http: ["https://sepolia.base.org"] } },
-});
 
 const MAX_CLANS = 12;
 const RESOURCE_NAMES = ["wood", "wheat", "fish", "iron"] as const;


### PR DESCRIPTION
## Summary
- Import the shared `baseSepolia` chain config from `@clan-world/shared/adapters` in the Convex indexer and heartbeat webhook.
- Remove the two duplicate local `defineChain({ id: 84532, name: "Base Sepolia", ... })` declarations from `apps/server/convex`.

## Choice
Option A: keep the existing local shared export in `IChainClient.ts`. The three declarations matched on chain id, name, native currency, and default RPC URL, so consolidating to the existing shared declaration preserves runtime behavior without introducing a separate viem preset migration in this PR.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @clan-world/server typecheck 2>&1 | tail -10`
- `pnpm --filter @clan-world/server test`
- `grep -rn "defineChain\|baseSepolia" apps/server/convex packages/shared/src/adapters`

Closes #474