### PR TITLE
fix(server, web): consolidate resource names and gold constant

### DIFF
--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -21,7 +21,10 @@ import {
   type Log,
   type ParseEventLogsReturnType,
 } from "viem";
-import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constants";
+import {
+  HEARTBEAT_INTERVAL_SECONDS,
+  RESOURCE_GOLD,
+} from "@clan-world/shared/generated/constants";
 import type { Doc } from "./_generated/dataModel";
 import { resetLocked } from "./resetLock";
 
@@ -33,7 +36,9 @@ const baseSepolia = defineChain({
 });
 
 const MAX_CLANS = 12;
-const RESOURCE_NAMES = ["wood", "wheat", "fish", "iron"] as const;
+// MarketState struct fields are wood/wheat/fish/iron, which is distinct from
+// ResourceType enum order (wood/iron/wheat/fish) used by RESOURCE_NAMES_BY_ENUM.
+const MARKET_POOL_KEYS = ["wood", "wheat", "fish", "iron"] as const;
 const DEFAULT_CONFIRMATION_DEPTH = 5;
 // Alchemy free tier caps eth_getLogs at 10 blocks. PAYG allows 10K.
 // Default to 9n so we stay under the free-tier cap when running against
@@ -207,8 +212,8 @@ export function pricePointFromEvent(
   const resourceOut = asNumber(event.args.resourceOut, 0);
   const amountIn = BigInt(asString(event.args.amountIn, "0"));
   const amountOut = BigInt(asString(event.args.amountOut, "0"));
-  const goldResourceType = 4;
-  const isBuy = resourceIn === goldResourceType;
+  const goldResourceId = Number(RESOURCE_GOLD);
+  const isBuy = resourceIn === goldResourceId;
   const resourceType = isBuy ? resourceOut : resourceIn;
   const resourceAmount = isBuy ? amountOut : amountIn;
   const goldAmount = isBuy ? amountIn : amountOut;
@@ -487,7 +492,7 @@ export const commitSnapshot = internalMutation({
     if (snapshot.market) {
       const market = snapshot.market;
       await ctx.db.insert("marketState", {
-        pools: RESOURCE_NAMES.map((resourceType) => {
+        pools: MARKET_POOL_KEYS.map((resourceType) => {
           const pool = objectAt(market, resourceType);
           return {
             resourceType,

--- a/apps/server/convex/vault.ts
+++ b/apps/server/convex/vault.ts
@@ -4,6 +4,8 @@ import {
   isClanWorldEventName,
   type IClanWorldAbiEventName,
 } from "@clan-world/contract-types";
+import { RESOURCE_GOLD } from "@clan-world/shared/generated/constants";
+import { RESOURCE_NAMES_BY_ENUM } from "@clan-world/shared/utils/resources";
 
 /**
  * Vault movement feed for a single clan.
@@ -41,16 +43,13 @@ function whole(value: unknown): number {
   }
 }
 
-// Solidity ResourceType enum, mirrored from contracts. 0..3 = wood/iron/wheat/fish.
 // Market events use resource id 4 to mean gold (the quote asset). See
 // `packages/contracts/src/IClanWorld.sol` constant `RESOURCE_GOLD = 4` and
 // `apps/server/convex/indexer.ts::pricePointFromEvent` for the same convention.
-const RESOURCE_NAMES = ["wood", "iron", "wheat", "fish"] as const;
-const GOLD_RESOURCE_ID = 4;
 function resourceName(index: unknown): string {
   const i = Number(index);
-  if (Number.isFinite(i) && i === GOLD_RESOURCE_ID) return "gold";
-  if (Number.isFinite(i) && i >= 0 && i < RESOURCE_NAMES.length) return RESOURCE_NAMES[i] ?? "resource";
+  if (Number.isFinite(i) && i === Number(RESOURCE_GOLD)) return "gold";
+  if (Number.isFinite(i)) return RESOURCE_NAMES_BY_ENUM[i] ?? "resource";
   return "resource";
 }
 

--- a/apps/web/src/EventTicker.tsx
+++ b/apps/web/src/EventTicker.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useEffect, useState } from 'react';
 import { BanditState } from '@clan-world/shared/generated/enums';
+import { RESOURCE_NAMES_BY_ENUM } from '@clan-world/shared/utils/resources';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { api } from '../../server/convex/_generated/api';
 import type { Doc } from '../../server/convex/_generated/dataModel';
@@ -19,13 +20,6 @@ const REGION_NAMES: Record<number, string> = {
   6: 'West Docks',
   7: 'East Docks',
   8: 'Deep Sea',
-};
-
-const RESOURCE_NAMES: Record<number, string> = {
-  0: 'wood',
-  1: 'iron',
-  2: 'wheat',
-  3: 'fish',
 };
 
 const ACTION_LABELS: Record<number, string> = {
@@ -120,7 +114,7 @@ export function formatChainEvent(ev: ChainEventForTicker): TickerEntry | null {
       ['wood', 'iron', 'wheat', 'fish'].forEach((r, i) => {
         const key = `${r}Gained`;
         const amt = resourceAmount(args[key] ?? args[r]);
-        if (amt) parts.push(`${amt} ${RESOURCE_NAMES[i]}`);
+        if (amt) parts.push(`${amt} ${RESOURCE_NAMES_BY_ENUM[i]}`);
       });
       if (!parts.length) return null;
       return { text: `${clanLabel} gathered ${parts.join(', ')}`, clanColor };
@@ -131,7 +125,7 @@ export function formatChainEvent(ev: ChainEventForTicker): TickerEntry | null {
         const title = r.charAt(0).toUpperCase() + r.slice(1);
         const raw = args[`${r}Delta`] ?? args[r] ?? args[`amount${title}`];
         const amt = resourceAmount(raw);
-        if (amt) parts.push(`${amt} ${RESOURCE_NAMES[i]}`);
+        if (amt) parts.push(`${amt} ${RESOURCE_NAMES_BY_ENUM[i]}`);
       });
       if (!parts.length) return { text: `${clanLabel} deposited resources`, clanColor };
       return { text: `${clanLabel} deposited ${parts.join(', ')}`, clanColor };
@@ -143,8 +137,8 @@ export function formatChainEvent(ev: ChainEventForTicker): TickerEntry | null {
       const amtIn = safeNum(args.amountIn, 0);
       const amtOut = safeNum(args.amountOut, 0);
       if (resourceIn === -1 || resourceOut === -1) return null;
-      const inName = RESOURCE_NAMES[resourceIn] ?? `res${resourceIn}`;
-      const outName = RESOURCE_NAMES[resourceOut] ?? `res${resourceOut}`;
+      const inName = RESOURCE_NAMES_BY_ENUM[resourceIn] ?? `res${resourceIn}`;
+      const outName = RESOURCE_NAMES_BY_ENUM[resourceOut] ?? `res${resourceOut}`;
       return {
         text: `${clanLabel} traded ${amtIn} ${inName} → ${amtOut} ${outName} at Unicorn Town`,
         clanColor,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./adapters": "./src/adapters/index.ts",
-    "./generated/*": "./src/generated/*.ts"
+    "./generated/*": "./src/generated/*.ts",
+    "./utils/*": "./src/utils/*.ts"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types';
 export * from './utils/assertSafeInboxKey';
+export * from './utils/resources';
 export * as adapters from './adapters';
 export * from './mocks/clanWorldFixture';

--- a/packages/shared/src/utils/resources.ts
+++ b/packages/shared/src/utils/resources.ts
@@ -1,0 +1,7 @@
+import { ResourceType } from '../generated/enums';
+
+export const RESOURCE_NAMES_BY_ENUM: Record<number, string> = Object.fromEntries(
+  Object.entries(ResourceType)
+    .filter(([, value]) => typeof value === 'number')
+    .map(([key, value]) => [value as number, key.toLowerCase()]),
+) as Record<number, string>;


### PR DESCRIPTION
## Summary
- Add a shared `RESOURCE_NAMES_BY_ENUM` utility derived from the generated `ResourceType` enum.
- Use that shared enum lookup in the vault projection and EventTicker.
- Rename the indexer market snapshot array to `MARKET_POOL_KEYS` with a comment separating MarketState field order from ResourceType enum order.
- Replace hard-coded gold resource ids with `Number(RESOURCE_GOLD)`.

Closes #471

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/server typecheck`
- `pnpm --filter @clan-world/web typecheck`
- `pnpm --filter @clan-world/server test`
- `grep -rn "RESOURCE_NAMES\|GOLD_RESOURCE_ID\|goldResourceType\|RESOURCE_GOLD" apps/server/convex apps/web/src`