### PR TITLE
fix(shared, web): derive region tables from generated REGION_* constants

### DIFF
--- a/apps/orchestrator/src/main.ts
+++ b/apps/orchestrator/src/main.ts
@@ -1,5 +1,6 @@
-import { REGION_FOREST, type ClanOrder } from '@clan-world/shared';
+import { type ClanOrder } from '@clan-world/shared';
 import { createChainClient, createConvexClient } from '@clan-world/shared/adapters';
+import { REGION_FOREST } from '@clan-world/shared/generated/constants';
 import { ActionType } from '@clan-world/shared/generated/enums';
 
 const CLAN_ID = process.env.CLAN_ID || '1';
@@ -16,7 +17,7 @@ async function main(): Promise<void> {
   const orders: ClanOrder[] = [
     {
       kind: 'mission',
-      payload: { clansmanId: 1, gotoRegion: REGION_FOREST, action: ActionType.ChopWood },
+      payload: { clansmanId: 1, gotoRegion: Number(REGION_FOREST), action: ActionType.ChopWood },
     },
   ];
 

--- a/apps/web/src/EventTicker.tsx
+++ b/apps/web/src/EventTicker.tsx
@@ -1,4 +1,14 @@
 import { useMemo, useRef, useEffect, useState } from 'react';
+import {
+  REGION_DEEP_SEA,
+  REGION_EAST_DOCKS,
+  REGION_EAST_FARMS,
+  REGION_FOREST,
+  REGION_MOUNTAINS,
+  REGION_UNICORN_TOWN,
+  REGION_WEST_DOCKS,
+  REGION_WEST_FARMS,
+} from '@clan-world/shared/generated/constants';
 import { ActionType, BanditState } from '@clan-world/shared/generated/enums';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { api } from '../../server/convex/_generated/api';
@@ -11,14 +21,14 @@ const DEMO_MODE = import.meta.env?.VITE_CLANWORLD_DEMO_MODE === 'true';
 // --- Region + action label tables (mirrors WorldMap.tsx) ---
 
 const REGION_NAMES: Record<number, string> = {
-  1: 'Forest',
-  2: 'Mountains',
-  3: 'Unicorn Town',
-  4: 'West Farms',
-  5: 'East Farms',
-  6: 'West Docks',
-  7: 'East Docks',
-  8: 'Deep Sea',
+  [Number(REGION_FOREST)]: 'Forest',
+  [Number(REGION_MOUNTAINS)]: 'Mountains',
+  [Number(REGION_UNICORN_TOWN)]: 'Unicorn Town',
+  [Number(REGION_WEST_FARMS)]: 'West Farms',
+  [Number(REGION_EAST_FARMS)]: 'East Farms',
+  [Number(REGION_WEST_DOCKS)]: 'West Docks',
+  [Number(REGION_EAST_DOCKS)]: 'East Docks',
+  [Number(REGION_DEEP_SEA)]: 'Deep Sea',
 };
 
 const RESOURCE_NAMES: Record<number, string> = {

--- a/apps/web/src/components/mapGeometry.ts
+++ b/apps/web/src/components/mapGeometry.ts
@@ -8,6 +8,15 @@
  * constants without dragging the PixiJS bundle into its own chunk.
  */
 
+import {
+  REGION_EAST_DOCKS,
+  REGION_EAST_FARMS,
+  REGION_FOREST,
+  REGION_MOUNTAINS,
+  REGION_WEST_DOCKS,
+  REGION_WEST_FARMS,
+} from '@clan-world/shared/generated/constants';
+
 // ---------------------------------------------------------------------------
 // World dimensions
 // ---------------------------------------------------------------------------
@@ -37,12 +46,12 @@ export const REGION_CENTERS_BY_KEY: Readonly<Record<string, { nx: number; ny: nu
 // ---------------------------------------------------------------------------
 
 export const LIVE_CLAN_REGION_BY_ID: Readonly<Record<number, string>> = {
-  1: 'forest',
-  2: 'mountains',
-  4: 'west-farms',
-  5: 'east-farms',
-  6: 'west-docks',
-  7: 'east-docks',
+  [Number(REGION_FOREST)]: 'forest',
+  [Number(REGION_MOUNTAINS)]: 'mountains',
+  [Number(REGION_WEST_FARMS)]: 'west-farms',
+  [Number(REGION_EAST_FARMS)]: 'east-farms',
+  [Number(REGION_WEST_DOCKS)]: 'west-docks',
+  [Number(REGION_EAST_DOCKS)]: 'east-docks',
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -4,9 +4,6 @@
 
 export type Tick = number;
 
-/** Mirrors ClanWorldConstants.REGION_FOREST in packages/contracts/src/IClanWorld.sol. */
-export const REGION_FOREST = 1;
-
 export interface TickEpoch {
   /** Unix seconds when this tick window started. */
   startedAt: number;


### PR DESCRIPTION
Closes #473

## What changed
- Removed the legacy numeric `REGION_FOREST` export from `packages/shared/src/types.ts`.
- Updated orchestrator to import generated `REGION_FOREST` and cast with `Number(...)` at the mission payload use site.
- Derived web region lookup keys from generated `REGION_*` constants in `EventTicker.tsx` and `mapGeometry.ts`.

## Why
Generated contract constants are the canonical source for region IDs. This avoids hand-maintained duplicates drifting if Solidity region ordering changes.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/web typecheck`
- `pnpm --filter @clan-world/orchestrator typecheck`
- `pnpm --filter @clan-world/shared test`
- `grep -rn "REGION_FOREST\|REGION_NAMES\|LIVE_CLAN_REGION_BY_ID" packages/shared apps/web apps/orchestrator`

## Notes
- `pnpm typecheck 2>&1 | tail -20` is currently blocked by existing `@clan-world/seeker` / mobile JSX type errors around `WebView` and `LinearGradient`.
- Full `pnpm test` is currently blocked by mobile requiring `CLAN_WORLD_MAP_URL` at build time. Shared tests passed, and the affected workspaces typecheck clean.
