### PR TITLE
v2.11: typechain hardening — integration-seam audit findings (5 PRs)

### DIFF
--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           version: stable
       - run: pnpm install --frozen-lockfile
+      - name: Check generated constants are current
+        run: pnpm gen:constants -- --check
+      - name: Check generated enums are current
+        run: pnpm gen:enums -- --check
       - name: Verify committed ABI JSON matches forge artifacts
         run: pnpm --filter @clan-world/contracts run check:abi
       # codegen:check reads the ABI JSON and exits non-zero if the committed

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -21,7 +21,10 @@ import {
   type Log,
   type ParseEventLogsReturnType,
 } from "viem";
-import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constants";
+import {
+  HEARTBEAT_INTERVAL_SECONDS,
+  RESOURCE_GOLD,
+} from "@clan-world/shared/generated/constants";
 import type { Doc } from "./_generated/dataModel";
 import { resetLocked } from "./resetLock";
 
@@ -33,7 +36,9 @@ const baseSepolia = defineChain({
 });
 
 const MAX_CLANS = 12;
-const RESOURCE_NAMES = ["wood", "wheat", "fish", "iron"] as const;
+// MarketState struct fields are wood/wheat/fish/iron, which is distinct from
+// ResourceType enum order (wood/iron/wheat/fish) used by RESOURCE_NAMES_BY_ENUM.
+const MARKET_POOL_KEYS = ["wood", "wheat", "fish", "iron"] as const;
 const DEFAULT_CONFIRMATION_DEPTH = 5;
 // Alchemy free tier caps eth_getLogs at 10 blocks. PAYG allows 10K.
 // Default to 9n so we stay under the free-tier cap when running against
