### PR TITLE
fix(contract-types): derive contracts list from abi-targets.mjs

### DIFF
--- a/packages/contract-types/index.ts
+++ b/packages/contract-types/index.ts
@@ -1,4 +1,7 @@
 export * from "./src/ClanAgentNFT.js";
 export * from "./src/IClanWorld.js";
 export * from "./src/IClanWorldLens.js";
+export * from "./src/IDiamondLoupe.js";
+export * from "./src/IDiamondCut.js";
+export * from "./src/OwnershipFacet.js";
 export * from "./src/eventNames.js";

--- a/packages/contract-types/scripts/generate.mjs
+++ b/packages/contract-types/scripts/generate.mjs
@@ -6,8 +6,9 @@
  * Check: node scripts/generate.mjs --check
  */
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { resolve, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { abiTargets } from '../../../scripts/abi-targets.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(__dirname, '..');
@@ -47,11 +48,18 @@ function generateFile(varName, abi) {
   return lines.join('\n');
 }
 
-const contracts = [
-  { abiFile: 'IClanWorld', varName: 'iClanWorldAbi', outFile: 'IClanWorld.ts' },
-  { abiFile: 'IClanWorldLens', varName: 'iClanWorldLensAbi', outFile: 'IClanWorldLens.ts' },
-  { abiFile: 'ClanAgentNFT', varName: 'clanAgentNftAbi', outFile: 'ClanAgentNFT.ts' },
-];
+function lowerFirst(value) {
+  return `${value.charAt(0).toLowerCase()}${value.slice(1)}`;
+}
+
+const contracts = abiTargets.map(({ targetPath }) => {
+  const abiFile = basename(targetPath, '.json');
+  return {
+    abiFile,
+    varName: `${lowerFirst(abiFile)}Abi`,
+    outFile: `${abiFile}.ts`,
+  };
+});
 
 for (const { abiFile, varName, outFile } of contracts) {
   const abi = readAbi(abiFile);

--- a/packages/contract-types/src/ClanAgentNFT.ts
+++ b/packages/contract-types/src/ClanAgentNFT.ts
@@ -1,5 +1,5 @@
 // @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
-export const clanAgentNftAbi = [
+export const clanAgentNFTAbi = [
   {
     "type": "constructor",
     "inputs": [
@@ -882,17 +882,17 @@ export const clanAgentNftAbi = [
   }
 ] as const;
 
-export type ClanAgentNftAbiType = typeof clanAgentNftAbi;
+export type ClanAgentNFTAbiType = typeof clanAgentNFTAbi;
 
 // Derived event name union
-export type ClanAgentNftAbiEventName = (typeof clanAgentNftAbi)[number] extends infer T
+export type ClanAgentNFTAbiEventName = (typeof clanAgentNFTAbi)[number] extends infer T
   ? T extends { type: 'event'; name: string }
     ? T['name']
     : never
   : never;
 
 // Derived function name union
-export type ClanAgentNftAbiFunctionName = (typeof clanAgentNftAbi)[number] extends infer T
+export type ClanAgentNFTAbiFunctionName = (typeof clanAgentNFTAbi)[number] extends infer T
   ? T extends { type: 'function'; name: string }
     ? T['name']
     : never

--- a/packages/contract-types/src/IDiamondCut.ts
+++ b/packages/contract-types/src/IDiamondCut.ts
@@ -1,0 +1,101 @@
+// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
+export const iDiamondCutAbi = [
+  {
+    "type": "function",
+    "name": "diamondCut",
+    "inputs": [
+      {
+        "name": "diamondCut_",
+        "type": "tuple[]",
+        "internalType": "struct IDiamondCut.FacetCut[]",
+        "components": [
+          {
+            "name": "facetAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "action",
+            "type": "uint8",
+            "internalType": "enum IDiamondCut.FacetCutAction"
+          },
+          {
+            "name": "functionSelectors",
+            "type": "bytes4[]",
+            "internalType": "bytes4[]"
+          }
+        ]
+      },
+      {
+        "name": "init",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "DiamondCut",
+    "inputs": [
+      {
+        "name": "diamondCut",
+        "type": "tuple[]",
+        "indexed": false,
+        "internalType": "struct IDiamondCut.FacetCut[]",
+        "components": [
+          {
+            "name": "facetAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "action",
+            "type": "uint8",
+            "internalType": "enum IDiamondCut.FacetCutAction"
+          },
+          {
+            "name": "functionSelectors",
+            "type": "bytes4[]",
+            "internalType": "bytes4[]"
+          }
+        ]
+      },
+      {
+        "name": "init",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  }
+] as const;
+
+export type IDiamondCutAbiType = typeof iDiamondCutAbi;
+
+// Derived event name union
+export type IDiamondCutAbiEventName = (typeof iDiamondCutAbi)[number] extends infer T
+  ? T extends { type: 'event'; name: string }
+    ? T['name']
+    : never
+  : never;
+
+// Derived function name union
+export type IDiamondCutAbiFunctionName = (typeof iDiamondCutAbi)[number] extends infer T
+  ? T extends { type: 'function'; name: string }
+    ? T['name']
+    : never
+  : never;

--- a/packages/contract-types/src/IDiamondLoupe.ts
+++ b/packages/contract-types/src/IDiamondLoupe.ts
@@ -1,0 +1,95 @@
+// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
+export const iDiamondLoupeAbi = [
+  {
+    "type": "function",
+    "name": "facetAddress",
+    "inputs": [
+      {
+        "name": "selector",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "facet",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "facetAddresses",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "facetAddresses_",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "facetFunctionSelectors",
+    "inputs": [
+      {
+        "name": "facet",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "selectors",
+        "type": "bytes4[]",
+        "internalType": "bytes4[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "facets",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "facets_",
+        "type": "tuple[]",
+        "internalType": "struct IDiamondLoupe.Facet[]",
+        "components": [
+          {
+            "name": "facetAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "functionSelectors",
+            "type": "bytes4[]",
+            "internalType": "bytes4[]"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  }
+] as const;
+
+export type IDiamondLoupeAbiType = typeof iDiamondLoupeAbi;
+
+// Derived event name union
+export type IDiamondLoupeAbiEventName = (typeof iDiamondLoupeAbi)[number] extends infer T
+  ? T extends { type: 'event'; name: string }
+    ? T['name']
+    : never
+  : never;
+
+// Derived function name union
+export type IDiamondLoupeAbiFunctionName = (typeof iDiamondLoupeAbi)[number] extends infer T
+  ? T extends { type: 'function'; name: string }
+    ? T['name']
+    : never
+  : never;

--- a/packages/contract-types/src/OwnershipFacet.ts
+++ b/packages/contract-types/src/OwnershipFacet.ts
@@ -1,0 +1,75 @@
+// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
+export const ownershipFacetAbi = [
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "DiamondNotOwner",
+    "inputs": [
+      {
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  }
+] as const;
+
+export type OwnershipFacetAbiType = typeof ownershipFacetAbi;
+
+// Derived event name union
+export type OwnershipFacetAbiEventName = (typeof ownershipFacetAbi)[number] extends infer T
+  ? T extends { type: 'event'; name: string }
+    ? T['name']
+    : never
+  : never;
+
+// Derived function name union
+export type OwnershipFacetAbiFunctionName = (typeof ownershipFacetAbi)[number] extends infer T
+  ? T extends { type: 'function'; name: string }
+    ? T['name']
+    : never
+  : never;


### PR DESCRIPTION
## Summary

- Derive `packages/contract-types` generation targets from canonical `scripts/abi-targets.mjs` instead of a hand-maintained local list.
- Regenerate typed ABI files for all current ABI targets.
- Export the new generated diamond/admin ABI modules from `@clan-world/contract-types`.

## Generated ABI Delta

New strict-superset files:

- `packages/contract-types/src/IDiamondLoupe.ts`
- `packages/contract-types/src/IDiamondCut.ts`
- `packages/contract-types/src/OwnershipFacet.ts`

No existing generated contract type files were removed.

Closes #468

## Validation

- `pnpm install --frozen-lockfile`
- `node packages/contract-types/scripts/generate.mjs`
- `node packages/contract-types/scripts/generate.mjs --check`
- `pnpm --filter @clan-world/contract-types typecheck`
- `pnpm test:chainclient-abi`
- `pnpm test:abi-parity`
- `pnpm --filter @clan-world/server typecheck`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/dev-ui typecheck`

Note: full `pnpm typecheck` is still blocked by existing `@clan-world/seeker` / mobile React JSX type incompatibilities unrelated to this change.
