### PR TITLE
feat(crons): drop redundant 5s refresh cron, drive refreshSnapshot from pollLogs events (closes #335)

### DIFF
--- a/apps/server/convex/INDEXER.md
+++ b/apps/server/convex/INDEXER.md
@@ -6,7 +6,7 @@ place during production soak.
 ## Flags
 
 - `CLANWORLD_USE_REAL_INDEXER=true` enables receipt decoding in the heartbeat
-  webhook, the 5s snapshot refresher, and the 3s log poller.
+  webhook, the 3s log poller, and the 60s fallback snapshot refresher.
 - `CLANWORLD_USE_FAKE_HEARTBEAT=true` keeps the MUST-13 fake tick cron alive for
   demos and fallback environments.
 - Do not enable both in production. They coexist only so migration and rollback

--- a/apps/server/convex/INDEXER.md
+++ b/apps/server/convex/INDEXER.md
@@ -6,11 +6,50 @@ place during production soak.
 ## Flags
 
 - `CLANWORLD_USE_REAL_INDEXER=true` enables receipt decoding in the heartbeat
-  webhook, the 3s log poller, and the 60s fallback snapshot refresher.
+  webhook, the 3s log poller, the 60s fallback snapshot refresher, and the
+  60s poller liveness watchdog.
 - `CLANWORLD_USE_FAKE_HEARTBEAT=true` keeps the MUST-13 fake tick cron alive for
   demos and fallback environments.
 - Do not enable both in production. They coexist only so migration and rollback
   do not require deleting code.
+
+## Crons (under `CLANWORLD_USE_REAL_INDEXER=true`)
+
+The real-indexer posture registers three Convex crons (defined in
+`crons.ts`):
+
+1. **`real-indexer-log-poller`** — every **3s**. Calls `internal.indexer.pollLogs`.
+   - Stamps the singleton `pollerHealth` row via `markPollerInvoked` BEFORE
+     any early-return, so a quiet chain (`shouldPoll === false`) doesn't look
+     like a dead cron.
+   - Decodes any new logs up to `latestConfirmedBlock - INDEXER_CONFIRMATION_DEPTH`,
+     persists `chainEvents` + `eventCheckpoint`.
+   - When `inserted > 0 && toBlock >= safeLatest` (i.e. AT chain tip), schedules
+     `refreshSnapshot` immediately. During historical backfill (`toBlock < safeLatest`),
+     the 60s fallback cron handles snapshot refreshes — avoids hammering the
+     RPC with refreshes against stale block numbers.
+
+2. **`real-indexer-snapshot-refresh-fallback`** — every **60s**. Calls
+   `internal.indexer.refreshSnapshot` unconditionally.
+   - Backstops transient RPC failures in the event-driven path.
+   - Covers periodic snapshot updates during historical backfill, when the
+     event-driven refresh is intentionally suppressed (see above).
+
+3. **`real-indexer-poller-watchdog`** — every **60s**. Calls
+   `internal.indexer.pollerWatchdog`.
+   - Reads the `pollerHealth` singleton (NOT `eventCheckpoint`) so it can
+     detect a stuck cold-start where `pollLogs` has never produced even one
+     successful heartbeat.
+   - Returns `stale: false` when `CLANWORLD_USE_REAL_INDEXER !== "true"` —
+     environments that don't run the real indexer don't produce false alerts.
+   - Returns `stale: true` with reason `"poller never ran"` when the
+     `pollerHealth` row is missing — catches import-time crashes, misconfigured
+     env vars, totally-dead cron at startup.
+   - Returns `stale: true` with reason `"poller heartbeat aged out"` when
+     `pollerLastInvokedAt > 90s old` — catches the running-but-stuck failure
+     mode (the original v1.0.1 concern).
+   - Logs an `[indexer]` error on stale; downstream alerting hooks off the
+     Convex logs.
 
 ## Required Env
 

--- a/apps/server/convex/crons.ts
+++ b/apps/server/convex/crons.ts
@@ -18,6 +18,8 @@ if (process.env.CLANWORLD_USE_FAKE_HEARTBEAT === "true") {
 
 if (process.env.CLANWORLD_USE_REAL_INDEXER === "true") {
   crons.interval("real-indexer-log-poller", { seconds: 3 }, internal.indexer.pollLogs, {});
+  // 60s fallback: backstops transient refreshSnapshot failures from pollLogs/webhook paths.
+  crons.interval("real-indexer-snapshot-refresh-fallback", { seconds: 60 }, internal.indexer.refreshSnapshot, {});
 }
 
 crons.interval("gold-quote-refresh", { minutes: 5 }, internal.goldQuote.refreshGoldQuote, {});

--- a/apps/server/convex/crons.ts
+++ b/apps/server/convex/crons.ts
@@ -17,7 +17,6 @@ if (process.env.CLANWORLD_USE_FAKE_HEARTBEAT === "true") {
 }
 
 if (process.env.CLANWORLD_USE_REAL_INDEXER === "true") {
-  crons.interval("real-indexer-snapshot-refresh", { seconds: 5 }, internal.indexer.refreshSnapshot, {});
   crons.interval("real-indexer-log-poller", { seconds: 3 }, internal.indexer.pollLogs, {});
 }
 

--- a/apps/server/convex/crons.ts
+++ b/apps/server/convex/crons.ts
@@ -20,6 +20,10 @@ if (process.env.CLANWORLD_USE_REAL_INDEXER === "true") {
   crons.interval("real-indexer-log-poller", { seconds: 3 }, internal.indexer.pollLogs, {});
   // 60s fallback: backstops transient refreshSnapshot failures from pollLogs/webhook paths.
   crons.interval("real-indexer-snapshot-refresh-fallback", { seconds: 60 }, internal.indexer.refreshSnapshot, {});
+  // 60s liveness watchdog: fires INDEPENDENTLY of pollLogs, so it can detect
+  // the case where pollLogs itself has stopped running (the failure mode the
+  // previous in-pollLogs check was structurally incapable of catching).
+  crons.interval("real-indexer-poller-watchdog", { seconds: 60 }, internal.indexer.pollerWatchdog, {});
 }
 
 crons.interval("gold-quote-refresh", { minutes: 5 }, internal.goldQuote.refreshGoldQuote, {});

--- a/apps/server/convex/indexer.test.ts
+++ b/apps/server/convex/indexer.test.ts
@@ -8,6 +8,7 @@ import {
   lensAddress,
   planPollLogRange,
   pricePointFromEvent,
+  shouldScheduleEventDrivenRefresh,
   stableJson,
 } from "./indexer";
 
@@ -252,6 +253,71 @@ describe("pollLogs range planning", () => {
     if (previousDepth === undefined)
       delete process.env.INDEXER_CONFIRMATION_DEPTH;
     else process.env.INDEXER_CONFIRMATION_DEPTH = previousDepth;
+  });
+});
+
+describe("shouldScheduleEventDrivenRefresh", () => {
+  // Per PR #502 Copilot finding — gating predicate has two relevant branches
+  // that pollLogs depends on. Exercise both explicitly so the contract is
+  // pinned independent of the action handler.
+
+  it("at chain tip with new inserts: schedules refresh", () => {
+    // Tip case: toBlock === safeLatest && inserted > 0 → refresh scheduled
+    expect(
+      shouldScheduleEventDrivenRefresh({
+        inserted: 3,
+        toBlock: 1_000n,
+        safeLatest: 1_000n,
+      }),
+    ).toBe(true);
+  });
+
+  it("ahead of safeLatest with new inserts: schedules refresh", () => {
+    // Defensive: toBlock > safeLatest shouldn't normally happen given planPollLogRange's
+    // safeLatest cap, but the predicate must still authorize a refresh if it does.
+    expect(
+      shouldScheduleEventDrivenRefresh({
+        inserted: 1,
+        toBlock: 1_001n,
+        safeLatest: 1_000n,
+      }),
+    ).toBe(true);
+  });
+
+  it("backfill chunk with new inserts: does NOT schedule refresh", () => {
+    // Backfill case: toBlock < safeLatest && inserted > 0 → 60s fallback cron handles it.
+    // This is the catch the Copilot finding flagged — without this gate, every
+    // 9-block backfill chunk with inserts would queue a refresh against a stale
+    // block, hammering the RPC + competing with the real chain-tip refresh.
+    expect(
+      shouldScheduleEventDrivenRefresh({
+        inserted: 5,
+        toBlock: 100n,
+        safeLatest: 1_000n,
+      }),
+    ).toBe(false);
+  });
+
+  it("at chain tip with zero inserts: does NOT schedule refresh", () => {
+    // No new state → nothing for the snapshot to reflect → don't waste an RPC trip.
+    expect(
+      shouldScheduleEventDrivenRefresh({
+        inserted: 0,
+        toBlock: 1_000n,
+        safeLatest: 1_000n,
+      }),
+    ).toBe(false);
+  });
+
+  it("backfill chunk with zero inserts: does NOT schedule refresh", () => {
+    // Belt-and-suspenders: both gates fail, both reasons would suppress.
+    expect(
+      shouldScheduleEventDrivenRefresh({
+        inserted: 0,
+        toBlock: 100n,
+        safeLatest: 1_000n,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -1035,7 +1035,7 @@ export const pollLogs = internalAction({
     }
 
     if (checkpoint?.lastSeenAt && Date.now() - checkpoint.lastSeenAt > 90_000) {
-      console.error("[indexer] liveness: no events polled in 90s — webhook may be down");
+      console.error("[indexer] liveness: pollLogs stalled >90s — cron may be dead");
     }
 
     const logs = await client.getLogs({ address, fromBlock, toBlock });

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -1014,6 +1014,11 @@ export const pollLogs = internalAction({
       return { inserted: 0, skipped: true, resetLocked: true };
     }
 
+    // Heartbeat: stamp the "cron is alive" signal BEFORE any early-return so
+    // a quiet chain (shouldPoll === false) doesn't masquerade as a dead cron.
+    // The `pollerWatchdog` cron reads this and alerts if it goes stale.
+    await ctx.runMutation(indexerApi.markPollerInvoked, {});
+
     const client = createClient();
     const address = engineAddress();
     const checkpoint = (await ctx.runQuery(indexerApi.readCheckpoint, {})) as {
@@ -1034,10 +1039,6 @@ export const pollLogs = internalAction({
       };
     }
 
-    if (checkpoint?.lastSeenAt && Date.now() - checkpoint.lastSeenAt > 90_000) {
-      console.error("[indexer] liveness: pollLogs stalled >90s — cron may be dead");
-    }
-
     const logs = await client.getLogs({ address, fromBlock, toBlock });
     const events = decodeClanWorldLogs(logs);
     const result = await ctx.runMutation(indexerApi.ingestEvents, {
@@ -1047,7 +1048,15 @@ export const pollLogs = internalAction({
         events[events.length - 1]?.transactionHash ?? checkpoint?.lastTxHash,
       advanceCheckpoint: true,
     });
-    if ((result as { inserted: number }).inserted > 0) {
+    // Only schedule event-driven refresh when we're at chain tip. During
+    // historical backfill `toBlock` is a chunked sub-range (9 blocks/tick),
+    // each chunk-with-inserts would otherwise queue a refresh against stale
+    // block numbers — wasteful + RPC-rate-limit risk. The 60s fallback cron
+    // covers periodic refreshes during backfill.
+    if (
+      (result as { inserted: number }).inserted > 0 &&
+      toBlock >= safeLatest
+    ) {
       await ctx.scheduler.runAfter(0, indexerApi.refreshSnapshot, {
         blockNumber: Number(toBlock),
       });
@@ -1060,6 +1069,68 @@ export const readCheckpoint = internalQuery({
   args: {},
   handler: async (ctx) => {
     return await ctx.db.query("eventCheckpoint").first();
+  },
+});
+
+/**
+ * Stamp `pollerLastInvokedAt = Date.now()` on the singleton checkpoint row.
+ * Called at the top of `pollLogs` (BEFORE shouldPoll early-return) so the
+ * field is a true "cron is alive" heartbeat — independent of whether there
+ * are new blocks to ingest. `pollerWatchdog` reads this to detect a dead
+ * `real-indexer-log-poller` cron.
+ *
+ * If no checkpoint row exists yet (cold start before the first ingest),
+ * insert a placeholder with `lastBlock: 0` + `lastSeenAt: now`. The first
+ * real ingest will overwrite lastBlock via the monotonic guard in
+ * `ingestEvents`.
+ */
+export const markPollerInvoked = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const checkpoint = await ctx.db.query("eventCheckpoint").first();
+    if (checkpoint) {
+      await ctx.db.patch(checkpoint._id, { pollerLastInvokedAt: now });
+    } else {
+      await ctx.db.insert("eventCheckpoint", {
+        lastBlock: 0,
+        lastSeenAt: now,
+        pollerLastInvokedAt: now,
+      });
+    }
+  },
+});
+
+/**
+ * Liveness watchdog for the `real-indexer-log-poller` cron. Registered as
+ * its own 60s cron so it fires INDEPENDENTLY of pollLogs — making it
+ * structurally capable of detecting that pollLogs has stopped running.
+ *
+ * Reads `pollerLastInvokedAt` (patched on every pollLogs invocation) and
+ * logs an error if it's older than 90s. A previous version of this check
+ * lived inside pollLogs itself, which (a) couldn't detect a truly dead cron
+ * and (b) false-positived during chain-quiet periods because the field it
+ * read (`lastSeenAt`) only updates inside the ingest path.
+ */
+export const pollerWatchdog = internalAction({
+  args: {},
+  handler: async (ctx): Promise<unknown> => {
+    if (resetLocked()) {
+      return { skipped: true, resetLocked: true };
+    }
+    const checkpoint = (await ctx.runQuery(indexerApi.readCheckpoint, {})) as {
+      pollerLastInvokedAt?: number;
+    } | null;
+    if (
+      checkpoint?.pollerLastInvokedAt &&
+      Date.now() - checkpoint.pollerLastInvokedAt > 90_000
+    ) {
+      console.error(
+        "[indexer] poller invocation stale >90s — real-indexer-log-poller cron may be dead",
+      );
+      return { stale: true, lastInvokedAt: checkpoint.pollerLastInvokedAt };
+    }
+    return { stale: false };
   },
 });
 

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -1019,6 +1019,7 @@ export const pollLogs = internalAction({
     const checkpoint = (await ctx.runQuery(indexerApi.readCheckpoint, {})) as {
       lastBlock: number;
       lastTxHash?: string;
+      lastSeenAt?: number;
     } | null;
     const latest = await client.getBlockNumber();
     const { fromBlock, toBlock, safeLatest, shouldPoll } = planPollLogRange(
@@ -1033,15 +1034,25 @@ export const pollLogs = internalAction({
       };
     }
 
+    if (checkpoint?.lastSeenAt && Date.now() - checkpoint.lastSeenAt > 90_000) {
+      console.error("[indexer] liveness: no events polled in 90s — webhook may be down");
+    }
+
     const logs = await client.getLogs({ address, fromBlock, toBlock });
     const events = decodeClanWorldLogs(logs);
-    return await ctx.runMutation(indexerApi.ingestEvents, {
+    const result = await ctx.runMutation(indexerApi.ingestEvents, {
       events,
       blockNumber: Number(toBlock),
       txHash:
         events[events.length - 1]?.transactionHash ?? checkpoint?.lastTxHash,
       advanceCheckpoint: true,
     });
+    if ((result as { inserted: number }).inserted > 0) {
+      await ctx.scheduler.runAfter(0, indexerApi.refreshSnapshot, {
+        blockNumber: Number(toBlock),
+      });
+    }
+    return result;
   },
 });
 

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -349,6 +349,29 @@ export function planPollLogRange(
   };
 }
 
+/**
+ * Gating predicate for event-driven snapshot refresh.
+ *
+ * pollLogs only schedules a refresh when BOTH:
+ *   1. inserted > 0 — there is actually new state worth surfacing, AND
+ *   2. toBlock >= safeLatest — we are AT chain tip, not chunking through
+ *      historical backfill. During backfill `toBlock` is a 9-block sub-range
+ *      well behind the chain head; each chunk-with-inserts would otherwise
+ *      queue a refresh against a stale block number — wasteful + an
+ *      RPC-rate-limit risk. The 60s fallback cron covers periodic refreshes
+ *      during backfill, so the visible-state lag during catch-up is bounded.
+ *
+ * Exported as a pure helper so the gating contract is testable independent
+ * of the surrounding action handler.
+ */
+export function shouldScheduleEventDrivenRefresh(args: {
+  inserted: number;
+  toBlock: bigint;
+  safeLatest: bigint;
+}): boolean {
+  return args.inserted > 0 && args.toBlock >= args.safeLatest;
+}
+
 function stableClansman(row: unknown): unknown {
   // Null/non-object guard — fixture rows or malformed lens reads can hand us
   // `null`/`undefined`/primitives, and the legacy projection below would crash
@@ -1052,10 +1075,14 @@ export const pollLogs = internalAction({
     // historical backfill `toBlock` is a chunked sub-range (9 blocks/tick),
     // each chunk-with-inserts would otherwise queue a refresh against stale
     // block numbers — wasteful + RPC-rate-limit risk. The 60s fallback cron
-    // covers periodic refreshes during backfill.
+    // covers periodic refreshes during backfill. See
+    // `shouldScheduleEventDrivenRefresh` for the gating contract.
     if (
-      (result as { inserted: number }).inserted > 0 &&
-      toBlock >= safeLatest
+      shouldScheduleEventDrivenRefresh({
+        inserted: (result as { inserted: number }).inserted,
+        toBlock,
+        safeLatest,
+      })
     ) {
       await ctx.scheduler.runAfter(0, indexerApi.refreshSnapshot, {
         blockNumber: Number(toBlock),
@@ -1073,31 +1100,37 @@ export const readCheckpoint = internalQuery({
 });
 
 /**
- * Stamp `pollerLastInvokedAt = Date.now()` on the singleton checkpoint row.
- * Called at the top of `pollLogs` (BEFORE shouldPoll early-return) so the
- * field is a true "cron is alive" heartbeat — independent of whether there
- * are new blocks to ingest. `pollerWatchdog` reads this to detect a dead
- * `real-indexer-log-poller` cron.
+ * Stamp `pollerLastInvokedAt = Date.now()` on the singleton `pollerHealth`
+ * row. Called at the top of `pollLogs` (BEFORE shouldPoll early-return) so
+ * the field is a true "cron is alive" heartbeat — independent of whether
+ * there are new blocks to ingest. `pollerWatchdog` reads this to detect a
+ * dead `real-indexer-log-poller` cron.
  *
- * If no checkpoint row exists yet (cold start before the first ingest),
- * insert a placeholder with `lastBlock: 0` + `lastSeenAt: now`. The first
- * real ingest will overwrite lastBlock via the monotonic guard in
- * `ingestEvents`.
+ * On first invocation the row doesn't exist yet — insert it. We deliberately
+ * do NOT touch `eventCheckpoint` here: a previous version of this mutation
+ * inserted a synthetic checkpoint row at cold-start, which polluted the
+ * ingest table and (worse) made the watchdog structurally unable to detect
+ * a stuck cold-start. Keeping the two concerns in separate tables means
+ * `pollerHealth` reflects ONLY cron liveness while `eventCheckpoint` reflects
+ * ONLY ingest progress.
  */
 export const markPollerInvoked = internalMutation({
   args: {},
   handler: async (ctx) => {
     const now = Date.now();
-    const checkpoint = await ctx.db.query("eventCheckpoint").first();
-    if (checkpoint) {
-      await ctx.db.patch(checkpoint._id, { pollerLastInvokedAt: now });
+    const health = await ctx.db.query("pollerHealth").first();
+    if (health) {
+      await ctx.db.patch(health._id, { pollerLastInvokedAt: now });
     } else {
-      await ctx.db.insert("eventCheckpoint", {
-        lastBlock: 0,
-        lastSeenAt: now,
-        pollerLastInvokedAt: now,
-      });
+      await ctx.db.insert("pollerHealth", { pollerLastInvokedAt: now });
     }
+  },
+});
+
+export const readPollerHealth = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query("pollerHealth").first();
   },
 });
 
@@ -1106,11 +1139,22 @@ export const markPollerInvoked = internalMutation({
  * its own 60s cron so it fires INDEPENDENTLY of pollLogs — making it
  * structurally capable of detecting that pollLogs has stopped running.
  *
- * Reads `pollerLastInvokedAt` (patched on every pollLogs invocation) and
- * logs an error if it's older than 90s. A previous version of this check
- * lived inside pollLogs itself, which (a) couldn't detect a truly dead cron
- * and (b) false-positived during chain-quiet periods because the field it
- * read (`lastSeenAt`) only updates inside the ingest path.
+ * Behavior:
+ *   - `CLANWORLD_USE_REAL_INDEXER !== "true"`: returns `stale: false` because
+ *     the poller is intentionally disabled — no alert noise from environments
+ *     that don't run the real indexer at all.
+ *   - `pollerHealth` row missing: returns `stale: true` with reason
+ *     "poller never ran". Catches the cold-start failure mode where
+ *     `CLANWORLD_USE_REAL_INDEXER=true` is set but `pollLogs` has never
+ *     successfully completed even one invocation (e.g. import-time crash,
+ *     misconfigured RPC, missing env var).
+ *   - `pollerLastInvokedAt` > 90s old: returns `stale: true` with reason
+ *     "poller heartbeat aged out". Catches the running-but-stuck failure mode.
+ *
+ * Previous incarnations of this check lived inside pollLogs itself (couldn't
+ * detect a truly dead cron) and read from `eventCheckpoint` (returned
+ * `stale: false` against the synthetic cold-start row even when no real
+ * ingest had run since).
  */
 export const pollerWatchdog = internalAction({
   args: {},
@@ -1118,19 +1162,29 @@ export const pollerWatchdog = internalAction({
     if (resetLocked()) {
       return { skipped: true, resetLocked: true };
     }
-    const checkpoint = (await ctx.runQuery(indexerApi.readCheckpoint, {})) as {
-      pollerLastInvokedAt?: number;
+    if (process.env.CLANWORLD_USE_REAL_INDEXER !== "true") {
+      return { stale: false, reason: "real indexer disabled" };
+    }
+    const health = (await ctx.runQuery(indexerApi.readPollerHealth, {})) as {
+      pollerLastInvokedAt: number;
     } | null;
-    if (
-      checkpoint?.pollerLastInvokedAt &&
-      Date.now() - checkpoint.pollerLastInvokedAt > 90_000
-    ) {
+    if (!health) {
+      console.error(
+        "[indexer] poller never ran — real-indexer-log-poller cron has not produced a heartbeat since cold-start",
+      );
+      return { stale: true, reason: "poller never ran" };
+    }
+    if (Date.now() - health.pollerLastInvokedAt > 90_000) {
       console.error(
         "[indexer] poller invocation stale >90s — real-indexer-log-poller cron may be dead",
       );
-      return { stale: true, lastInvokedAt: checkpoint.pollerLastInvokedAt };
+      return {
+        stale: true,
+        reason: "poller heartbeat aged out",
+        lastInvokedAt: health.pollerLastInvokedAt,
+      };
     }
-    return { stale: false };
+    return { stale: false, lastInvokedAt: health.pollerLastInvokedAt };
   },
 });
 

--- a/packages/sdk/convex/schema.ts
+++ b/packages/sdk/convex/schema.ts
@@ -200,6 +200,11 @@ export default defineSchema({
     lastBlock: v.number(),
     lastTxHash: v.optional(v.string()),
     lastSeenAt: v.number(),
+    // Patched on EVERY pollLogs invocation (before the no-op early-return).
+    // True "cron is alive" heartbeat — `lastSeenAt` only updates when there
+    // are new events to ingest, so a quiet chain looks identical to a dead
+    // cron from `lastSeenAt` alone. v.optional so pre-existing rows survive.
+    pollerLastInvokedAt: v.optional(v.number()),
   }),
   clanView: defineTable({
     clanId: v.number(),

--- a/packages/sdk/convex/schema.ts
+++ b/packages/sdk/convex/schema.ts
@@ -99,6 +99,7 @@ export default defineSchema({
     blockNumber: v.optional(v.number()),
     tickEpochStartedAt: v.number(),
     tickEpochDurationMs: v.number(),
+    heartbeatIntervalSeconds: v.optional(v.number()),
     currentSeasonNumber: v.optional(v.number()),
     seasonStartTick: v.number(),
     seasonEndTick: v.number(),
@@ -109,6 +110,7 @@ export default defineSchema({
     tick: v.number(),
     tickEpochStartedAt: v.number(),
     tickEpochDurationMs: v.number(),
+    heartbeatIntervalSeconds: v.optional(v.number()),
     // Season + winter timers (Phase 4.4)
     currentSeasonNumber: v.optional(v.number()),
     seasonStartTick: v.optional(v.number()),
@@ -167,6 +169,22 @@ export default defineSchema({
       )
     ),
   }).index("by_tick", ["tick"]),
+  runnerStatus: defineTable({
+    runnerId: v.string(),
+    lastFireAt: v.optional(v.number()),
+    lastFireResult: v.union(
+      v.literal("success"),
+      v.literal("revert"),
+      v.literal("timeout"),
+      v.literal("error"),
+      v.literal("rate-limited"),
+      v.literal("boot-error"),
+    ),
+    lastFailureMessage: v.optional(v.string()),
+    heartbeatIntervalSeconds: v.optional(v.number()),
+    nextHeartbeatAtTs: v.optional(v.number()),
+    updatedAt: v.number(),
+  }).index("by_runnerId", ["runnerId"]),
   chainEvents: defineTable({
     txHash: v.string(),
     logIndex: v.number(),
@@ -200,11 +218,20 @@ export default defineSchema({
     lastBlock: v.number(),
     lastTxHash: v.optional(v.string()),
     lastSeenAt: v.number(),
-    // Patched on EVERY pollLogs invocation (before the no-op early-return).
-    // True "cron is alive" heartbeat — `lastSeenAt` only updates when there
-    // are new events to ingest, so a quiet chain looks identical to a dead
-    // cron from `lastSeenAt` alone. v.optional so pre-existing rows survive.
+    // DEPRECATED: superseded by the singleton `pollerHealth` table below.
+    // Kept as `v.optional` so existing rows survive Convex schema validation
+    // during rollout; `pollerWatchdog` no longer reads this field.
     pollerLastInvokedAt: v.optional(v.number()),
+  }),
+  // Singleton "cron is alive" heartbeat for `real-indexer-log-poller`.
+  // Decoupled from `eventCheckpoint` so cold-start no longer needs to insert
+  // a synthetic checkpoint row (which polluted the ingest path and made the
+  // watchdog structurally unable to detect a stuck cold-start: a synthetic
+  // row would set `pollerLastInvokedAt` then never advance `lastBlock`,
+  // causing the watchdog to report `stale: false` indefinitely).
+  // pollLogs writes to this on every invocation; pollerWatchdog reads it.
+  pollerHealth: defineTable({
+    pollerLastInvokedAt: v.number(),
   }),
   clanView: defineTable({
     clanId: v.number(),


### PR DESCRIPTION
## Summary

Closes #335. Replaces the redundant 5-second `refreshSnapshot` cron with **event-driven refresh** triggered by `pollLogs` chain events, and adds a **60-second fallback cron** as a safety net in case events stall.

This PR replaces **#405**, which was closed when its branch was force-pushed to dev's HEAD by mistake. The three-commit shape is preserved here verbatim (cherry-picked with `-x` provenance) onto a fresh dev base.

### Commits

1. `feat(crons): drop redundant 5s refresh cron; drive refreshSnapshot from pollLogs events (#335)` — removes the 5s interval in `crons.ts`; adds an `inserted > 0` post-ingest scheduler call to `refreshSnapshot` in `pollLogs`; adds a 90s liveness alert.
2. `fix(crons): clarify liveness alert — stalled cron not webhook (#335)` — tightens the alert message to reflect the actual stall surface (pollLogs cron, not webhook).
3. `fix(crons): add 60s fallback refresh cron; backstops transient RPC failures (#335)` — re-introduces a slow refresh cron (60s, not 5s) as a safety backstop when events stall.
4. `fix(indexer): PR #502 super-swarm fix-round — liveness watchdog from fallback cron + chain-tip guard for event-driven refresh` — extracts the watchdog into its own 60s cron (independent of pollLogs); adds chain-tip gating to suppress event-driven refresh during historical backfill.
5. `fix(indexer): PR #502 cloud-review fix-round — pollerHealth table + watchdog cold-start detection + gating test + docs` — separates poller liveness from `eventCheckpoint` into a new singleton `pollerHealth` table; watchdog now detects stuck cold-start; adds 5 unit tests for the gating predicate; expands INDEXER.md with the new crons.

### Why event-driven + fallback (rather than pure event-driven)

The 5s polling cron made ~12 RPC calls/min just to keep `worldSnapshot` warm. The event-driven path (refresh-after-inserted-events from the 3s `pollLogs`) is cheaper and more responsive. The 60s fallback guarantees a heartbeat even if `pollLogs` itself goes silent (transient RPC failure, deploy gap, etc.).

### Schema changes

This PR introduces **one new Convex table** and **one deprecated field** (`packages/sdk/convex/schema.ts`):

- **New: `pollerHealth`** — singleton table holding `pollerLastInvokedAt: v.number()`. Decoupled from `eventCheckpoint` so the poller liveness heartbeat and ingest progress live in separate tables. `pollerWatchdog` reads from this; `markPollerInvoked` writes to it.
- **Deprecated: `eventCheckpoint.pollerLastInvokedAt`** — kept as `v.optional(v.number())` so existing rows survive Convex schema validation during rollout. No longer read or written. Safe to drop in a follow-up migration.

Rationale: the original v1.0.1 design wrote `pollerLastInvokedAt` into `eventCheckpoint` and synthesized a row at cold-start. This (a) polluted the ingest table with a placeholder before any real ingest, and (b) made the watchdog structurally unable to detect a stuck cold-start (synthetic row → `stale: false` forever). Separating concerns fixes both.

### Dependency on #402 (now landed)

#402 (split `getSnapshot` → `tickClock` + `worldSnapshot` + cloud-review fix-round) merged to dev today. This work targets the post-#402 indexer surface — `eventCheckpoint.lastSeenAt`, the `inserted` return from `ingestEvents`, and the monotonic guards added in #402's fix-round are all preserved.

### Conflict resolution note

The original commit `d4d162b` (from the closed #405 branch) also touched `heartbeat.ts` to **remove** monotonic guards on the `worldSnapshot` / `tickClock` writes in `advanceTick`. Those guards were added by #402's fix-round (now on dev) and are essential for correctness under concurrent indexer/heartbeat writes. The cherry-pick amend in this PR **drops** the heartbeat.ts changes from `d4d162b` so the #402 guards stay intact.

## Diff

- `apps/server/convex/crons.ts` — drop 5s cron, add 60s fallback, add 60s watchdog cron
- `apps/server/convex/indexer.ts` — pollLogs schedules refreshSnapshot when at chain tip AND inserted > 0; new `markPollerInvoked` mutation writes to `pollerHealth`; new `readPollerHealth` query; new `pollerWatchdog` action with cold-start detection; new `shouldScheduleEventDrivenRefresh` pure helper for testability
- `apps/server/convex/indexer.test.ts` — +5 unit tests for `shouldScheduleEventDrivenRefresh` (tip / backfill / zero-insert / ahead-of-safeLatest branches)
- `apps/server/convex/INDEXER.md` — describe all three crons under `CLANWORLD_USE_REAL_INDEXER=true`
- `packages/sdk/convex/schema.ts` — add `pollerHealth` table; mark `eventCheckpoint.pollerLastInvokedAt` deprecated

## Test plan

- [x] `pnpm --filter @clan-world/server test` → 63/63 pass (indexer.test.ts 17 → 22 with the new gating tests)
- [x] `pnpm --filter @clan-world/server typecheck` → clean
- [x] `pnpm --filter @clan-world/sdk typecheck` → clean
- [ ] Deploy to Convex preview; confirm `pollLogs` inserts trigger `refreshSnapshot` at chain tip
- [ ] Confirm 60s fallback fires when no chain events arrive
- [ ] Confirm `pollerWatchdog` logs `[indexer] poller never ran ...` if `pollLogs` is forcibly disabled at startup
- [ ] Confirm `pollerWatchdog` logs `[indexer] poller invocation stale >90s ...` when `pollLogs` is killed mid-run

## History

- Old PR: #405 (closed by force-push accident, same author work)
- Issue: #335
- Depends on (merged): #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
