### PR TITLE
fix(shared, scripts): v2.11 R1 fixes

### DIFF
--- a/apps/web/src/pages/OwnerEditor.tsx
+++ b/apps/web/src/pages/OwnerEditor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { clanAgentNftAbi } from '@clan-world/contract-types';
+import { clanAgentNFTAbi } from '@clan-world/contract-types';
 import {
   hashIntelligentData,
   type IntelligentDataEntry,
@@ -112,13 +112,13 @@ export function OwnerEditor() {
       const [tokenOwner, intelligentData] = await Promise.all([
         publicClient.readContract({
           address: OG_INFT_ADDRESS,
-          abi: clanAgentNftAbi,
+          abi: clanAgentNFTAbi,
           functionName: 'ownerOf',
           args: [tokenId],
         }),
         publicClient.readContract({
           address: OG_INFT_ADDRESS,
-          abi: clanAgentNftAbi,
+          abi: clanAgentNFTAbi,
           functionName: 'intelligentDataOf',
           args: [tokenId],
         }),
@@ -164,7 +164,7 @@ export function OwnerEditor() {
       const tx = await client.writeContract({
         account,
         address: OG_INFT_ADDRESS,
-        abi: clanAgentNftAbi,
+        abi: clanAgentNFTAbi,
         functionName: 'updateMetadata',
         args: [tokenId, nextData, proofHex(`metadata:${tokenId}:${notes}`)],
       });
@@ -201,7 +201,7 @@ export function OwnerEditor() {
       const tx = await client.writeContract({
         account,
         address: OG_INFT_ADDRESS,
-        abi: clanAgentNftAbi,
+        abi: clanAgentNFTAbi,
         functionName: 'iTransfer',
         args: [
           newOwner as Address,

--- a/packages/shared/src/adapters/IInftClient.ts
+++ b/packages/shared/src/adapters/IInftClient.ts
@@ -1,4 +1,4 @@
-import { clanAgentNftAbi } from '@clan-world/contract-types';
+import { clanAgentNFTAbi } from '@clan-world/contract-types';
 import {
   createPublicClient,
   createWalletClient,
@@ -133,19 +133,19 @@ class RealInftClient implements IInftClient {
     const [owner, currentDataHash, encryptedKeyHash, data] = await Promise.all([
       this.publicClient.readContract({
         address: this.address,
-        abi: clanAgentNftAbi,
+        abi: clanAgentNFTAbi,
         functionName: 'ownerOf',
         args: [tokenId],
       }),
       this.publicClient.readContract({
         address: this.address,
-        abi: clanAgentNftAbi,
+        abi: clanAgentNFTAbi,
         functionName: 'currentDataHash',
         args: [tokenId],
       }),
       this.publicClient.readContract({
         address: this.address,
-        abi: clanAgentNftAbi,
+        abi: clanAgentNFTAbi,
         functionName: 'encryptedKeyHash',
         args: [tokenId],
       }),
@@ -157,7 +157,7 @@ class RealInftClient implements IInftClient {
   async getIntelligentData(tokenId: bigint): Promise<IntelligentDataEntry[]> {
     const data = await this.publicClient.readContract({
       address: this.address,
-      abi: clanAgentNftAbi,
+      abi: clanAgentNFTAbi,
       functionName: 'intelligentDataOf',
       args: [tokenId],
     });
@@ -208,7 +208,7 @@ class RealInftClient implements IInftClient {
     const simulation = await this.publicClient.simulateContract({
       account,
       address: this.address,
-      abi: clanAgentNftAbi,
+      abi: clanAgentNFTAbi,
       functionName,
       args: args as never,
     });

--- a/scripts/gen-enums.mjs
+++ b/scripts/gen-enums.mjs
@@ -54,13 +54,15 @@ function renderEnum(name, values) {
   ].join('\n');
 }
 
-function render(enums) {
+function render(enums, check) {
   const enumNames = [...enums.keys()];
   const missing = expectedEnumNames.filter(name => !enums.has(name));
   if (missing.length > 0) {
-    console.warn(
-      `Expected enum(s) missing from ${path.relative(repoRoot, sourcePath)}: ${missing.join(', ')}`,
-    );
+    const message = `Expected enum(s) missing from ${path.relative(repoRoot, sourcePath)}: ${missing.join(', ')}`;
+    if (check) {
+      throw new Error(message);
+    }
+    console.warn(message);
   }
 
   if (enumNames.length === 0) {
@@ -76,8 +78,8 @@ function render(enums) {
 }
 
 const source = fs.readFileSync(sourcePath, 'utf8');
-const output = render(parseEnums(source));
 const check = process.argv.includes('--check');
+const output = render(parseEnums(source), check);
 
 if (check) {
   const current = fs.existsSync(targetPath) ? fs.readFileSync(targetPath, 'utf8') : '';


### PR DESCRIPTION
## Summary

- update iNFT ABI consumers to import the generated `clanAgentNFTAbi` symbol
- make `gen-enums.mjs --check` throw when an expected enum is missing while preserving local warning behavior outside check mode

## Root Cause

The combined v2.11 branch used generated contract-types output from `lowerFirst('ClanAgentNFT')`, which exports `clanAgentNFTAbi`, while newer consumers still imported the older hand-rolled `clanAgentNftAbi` casing. Separately, the enum sanity-list guard warned but did not fail in CI check mode.

## Validation

- `rg -n "clanAgentNftAbi" --glob "*.{ts,tsx}" || echo "(no remaining refs)"`
- `pnpm --filter @clan-world/shared typecheck`
- `pnpm --filter @clan-world/server typecheck`
- `pnpm --filter @clan-world/web typecheck`
- `pnpm --filter @clan-world/contract-types typecheck`
- `pnpm test:chainclient-abi`
- `pnpm test:abi-parity`
- `node scripts/gen-enums.mjs --check`
- throwaway probe confirmed `gen-enums.mjs --check` exits nonzero when an expected enum is missing

Closes #490