### PR TITLE
fix(scripts, ci): derive enumNames + wire freshness checks

### DIFF
--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           version: stable
       - run: pnpm install --frozen-lockfile
+      - name: Check generated constants are current
+        run: pnpm gen:constants -- --check
+      - name: Check generated enums are current
+        run: pnpm gen:enums -- --check
       - name: Verify committed ABI JSON matches forge artifacts
         run: pnpm --filter @clan-world/contracts run check:abi
       # codegen:check reads the ABI JSON and exits non-zero if the committed

--- a/packages/shared/src/generated/enums.ts
+++ b/packages/shared/src/generated/enums.ts
@@ -2,6 +2,44 @@
 
 
 
+export const ClanState = {
+  ACTIVE: 0,
+  DEAD: 1,
+} as const;
+export type ClanState = (typeof ClanState)[keyof typeof ClanState];
+
+export const ClansmanState = {
+  WAITING: 0,
+  TRAVELING: 1,
+  ACTING: 2,
+  DEAD: 3,
+} as const;
+export type ClansmanState = (typeof ClansmanState)[keyof typeof ClansmanState];
+
+export const BanditState = {
+  None: 0,
+  Spawned: 1,
+  Camped: 2,
+  Attacking: 3,
+  Defeated: 4,
+} as const;
+export type BanditState = (typeof BanditState)[keyof typeof BanditState];
+
+export const WheatPlotState = {
+  Harvestable: 0,
+  Regrowing: 1,
+  WinterLocked: 2,
+} as const;
+export type WheatPlotState = (typeof WheatPlotState)[keyof typeof WheatPlotState];
+
+export const ResourceType = {
+  Wood: 0,
+  Iron: 1,
+  Wheat: 2,
+  Fish: 3,
+} as const;
+export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType];
+
 export const ActionType = {
   None: 0,
   ChopWood: 1,
@@ -20,6 +58,13 @@ export const ActionType = {
   WithdrawResources: 14,
 } as const;
 export type ActionType = (typeof ActionType)[keyof typeof ActionType];
+
+export const MarketExecutionMode = {
+  None: 0,
+  Immediate: 1,
+  Scheduled: 2,
+} as const;
+export type MarketExecutionMode = (typeof MarketExecutionMode)[keyof typeof MarketExecutionMode];
 
 export const StatusCode = {
   OK: 0,
@@ -56,49 +101,4 @@ export const StatusCode = {
   ERR_SLIPPAGE_REQUIRED: 31,
 } as const;
 export type StatusCode = (typeof StatusCode)[keyof typeof StatusCode];
-
-export const ResourceType = {
-  Wood: 0,
-  Iron: 1,
-  Wheat: 2,
-  Fish: 3,
-} as const;
-export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType];
-
-export const ClansmanState = {
-  WAITING: 0,
-  TRAVELING: 1,
-  ACTING: 2,
-  DEAD: 3,
-} as const;
-export type ClansmanState = (typeof ClansmanState)[keyof typeof ClansmanState];
-
-export const ClanState = {
-  ACTIVE: 0,
-  DEAD: 1,
-} as const;
-export type ClanState = (typeof ClanState)[keyof typeof ClanState];
-
-export const BanditState = {
-  None: 0,
-  Spawned: 1,
-  Camped: 2,
-  Attacking: 3,
-  Defeated: 4,
-} as const;
-export type BanditState = (typeof BanditState)[keyof typeof BanditState];
-
-export const WheatPlotState = {
-  Harvestable: 0,
-  Regrowing: 1,
-  WinterLocked: 2,
-} as const;
-export type WheatPlotState = (typeof WheatPlotState)[keyof typeof WheatPlotState];
-
-export const MarketExecutionMode = {
-  None: 0,
-  Immediate: 1,
-  Scheduled: 2,
-} as const;
-export type MarketExecutionMode = (typeof MarketExecutionMode)[keyof typeof MarketExecutionMode];
 

--- a/scripts/gen-enums.mjs
+++ b/scripts/gen-enums.mjs
@@ -9,7 +9,7 @@ const repoRoot = path.resolve(__dirname, '..');
 const sourcePath = path.join(repoRoot, 'packages/contracts/src/IClanWorld.sol');
 const targetPath = path.join(repoRoot, 'packages/shared/src/generated/enums.ts');
 
-const enumNames = [
+const expectedEnumNames = [
   'ActionType',
   'StatusCode',
   'ResourceType',
@@ -55,9 +55,16 @@ function renderEnum(name, values) {
 }
 
 function render(enums) {
-  const missing = enumNames.filter(name => !enums.has(name));
+  const enumNames = [...enums.keys()];
+  const missing = expectedEnumNames.filter(name => !enums.has(name));
   if (missing.length > 0) {
-    throw new Error(`Missing enum(s) in ${path.relative(repoRoot, sourcePath)}: ${missing.join(', ')}`);
+    console.warn(
+      `Expected enum(s) missing from ${path.relative(repoRoot, sourcePath)}: ${missing.join(', ')}`,
+    );
+  }
+
+  if (enumNames.length === 0) {
+    throw new Error(`No enums found in ${path.relative(repoRoot, sourcePath)}`);
   }
 
   return [


### PR DESCRIPTION
## Summary

- Derive generated enum ordering from parseEnums() by rendering every enum discovered in IClanWorld.sol.
- Keep the prior expected enum list as a warning-only sanity guard so missing known enums are surfaced without suppressing newly discovered enums.
- Add explicit CI freshness checks for `pnpm gen:constants -- --check` and `pnpm gen:enums -- --check`.

## Generated enums delta

- `pnpm gen:enums` changed `packages/shared/src/generated/enums.ts` ordering only: all 8 previously listed enums are still present, now emitted in Solidity source order (`ClanState`, `ClansmanState`, `BanditState`, `WheatPlotState`, `ResourceType`, `ActionType`, `MarketExecutionMode`, `StatusCode`).
- No expected enum disappeared, so the sanity warning did not fire.

Closes #469

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm gen:enums`
- `pnpm gen:constants -- --check`
- `pnpm gen:enums -- --check`
- `pnpm --filter @clan-world/shared run typecheck`
- `pnpm --filter @clan-world/shared run test`

## Known repo-wide blockers

- `pnpm typecheck` still fails in `@clan-world/seeker` with existing React JSX component type errors around `ConvexProvider`, `SafeAreaView`, `Svg`, `LinearGradient`, and `WebView`.
- `pnpm test` still fails in `@clan-world/mobile` because `CLAN_WORLD_MAP_URL` is required at Gradle build time.