### PR TITLE
fix(convex): factor v.object validators into shared schema constants

### DIFF
--- a/apps/server/convex/comms.ts
+++ b/apps/server/convex/comms.ts
@@ -1,6 +1,7 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import { requireIndexerSecret } from "./authShared";
+import { humanSteeringMessageInputFields, orchEventInputFields, whisperInputFields } from "./schema";
 
 /**
  * Combined Comms feed for one clan's AXL view.
@@ -84,11 +85,7 @@ export const getCombinedComms = query({
 export const sendWhisper = mutation({
   args: {
     secret: v.string(),
-    tick: v.number(),
-    fromClanId: v.number(),
-    toClanIds: v.array(v.number()),
-    body: v.string(),
-    msgId: v.optional(v.string()),
+    ...whisperInputFields,
   },
   handler: async (ctx, args) => {
     requireIndexerSecret(args.secret);
@@ -108,10 +105,7 @@ export const sendWhisper = mutation({
 export const seedOrchEvent = mutation({
   args: {
     secret: v.string(),
-    tick: v.number(),
-    kind: v.union(v.literal("world_event"), v.literal("directive"), v.literal("narration")),
-    body: v.string(),
-    targetClanId: v.optional(v.number()),
+    ...orchEventInputFields,
   },
   handler: async (ctx, args) => {
     requireIndexerSecret(args.secret);
@@ -123,12 +117,7 @@ export const seedOrchEvent = mutation({
 export const seedHumanSteering = mutation({
   args: {
     secret: v.string(),
-    tick: v.number(),
-    targetClanId: v.number(),
-    body: v.string(),
-    // Optional wallet/owner address of the sender — surfaced on the
-    // cockpit feed. Optional in the humanSteeringMessages table schema.
-    sentBy: v.optional(v.string()),
+    ...humanSteeringMessageInputFields,
   },
   handler: async (ctx, args) => {
     requireIndexerSecret(args.secret);

--- a/apps/server/convex/goldQuote.ts
+++ b/apps/server/convex/goldQuote.ts
@@ -1,6 +1,7 @@
 import { internalAction, internalMutation, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
+import { goldQuoteInputFields } from "./schema";
 
 const GOLD_TOKEN_MINT = "4kWysUHVqtFmxrvwPUxA66exm2iJBMkvD4EBRrNmcieL";
 const JUPITER_ASSET_SEARCH_URL =
@@ -154,18 +155,7 @@ export const refreshGoldQuote = internalAction({
 
 export const upsertGoldQuote = internalMutation({
   args: {
-    quote: v.object({
-      tokenMint: v.string(),
-      symbol: v.string(),
-      name: v.string(),
-      usdPrice: v.number(),
-      priceChange1h: v.optional(v.number()),
-      priceChange6h: v.optional(v.number()),
-      priceChange24h: v.optional(v.number()),
-      priceChange7d: v.optional(v.number()),
-      iconUrl: v.optional(v.string()),
-      sourceUpdatedAt: v.optional(v.string()),
-    }),
+    quote: v.object(goldQuoteInputFields),
     sparkline24h: v.optional(
       v.array(
         v.object({

--- a/apps/server/convex/kickstart.ts
+++ b/apps/server/convex/kickstart.ts
@@ -1,6 +1,7 @@
 import { action, internalAction, internalMutation, internalQuery, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { ConvexError, v } from "convex/values";
+import { kickstartTokenInputFields } from "./schema";
 
 const KICKSTART_HOME_URL = "https://kickstart.easya.io/api/home-launches";
 const PAGE_SIZE = 48;
@@ -265,40 +266,7 @@ export const listWatchedTokens = internalQuery({
   },
 });
 
-// Mirrors the on-disk `kickstartTokens` table validator in schema.ts. Defining
-// it here (and applying it as the mutation arg validator below) means we
-// reject malformed input at the boundary instead of relying on a
-// `as KickstartTokenInput[]` cast that v.any() previously waved through.
-const kickstartTokenInputValidator = v.object({
-  tokenMint: v.string(),
-  poolAddress: v.string(),
-  name: v.string(),
-  symbol: v.string(),
-  iconUrl: v.optional(v.string()),
-  usdPrice: v.number(),
-  mcap: v.number(),
-  liquidity: v.optional(v.number()),
-  volume24h: v.optional(v.number()),
-  priceChange1h: v.optional(v.number()),
-  priceChange6h: v.optional(v.number()),
-  priceChange24h: v.optional(v.number()),
-  priceChange7d: v.optional(v.number()),
-  rank: v.number(),
-  sourceUpdatedAt: v.optional(v.string()),
-  sparkline24h: v.optional(
-    v.array(
-      v.object({
-        price: v.number(),
-        open: v.optional(v.number()),
-        high: v.optional(v.number()),
-        low: v.optional(v.number()),
-        close: v.optional(v.number()),
-        volume: v.optional(v.number()),
-        observedAt: v.number(),
-      }),
-    ),
-  ),
-});
+const kickstartTokenInputValidator = v.object(kickstartTokenInputFields);
 
 export const replaceKickstartTokens = internalMutation({
   args: { tokens: v.array(kickstartTokenInputValidator) },

--- a/apps/server/convex/schema.ts
+++ b/apps/server/convex/schema.ts
@@ -1,6 +1,96 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
+export const goldQuoteInputFields = {
+  tokenMint: v.string(),
+  symbol: v.string(),
+  name: v.string(),
+  usdPrice: v.number(),
+  priceChange1h: v.optional(v.number()),
+  priceChange6h: v.optional(v.number()),
+  priceChange24h: v.optional(v.number()),
+  priceChange7d: v.optional(v.number()),
+  iconUrl: v.optional(v.string()),
+  sourceUpdatedAt: v.optional(v.string()),
+};
+
+export const goldQuoteFields = {
+  ...goldQuoteInputFields,
+  fetchedAt: v.number(),
+};
+
+export const kickstartTokenInputFields = {
+  tokenMint: v.string(),
+  poolAddress: v.string(),
+  name: v.string(),
+  symbol: v.string(),
+  iconUrl: v.optional(v.string()),
+  usdPrice: v.number(),
+  mcap: v.number(),
+  liquidity: v.optional(v.number()),
+  volume24h: v.optional(v.number()),
+  priceChange1h: v.optional(v.number()),
+  priceChange6h: v.optional(v.number()),
+  priceChange24h: v.optional(v.number()),
+  priceChange7d: v.optional(v.number()),
+  rank: v.number(),
+  sourceUpdatedAt: v.optional(v.string()),
+  sparkline24h: v.optional(
+    v.array(v.object({
+      price: v.number(),
+      open: v.optional(v.number()),
+      high: v.optional(v.number()),
+      low: v.optional(v.number()),
+      close: v.optional(v.number()),
+      volume: v.optional(v.number()),
+      observedAt: v.number(),
+    })),
+  ),
+};
+
+export const kickstartTokenFields = {
+  ...kickstartTokenInputFields,
+  fetchedAt: v.number(),
+};
+
+export const whisperInputFields = {
+  tick: v.number(),
+  fromClanId: v.number(),
+  toClanIds: v.array(v.number()),
+  body: v.string(),
+  msgId: v.optional(v.string()),
+};
+
+export const whisperFields = {
+  ...whisperInputFields,
+  timestamp: v.number(),
+};
+
+export const orchEventInputFields = {
+  tick: v.number(),
+  kind: v.union(v.literal("world_event"), v.literal("directive"), v.literal("narration")),
+  body: v.string(),
+  targetClanId: v.optional(v.number()),
+};
+
+export const orchEventFields = {
+  ...orchEventInputFields,
+  timestamp: v.number(),
+};
+
+export const humanSteeringMessageInputFields = {
+  tick: v.number(),
+  targetClanId: v.number(),
+  body: v.string(),
+  sentBy: v.optional(v.string()),
+};
+
+export const humanSteeringMessageFields = {
+  ...humanSteeringMessageInputFields,
+  txHash: v.optional(v.string()),
+  timestamp: v.number(),
+};
+
 export default defineSchema({
   worldSnapshot: defineTable({
     tick: v.number(),
@@ -172,19 +262,7 @@ export default defineSchema({
   })
     .index("by_tick", ["tick"])
     .index("by_resource_tick", ["resourceType", "tick"]),
-  goldQuote: defineTable({
-    tokenMint: v.string(),
-    symbol: v.string(),
-    name: v.string(),
-    usdPrice: v.number(),
-    priceChange1h: v.optional(v.number()),
-    priceChange6h: v.optional(v.number()),
-    priceChange24h: v.optional(v.number()),
-    priceChange7d: v.optional(v.number()),
-    iconUrl: v.optional(v.string()),
-    sourceUpdatedAt: v.optional(v.string()),
-    fetchedAt: v.number(),
-  }).index("by_token", ["tokenMint"]),
+  goldQuote: defineTable(goldQuoteFields).index("by_token", ["tokenMint"]),
   goldQuoteSample: defineTable({
     tokenMint: v.string(),
     usdPrice: v.number(),
@@ -200,35 +278,7 @@ export default defineSchema({
     memo: v.string(),
     observedAt: v.number(),
   }).index("by_signature", ["signature"]),
-  kickstartTokens: defineTable({
-    tokenMint: v.string(),
-    poolAddress: v.string(),
-    name: v.string(),
-    symbol: v.string(),
-    iconUrl: v.optional(v.string()),
-    usdPrice: v.number(),
-    mcap: v.number(),
-    liquidity: v.optional(v.number()),
-    volume24h: v.optional(v.number()),
-    priceChange1h: v.optional(v.number()),
-    priceChange6h: v.optional(v.number()),
-    priceChange24h: v.optional(v.number()),
-    priceChange7d: v.optional(v.number()),
-    rank: v.number(),
-    sourceUpdatedAt: v.optional(v.string()),
-    sparkline24h: v.optional(
-      v.array(v.object({
-        price: v.number(),
-        open: v.optional(v.number()),
-        high: v.optional(v.number()),
-        low: v.optional(v.number()),
-        close: v.optional(v.number()),
-        volume: v.optional(v.number()),
-        observedAt: v.number(),
-      })),
-    ),
-    fetchedAt: v.number(),
-  })
+  kickstartTokens: defineTable(kickstartTokenFields)
     .index("by_token", ["tokenMint"])
     .index("by_rank", ["rank"]),
   kickstartWatchedTokens: defineTable({
@@ -301,42 +351,18 @@ export default defineSchema({
   // "0G Bulletin" view + the cross-clan flyout.
 
   /** AXL direct whispers between clans. Recorded by elder CLI via Convex. */
