### PR TITLE
fix(web): derive ACTION_LABELS from generated ActionType enum

### DIFF
--- a/apps/web/src/EventTicker.tsx
+++ b/apps/web/src/EventTicker.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useEffect, useState } from 'react';
-import { BanditState } from '@clan-world/shared/generated/enums';
+import { ActionType, BanditState } from '@clan-world/shared/generated/enums';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { api } from '../../server/convex/_generated/api';
 import type { Doc } from '../../server/convex/_generated/dataModel';
@@ -28,22 +28,28 @@ const RESOURCE_NAMES: Record<number, string> = {
   3: 'fish',
 };
 
-const ACTION_LABELS: Record<number, string> = {
-  1: 'chop wood',
-  2: 'mine iron',
-  3: 'fish the docks',
-  4: 'fish the deep sea',
-  5: 'harvest wheat',
-  6: 'deposit resources',
-  7: 'upgrade wall',
-  8: 'upgrade base',
-  9: 'upgrade monument',
-  10: 'defend base',
-  11: 'buy at market',
-  12: 'sell at market',
-  13: 'wait',
-  14: 'withdraw resources',
+const ACTION_LABEL_BY_NAME: Record<string, string> = {
+  ChopWood: 'chop wood',
+  MineIron: 'mine iron',
+  FishDocks: 'fish the docks',
+  FishDeepSea: 'fish the deep sea',
+  HarvestWheat: 'harvest wheat',
+  DepositResources: 'deposit resources',
+  UpgradeWall: 'upgrade wall',
+  UpgradeBase: 'upgrade base',
+  UpgradeMonument: 'upgrade monument',
+  DefendBase: 'defend base',
+  MarketBuy: 'buy at market',
+  MarketSell: 'sell at market',
+  Wait: 'wait',
+  WithdrawResources: 'withdraw resources',
 };
+
+const ACTION_LABELS: Record<number, string> = Object.fromEntries(
+  Object.entries(ActionType)
+    .filter(([, value]) => typeof value === 'number' && value > 0)
+    .map(([name, value]) => [value, ACTION_LABEL_BY_NAME[name] ?? name]),
+);
 
 // Clan color palette — matches heraldic colors in spec §1.2 + WorldMap.tsx MOCK_CLANS
 const CLAN_COLORS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Derive `ACTION_LABELS` from generated `ActionType` enum entries instead of hand-keyed numeric indices.
- Preserve all 14 existing label strings exactly.
- Use explicit Option A name-to-label mapping so labels like `FishDocks` remain `fish the docks` instead of relying on auto-generated wording.

## Why
If Solidity inserts or reorders an `ActionType` enum member, generated enum values change. Keying labels from generated enum names prevents silent mid-list mis-labeling. Unknown positive enum entries fall back to their enum name so the ticker still renders.

Closes #475

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @clan-world/web typecheck 2>&1 | tail -10`
- `grep -n "ACTION_LABELS\|ActionType" apps/web/src/EventTicker.tsx`

## Notes
- Attempted targeted EventTicker Playwright run, but `apps/web/playwright.config.ts` discovers only `./tests/e2e`, so `apps/web/src/EventTicker.test.ts` is not picked up by that config. No action-label-specific test currently ran.