@@ -207,8 +212,8 @@ export function pricePointFromEvent(
   const resourceOut = asNumber(event.args.resourceOut, 0);
   const amountIn = BigInt(asString(event.args.amountIn, "0"));
   const amountOut = BigInt(asString(event.args.amountOut, "0"));
-  const goldResourceType = 4;
-  const isBuy = resourceIn === goldResourceType;
+  const goldResourceId = Number(RESOURCE_GOLD);
+  const isBuy = resourceIn === goldResourceId;
   const resourceType = isBuy ? resourceOut : resourceIn;
   const resourceAmount = isBuy ? amountOut : amountIn;
   const goldAmount = isBuy ? amountIn : amountOut;
@@ -487,7 +492,7 @@ export const commitSnapshot = internalMutation({
     if (snapshot.market) {
       const market = snapshot.market;
       await ctx.db.insert("marketState", {
-        pools: RESOURCE_NAMES.map((resourceType) => {
+        pools: MARKET_POOL_KEYS.map((resourceType) => {
           const pool = objectAt(market, resourceType);
           return {
             resourceType,

--- a/apps/server/convex/vault.ts
+++ b/apps/server/convex/vault.ts
@@ -4,6 +4,8 @@ import {
   isClanWorldEventName,
   type IClanWorldAbiEventName,
 } from "@clan-world/contract-types";
+import { RESOURCE_GOLD } from "@clan-world/shared/generated/constants";
+import { RESOURCE_NAMES_BY_ENUM } from "@clan-world/shared/utils/resources";
 
 /**
  * Vault movement feed for a single clan.
@@ -41,16 +43,13 @@ function whole(value: unknown): number {
   }
 }
 
-// Solidity ResourceType enum, mirrored from contracts. 0..3 = wood/iron/wheat/fish.
 // Market events use resource id 4 to mean gold (the quote asset). See
 // `packages/contracts/src/IClanWorld.sol` constant `RESOURCE_GOLD = 4` and
 // `apps/server/convex/indexer.ts::pricePointFromEvent` for the same convention.
-const RESOURCE_NAMES = ["wood", "iron", "wheat", "fish"] as const;
-const GOLD_RESOURCE_ID = 4;
 function resourceName(index: unknown): string {
   const i = Number(index);
-  if (Number.isFinite(i) && i === GOLD_RESOURCE_ID) return "gold";
-  if (Number.isFinite(i) && i >= 0 && i < RESOURCE_NAMES.length) return RESOURCE_NAMES[i] ?? "resource";
+  if (Number.isFinite(i) && i === Number(RESOURCE_GOLD)) return "gold";
+  if (Number.isFinite(i)) return RESOURCE_NAMES_BY_ENUM[i] ?? "resource";
   return "resource";
 }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "playwright": "playwright"
   },
   "dependencies": {
+    "@clan-world/contract-types": "workspace:*",
     "@clan-world/shared": "workspace:*",
     "convex": "1.17.4",
     "framer-motion": "^12.38.0",

--- a/apps/web/src/EventTicker.tsx
+++ b/apps/web/src/EventTicker.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useEffect, useState } from 'react';
 import { BanditState } from '@clan-world/shared/generated/enums';
+import { RESOURCE_NAMES_BY_ENUM } from '@clan-world/shared/utils/resources';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { api } from '../../server/convex/_generated/api';
 import type { Doc } from '../../server/convex/_generated/dataModel';
@@ -19,13 +20,6 @@ const REGION_NAMES: Record<number, string> = {
   6: 'West Docks',
   7: 'East Docks',
   8: 'Deep Sea',
-};
-
-const RESOURCE_NAMES: Record<number, string> = {
-  0: 'wood',
-  1: 'iron',
-  2: 'wheat',
-  3: 'fish',
 };
 
 const ACTION_LABELS: Record<number, string> = {
@@ -120,7 +114,7 @@ export function formatChainEvent(ev: ChainEventForTicker): TickerEntry | null {
       ['wood', 'iron', 'wheat', 'fish'].forEach((r, i) => {
         const key = `${r}Gained`;
         const amt = resourceAmount(args[key] ?? args[r]);
-        if (amt) parts.push(`${amt} ${RESOURCE_NAMES[i]}`);
+        if (amt) parts.push(`${amt} ${RESOURCE_NAMES_BY_ENUM[i]}`);
       });
       if (!parts.length) return null;
       return { text: `${clanLabel} gathered ${parts.join(', ')}`, clanColor };
@@ -131,7 +125,7 @@ export function formatChainEvent(ev: ChainEventForTicker): TickerEntry | null {
         const title = r.charAt(0).toUpperCase() + r.slice(1);
         const raw = args[`${r}Delta`] ?? args[r] ?? args[`amount${title}`];
         const amt = resourceAmount(raw);
-        if (amt) parts.push(`${amt} ${RESOURCE_NAMES[i]}`);
+        if (amt) parts.push(`${amt} ${RESOURCE_NAMES_BY_ENUM[i]}`);
       });
       if (!parts.length) return { text: `${clanLabel} deposited resources`, clanColor };
       return { text: `${clanLabel} deposited ${parts.join(', ')}`, clanColor };
@@ -143,8 +137,8 @@ export function formatChainEvent(ev: ChainEventForTicker): TickerEntry | null {
       const amtIn = safeNum(args.amountIn, 0);
       const amtOut = safeNum(args.amountOut, 0);
       if (resourceIn === -1 || resourceOut === -1) return null;
-      const inName = RESOURCE_NAMES[resourceIn] ?? `res${resourceIn}`;
-      const outName = RESOURCE_NAMES[resourceOut] ?? `res${resourceOut}`;
+      const inName = RESOURCE_NAMES_BY_ENUM[resourceIn] ?? `res${resourceIn}`;
+      const outName = RESOURCE_NAMES_BY_ENUM[resourceOut] ?? `res${resourceOut}`;
       return {
         text: `${clanLabel} traded ${amtIn} ${inName} → ${amtOut} ${outName} at Unicorn Town`,
         clanColor,

--- a/apps/web/src/TopHud.tsx
+++ b/apps/web/src/TopHud.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { api } from '../../server/convex/_generated/api';
+import type { Doc } from '../../server/convex/_generated/dataModel';
+import { SEASON_DURATION_TICKS } from '@clan-world/shared/generated/constants';
 import { DEMO_MODE } from './config/env';
 
-// Season length in ticks — matches TICKS_PER_DAY_CYCLE * seasons (hardcoded to 360
-// as per spec until server exposes it). Used for progress bar.
-const TICKS_PER_SEASON = 360;
+const TICKS_PER_SEASON = Number(SEASON_DURATION_TICKS);
 
 // Demo bandit state mirrors WorldMap.tsx DEMO_BANDIT so both components agree.
 const DEMO_BANDIT_ATTACKS_AT_TICK = 48;
@@ -23,10 +23,7 @@ type TickCountdownAnchor = {
   durationMs: number;
 };
 
-type SnapshotBandit = {
-  state: number;
-  nextActionTick: number;
-};
+type SnapshotBandit = Pick<Doc<'banditView'>, 'state' | 'nextActionTick'>;
 
 function useBanditWarning(liveTick: number, bandit: SnapshotBandit | null): { active: boolean; ticksUntil: number } {
   const attackTick = DEMO_MODE ? DEMO_BANDIT_ATTACKS_AT_TICK : bandit?.nextActionTick;

--- a/apps/web/src/WorldMap.tsx
+++ b/apps/web/src/WorldMap.tsx
@@ -12,6 +12,7 @@ import { MapGhostLayer } from './components/MapGhostLayer';
 import { VersionBadge } from './components/cockpit/VersionBadge';
 import { MAP_WIDTH, MAP_HEIGHT, LIVE_CLAN_REGION_BY_ID } from './components/mapGeometry';
 import { api } from '../../server/convex/_generated/api';
+import type { Doc } from '../../server/convex/_generated/dataModel';
 import worldMapBg from './assets/world-map.png';
 import worldMapWinterBg from './assets/world-map-winter.png';
 import { DEMO_MODE } from './config/env';
@@ -104,47 +105,41 @@ interface ClanDef {
   level?: number;
 }
 
-type SnapshotClan = {
-  id: string;
-  name: string;
-  treasury: string;
-  goldBalance?: string;
-  vaultWood?: string;
-  vaultIron?: string;
-  vaultWheat?: string;
-  vaultFish?: string;
-  baseRegion?: number;
-  baseLevel?: number;
-  wallLevel?: number;
-  monumentLevel?: number;
-  livingClansmen?: number;
-  owner?: string;
-  clansmen?: unknown[];
-};
+type WorldSnapshotClan = Doc<'worldSnapshot'>['clans'][number];
+type SnapshotClan = Pick<
+  WorldSnapshotClan,
+  | 'id'
+  | 'name'
+  | 'treasury'
+  | 'goldBalance'
+  | 'blueprintBalance'
+  | 'vaultWood'
+  | 'vaultIron'
+  | 'vaultWheat'
+  | 'vaultFish'
+  | 'baseRegion'
+  | 'baseLevel'
+  | 'wallLevel'
+  | 'monumentLevel'
+  | 'livingClansmen'
+  | 'owner'
+  | 'clansmen'
+>;
 
-type SnapshotBandit = {
-  id: number;
-  region: number;
-  state: number;
-  tier: number;
-  attackPower: number;
-  stateEnteredTick: number;
-  nextActionTick: number;
-  projectedTargetClanId: number;
-};
+type BanditViewDoc = Doc<'banditView'>;
+type SnapshotBandit = Pick<
+  BanditViewDoc,
+  | 'id'
+  | 'region'
+  | 'state'
+  | 'tier'
+  | 'attackPower'
+  | 'stateEnteredTick'
+  | 'nextActionTick'
+  | 'projectedTargetClanId'
+>;
 
-type ChainEvent = {
-  _id?: string;
-  txHash?: string;
-  logIndex?: number;
-  blockNumber?: number;
-  eventName: string;
-  tick?: number;
-  banditId?: number;
-  clanId?: number;
-  decodedAt?: number;
-  args: unknown;
-};
+type ChainEvent = Doc<'chainEvents'>;
 
 type LiveClansmanMarker = {
   key: string;
@@ -1339,7 +1334,7 @@ export function WorldMap() {
   // Grace period before showing the "no chain data yet" placeholder — see the
   // useEffect a few hooks below for the 5s debounce.
   const [showNoChainDataPlaceholder, setShowNoChainDataPlaceholder] = useState(false);
-  const rawChainEvents = useQuery(api.events.getRecentChainEvents) as ChainEvent[] | undefined;
+  const rawChainEvents = useQuery(api.events.getRecentChainEvents);
 
   // Derived live tick counter — the worldSnapshot.tick field is currently
   // unwritten by the orchestrator script (it only writes to agentLogs), so

--- a/apps/web/src/pages/OwnerEditor.tsx
+++ b/apps/web/src/pages/OwnerEditor.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
+import { clanAgentNftAbi } from '@clan-world/contract-types';
 import {
-  CLAN_AGENT_NFT_ABI,
   hashIntelligentData,
   type IntelligentDataEntry,
 } from '@clan-world/shared/adapters';
@@ -112,13 +112,13 @@ export function OwnerEditor() {
       const [tokenOwner, intelligentData] = await Promise.all([
         publicClient.readContract({
           address: OG_INFT_ADDRESS,
-          abi: CLAN_AGENT_NFT_ABI,
+          abi: clanAgentNftAbi,
           functionName: 'ownerOf',
           args: [tokenId],
         }),
         publicClient.readContract({
           address: OG_INFT_ADDRESS,
-          abi: CLAN_AGENT_NFT_ABI,
+          abi: clanAgentNftAbi,
           functionName: 'intelligentDataOf',
           args: [tokenId],
         }),
@@ -164,7 +164,7 @@ export function OwnerEditor() {
       const tx = await client.writeContract({
         account,
         address: OG_INFT_ADDRESS,
-        abi: CLAN_AGENT_NFT_ABI,
+        abi: clanAgentNftAbi,
         functionName: 'updateMetadata',
         args: [tokenId, nextData, proofHex(`metadata:${tokenId}:${notes}`)],
       });
@@ -201,7 +201,7 @@ export function OwnerEditor() {
       const tx = await client.writeContract({
         account,
         address: OG_INFT_ADDRESS,
-        abi: CLAN_AGENT_NFT_ABI,
+        abi: clanAgentNftAbi,
         functionName: 'iTransfer',
         args: [
           newOwner as Address,

--- a/apps/web/src/pages/OwnerEditor.tsx
+++ b/apps/web/src/pages/OwnerEditor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { clanAgentNftAbi } from '@clan-world/contract-types';
+import { clanAgentNFTAbi } from '@clan-world/contract-types';
 import {
   hashIntelligentData,
   type IntelligentDataEntry,
@@ -112,13 +112,13 @@ export function OwnerEditor() {
       const [tokenOwner, intelligentData] = await Promise.all([
         publicClient.readContract({
           address: OG_INFT_ADDRESS,
-          abi: clanAgentNftAbi,
+          abi: clanAgentNFTAbi,
           functionName: 'ownerOf',
           args: [tokenId],
         }),
         publicClient.readContract({
           address: OG_INFT_ADDRESS,
-          abi: clanAgentNftAbi,
+          abi: clanAgentNFTAbi,
           functionName: 'intelligentDataOf',
           args: [tokenId],
         }),
@@ -164,7 +164,7 @@ export function OwnerEditor() {
       const tx = await client.writeContract({
         account,
         address: OG_INFT_ADDRESS,
-        abi: clanAgentNftAbi,
+        abi: clanAgentNFTAbi,
         functionName: 'updateMetadata',
         args: [tokenId, nextData, proofHex(`metadata:${tokenId}:${notes}`)],
       });
@@ -201,7 +201,7 @@ export function OwnerEditor() {
       const tx = await client.writeContract({
         account,
         address: OG_INFT_ADDRESS,
-        abi: clanAgentNftAbi,
+        abi: clanAgentNFTAbi,
         functionName: 'iTransfer',
         args: [
           newOwner as Address,

--- a/packages/contract-types/index.ts
+++ b/packages/contract-types/index.ts
@@ -1,3 +1,4 @@
+export * from "./src/ClanAgentNFT.js";
 export * from "./src/IClanWorld.js";
 export * from "./src/IClanWorldLens.js";
 export * from "./src/eventNames.js";

--- a/packages/contract-types/index.ts
+++ b/packages/contract-types/index.ts
@@ -1,4 +1,7 @@
 export * from "./src/ClanAgentNFT.js";
 export * from "./src/IClanWorld.js";
 export * from "./src/IClanWorldLens.js";
+export * from "./src/IDiamondLoupe.js";
+export * from "./src/IDiamondCut.js";
+export * from "./src/OwnershipFacet.js";
 export * from "./src/eventNames.js";

--- a/packages/contract-types/scripts/generate.mjs
+++ b/packages/contract-types/scripts/generate.mjs
@@ -50,6 +50,7 @@ function generateFile(varName, abi) {
 const contracts = [
   { abiFile: 'IClanWorld', varName: 'iClanWorldAbi', outFile: 'IClanWorld.ts' },
   { abiFile: 'IClanWorldLens', varName: 'iClanWorldLensAbi', outFile: 'IClanWorldLens.ts' },
+  { abiFile: 'ClanAgentNFT', varName: 'clanAgentNftAbi', outFile: 'ClanAgentNFT.ts' },
 ];
 
 for (const { abiFile, varName, outFile } of contracts) {

--- a/packages/contract-types/scripts/generate.mjs
+++ b/packages/contract-types/scripts/generate.mjs
@@ -6,8 +6,9 @@
  * Check: node scripts/generate.mjs --check
  */
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { resolve, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { abiTargets } from '../../../scripts/abi-targets.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(__dirname, '..');
@@ -47,11 +48,18 @@ function generateFile(varName, abi) {
   return lines.join('\n');
 }
 
-const contracts = [
-  { abiFile: 'IClanWorld', varName: 'iClanWorldAbi', outFile: 'IClanWorld.ts' },
-  { abiFile: 'IClanWorldLens', varName: 'iClanWorldLensAbi', outFile: 'IClanWorldLens.ts' },
-  { abiFile: 'ClanAgentNFT', varName: 'clanAgentNftAbi', outFile: 'ClanAgentNFT.ts' },
-];
+function lowerFirst(value) {
+  return `${value.charAt(0).toLowerCase()}${value.slice(1)}`;
+}
+
+const contracts = abiTargets.map(({ targetPath }) => {
+  const abiFile = basename(targetPath, '.json');
+  return {
+    abiFile,
+    varName: `${lowerFirst(abiFile)}Abi`,
+    outFile: `${abiFile}.ts`,
+  };
+});
 
 for (const { abiFile, varName, outFile } of contracts) {
   const abi = readAbi(abiFile);

--- a/packages/contract-types/src/ClanAgentNFT.ts
+++ b/packages/contract-types/src/ClanAgentNFT.ts
@@ -1,0 +1,899 @@
+// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
+export const clanAgentNftAbi = [
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "name_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "symbol_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "verifier_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "authorizeUsage",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "tokenOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "currentDataHash",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "delegateAccess",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "delegate",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "delegatedAccess",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "encryptedKeyHash",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getApproved",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "iTransfer",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "newData",
+        "type": "tuple[]",
+        "internalType": "struct ClanAgentNFT.IntelligentData[]",
+        "components": [
+          {
+            "name": "label",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "dataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "uri",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      },
+      {
+        "name": "transferProof",
+        "type": "tuple",
+        "internalType": "struct ClanAgentNFT.TransferProof",
+        "components": [
+          {
+            "name": "newDataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "encryptedKeyHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "newUri",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "proof",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "intelligentDataOf",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct ClanAgentNFT.IntelligentData[]",
+        "components": [
+          {
+            "name": "label",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "dataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "uri",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isApprovedForAll",
+    "inputs": [
+      {
+        "name": "tokenOwner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mint",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "tuple[]",
+        "internalType": "struct ClanAgentNFT.IntelligentData[]",
+        "components": [
+          {
+            "name": "label",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "dataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "uri",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ownerOf",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "revokeAuthorization",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setApprovalForAll",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setVerifier",
+    "inputs": [
+      {
+        "name": "newVerifier",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateMetadata",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "tuple[]",
+        "internalType": "struct ClanAgentNFT.IntelligentData[]",
+        "components": [
+          {
+            "name": "label",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "dataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "uri",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      },
+      {
+        "name": "proof",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "usageAuthorizations",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "verifier",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IAgentTransferVerifier"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "AccessDelegated",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "delegate",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ApprovalForAll",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IntelligentDataItem",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "slot",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "label",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "dataHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "uri",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IntelligentDataUpdated",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "dataHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "uri",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IntelligentTransfer",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newDataHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "encryptedKeyHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "newUri",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UsageAuthorized",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UsageRevoked",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "VerifierUpdated",
+    "inputs": [
+      {
+        "name": "verifier",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "InvalidAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidData",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProof",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotApprovedOrOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TokenNotFound",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UnsafeRecipient",
+    "inputs": []
+  }
+] as const;
+
+export type ClanAgentNftAbiType = typeof clanAgentNftAbi;
+
+// Derived event name union
+export type ClanAgentNftAbiEventName = (typeof clanAgentNftAbi)[number] extends infer T
+  ? T extends { type: 'event'; name: string }
+    ? T['name']
+    : never
+  : never;
+
+// Derived function name union
+export type ClanAgentNftAbiFunctionName = (typeof clanAgentNftAbi)[number] extends infer T
+  ? T extends { type: 'function'; name: string }
+    ? T['name']
+    : never
+  : never;

--- a/packages/contract-types/src/ClanAgentNFT.ts
+++ b/packages/contract-types/src/ClanAgentNFT.ts
@@ -1,5 +1,5 @@
 // @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
-export const clanAgentNftAbi = [
+export const clanAgentNFTAbi = [
   {
     "type": "constructor",
     "inputs": [
@@ -882,17 +882,17 @@ export const clanAgentNftAbi = [
   }
 ] as const;
 
-export type ClanAgentNftAbiType = typeof clanAgentNftAbi;
+export type ClanAgentNFTAbiType = typeof clanAgentNFTAbi;
 
 // Derived event name union
-export type ClanAgentNftAbiEventName = (typeof clanAgentNftAbi)[number] extends infer T
+export type ClanAgentNFTAbiEventName = (typeof clanAgentNFTAbi)[number] extends infer T
   ? T extends { type: 'event'; name: string }
     ? T['name']
     : never
   : never;
 
 // Derived function name union
-export type ClanAgentNftAbiFunctionName = (typeof clanAgentNftAbi)[number] extends infer T
+export type ClanAgentNFTAbiFunctionName = (typeof clanAgentNFTAbi)[number] extends infer T
   ? T extends { type: 'function'; name: string }
     ? T['name']
     : never

--- a/packages/contract-types/src/IDiamondCut.ts
+++ b/packages/contract-types/src/IDiamondCut.ts
@@ -1,0 +1,101 @@
+// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
+export const iDiamondCutAbi = [
+  {
+    "type": "function",
+    "name": "diamondCut",
+    "inputs": [
+      {
+        "name": "diamondCut_",
+        "type": "tuple[]",
+        "internalType": "struct IDiamondCut.FacetCut[]",
+        "components": [
+          {
+            "name": "facetAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "action",
+            "type": "uint8",
+            "internalType": "enum IDiamondCut.FacetCutAction"
+          },
+          {
+            "name": "functionSelectors",
+            "type": "bytes4[]",
+            "internalType": "bytes4[]"
+          }
+        ]
+      },
+      {
+        "name": "init",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "DiamondCut",
+    "inputs": [
+      {
+        "name": "diamondCut",
+        "type": "tuple[]",
+        "indexed": false,
+        "internalType": "struct IDiamondCut.FacetCut[]",
+        "components": [
+          {
+            "name": "facetAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "action",
+            "type": "uint8",
+            "internalType": "enum IDiamondCut.FacetCutAction"
+          },
+          {
+            "name": "functionSelectors",
+            "type": "bytes4[]",
+            "internalType": "bytes4[]"
+          }
+        ]
+      },
+      {
+        "name": "init",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  }
+] as const;
+
+export type IDiamondCutAbiType = typeof iDiamondCutAbi;
+
+// Derived event name union
+export type IDiamondCutAbiEventName = (typeof iDiamondCutAbi)[number] extends infer T
+  ? T extends { type: 'event'; name: string }
+    ? T['name']
+    : never
+  : never;
+
+// Derived function name union
+export type IDiamondCutAbiFunctionName = (typeof iDiamondCutAbi)[number] extends infer T
+  ? T extends { type: 'function'; name: string }
+    ? T['name']
+    : never
+  : never;

--- a/packages/contract-types/src/IDiamondLoupe.ts
+++ b/packages/contract-types/src/IDiamondLoupe.ts
@@ -1,0 +1,95 @@
+// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
+export const iDiamondLoupeAbi = [
+  {
+    "type": "function",
+    "name": "facetAddress",
+    "inputs": [
+      {
+        "name": "selector",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "facet",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "facetAddresses",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "facetAddresses_",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "facetFunctionSelectors",
+    "inputs": [
+      {
+        "name": "facet",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "selectors",
+        "type": "bytes4[]",
+        "internalType": "bytes4[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "facets",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "facets_",
+        "type": "tuple[]",
+        "internalType": "struct IDiamondLoupe.Facet[]",
+        "components": [
+          {
+            "name": "facetAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "functionSelectors",
+            "type": "bytes4[]",
+            "internalType": "bytes4[]"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  }
+] as const;
+
+export type IDiamondLoupeAbiType = typeof iDiamondLoupeAbi;
+
+// Derived event name union
+export type IDiamondLoupeAbiEventName = (typeof iDiamondLoupeAbi)[number] extends infer T
+  ? T extends { type: 'event'; name: string }
+    ? T['name']
+    : never
+  : never;
+
+// Derived function name union
+export type IDiamondLoupeAbiFunctionName = (typeof iDiamondLoupeAbi)[number] extends infer T
+  ? T extends { type: 'function'; name: string }
+    ? T['name']
+    : never
+  : never;

--- a/packages/contract-types/src/OwnershipFacet.ts
+++ b/packages/contract-types/src/OwnershipFacet.ts
@@ -1,0 +1,75 @@
+// @generated — do not edit by hand. Run: pnpm --filter @clan-world/contract-types codegen
+export const ownershipFacetAbi = [
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "DiamondNotOwner",
+    "inputs": [
+      {
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  }
+] as const;
+
+export type OwnershipFacetAbiType = typeof ownershipFacetAbi;
+
+// Derived event name union
+export type OwnershipFacetAbiEventName = (typeof ownershipFacetAbi)[number] extends infer T
+  ? T extends { type: 'event'; name: string }
+    ? T['name']
+    : never
+  : never;
+
+// Derived function name union
+export type OwnershipFacetAbiFunctionName = (typeof ownershipFacetAbi)[number] extends infer T
+  ? T extends { type: 'function'; name: string }
+    ? T['name']
+    : never
+  : never;

--- a/packages/contracts/abi/ClanAgentNFT.json
+++ b/packages/contracts/abi/ClanAgentNFT.json
@@ -1,0 +1,884 @@
+{
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "name_",
+          "type": "string",
+          "internalType": "string"
+        },
+        {
+          "name": "symbol_",
+          "type": "string",
+          "internalType": "string"
+        },
+        {
+          "name": "verifier_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "approve",
+      "inputs": [
+        {
+          "name": "to",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "authorizeUsage",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "balanceOf",
+      "inputs": [
+        {
+          "name": "tokenOwner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "currentDataHash",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "delegateAccess",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "delegate",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "delegatedAccess",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "encryptedKeyHash",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getApproved",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "iTransfer",
+      "inputs": [
+        {
+          "name": "to",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "newData",
+          "type": "tuple[]",
+          "internalType": "struct ClanAgentNFT.IntelligentData[]",
+          "components": [
+            {
+              "name": "label",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "dataHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "uri",
+              "type": "string",
+              "internalType": "string"
+            }
+          ]
+        },
+        {
+          "name": "transferProof",
+          "type": "tuple",
+          "internalType": "struct ClanAgentNFT.TransferProof",
+          "components": [
+            {
+              "name": "newDataHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "encryptedKeyHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "newUri",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "proof",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "intelligentDataOf",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct ClanAgentNFT.IntelligentData[]",
+          "components": [
+            {
+              "name": "label",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "dataHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "uri",
+              "type": "string",
+              "internalType": "string"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "isApprovedForAll",
+      "inputs": [
+        {
+          "name": "tokenOwner",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "operator",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "mint",
+      "inputs": [
+        {
+          "name": "to",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "data",
+          "type": "tuple[]",
+          "internalType": "struct ClanAgentNFT.IntelligentData[]",
+          "components": [
+            {
+              "name": "label",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "dataHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "uri",
+              "type": "string",
+              "internalType": "string"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "name",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string",
+          "internalType": "string"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "owner",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ownerOf",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "revokeAuthorization",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "safeTransferFrom",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "to",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "safeTransferFrom",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "to",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "data",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setApprovalForAll",
+      "inputs": [
+        {
+          "name": "operator",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "approved",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setVerifier",
+      "inputs": [
+        {
+          "name": "newVerifier",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "symbol",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string",
+          "internalType": "string"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "transferFrom",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "to",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "updateMetadata",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "data",
+          "type": "tuple[]",
+          "internalType": "struct ClanAgentNFT.IntelligentData[]",
+          "components": [
+            {
+              "name": "label",
+              "type": "string",
+              "internalType": "string"
+            },
+            {
+              "name": "dataHash",
+              "type": "bytes32",
+              "internalType": "bytes32"
+            },
+            {
+              "name": "uri",
+              "type": "string",
+              "internalType": "string"
+            }
+          ]
+        },
+        {
+          "name": "proof",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "usageAuthorizations",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "verifier",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract IAgentTransferVerifier"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "event",
+      "name": "AccessDelegated",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "delegate",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Approval",
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "approved",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ApprovalForAll",
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "operator",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "approved",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "IntelligentDataItem",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "slot",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "label",
+          "type": "string",
+          "indexed": false,
+          "internalType": "string"
+        },
+        {
+          "name": "dataHash",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "uri",
+          "type": "string",
+          "indexed": false,
+          "internalType": "string"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "IntelligentDataUpdated",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "dataHash",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "uri",
+          "type": "string",
+          "indexed": false,
+          "internalType": "string"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "IntelligentTransfer",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "from",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "to",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newDataHash",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "encryptedKeyHash",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "newUri",
+          "type": "string",
+          "indexed": false,
+          "internalType": "string"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Transfer",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "to",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "UsageAuthorized",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "user",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "UsageRevoked",
+      "inputs": [
+        {
+          "name": "tokenId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "user",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "VerifierUpdated",
+      "inputs": [
+        {
+          "name": "verifier",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "error",
+      "name": "InvalidAddress",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InvalidData",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InvalidProof",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "NotApprovedOrOwner",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "NotOwner",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "TokenNotFound",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "UnsafeRecipient",
+      "inputs": []
+    }
+  ]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./adapters": "./src/adapters/index.ts",
-    "./generated/*": "./src/generated/*.ts"
+    "./generated/*": "./src/generated/*.ts",
+    "./utils/*": "./src/utils/*.ts"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/shared/src/adapters/IInftClient.ts
+++ b/packages/shared/src/adapters/IInftClient.ts
@@ -1,4 +1,4 @@
-import { clanAgentNftAbi } from '@clan-world/contract-types';
+import { clanAgentNFTAbi } from '@clan-world/contract-types';
 import {
   createPublicClient,
   createWalletClient,
@@ -133,19 +133,19 @@ class RealInftClient implements IInftClient {
     const [owner, currentDataHash, encryptedKeyHash, data] = await Promise.all([
       this.publicClient.readContract({
         address: this.address,
-        abi: clanAgentNftAbi,
+        abi: clanAgentNFTAbi,
         functionName: 'ownerOf',
         args: [tokenId],
       }),
       this.publicClient.readContract({
         address: this.address,
-        abi: clanAgentNftAbi,
+        abi: clanAgentNFTAbi,
         functionName: 'currentDataHash',
         args: [tokenId],
       }),
       this.publicClient.readContract({
         address: this.address,
-        abi: clanAgentNftAbi,
+        abi: clanAgentNFTAbi,
         functionName: 'encryptedKeyHash',
         args: [tokenId],
       }),
@@ -157,7 +157,7 @@ class RealInftClient implements IInftClient {
   async getIntelligentData(tokenId: bigint): Promise<IntelligentDataEntry[]> {
     const data = await this.publicClient.readContract({
       address: this.address,
-      abi: clanAgentNftAbi,
+      abi: clanAgentNFTAbi,
       functionName: 'intelligentDataOf',
       args: [tokenId],
     });
@@ -208,7 +208,7 @@ class RealInftClient implements IInftClient {
     const simulation = await this.publicClient.simulateContract({
       account,
       address: this.address,
-      abi: clanAgentNftAbi,
+      abi: clanAgentNFTAbi,
       functionName,
       args: args as never,
     });

--- a/packages/shared/src/adapters/IInftClient.ts
+++ b/packages/shared/src/adapters/IInftClient.ts
@@ -1,3 +1,4 @@
+import { clanAgentNftAbi } from '@clan-world/contract-types';
 import {
   createPublicClient,
   createWalletClient,
@@ -42,115 +43,6 @@ export interface IInftClient {
   authorizeUsage(tokenId: bigint, user: Address): Promise<Hex>;
   revokeAuthorization(tokenId: bigint, user: Address): Promise<Hex>;
 }
-
-export const CLAN_AGENT_NFT_ABI = [
-  {
-    type: 'function',
-    name: 'ownerOf',
-    stateMutability: 'view',
-    inputs: [{ name: 'tokenId', type: 'uint256' }],
-    outputs: [{ name: '', type: 'address' }],
-  },
-  {
-    type: 'function',
-    name: 'currentDataHash',
-    stateMutability: 'view',
-    inputs: [{ name: 'tokenId', type: 'uint256' }],
-    outputs: [{ name: '', type: 'bytes32' }],
-  },
-  {
-    type: 'function',
-    name: 'encryptedKeyHash',
-    stateMutability: 'view',
-    inputs: [{ name: 'tokenId', type: 'uint256' }],
-    outputs: [{ name: '', type: 'bytes32' }],
-  },
-  {
-    type: 'function',
-    name: 'intelligentDataOf',
-    stateMutability: 'view',
-    inputs: [{ name: 'tokenId', type: 'uint256' }],
-    outputs: [
-      {
-        name: '',
-        type: 'tuple[]',
-        components: [
-          { name: 'label', type: 'string' },
-          { name: 'dataHash', type: 'bytes32' },
-          { name: 'uri', type: 'string' },
-        ],
-      },
-    ],
-  },
-  {
-    type: 'function',
-    name: 'updateMetadata',
-    stateMutability: 'nonpayable',
-    inputs: [
-      { name: 'tokenId', type: 'uint256' },
-      {
-        name: 'data',
-        type: 'tuple[]',
-        components: [
-          { name: 'label', type: 'string' },
-          { name: 'dataHash', type: 'bytes32' },
-          { name: 'uri', type: 'string' },
-        ],
-      },
-      { name: 'proof', type: 'bytes' },
-    ],
-    outputs: [],
-  },
-  {
-    type: 'function',
-    name: 'iTransfer',
-    stateMutability: 'nonpayable',
-    inputs: [
-      { name: 'to', type: 'address' },
-      { name: 'tokenId', type: 'uint256' },
-      {
-        name: 'newData',
-        type: 'tuple[]',
-        components: [
-          { name: 'label', type: 'string' },
-          { name: 'dataHash', type: 'bytes32' },
-          { name: 'uri', type: 'string' },
-        ],
-      },
-      {
-        name: 'transferProof',
-        type: 'tuple',
-        components: [
-          { name: 'newDataHash', type: 'bytes32' },
-          { name: 'encryptedKeyHash', type: 'bytes32' },
-          { name: 'newUri', type: 'string' },
-          { name: 'proof', type: 'bytes' },
-        ],
-      },
-    ],
-    outputs: [],
-  },
-  {
-    type: 'function',
-    name: 'authorizeUsage',
-    stateMutability: 'nonpayable',
-    inputs: [
-      { name: 'tokenId', type: 'uint256' },
-      { name: 'user', type: 'address' },
-    ],
-    outputs: [],
-  },
-  {
-    type: 'function',
-    name: 'revokeAuthorization',
-    stateMutability: 'nonpayable',
-    inputs: [
-      { name: 'tokenId', type: 'uint256' },
-      { name: 'user', type: 'address' },
-    ],
-    outputs: [],
-  },
-] as const;
 
 const ZERO_BYTES32 = `0x${'00'.repeat(32)}` as Hex;
 
@@ -241,19 +133,19 @@ class RealInftClient implements IInftClient {
     const [owner, currentDataHash, encryptedKeyHash, data] = await Promise.all([
       this.publicClient.readContract({
         address: this.address,
-        abi: CLAN_AGENT_NFT_ABI,
+        abi: clanAgentNftAbi,
         functionName: 'ownerOf',
         args: [tokenId],
       }),
       this.publicClient.readContract({
         address: this.address,
-        abi: CLAN_AGENT_NFT_ABI,
+        abi: clanAgentNftAbi,
         functionName: 'currentDataHash',
         args: [tokenId],
       }),
       this.publicClient.readContract({
         address: this.address,
-        abi: CLAN_AGENT_NFT_ABI,
+        abi: clanAgentNftAbi,
         functionName: 'encryptedKeyHash',
         args: [tokenId],
       }),
@@ -265,7 +157,7 @@ class RealInftClient implements IInftClient {
   async getIntelligentData(tokenId: bigint): Promise<IntelligentDataEntry[]> {
     const data = await this.publicClient.readContract({
       address: this.address,
-      abi: CLAN_AGENT_NFT_ABI,
+      abi: clanAgentNftAbi,
       functionName: 'intelligentDataOf',
       args: [tokenId],
     });
@@ -316,7 +208,7 @@ class RealInftClient implements IInftClient {
     const simulation = await this.publicClient.simulateContract({
       account,
       address: this.address,
-      abi: CLAN_AGENT_NFT_ABI,
+      abi: clanAgentNftAbi,
       functionName,
       args: args as never,
     });

--- a/packages/shared/src/generated/enums.ts
+++ b/packages/shared/src/generated/enums.ts
@@ -2,6 +2,44 @@
 
 
 
+export const ClanState = {
+  ACTIVE: 0,
+  DEAD: 1,
+} as const;
+export type ClanState = (typeof ClanState)[keyof typeof ClanState];
+
+export const ClansmanState = {
+  WAITING: 0,
+  TRAVELING: 1,
+  ACTING: 2,
+  DEAD: 3,
+} as const;
+export type ClansmanState = (typeof ClansmanState)[keyof typeof ClansmanState];
+
+export const BanditState = {
+  None: 0,
+  Spawned: 1,
+  Camped: 2,
+  Attacking: 3,
+  Defeated: 4,
+} as const;
+export type BanditState = (typeof BanditState)[keyof typeof BanditState];
+
+export const WheatPlotState = {
+  Harvestable: 0,
+  Regrowing: 1,
+  WinterLocked: 2,
+} as const;
+export type WheatPlotState = (typeof WheatPlotState)[keyof typeof WheatPlotState];
+
+export const ResourceType = {
+  Wood: 0,
+  Iron: 1,
+  Wheat: 2,
+  Fish: 3,
+} as const;
+export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType];
+
 export const ActionType = {
   None: 0,
   ChopWood: 1,
@@ -20,6 +58,13 @@ export const ActionType = {
   WithdrawResources: 14,
 } as const;
 export type ActionType = (typeof ActionType)[keyof typeof ActionType];
+
+export const MarketExecutionMode = {
+  None: 0,
+  Immediate: 1,
+  Scheduled: 2,
+} as const;
+export type MarketExecutionMode = (typeof MarketExecutionMode)[keyof typeof MarketExecutionMode];
 
 export const StatusCode = {
   OK: 0,
@@ -56,49 +101,4 @@ export const StatusCode = {
   ERR_SLIPPAGE_REQUIRED: 31,
 } as const;
 export type StatusCode = (typeof StatusCode)[keyof typeof StatusCode];
-
-export const ResourceType = {
-  Wood: 0,
-  Iron: 1,
-  Wheat: 2,
-  Fish: 3,
-} as const;
-export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType];
-
-export const ClansmanState = {
-  WAITING: 0,
-  TRAVELING: 1,
-  ACTING: 2,
-  DEAD: 3,
-} as const;
-export type ClansmanState = (typeof ClansmanState)[keyof typeof ClansmanState];
-
-export const ClanState = {
-  ACTIVE: 0,
-  DEAD: 1,
-} as const;
-export type ClanState = (typeof ClanState)[keyof typeof ClanState];
-
-export const BanditState = {
-  None: 0,
-  Spawned: 1,
-  Camped: 2,
-  Attacking: 3,
-  Defeated: 4,
-} as const;
-export type BanditState = (typeof BanditState)[keyof typeof BanditState];
-
-export const WheatPlotState = {
-  Harvestable: 0,
-  Regrowing: 1,
-  WinterLocked: 2,
-} as const;
-export type WheatPlotState = (typeof WheatPlotState)[keyof typeof WheatPlotState];
-
-export const MarketExecutionMode = {
-  None: 0,
-  Immediate: 1,
-  Scheduled: 2,
-} as const;
-export type MarketExecutionMode = (typeof MarketExecutionMode)[keyof typeof MarketExecutionMode];
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types';
 export * from './utils/assertSafeInboxKey';
+export * from './utils/resources';
 export * as adapters from './adapters';
 export * from './mocks/clanWorldFixture';

--- a/packages/shared/src/utils/resources.ts
+++ b/packages/shared/src/utils/resources.ts
@@ -1,0 +1,7 @@
+import { ResourceType } from '../generated/enums';
+
+export const RESOURCE_NAMES_BY_ENUM: Record<number, string> = Object.fromEntries(
+  Object.entries(ResourceType)
+    .filter(([, value]) => typeof value === 'number')
+    .map(([key, value]) => [value as number, key.toLowerCase()]),
+) as Record<number, string>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@clan-world/contract-types':
+        specifier: workspace:*
+        version: link:../../packages/contract-types
       '@clan-world/shared':
         specifier: workspace:*
         version: link:../../packages/shared

--- a/scripts/abi-targets.mjs
+++ b/scripts/abi-targets.mjs
@@ -24,6 +24,11 @@ export const abiTargets = [
     artifactPath: path.join(repoRoot, 'packages/contracts/out/IClanWorldLens.sol/IClanWorldLens.json'),
     targetPath: path.join(repoRoot, 'packages/contracts/abi/IClanWorldLens.json'),
   },
+  {
+    sourcePath: 'src/ClanAgentNFT.sol',
+    artifactPath: path.join(repoRoot, 'packages/contracts/out/ClanAgentNFT.sol/ClanAgentNFT.json'),
+    targetPath: path.join(repoRoot, 'packages/contracts/abi/ClanAgentNFT.json'),
+  },
   // Diamond / Ownership facet ABIs consumed by apps/dev-ui (generic write/read UI over the
   // ClanWorld diamond). Kept canonical here so dev-ui never vendors a stale copy.
   {

--- a/scripts/gen-enums.mjs
+++ b/scripts/gen-enums.mjs
@@ -54,13 +54,15 @@ function renderEnum(name, values) {
   ].join('\n');
 }
 
-function render(enums) {
+function render(enums, check) {
   const enumNames = [...enums.keys()];
   const missing = expectedEnumNames.filter(name => !enums.has(name));
   if (missing.length > 0) {
-    console.warn(
-      `Expected enum(s) missing from ${path.relative(repoRoot, sourcePath)}: ${missing.join(', ')}`,
-    );
+    const message = `Expected enum(s) missing from ${path.relative(repoRoot, sourcePath)}: ${missing.join(', ')}`;
+    if (check) {
+      throw new Error(message);
+    }
+    console.warn(message);
   }
 
   if (enumNames.length === 0) {
@@ -76,8 +78,8 @@ function render(enums) {
 }
 
 const source = fs.readFileSync(sourcePath, 'utf8');
-const output = render(parseEnums(source));
 const check = process.argv.includes('--check');
+const output = render(parseEnums(source), check);
 
 if (check) {
   const current = fs.existsSync(targetPath) ? fs.readFileSync(targetPath, 'utf8') : '';

--- a/scripts/gen-enums.mjs
+++ b/scripts/gen-enums.mjs
@@ -9,7 +9,7 @@ const repoRoot = path.resolve(__dirname, '..');
 const sourcePath = path.join(repoRoot, 'packages/contracts/src/IClanWorld.sol');
 const targetPath = path.join(repoRoot, 'packages/shared/src/generated/enums.ts');
 
-const enumNames = [
+const expectedEnumNames = [
   'ActionType',
   'StatusCode',
   'ResourceType',
@@ -55,9 +55,16 @@ function renderEnum(name, values) {
 }
 
 function render(enums) {
-  const missing = enumNames.filter(name => !enums.has(name));
+  const enumNames = [...enums.keys()];
+  const missing = expectedEnumNames.filter(name => !enums.has(name));
   if (missing.length > 0) {
-    throw new Error(`Missing enum(s) in ${path.relative(repoRoot, sourcePath)}: ${missing.join(', ')}`);
+    console.warn(
+      `Expected enum(s) missing from ${path.relative(repoRoot, sourcePath)}: ${missing.join(', ')}`,
+    );
+  }
+
+  if (enumNames.length === 0) {
+    throw new Error(`No enums found in ${path.relative(repoRoot, sourcePath)}`);
   }
 
   return [


### PR DESCRIPTION
v2.11 release — integration-seam audit findings batch 1 (cross-validated by parallel Claude + Codex audits 2026-05-17).

## What landed

| Issue | PR | Scope |
|---|---|---|
| #468 | #480 | Derive contracts list in `packages/contract-types/scripts/generate.mjs` from `abi-targets.mjs` (META hazard fix — parallel to v2.10 D-12+R2) |
| #469 | #481 | Derive `enumNames` from `parseEnums()` + wire CI `--check` for gen-constants/gen-enums |
| #467 | #487 | Add ClanAgentNFT to abi-targets + drop 107-line hand-rolled `CLAN_AGENT_NFT_ABI` in `packages/shared/src/adapters/IInftClient.ts` |
| #470 | #484 | Apply D-11 Doc-derivation pattern to `apps/web` — `SnapshotClan`/`SnapshotBandit`/`ChainEvent` in WorldMap.tsx + TopHud.tsx, plus `TICKS_PER_SEASON` from generated constant |
| #471 | #486 | Consolidate `RESOURCE_NAMES` drift between indexer.ts + vault.ts + EventTicker.tsx (one disambiguating concept rename + shared enum-derived map) + use `RESOURCE_GOLD` constant |

## META hazard payoffs in this release

Per pattern from v2.10 (#459 D-12 + #461 R2):
- **#480 contracts-derive**: auto-included IDiamondLoupe, IDiamondCut, OwnershipFacet as typed ABI exports (previously hand-rolled list was just IClanWorld + IClanWorldLens)
- **#487 ClanAgentNFT**: 107 lines of hand-rolled ABI removed; foundry-generated artifact wired through `@clan-world/contract-types`
- **#481 enums derive**: regen run cleanly — no silent enum drift surfaced (gen-enums.mjs had no missing enums in the hand-list, but the META hazard pattern is now closed)

## Verification

- All 5 sub-PRs CI green on the integration branch
- pnpm typecheck clean across server + web + shared + contract-types
- Server tests pass, ChainClient ABI parity tests pass

## Release plan

- This release is independent of v2.12 (parallel integration branch dev-typechain-v2-12).
- Recommended order: **merge v2.11 first**, then re-evaluate v2.12 (it will need rebase if v2.11 lands first, OR it can be merged directly if v2.11 is held).
- Tag plan: `v2.11.0` on the merge commit.

## Follow-ups already filed for v2.13+

- #488 — remove `@clan-world/shared/generated/*` compat re-exports (post-SDK migration cleanup)
- #477 — Android Kotlin Convex codegen (now tractable since #476 SDK exists)
- #478 — dev-ui typed ABIs (XS once contract-types derives via SDK)

Part of the v2.10→v2.11→v2.12 typechain hardening arc.