-  whispers: defineTable({
-    tick: v.number(),
-    fromClanId: v.number(),
-    /** Recipient clan IDs. Whispers are point-to-point or broadcast. */
-    toClanIds: v.array(v.number()),
-    body: v.string(),
-    msgId: v.optional(v.string()),
-    timestamp: v.number(),
-  })
+  whispers: defineTable(whisperFields)
     .index("by_tick", ["tick"])
     .index("by_from_clan", ["fromClanId", "tick"])
     .index("by_from_clan_tick_msgid", ["fromClanId", "tick", "msgId"]),
 
   /** Orchestrator-emitted world events surfaced to the cockpit Comms tab. */
-  orchEvents: defineTable({
-    tick: v.number(),
-    /** Discriminator — narration of world state vs. directive issued to clans. */
-    kind: v.union(v.literal("world_event"), v.literal("directive"), v.literal("narration")),
-    body: v.string(),
-    /** When set, orchestrator targeted a specific clan; null = global broadcast. */
-    targetClanId: v.optional(v.number()),
-    timestamp: v.number(),
-  })
+  orchEvents: defineTable(orchEventFields)
     .index("by_tick", ["tick"])
     .index("by_target_clan", ["targetClanId", "tick"]),
 
   /** Human ("iNFT Owner") steering messages routed to a specific clan. */
