### PR TITLE
fix(web): apply D-11 Doc derivation pattern

### DIFF
--- a/apps/web/src/TopHud.tsx
+++ b/apps/web/src/TopHud.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { api } from '../../server/convex/_generated/api';
+import type { Doc } from '../../server/convex/_generated/dataModel';
+import { SEASON_DURATION_TICKS } from '@clan-world/shared/generated/constants';
 import { DEMO_MODE } from './config/env';
 
-// Season length in ticks — matches TICKS_PER_DAY_CYCLE * seasons (hardcoded to 360
-// as per spec until server exposes it). Used for progress bar.
-const TICKS_PER_SEASON = 360;
+const TICKS_PER_SEASON = Number(SEASON_DURATION_TICKS);
 
 // Demo bandit state mirrors WorldMap.tsx DEMO_BANDIT so both components agree.
 const DEMO_BANDIT_ATTACKS_AT_TICK = 48;
@@ -23,10 +23,7 @@ type TickCountdownAnchor = {
   durationMs: number;
 };
 
-type SnapshotBandit = {
-  state: number;
-  nextActionTick: number;
-};
+type SnapshotBandit = Pick<Doc<'banditView'>, 'state' | 'nextActionTick'>;
 
 function useBanditWarning(liveTick: number, bandit: SnapshotBandit | null): { active: boolean; ticksUntil: number } {
   const attackTick = DEMO_MODE ? DEMO_BANDIT_ATTACKS_AT_TICK : bandit?.nextActionTick;

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -12,6 +12,7 @@ import { MapGhostLayer } from './components/MapGhostLayer';
 import { VersionBadge } from './components/cockpit/VersionBadge';
 import { MAP_WIDTH, MAP_HEIGHT, LIVE_CLAN_REGION_BY_ID } from './components/mapGeometry';
 import { api } from '../../server/convex/_generated/api';
+import type { Doc } from '../../server/convex/_generated/dataModel';
 import worldMapBg from './assets/world-map.png';
 import worldMapWinterBg from './assets/world-map-winter.png';
 import { DEMO_MODE } from './config/env';
@@ -104,47 +105,41 @@ interface ClanDef {
   level?: number;
 }
 
-type SnapshotClan = {
-  id: string;
-  name: string;
-  treasury: string;
-  goldBalance?: string;
-  vaultWood?: string;
-  vaultIron?: string;
-  vaultWheat?: string;
-  vaultFish?: string;
-  baseRegion?: number;
-  baseLevel?: number;
-  wallLevel?: number;
-  monumentLevel?: number;
-  livingClansmen?: number;
-  owner?: string;
-  clansmen?: unknown[];
-};
+type WorldSnapshotClan = Doc<'worldSnapshot'>['clans'][number];
+type SnapshotClan = Pick<
+  WorldSnapshotClan,
+  | 'id'
+  | 'name'
+  | 'treasury'
+  | 'goldBalance'
+  | 'blueprintBalance'
+  | 'vaultWood'
+  | 'vaultIron'
+  | 'vaultWheat'
+  | 'vaultFish'
+  | 'baseRegion'
+  | 'baseLevel'
+  | 'wallLevel'
+  | 'monumentLevel'
+  | 'livingClansmen'
+  | 'owner'
+  | 'clansmen'
+>;
 
-type SnapshotBandit = {
-  id: number;
-  region: number;
-  state: number;
-  tier: number;
-  attackPower: number;
-  stateEnteredTick: number;
-  nextActionTick: number;
-  projectedTargetClanId: number;
-};
+type BanditViewDoc = Doc<'banditView'>;
+type SnapshotBandit = Pick<
+  BanditViewDoc,
+  | 'id'
+  | 'region'
+  | 'state'
+  | 'tier'
+  | 'attackPower'
+  | 'stateEnteredTick'
+  | 'nextActionTick'
+  | 'projectedTargetClanId'
+>;
 
-type ChainEvent = {
-  _id?: string;
-  txHash?: string;
-  logIndex?: number;
-  blockNumber?: number;
-  eventName: string;
-  tick?: number;
-  banditId?: number;
-  clanId?: number;
-  decodedAt?: number;
-  args: unknown;
-};
+type ChainEvent = Doc<'chainEvents'>;
 
 type LiveClansmanMarker = {
   key: string;
@@ -1339,7 +1334,7 @@ export function WorldMap() {
   // Grace period before showing the "no chain data yet" placeholder — see the
   // useEffect a few hooks below for the 5s debounce.
   const [showNoChainDataPlaceholder, setShowNoChainDataPlaceholder] = useState(false);
-  const rawChainEvents = useQuery(api.events.getRecentChainEvents) as ChainEvent[] | undefined;
+  const rawChainEvents = useQuery(api.events.getRecentChainEvents);
 
   // Derived live tick counter — the worldSnapshot.tick field is currently
   // unwritten by the orchestrator script (it only writes to agentLogs), so


### PR DESCRIPTION
## Summary
- derive WorldMap snapshot clan, bandit, and chain-event types from Convex `Doc<>` types
- derive TopHud bandit subset from `Doc<'banditView'>`
- use generated `SEASON_DURATION_TICKS` for `TICKS_PER_SEASON`

Closes #470

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @clan-world/web typecheck`
- `pnpm --filter @clan-world/web typecheck 2>&1 | tail -30`
- `pnpm --filter @clan-world/web test` exits 0; package has no `test` script, so this is a pnpm no-op
- `grep -n "type SnapshotClan\|type SnapshotBandit\|type ChainEvent\|TICKS_PER_SEASON" apps/web/src/WorldMap.tsx apps/web/src/TopHud.tsx`

## Notes
- `worldSnapshot` stores `activeBanditId`; the live bandit projection returned by `getSnapshot` is sourced from `banditView`, so the web bandit aliases use `Doc<'banditView'>`.
- Removed the `as ChainEvent[]` cast from `WorldMap.tsx` so the recent-events query keeps its inferred Convex type.