### PR TITLE
chore(gemini): disable auto-review; rely on /gemini review slash command

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,22 @@
+# Gemini Code Assist configuration
+# https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github
+#
+# DECISION (Liam directive 2026-05-20 voice msg 15314):
+# Disable auto-review on PR open to prevent external contributors from burning
+# the 33/day per-installation quota. The /gemini review slash command STILL
+# works for any commenter, so team members trigger reviews manually when needed.
+#
+# Trade-off: team-member PRs lose auto-review. ~10 seconds of inconvenience per
+# PR for total external-quota protection.
+#
+# To re-enable auto-review, set `code_review.disable: false` and add an
+# `author_association` filter via `.github/workflows/gemini-review.yml`. See
+# `~/claudes-world/tmp/gemini-review-external-contrib-research-20260520.md`
+# for Path 1 / Path 2 alternatives.
+
+code_review:
+  disable: true   # no automatic reviews on PR open
+
+pull_request_opened:
+  code_review: false
+  summary: false


### PR DESCRIPTION
## Summary

- Adds `.gemini/config.yaml` that disables Gemini Code Assist auto-trigger on PR open
- `/gemini review` slash command still works for any commenter — team members manually trigger when wanted
- Protects daily quota from external-contributor PRs (currently 33/day per installation, consumer tier)

## Motivation

Liam directive 2026-05-20 voice msg 15314. External contributor PR #464 (`leno23`, "Hermes" auto-agent) triggered an auto-review and burned daily quota. Liam wants the repo to STAY open to external contributors but not let strangers burn the budget.

## Why Path 3 (full disable) over Path 1 (GH Actions with author filter)

Research doc: `~/claudes-world/tmp/gemini-review-external-contrib-research-20260520.md`. Three paths considered:

- **Path 1** — disable app auto-review + add GH Actions workflow with `author_association` filter. Most flexible but adds workflow complexity + fork-PR token gotchas.
- **Path 2** — same but `pull_request_target` for fork safety. Security caveat: easy to misconfigure.
- **Path 3** (this PR) — full disable + manual `/gemini review` for team. Simplest. ~10s of inconvenience per PR in exchange for total external-quota protection. Zero workflow complexity. Easy to reverse.

If team auto-review turns out to be missed enough, switch to Path 1 later.

## Test plan

- [ ] Merge to dev
- [ ] Open a test PR; verify Gemini does NOT auto-review on open
- [ ] Comment `/gemini review` in the PR; verify Gemini DOES review on demand
- [ ] Confirm external contributor PRs no longer trigger reviews

## Reversal

Delete the file or change `code_review.disable: false` + `pull_request_opened.code_review: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)