-  humanSteeringMessages: defineTable({
-    tick: v.number(),
-    targetClanId: v.number(),
-    body: v.string(),
-    /** Wallet/owner address of the sender (when known). */
-    sentBy: v.optional(v.string()),
-    txHash: v.optional(v.string()),
-    timestamp: v.number(),
-  })
+  humanSteeringMessages: defineTable(humanSteeringMessageFields)
     .index("by_target_clan", ["targetClanId", "tick"])
     .index("by_tick", ["tick"]),
 });


### PR DESCRIPTION
## Summary

- exported shared Convex validator field constants from `schema.ts` for gold quotes, kickstart tokens, and comms rows
- reused those constants in `defineTable(...)` and the matching mutation arg validators
- kept server-populated/auth-only fields out of public mutation input while still centralizing the shared row fields

## Semantic differences kept intentional

- `goldQuote.fetchedAt` and `kickstartTokens.fetchedAt` remain table-only because the mutations set them server-side.
- comms `timestamp` fields remain table-only because the mutations set them with `Date.now()`.
- `secret` remains mutation-only for auth and is not part of any table row.
- `humanSteeringMessages.txHash` remains table-only/optional; the current seed mutation did not previously accept it, so this PR does not broaden the API.

Closes #472

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @clan-world/server typecheck`
- `pnpm --filter @clan-world/server test`
- `grep -n "v.object\|kickstartTokenFields\|goldQuoteFields\|whisperFields" apps/server/convex/{schema.ts,kickstart.ts,goldQuote.ts,comms.ts}`
