### PR TITLE
feat(heartbeat): on-chain interval as single source of truth + self-scheduling runner

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -44,9 +44,11 @@ HEARTBEAT_CALLER_ENABLED=false
 # Opt-in local/demo fake Convex heartbeat. Leave unset/false for real-deal
 # testing and production; v1.1 replaces this with a chain-reader indexer.
 CLANWORLD_USE_FAKE_HEARTBEAT=false
-# Preferred explicit HTTP actions base URL. If unset, the runner derives this
-# from CONVEX_DEPLOY_URL by replacing `.convex.cloud` with `.convex.site`.
-CONVEX_WEBHOOK_URL=
+# Preferred explicit HTTP actions base URL. If UNSET (commented out), the runner
+# derives this from CONVEX_DEPLOY_URL by replacing `.convex.cloud` with
+# `.convex.site`. Set to an explicit URL to override. Set to empty string ("")
+# to intentionally disable the webhook (e.g. local dev without HTTP actions).
+# CONVEX_WEBHOOK_URL=
 WEBHOOK_SHARED_SECRET=
 
 # ============================================================

--- a/.env.template
+++ b/.env.template
@@ -43,6 +43,7 @@ HEARTBEAT_CALLER_ENABLED=false
 # Opt-in local/demo fake Convex heartbeat. Leave unset/false for real-deal
 # testing and production; v1.1 replaces this with a chain-reader indexer.
 CLANWORLD_USE_FAKE_HEARTBEAT=false
+CONVEX_WEBHOOK_URL=
 WEBHOOK_SHARED_SECRET=
 
 # ============================================================

--- a/.env.template
+++ b/.env.template
@@ -38,7 +38,6 @@ CLAN_WORLD_GOLD_TREASURY_OWNER=5YqhQK4LfJmaaZQLqSEfcJc4ViUQHX15quVCXwNJDFnd
 CLAN_WORLD_GOLD_TREASURY_ATA=4jQN1PfXQ2yfU75K4pMiY4Ue62yXknjKFJ7L9wukSRn8
 
 # --- Tick + heartbeat ---
-TICK_DURATION_MS=20000
 KEEPER_MODE=foundry-loop
 HEARTBEAT_CALLER_ENABLED=false
 # Opt-in local/demo fake Convex heartbeat. Leave unset/false for real-deal

--- a/.env.template
+++ b/.env.template
@@ -23,6 +23,7 @@ DEPLOYER_PRIVATE_KEY=
 
 # --- Convex backend ---
 CONVEX_URL=
+CONVEX_DEPLOY_URL=
 # Required for cockpit-mirror writes (elder peer whisper, bulletins, orch events, human steering).
 # Must match the deployment-side value set via:
 #   npx convex env set INDEXER_SECRET <value>
@@ -43,6 +44,8 @@ HEARTBEAT_CALLER_ENABLED=false
 # Opt-in local/demo fake Convex heartbeat. Leave unset/false for real-deal
 # testing and production; v1.1 replaces this with a chain-reader indexer.
 CLANWORLD_USE_FAKE_HEARTBEAT=false
+# Preferred explicit HTTP actions base URL. If unset, the runner derives this
+# from CONVEX_DEPLOY_URL by replacing `.convex.cloud` with `.convex.site`.
 CONVEX_WEBHOOK_URL=
 WEBHOOK_SHARED_SECRET=
 

--- a/TEAMMATE-SETUP.md
+++ b/TEAMMATE-SETUP.md
@@ -53,7 +53,6 @@ cp .env.template .env.local
 | `CLANWORLD_USE_FAKE_HEARTBEAT=false` | hardcode | use real chain heartbeat |
 | `WEBHOOK_SHARED_SECRET` | from Liam | shared secret between Convex webhook caller + verifier |
 | `CLAUDE_CODE_OAUTH_TOKEN` | your own from [Claude Code account](https://claude.com/code) | for elder REPLs only — your token, not Liam's |
-| `TICK_DURATION_MS=20000` | hardcode | seconds × 1000 between elder reasoning passes |
 
 ### 2b. Server `.env.local`
 

--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -34,6 +34,7 @@ import type * as mock from "../mock.js";
 import type * as ops from "../ops.js";
 import type * as resetLock from "../resetLock.js";
 import type * as retention from "../retention.js";
+import type * as runnerStatus from "../runnerStatus.js";
 import type * as vault from "../vault.js";
 
 /**
@@ -66,6 +67,7 @@ declare const fullApi: ApiFromModules<{
   ops: typeof ops;
   resetLock: typeof resetLock;
   retention: typeof retention;
+  runnerStatus: typeof runnerStatus;
   vault: typeof vault;
 }>;
 export declare const api: FilterApi<

--- a/apps/server/convex/clansmen.ts
+++ b/apps/server/convex/clansmen.ts
@@ -137,8 +137,14 @@ export const getClanClansmen = query({
 
     const snap = await ctx.db.query("worldSnapshot").order("desc").first();
     const currentTick = snap?.tick ?? Number(view.derivedAtTick) ?? 0;
+    const snapshotHeartbeatIntervalSeconds =
+      typeof snap?.heartbeatIntervalSeconds === "number" && snap.heartbeatIntervalSeconds > 0
+        ? snap.heartbeatIntervalSeconds
+        : undefined;
     const tickDurationMs =
-      snap?.tickEpochDurationMs ?? Number(HEARTBEAT_INTERVAL_SECONDS) * 1000;
+      snapshotHeartbeatIntervalSeconds !== undefined
+        ? snapshotHeartbeatIntervalSeconds * 1000
+        : snap?.tickEpochDurationMs ?? Number(HEARTBEAT_INTERVAL_SECONDS) * 1000;
     const tickDurationSeconds = Math.max(1, Math.floor(tickDurationMs / 1000));
 
     const rows = Array.isArray(view.clansmen) ? view.clansmen : [];

--- a/apps/server/convex/clansmen.ts
+++ b/apps/server/convex/clansmen.ts
@@ -1,7 +1,7 @@
 import { query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
-import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constants";
 import { ClansmanState } from "@clan-world/shared/generated/enums";
+import { resolveHeartbeatIntervalSecondsForSnap } from "./getSnapshot";
 
 /**
  * Per-clansman roster for ClansmanTab. Reads the latest `clanView` row, maps
@@ -137,14 +137,10 @@ export const getClanClansmen = query({
 
     const snap = await ctx.db.query("worldSnapshot").order("desc").first();
     const currentTick = snap?.tick ?? Number(view.derivedAtTick) ?? 0;
-    const snapshotHeartbeatIntervalSeconds =
-      typeof snap?.heartbeatIntervalSeconds === "number" && snap.heartbeatIntervalSeconds > 0
-        ? snap.heartbeatIntervalSeconds
-        : undefined;
-    const tickDurationMs =
-      snapshotHeartbeatIntervalSeconds !== undefined
-        ? snapshotHeartbeatIntervalSeconds * 1000
-        : snap?.tickEpochDurationMs ?? Number(HEARTBEAT_INTERVAL_SECONDS) * 1000;
+    const tickDurationMs = resolveHeartbeatIntervalSecondsForSnap({
+      heartbeatIntervalSeconds: snap?.heartbeatIntervalSeconds,
+      tickEpochDurationMs: snap?.tickEpochDurationMs,
+    }) * 1000;
     const tickDurationSeconds = Math.max(1, Math.floor(tickDurationMs / 1000));
 
     const rows = Array.isArray(view.clansmen) ? view.clansmen : [];

--- a/apps/server/convex/getSnapshot.test.ts
+++ b/apps/server/convex/getSnapshot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   deriveSeasonState,
+  getSnapshot,
   normalizePausedAtTs,
   resolveHeartbeatIntervalSecondsForSnap,
   resolvePauseStateForSnap,
@@ -12,6 +13,42 @@ import {
 const SEASON_LEN = 360;
 const WINTER_START = 110;
 const WINTER_DUR = 10;
+
+function createDb(tables: Record<string, any[]> = {}) {
+  return {
+    query(table: string) {
+      let rows = [...(tables[table] ?? [])];
+      const builder = {
+        withIndex(_name: string, apply: (q: any) => unknown) {
+          const clauses: Array<{ field: string; value: unknown }> = [];
+          const q = {
+            eq(field: string, value: unknown) {
+              clauses.push({ field, value });
+              return q;
+            },
+          };
+          apply(q);
+          rows = rows.filter((row) =>
+            clauses.every((clause) => row[clause.field] === clause.value),
+          );
+          return builder;
+        },
+        order(direction: "asc" | "desc") {
+          rows = [...rows].sort((a, b) =>
+            direction === "desc"
+              ? (b._creationTime ?? 0) - (a._creationTime ?? 0)
+              : (a._creationTime ?? 0) - (b._creationTime ?? 0),
+          );
+          return builder;
+        },
+        async first() {
+          return rows[0] ?? null;
+        },
+      };
+      return builder;
+    },
+  };
+}
 
 describe("resolveSeasonStateForSnap (issue #435 regression)", () => {
   it("season-freeze window: tick === seasonEndTick && !seasonFinalized returns persisted OLD season, NOT derived next season", () => {
@@ -196,5 +233,39 @@ describe("resolveHeartbeatIntervalSecondsForSnap", () => {
     expect(resolveHeartbeatIntervalSecondsForSnap({
       tickEpochDurationMs: 30_000,
     })).toBe(30);
+  });
+});
+
+describe("getSnapshot heartbeat interval", () => {
+  it("returns the latest persisted on-chain heartbeatIntervalSeconds", async () => {
+    const db = createDb({
+      worldSnapshot: [
+        {
+          _creationTime: 1,
+          tick: 8,
+          heartbeatIntervalSeconds: 60,
+          tickEpochStartedAt: 1_000,
+          tickEpochDurationMs: 60_000,
+          regions: [],
+          clans: [],
+          activeBanditId: 0,
+        },
+        {
+          _creationTime: 2,
+          tick: 8,
+          heartbeatIntervalSeconds: 45,
+          tickEpochStartedAt: 2_000,
+          tickEpochDurationMs: 60_000,
+          regions: [],
+          clans: [],
+          activeBanditId: 0,
+        },
+      ],
+    });
+
+    const result = await (getSnapshot as any)._handler({ db });
+
+    expect(result.heartbeatIntervalSeconds).toBe(45);
+    expect(result.tickEpoch.durationMs).toBe(60_000);
   });
 });

--- a/apps/server/convex/getSnapshot.test.ts
+++ b/apps/server/convex/getSnapshot.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   deriveSeasonState,
   normalizePausedAtTs,
+  resolveHeartbeatIntervalSecondsForSnap,
   resolvePauseStateForSnap,
   resolveSeasonStateForSnap,
   type PersistedSnapshotSeasonFields,
@@ -180,5 +181,20 @@ describe("normalizePausedAtTs", () => {
       worldPaused: false,
       pausedAtTs: null,
     });
+  });
+});
+
+describe("resolveHeartbeatIntervalSecondsForSnap", () => {
+  it("prefers persisted on-chain heartbeatIntervalSeconds", () => {
+    expect(resolveHeartbeatIntervalSecondsForSnap({
+      heartbeatIntervalSeconds: 45,
+      tickEpochDurationMs: 60_000,
+    })).toBe(45);
+  });
+
+  it("falls back to legacy tickEpochDurationMs", () => {
+    expect(resolveHeartbeatIntervalSecondsForSnap({
+      tickEpochDurationMs: 30_000,
+    })).toBe(30);
   });
 });

--- a/apps/server/convex/getSnapshot.ts
+++ b/apps/server/convex/getSnapshot.ts
@@ -81,6 +81,7 @@ export function deriveSeasonState(tick: number): DerivedSeasonState {
  */
 export interface PersistedSnapshotSeasonFields {
   tick: number;
+  heartbeatIntervalSeconds?: number;
   currentSeasonNumber?: number;
   seasonStartTick?: number;
   seasonEndTick?: number;
@@ -141,13 +142,36 @@ export function resolvePauseStateForSnap(snap: {
   };
 }
 
+export function resolveHeartbeatIntervalSecondsForSnap(snap: {
+  heartbeatIntervalSeconds?: unknown;
+  tickEpochDurationMs?: unknown;
+}): number {
+  if (
+    typeof snap.heartbeatIntervalSeconds === "number" &&
+    Number.isFinite(snap.heartbeatIntervalSeconds) &&
+    snap.heartbeatIntervalSeconds > 0
+  ) {
+    return snap.heartbeatIntervalSeconds;
+  }
+  if (
+    typeof snap.tickEpochDurationMs === "number" &&
+    Number.isFinite(snap.tickEpochDurationMs) &&
+    snap.tickEpochDurationMs > 0
+  ) {
+    return Math.max(1, Math.floor(snap.tickEpochDurationMs / 1000));
+  }
+  return Number(HEARTBEAT_INTERVAL_SECONDS);
+}
+
 export const getSnapshot = query({
   handler: async (ctx) => {
     const snap = await ctx.db.query("worldSnapshot").order("desc").first();
+    const defaultHeartbeatIntervalSeconds = Number(HEARTBEAT_INTERVAL_SECONDS);
     if (!snap) {
       return {
         tick: 0,
-        tickEpoch: { startedAt: 0, durationMs: Number(HEARTBEAT_INTERVAL_SECONDS) * 1000 },
+        heartbeatIntervalSeconds: defaultHeartbeatIntervalSeconds,
+        tickEpoch: { startedAt: 0, durationMs: defaultHeartbeatIntervalSeconds * 1000 },
         regions: [],
         clans: [],
         activeBanditId: undefined,
@@ -185,6 +209,7 @@ export const getSnapshot = query({
         : null;
     return {
       tick: snap.tick,
+      heartbeatIntervalSeconds: resolveHeartbeatIntervalSecondsForSnap(snap),
       tickEpoch: {
         startedAt: snap.tickEpochStartedAt,
         durationMs: snap.tickEpochDurationMs,

--- a/apps/server/convex/getTickClock.ts
+++ b/apps/server/convex/getTickClock.ts
@@ -15,6 +15,7 @@ export const getTickClock = query({
       blockNumber: clock.blockNumber,
       tickEpochStartedAt: clock.tickEpochStartedAt,
       tickEpochDurationMs: clock.tickEpochDurationMs,
+      heartbeatIntervalSeconds: clock.heartbeatIntervalSeconds,
       currentSeasonNumber: clock.currentSeasonNumber,
       seasonStartTick: clock.seasonStartTick,
       seasonEndTick: clock.seasonEndTick,

--- a/apps/server/convex/heartbeat.ts
+++ b/apps/server/convex/heartbeat.ts
@@ -251,6 +251,10 @@ export const advanceTick = internalMutation({
     const baseTick = clockRow?.tick ?? snap.tick;
     const baseEpochStartedAt = clockRow?.tickEpochStartedAt ?? snap.tickEpochStartedAt;
     const baseEpochDurationMs = clockRow?.tickEpochDurationMs ?? snap.tickEpochDurationMs;
+    const baseHeartbeatIntervalSeconds =
+      clockRow?.heartbeatIntervalSeconds ??
+      snap.heartbeatIntervalSeconds ??
+      Math.max(1, Math.floor(baseEpochDurationMs / 1000));
 
     // Staleness gate: only advance if the current epoch has elapsed.
     const nowSeconds = Math.floor(Date.now() / 1000);
@@ -269,6 +273,7 @@ export const advanceTick = internalMutation({
         tick: newTick,
         tickEpochStartedAt: newEpochStartedAt,
         tickEpochDurationMs: baseEpochDurationMs,
+        heartbeatIntervalSeconds: baseHeartbeatIntervalSeconds,
         regions: snap.regions,
         clans: snap.clans,
       });
@@ -285,12 +290,14 @@ export const advanceTick = internalMutation({
         await ctx.db.patch(clockRow._id, {
           tick: newTick,
           tickEpochStartedAt: newEpochStartedAt,
+          heartbeatIntervalSeconds: baseHeartbeatIntervalSeconds,
         });
       } else {
         await ctx.db.insert("tickClock", {
           tick: newTick,
           tickEpochStartedAt: newEpochStartedAt,
           tickEpochDurationMs: baseEpochDurationMs,
+          heartbeatIntervalSeconds: baseHeartbeatIntervalSeconds,
           seasonStartTick: 0,
           seasonEndTick: 0,
           winterActive: false,

--- a/apps/server/convex/indexer.test.ts
+++ b/apps/server/convex/indexer.test.ts
@@ -76,6 +76,7 @@ type CommitSnapshotTestHandler = (
     snapshot: {
       blockNumber: number;
       txHash?: string;
+      heartbeatIntervalSeconds?: number;
       world: Record<string, unknown>;
       clans: unknown[];
     };
@@ -631,6 +632,48 @@ describe("legacy snapshot backfill", () => {
     expect(advancedClock.tick).toBe(13);
     expect(advancedClock.tickEpochStartedAt).toBe(1_060);
     expect(advancedClock.tickEpochDurationMs).toBe(60_000);
+
+    now.mockRestore();
+  });
+
+  it("persists on-chain heartbeatIntervalSeconds and patches interval-only changes", async () => {
+    const { db, tables } = createDb();
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(2_000_000);
+
+    await runCommitSnapshot(
+      { db },
+      {
+        snapshot: {
+          blockNumber: 200,
+          heartbeatIntervalSeconds: 45,
+          world: { currentTick: 20 },
+          clans: [],
+        },
+      },
+    );
+
+    expect(tables.tickClock?.[0]?.heartbeatIntervalSeconds).toBe(45);
+    expect(tables.tickClock?.[0]?.tickEpochDurationMs).toBe(45_000);
+    expect(tables.worldSnapshot?.[0]?.heartbeatIntervalSeconds).toBe(45);
+    expect(tables.worldSnapshot?.[0]?.tickEpochDurationMs).toBe(45_000);
+
+    await runCommitSnapshot(
+      { db },
+      {
+        snapshot: {
+          blockNumber: 201,
+          heartbeatIntervalSeconds: 30,
+          world: { currentTick: 20 },
+          clans: [],
+        },
+      },
+    );
+
+    expect(tables.tickClock?.[0]?.heartbeatIntervalSeconds).toBe(30);
+    expect(tables.tickClock?.[0]?.tickEpochDurationMs).toBe(30_000);
+    expect(tables.worldSnapshot?.[0]?.heartbeatIntervalSeconds).toBe(30);
+    expect(tables.worldSnapshot?.[0]?.tickEpochDurationMs).toBe(30_000);
 
     now.mockRestore();
   });

--- a/apps/server/convex/indexer.ts
+++ b/apps/server/convex/indexer.ts
@@ -52,6 +52,8 @@ const GET_MARKET_STATE = "getMarketState" satisfies LensFunctionName;
 const GET_ACTIVE_BANDIT_VIEW =
   "getActiveBanditView" satisfies LensFunctionName;
 const GET_CLAN_IDS = "getClanIds" satisfies ClanWorldFunctionName;
+const GET_HEARTBEAT_INTERVAL_SECONDS =
+  "heartbeatIntervalSeconds" satisfies ClanWorldFunctionName;
 const GET_CLAN_FULL_VIEW = "getClanFullView" satisfies LensFunctionName;
 const LEGACY_REGIONS = [
   { id: "forest", name: "Forest", ownerClanId: null },
@@ -114,6 +116,7 @@ type ParsedIndexerEvent = {
 type SnapshotPayload = {
   blockNumber?: number;
   txHash?: string;
+  heartbeatIntervalSeconds?: number;
   world: Record<string, unknown>;
   market?: Record<string, unknown>;
   bandit?: Record<string, unknown>;
@@ -213,6 +216,19 @@ const asNumber = (value: unknown, fallback = 0): number => {
   if (typeof value === "bigint") return Number(value);
   if (typeof value === "string" && value !== "") return Number(value);
   return fallback;
+};
+
+const DEFAULT_HEARTBEAT_INTERVAL_SECONDS = Number(HEARTBEAT_INTERVAL_SECONDS);
+
+const resolveHeartbeatIntervalSeconds = (
+  incoming: unknown,
+  previous: unknown,
+): number => {
+  const next = asNumber(incoming, 0);
+  if (next > 0) return next;
+  const prior = asNumber(previous, 0);
+  if (prior > 0) return prior;
+  return DEFAULT_HEARTBEAT_INTERVAL_SECONDS;
 };
 
 const asString = (value: unknown, fallback = "0"): string =>
@@ -584,6 +600,7 @@ export const ingestEvents = internalMutation({
 const snapshotValidator = v.object({
   blockNumber: v.optional(v.number()),
   txHash: v.optional(v.string()),
+  heartbeatIntervalSeconds: v.optional(v.number()),
   // TODO(post-demo): tighten world/market/bandit/clans inner record shapes
   // once contract structs stabilize (M-5 audit).
   world: v.any(),
@@ -613,6 +630,10 @@ export const commitSnapshot = internalMutation({
       .query("worldSnapshot")
       .order("desc")
       .first();
+    const heartbeatIntervalSeconds = resolveHeartbeatIntervalSeconds(
+      snapshot.heartbeatIntervalSeconds,
+      previousWorldSnapshot?.heartbeatIntervalSeconds,
+    );
     // Fetch tickClock first — it's the always-advancing monotonic cursor.
     // worldSnapshot can freeze between content-change ticks (delta-check), so
     // previousWorldSnapshot.tick is not a reliable stale-gate cursor anymore.
@@ -653,7 +674,8 @@ export const commitSnapshot = internalMutation({
         tickClockRow?.tick === tick && !worldPausedChanged
           ? tickClockRow.tickEpochStartedAt
           : Math.floor(now / 1000),
-      tickEpochDurationMs: Number(HEARTBEAT_INTERVAL_SECONDS) * 1000,
+      tickEpochDurationMs: heartbeatIntervalSeconds * 1000,
+      heartbeatIntervalSeconds,
       currentSeasonNumber: asNumber(world.currentSeasonNumber),
       seasonStartTick: asNumber(world.seasonStartTick),
       seasonEndTick: asNumber(world.seasonEndTick),
@@ -834,6 +856,7 @@ export const commitSnapshot = internalMutation({
       tick,
       tickEpochStartedAt: tickClockData.tickEpochStartedAt,
       tickEpochDurationMs: tickClockData.tickEpochDurationMs,
+      heartbeatIntervalSeconds,
       currentSeasonNumber: asNumber(world.currentSeasonNumber),
       seasonStartTick: asNumber(world.seasonStartTick),
       seasonEndTick: asNumber(world.seasonEndTick),
@@ -957,13 +980,16 @@ export const refreshSnapshot = internalAction({
       blockNumber: pinnedBlockNumber,
     });
 
-    const [worldRaw, market, bandit] = await Promise.all([
+    const [worldRaw, market, bandit, heartbeatIntervalSecondsRaw] = await Promise.all([
       client
         .readContract(readLensArgs(GET_WORLD_SNAPSHOT))
         .catch(() => undefined),
       client.readContract(readLensArgs(GET_MARKET_STATE)).catch(() => undefined),
       client
         .readContract(readLensArgs(GET_ACTIVE_BANDIT_VIEW))
+        .catch(() => undefined),
+      client
+        .readContract(readWorldArgs(GET_HEARTBEAT_INTERVAL_SECONDS))
         .catch(() => undefined),
     ]);
 
@@ -998,6 +1024,9 @@ export const refreshSnapshot = internalAction({
     return await ctx.runMutation(indexerApi.commitSnapshot, {
       snapshot: {
         blockNumber,
+        heartbeatIntervalSeconds: heartbeatIntervalSecondsRaw === undefined
+          ? undefined
+          : asNumber(heartbeatIntervalSecondsRaw, DEFAULT_HEARTBEAT_INTERVAL_SECONDS),
         world: bigintSafe(world),
         market: bigintSafe(market),
         bandit: bigintSafe(bandit),

--- a/apps/server/convex/mock.ts
+++ b/apps/server/convex/mock.ts
@@ -3,6 +3,9 @@
 // Nothing reads MOCK_MODE at runtime yet — it's a placeholder toggle for Wave 1.
 
 import { internalMutation } from "./_generated/server";
+import { HEARTBEAT_INTERVAL_SECONDS } from "@clan-world/shared/generated/constants";
+
+const HEARTBEAT_INTERVAL = Number(HEARTBEAT_INTERVAL_SECONDS);
 
 const MOCK_REGIONS = [
   { id: "forest", name: "Forest", ownerClanId: "clan-iron" },
@@ -27,8 +30,9 @@ export const seedMockState = internalMutation({
     // Insert mock snapshot
     await ctx.db.insert("worldSnapshot", {
       tick: 42,
-      tickEpochStartedAt: Math.floor(Date.now() / 1000) - 42 * 20,
-      tickEpochDurationMs: 20_000,
+      tickEpochStartedAt: Math.floor(Date.now() / 1000) - 42 * HEARTBEAT_INTERVAL,
+      tickEpochDurationMs: HEARTBEAT_INTERVAL * 1000,
+      heartbeatIntervalSeconds: HEARTBEAT_INTERVAL,
       regions: MOCK_REGIONS,
       clans: MOCK_CLANS,
     });

--- a/apps/server/convex/ops.ts
+++ b/apps/server/convex/ops.ts
@@ -25,6 +25,7 @@ const RESET_TABLES = [
   "whispers",
   "orchEvents",
   "humanSteeringMessages",
+  "runnerStatus",
 ] as const;
 
 const MAX_FLUSH_WRITES = 9000;

--- a/apps/server/convex/runnerStatus.test.ts
+++ b/apps/server/convex/runnerStatus.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { getRunnerStatus } from "./runnerStatus";
+import { getRunnerStatus, updateRunnerStatus } from "./runnerStatus";
 
 function createDb(tables: Record<string, any[]> = {}) {
   return {
@@ -37,6 +37,22 @@ function createDb(tables: Record<string, any[]> = {}) {
       };
       return builder;
     },
+    async patch(id: string, patch: Record<string, unknown>) {
+      for (const rows of Object.values(tables)) {
+        const row = rows.find((candidate) => candidate._id === id);
+        if (row) {
+          Object.assign(row, patch);
+          return;
+        }
+      }
+      throw new Error(`row not found: ${id}`);
+    },
+    async insert(table: string, row: Record<string, unknown>) {
+      const id = `${table}:${(tables[table] ?? []).length + 1}`;
+      tables[table] ??= [];
+      tables[table].push({ _id: id, ...row });
+      return id;
+    },
   };
 }
 
@@ -65,5 +81,44 @@ describe("getRunnerStatus", () => {
     await expect(
       (getRunnerStatus as any)._handler({ db }, { secret: "", runnerId: "runner-a" }),
     ).rejects.toThrow("invalid indexer secret");
+  });
+});
+
+describe("updateRunnerStatus", () => {
+  const originalSecret = process.env.INDEXER_SECRET;
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.INDEXER_SECRET;
+    } else {
+      process.env.INDEXER_SECRET = originalSecret;
+    }
+  });
+
+  it("clears lastFailureMessage when a success update sends an empty string", async () => {
+    process.env.INDEXER_SECRET = "test-secret";
+    const tables = {
+      runnerStatus: [{
+        _id: "runnerStatus:1",
+        _creationTime: 1,
+        runnerId: "runner-a",
+        lastFireResult: "error",
+        lastFailureMessage: "rpc down",
+      }],
+    };
+    const db = createDb(tables);
+
+    await (updateRunnerStatus as any)._handler({ db }, {
+      secret: "test-secret",
+      runnerId: "runner-a",
+      lastFireResult: "success",
+      lastFailureMessage: "",
+    });
+
+    expect(tables.runnerStatus[0]).toMatchObject({
+      runnerId: "runner-a",
+      lastFireResult: "success",
+      lastFailureMessage: "",
+    });
   });
 });

--- a/apps/server/convex/runnerStatus.test.ts
+++ b/apps/server/convex/runnerStatus.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getRunnerStatus } from "./runnerStatus";
+
+function createDb(tables: Record<string, any[]> = {}) {
+  return {
+    query(table: string) {
+      let rows = [...(tables[table] ?? [])];
+      const builder = {
+        withIndex(_name: string, apply: (q: any) => unknown) {
+          const clauses: Array<{ field: string; value: unknown }> = [];
+          const q = {
+            eq(field: string, value: unknown) {
+              clauses.push({ field, value });
+              return q;
+            },
+          };
+          apply(q);
+          rows = rows.filter((row) =>
+            clauses.every((clause) => row[clause.field] === clause.value),
+          );
+          return builder;
+        },
+        order(direction: "asc" | "desc") {
+          rows = [...rows].sort((a, b) =>
+            direction === "desc"
+              ? (b._creationTime ?? 0) - (a._creationTime ?? 0)
+              : (a._creationTime ?? 0) - (b._creationTime ?? 0),
+          );
+          return builder;
+        },
+        async first() {
+          return rows[0] ?? null;
+        },
+        async collect() {
+          return rows;
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe("getRunnerStatus", () => {
+  const originalSecret = process.env.INDEXER_SECRET;
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.INDEXER_SECRET;
+    } else {
+      process.env.INDEXER_SECRET = originalSecret;
+    }
+  });
+
+  it("rejects unauthenticated reads", async () => {
+    process.env.INDEXER_SECRET = "test-secret";
+    const db = createDb({
+      runnerStatus: [{
+        _creationTime: 1,
+        runnerId: "runner-a",
+        lastFireResult: "error",
+        lastFailureMessage: "https://provider.example/key",
+      }],
+    });
+
+    await expect(
+      (getRunnerStatus as any)._handler({ db }, { secret: "", runnerId: "runner-a" }),
+    ).rejects.toThrow("invalid indexer secret");
+  });
+});

--- a/apps/server/convex/runnerStatus.ts
+++ b/apps/server/convex/runnerStatus.ts
@@ -7,6 +7,8 @@ const resultValidator = v.union(
   v.literal("revert"),
   v.literal("timeout"),
   v.literal("error"),
+  v.literal("rate-limited"),
+  v.literal("boot-error"),
 );
 
 export const getRunnerStatus = query({

--- a/apps/server/convex/runnerStatus.ts
+++ b/apps/server/convex/runnerStatus.ts
@@ -1,0 +1,61 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { requireIndexerSecret } from "./authShared";
+
+const resultValidator = v.union(
+  v.literal("success"),
+  v.literal("revert"),
+  v.literal("timeout"),
+  v.literal("error"),
+);
+
+export const getRunnerStatus = query({
+  args: {
+    runnerId: v.optional(v.string()),
+  },
+  handler: async (ctx, { runnerId }) => {
+    if (runnerId) {
+      return await ctx.db
+        .query("runnerStatus")
+        .withIndex("by_runnerId", (q) => q.eq("runnerId", runnerId))
+        .first();
+    }
+    return await ctx.db.query("runnerStatus").order("desc").collect();
+  },
+});
+
+export const updateRunnerStatus = mutation({
+  args: {
+    secret: v.string(),
+    runnerId: v.string(),
+    lastFireAt: v.optional(v.number()),
+    lastFireResult: resultValidator,
+    lastFailureMessage: v.optional(v.string()),
+    heartbeatIntervalSeconds: v.optional(v.number()),
+    nextHeartbeatAtTs: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    requireIndexerSecret(args.secret);
+
+    const existing = await ctx.db
+      .query("runnerStatus")
+      .withIndex("by_runnerId", (q) => q.eq("runnerId", args.runnerId))
+      .first();
+
+    const row = {
+      runnerId: args.runnerId,
+      ...(args.lastFireAt !== undefined ? { lastFireAt: args.lastFireAt } : {}),
+      lastFireResult: args.lastFireResult,
+      lastFailureMessage: args.lastFailureMessage,
+      heartbeatIntervalSeconds: args.heartbeatIntervalSeconds,
+      nextHeartbeatAtTs: args.nextHeartbeatAtTs,
+      updatedAt: Date.now(),
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, row);
+      return existing._id;
+    }
+    return await ctx.db.insert("runnerStatus", row);
+  },
+});

--- a/apps/server/convex/runnerStatus.ts
+++ b/apps/server/convex/runnerStatus.ts
@@ -13,9 +13,12 @@ const resultValidator = v.union(
 
 export const getRunnerStatus = query({
   args: {
+    secret: v.string(),
     runnerId: v.optional(v.string()),
   },
-  handler: async (ctx, { runnerId }) => {
+  handler: async (ctx, { secret, runnerId }) => {
+    requireIndexerSecret(secret);
+
     if (runnerId) {
       return await ctx.db
         .query("runnerStatus")

--- a/apps/server/convex/runnerStatus.ts
+++ b/apps/server/convex/runnerStatus.ts
@@ -51,9 +51,15 @@ export const updateRunnerStatus = mutation({
       runnerId: args.runnerId,
       ...(args.lastFireAt !== undefined ? { lastFireAt: args.lastFireAt } : {}),
       lastFireResult: args.lastFireResult,
-      lastFailureMessage: args.lastFailureMessage,
-      heartbeatIntervalSeconds: args.heartbeatIntervalSeconds,
-      nextHeartbeatAtTs: args.nextHeartbeatAtTs,
+      ...(args.lastFailureMessage !== undefined
+        ? { lastFailureMessage: args.lastFailureMessage }
+        : {}),
+      ...(args.heartbeatIntervalSeconds !== undefined
+        ? { heartbeatIntervalSeconds: args.heartbeatIntervalSeconds }
+        : {}),
+      ...(args.nextHeartbeatAtTs !== undefined
+        ? { nextHeartbeatAtTs: args.nextHeartbeatAtTs }
+        : {}),
       updatedAt: Date.now(),
     };
 

--- a/apps/web/src/TopHud.test.ts
+++ b/apps/web/src/TopHud.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRefreshTickCountdownAnchor } from './TopHud';
+
+describe('shouldRefreshTickCountdownAnchor', () => {
+  it('refreshes when the fallback duration changes during the same tick', () => {
+    expect(
+      shouldRefreshTickCountdownAnchor(
+        { tick: 12, startedAtMs: 1_000, durationMs: 60_000 },
+        12,
+        45_000,
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps the anchor when tick and duration are unchanged', () => {
+    expect(
+      shouldRefreshTickCountdownAnchor(
+        { tick: 12, startedAtMs: 1_000, durationMs: 45_000 },
+        12,
+        45_000,
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/TopHud.tsx
+++ b/apps/web/src/TopHud.tsx
@@ -2,10 +2,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSafeQuery as useQuery } from './hooks/useSafeQuery';
 import { api } from '../../server/convex/_generated/api';
 import type { Doc } from '../../server/convex/_generated/dataModel';
-import { SEASON_DURATION_TICKS } from '@clan-world/shared/generated/constants';
+import { HEARTBEAT_INTERVAL_SECONDS, SEASON_DURATION_TICKS } from '@clan-world/shared/generated/constants';
 import { DEMO_MODE } from './config/env';
 
 const TICKS_PER_SEASON = Number(SEASON_DURATION_TICKS);
+const GENERATED_TICK_DURATION_MS = Number(HEARTBEAT_INTERVAL_SECONDS) * 1000;
 
 // Demo bandit state mirrors WorldMap.tsx DEMO_BANDIT so both components agree.
 const DEMO_BANDIT_ATTACKS_AT_TICK = 48;
@@ -15,7 +16,6 @@ const BANDIT_RED = '#b23a48';
 const GOLD = '#d4a24c';
 const PARCHMENT = '#e8d8b5';
 const INK = '#3d2817';
-const FALLBACK_TICK_DURATION_MS = 59_000;
 
 type TickCountdownAnchor = {
   tick: number;
@@ -35,10 +35,19 @@ function useBanditWarning(liveTick: number, bandit: SnapshotBandit | null): { ac
 export function TopHud({ liveTick }: { liveTick: number }) {
   const clock = useQuery(api.getTickClock.getTickClock);
   const liveSnapshot = useQuery(api.getSnapshot.getSnapshot);
+  const fallbackTickDurationMs =
+    positiveDurationMs(clock?.tickEpochDurationMs) ??
+    positiveDurationMs(
+      typeof liveSnapshot?.heartbeatIntervalSeconds === 'number'
+        ? liveSnapshot.heartbeatIntervalSeconds * 1000
+        : undefined,
+    ) ??
+    positiveDurationMs(liveSnapshot?.tickEpoch.durationMs) ??
+    GENERATED_TICK_DURATION_MS;
   const tickCountdownAnchorRef = useRef<TickCountdownAnchor>({
     tick: liveTick,
     startedAtMs: Date.now(),
-    durationMs: FALLBACK_TICK_DURATION_MS,
+    durationMs: fallbackTickDurationMs,
   });
   const [nowMs, setNowMs] = useState(() => Date.now());
 
@@ -60,11 +69,11 @@ export function TopHud({ liveTick }: { liveTick: number }) {
             ? epoch.startedAt * 1000
             : epoch.startedAt
           : Date.now(),
-        durationMs: canUseClockEpoch ? epoch.durationMs : FALLBACK_TICK_DURATION_MS,
+        durationMs: canUseClockEpoch ? epoch.durationMs : fallbackTickDurationMs,
       };
     }
     setNowMs(Date.now());
-  }, [liveTick, clock?.tick, clock?.tickEpochStartedAt, clock?.tickEpochDurationMs]);
+  }, [liveTick, clock?.tick, clock?.tickEpochStartedAt, clock?.tickEpochDurationMs, fallbackTickDurationMs]);
 
   useEffect(() => {
     const id = window.setInterval(() => setNowMs(Date.now()), 250);
@@ -112,7 +121,7 @@ export function TopHud({ liveTick }: { liveTick: number }) {
       remainingPct: Math.max(0, Math.min(100, (1 - progress) * 100)),
       durationMs,
     };
-  }, [liveTick, nowMs, clock?.tick, clock?.tickEpochStartedAt, clock?.tickEpochDurationMs]);
+  }, [liveTick, nowMs, clock?.tick, clock?.tickEpochStartedAt, clock?.tickEpochDurationMs, fallbackTickDurationMs]);
 
   // Bar fill color: green → amber → red as season ages
   const barColor = seasonProgress < 0.5
@@ -320,6 +329,12 @@ export function TopHud({ liveTick }: { liveTick: number }) {
       `}</style>
     </div>
   );
+}
+
+function positiveDurationMs(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
 }
 
 // Lightweight version for contexts where we only have liveTick and no snapshot

--- a/apps/web/src/TopHud.tsx
+++ b/apps/web/src/TopHud.tsx
@@ -25,6 +25,14 @@ type TickCountdownAnchor = {
 
 type SnapshotBandit = Pick<Doc<'banditView'>, 'state' | 'nextActionTick'>;
 
+export function shouldRefreshTickCountdownAnchor(
+  anchor: TickCountdownAnchor,
+  liveTick: number,
+  fallbackTickDurationMs: number,
+): boolean {
+  return anchor.tick !== liveTick || anchor.durationMs !== fallbackTickDurationMs;
+}
+
 function useBanditWarning(liveTick: number, bandit: SnapshotBandit | null): { active: boolean; ticksUntil: number } {
   const attackTick = DEMO_MODE ? DEMO_BANDIT_ATTACKS_AT_TICK : bandit?.nextActionTick;
   if (typeof attackTick !== 'number') return { active: false, ticksUntil: 999 };
@@ -52,7 +60,7 @@ export function TopHud({ liveTick }: { liveTick: number }) {
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
-    if (tickCountdownAnchorRef.current.tick !== liveTick) {
+    if (shouldRefreshTickCountdownAnchor(tickCountdownAnchorRef.current, liveTick, fallbackTickDurationMs)) {
       const epoch = clock
         ? { startedAt: clock.tickEpochStartedAt, durationMs: clock.tickEpochDurationMs }
         : undefined;

--- a/docs/guides/stream-agents.md
+++ b/docs/guides/stream-agents.md
@@ -24,7 +24,7 @@ Four LLM "Elders" — one per clan. Each runs as a long-running Claude Code subp
 
 (Wave 1+ implementation)
 
-1. Orchestrator reads `CLAN_WORLD_CONTRACT_ADDRESS`, `CONVEX_URL`, `TICK_DURATION_MS` from env.
+1. Orchestrator reads `CLAN_WORLD_CONTRACT_ADDRESS` and `CONVEX_URL` from env. Heartbeat cadence is read from chain by the heartbeat runner.
 2. Orchestrator creates 4 Claude Code config dirs at `~/.claude-clan-{1..4}/` (one per Elder, isolation per `~/claudes-world` ADR 0013).
 3. Orchestrator spawns 4 `claude --print --resume <sid>` subprocesses with `CLAUDE_CONFIG_DIR` env override per Elder.
 4. Each Elder receives a startup prompt establishing its clan identity + toolbelt instructions.

--- a/docs/runbooks/base-sepolia-deployment.md
+++ b/docs/runbooks/base-sepolia-deployment.md
@@ -32,7 +32,7 @@ The unset/default cadence remains `60` seconds. The `1` second setting is for ma
 
 ## Convex Heartbeat Webhook
 
-Convex queries use the `.convex.cloud` URL, but HTTP actions are served from `.convex.site`. For the heartbeat loop, either set `CONVEX_WEBHOOK_URL` explicitly or let `scripts/start-heartbeat-loop.sh` derive it from `CONVEX_DEPLOY_URL`:
+Convex queries use the `.convex.cloud` URL, but HTTP actions are served from `.convex.site`. Prefer setting `CONVEX_WEBHOOK_URL` explicitly. If it is unset, the TypeScript runner derives it from `CONVEX_DEPLOY_URL` by replacing `.convex.cloud` with `.convex.site` and logs a deprecation warning:
 
 ```bash
 CONVEX_DEPLOY_URL=https://oceanic-hound-951.convex.cloud

--- a/docs/runbooks/fresh-vps-bootstrap.md
+++ b/docs/runbooks/fresh-vps-bootstrap.md
@@ -344,24 +344,34 @@ cast call "$LENS" 'getActiveClanCount()(uint32)' --rpc-url "$RPC_URL_PRIMARY"
 
 ### 9.1 `clanworld-heartbeat`
 
-Calls `heartbeat()` every **61 s** (3 s slack past the on-chain **58 s** rate-limit guard — see "Canonical defaults" below). The heartbeat advances the world tick + emits ChainHeartbeat events that the Convex webhook ingests.
+Runs the TypeScript heartbeat scheduler. The scheduler reads the on-chain
+`heartbeatIntervalSeconds()` value once at boot, then schedules each
+`heartbeat()` from `getWorldState().nextHeartbeatAtTs` with a 500 ms jitter
+buffer. The heartbeat advances the world tick + emits ChainHeartbeat events
+that Convex ingests.
 
 ```bash
 cd ~/code/clan-world/clan-world-game
 tmux new-session -d -s clanworld-heartbeat -c "$PWD" \
-  'export HEARTBEAT_SLEEP_SECONDS=61; while true; do bash scripts/start-heartbeat-loop.sh 2>&1 | tee -a /tmp/clanworld-heartbeat.log; echo "[$(date)] loop exited; restart in 5s" >> /tmp/clanworld-heartbeat.log; sleep 5; done'
+  'while true; do bash scripts/start-heartbeat-loop.sh 2>&1 | tee -a /tmp/clanworld-heartbeat.log; echo "[$(date)] loop exited; restart in 5s" >> /tmp/clanworld-heartbeat.log; sleep 5; done'
 ```
 
-The outer `while true` wrapper restarts the inner loop if it errors out (e.g., on a transient RPC blip — `start-heartbeat-loop.sh` has `set -e` so it exits on first error).
+The outer `while true` wrapper restarts the TypeScript scheduler if the process exits unexpectedly.
 
-#### Canonical defaults (heartbeat cadence)
+#### Changing heartbeat cadence
 
-| Setting | Value | How to set |
-|---|---|---|
-| **On-chain `heartbeatIntervalSeconds()` guard** | `58` s | `cast send $DIAMOND 'setHeartbeatIntervalSeconds(uint64)' 58 --rpc-url $RPC_URL_PRIMARY --private-key $DEPLOYER_PRIVATE_KEY` (owner-only) |
-| **Loop fire interval** (`HEARTBEAT_SLEEP_SECONDS`) | `61` s | env var on the heartbeat tmux session (see launch command above) |
+The on-chain value is the single source of truth. To change it:
 
-The relationship: `loop interval = on-chain guard + 3 s slack`. The 3 s prevents "rate limited" reverts from clock drift / RPC propagation lag. Adjust both together if you want to change cadence — e.g., 30 s ticks = on-chain `28`, loop `31`. The per-tick game economics calibrate to 60 s bins, so don't change without considering downstream impacts (mission durations, season length, etc.).
+```bash
+cast send $DIAMOND 'setHeartbeatIntervalSeconds(uint64)' 60 \
+  --rpc-url $RPC_URL_PRIMARY --private-key $DEPLOYER_PRIVATE_KEY
+tmux kill-session -t clanworld-heartbeat
+# Re-spawn per the command above so the scheduler reads the new interval at boot.
+```
+
+Do not set a separate loop interval env var. The per-tick game economics
+calibrate to 60 s bins, so don't change cadence without considering downstream
+impacts (mission durations, season length, etc.).
 
 ### 9.2 `clanworld-finalize`
 
@@ -530,9 +540,9 @@ For heavier loads, get a new Alchemy account or use Infura/Quicknode.
 
 ### 14.3 "ClanWorld: heartbeat rate limited" on every heartbeat call
 
-**Cause:** the diamond enforces a min interval (default 60 s) between heartbeats. If you re-spawn the heartbeat-loop within 60 s of the last call, the next call reverts.
+**Cause:** the diamond enforces the configured on-chain `heartbeatIntervalSeconds()` between heartbeats. If you re-spawn the heartbeat-loop before `getWorldState().nextHeartbeatAtTs`, the next call reverts.
 
-**Fix:** wait 60 s, or call the owner-only `setHeartbeatIntervalSeconds(uint64)` to change the interval (don't go below 1 second; default is 60).
+**Fix:** wait until `nextHeartbeatAtTs`, or call the owner-only `setHeartbeatIntervalSeconds(uint64)` to change the interval, then restart the heartbeat runner.
 
 ### 14.4 Heartbeat fires but ticks don't advance
 

--- a/docs/runbooks/full-game-reset.md
+++ b/docs/runbooks/full-game-reset.md
@@ -63,7 +63,9 @@ npx convex env set CLANWORLD_RESET_LOCK true --prod
 npx convex deploy --prod
 ```
 
-Wait at least 60 seconds after stopping heartbeat before deploying, so any in-flight nonce settles.
+Wait at least one heartbeat interval after stopping heartbeat before deploying,
+or confirm `getWorldState().nextHeartbeatAtTs` is safely in the past, so any
+in-flight nonce settles.
 
 ## 2. Deploy Active And Backup Diamonds
 
@@ -276,7 +278,7 @@ Restart heartbeat:
 
 ```bash
 tmux new-session -d -s clanworld-heartbeat -c "$PWD" \
-  'export PATH="$HOME/.foundry/bin:$PATH"; bash scripts/start-heartbeat-loop.sh 2>&1 | tee -a /tmp/clanworld-heartbeat.log'
+  'bash scripts/start-heartbeat-loop.sh 2>&1 | tee -a /tmp/clanworld-heartbeat.log'
 ```
 
 Restart runner and four Elder sessions using the current package scripts or host wrappers. Confirm each new process reads the new `.env.local` / elder `.env` values.
@@ -371,7 +373,7 @@ npx convex run indexer:refreshSnapshot '{}' --prod
 
 cd ../..
 tmux new-session -d -s clanworld-heartbeat -c "$PWD" \
-  'export PATH="$HOME/.foundry/bin:$PATH"; bash scripts/start-heartbeat-loop.sh 2>&1 | tee -a /tmp/clanworld-heartbeat.log'
+  'bash scripts/start-heartbeat-loop.sh 2>&1 | tee -a /tmp/clanworld-heartbeat.log'
 tmux new-session -d -s clanworld-runner -c "$PWD" \
   'pnpm --filter @clan-world/runner start 2>&1 | tee -a /tmp/clanworld-runner.log'
 ```

--- a/packages/agents/src/seams/IHeartbeatCaller.ts
+++ b/packages/agents/src/seams/IHeartbeatCaller.ts
@@ -25,10 +25,17 @@ export interface IHeartbeatCaller {
   callHeartbeat(): Promise<{ txHash: string }>;
 
   /**
-   * Check whether the rate limit window has elapsed without submitting a tx.
-   * Used by the runner to decide whether to attempt a heartbeat call.
+   * Read the owner-configured on-chain heartbeat interval.
+   * Runners read this once at boot; changing it operationally means calling
+   * setHeartbeatIntervalSeconds() on-chain, then restarting the runner.
    */
-  isHeartbeatDue(): Promise<boolean>;
+  readHeartbeatIntervalSeconds(): Promise<number>;
+
+  /**
+   * Read the chain's next accepted heartbeat timestamp (Unix seconds).
+   * This drives runner scheduling; no local heartbeat-duration env var exists.
+   */
+  readNextHeartbeatAtTs(): Promise<number>;
 }
 
 /** Thrown when heartbeat() is called before nextHeartbeatAtTs has elapsed. */

--- a/packages/agents/test/cli.test.ts
+++ b/packages/agents/test/cli.test.ts
@@ -33,6 +33,7 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
     async getSnapshot() { return STUB_SNAPSHOT; },
     async getClanFullView() { return STUB_CLAN_VIEW; },
     async postLog() {},
+    async postRunnerStatus() {},
     async postWhisper() {},
     async postOrchEvent() {},
     async postHumanSteering() {},

--- a/packages/agents/test/mcp.test.ts
+++ b/packages/agents/test/mcp.test.ts
@@ -25,6 +25,7 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
     async getSnapshot() { return STUB_SNAPSHOT; },
     async getClanFullView() { return STUB_CLAN_VIEW; },
     async postLog() {},
+    async postRunnerStatus() {},
     async postWhisper() {},
     async postOrchEvent() {},
     async postHumanSteering() {},

--- a/packages/contract-types/src/IClanWorld.ts
+++ b/packages/contract-types/src/IClanWorld.ts
@@ -2639,6 +2639,19 @@ export const iClanWorldAbi = [
   },
   {
     "type": "function",
+    "name": "heartbeatIntervalSeconds",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "initTreasury",
     "inputs": [
       {

--- a/packages/contracts/abi/IClanWorld.json
+++ b/packages/contracts/abi/IClanWorld.json
@@ -2639,6 +2639,19 @@
     },
     {
       "type": "function",
+      "name": "heartbeatIntervalSeconds",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
       "name": "initTreasury",
       "inputs": [
         {

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -42,6 +42,8 @@ import {RNG} from "./lib/RNG.sol";
 import {MinimalERC20} from "./MinimalERC20.sol";
 import {StubPool} from "./StubPool.sol";
 import {ReentrancyGuard} from "./util/ReentrancyGuard.sol";
+import {LibStorage} from "./diamond/lib/LibStorage.sol";
+import {LibWorldClock} from "./diamond/lib/LibWorldClock.sol";
 
 /// @dev Production storage excludes derived winter fields; _worldStateView() synthesizes the public ABI shape.
 struct StoredWorldState {
@@ -5166,8 +5168,8 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return _worldStateView();
     }
 
-    function heartbeatIntervalSeconds() external pure override returns (uint64) {
-        return ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS;
+    function heartbeatIntervalSeconds() external view override returns (uint64) {
+        return LibWorldClock.heartbeatIntervalSeconds(LibStorage.appStorage());
     }
 
     function getTreasuryState() external view override returns (TreasuryState memory) {

--- a/packages/contracts/src/ClanWorld.sol
+++ b/packages/contracts/src/ClanWorld.sol
@@ -5166,6 +5166,10 @@ contract ClanWorld is IClanWorld, ReentrancyGuard {
         return _worldStateView();
     }
 
+    function heartbeatIntervalSeconds() external pure override returns (uint64) {
+        return ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS;
+    }
+
     function getTreasuryState() external view override returns (TreasuryState memory) {
         return _treasury;
     }

--- a/packages/contracts/src/IClanWorld.sol
+++ b/packages/contracts/src/IClanWorld.sol
@@ -840,6 +840,8 @@ interface IClanWorld is IClanWorldEvents {
 
     function getWorldState() external view returns (WorldState memory);
 
+    function heartbeatIntervalSeconds() external view returns (uint64);
+
     function getTreasuryState() external view returns (TreasuryState memory);
 
     function getResourceToken(uint8 resourceType) external view returns (address);

--- a/packages/runner/.env.example
+++ b/packages/runner/.env.example
@@ -27,8 +27,15 @@ RUNNER_POLL_INTERVAL_MS=5000
 RUNNER_SETTLE_WINDOW_SEC=90
 RUNNER_DELIVERY_TIMEOUT_MS=10000
 RUNNER_ACK_TIMEOUT_MS=30000
-RUNNER_HEARTBEAT_CHECK_INTERVAL_MS=30000
 RUNNER_TMUX_SESSION_PREFIX=elder
+RUNNER_ID=clanworld-runner
+
+# Optional Telegram alerting for heartbeat retry exhaustion. If the bot token is
+# missing or Telegram fails, the runner logs locally and keeps running.
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_ALERT_CHAT_ID=-1003806628027
+# Optional forum topic id; unset posts to the main do-crew group.
+TELEGRAM_ALERT_THREAD_ID=
 
 # Optional — Elder-to-clan-id mapping. Defaults to 1→"1" ... 4→"4".
 ELDER_1_CLAN_ID=1

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -28,6 +28,33 @@ satisfies four seam interfaces from `@clan-world/agents/seams`:
 | `IElderPeerInbox`     | `FilePeerInbox` / `AxlPeerInbox` | JSONL per recipient clan or Gensyn AXL transport |
 | `IHeartbeatCaller`    | `RunnerCastHeartbeat`      | viem `writeContract`, dedicated runner wallet     |
 
+## Heartbeat timing
+
+Heartbeat cadence comes from the diamond's owner-configured
+`heartbeatIntervalSeconds()` value. To change cadence:
+
+1. Call `setHeartbeatIntervalSeconds(uint64)` on-chain as the contract owner.
+2. Restart the runner or `scripts/start-heartbeat-loop.sh`.
+
+The scheduler reads `heartbeatIntervalSeconds()` once at boot, then schedules
+each fire from `getWorldState().nextHeartbeatAtTs` with a 500 ms jitter buffer.
+When the full Elder runner is active, Cycle A still waits for Cycle B to settle
+before firing, so a heartbeat can intentionally land after the next-allowed
+timestamp if Elders are still in their settle window.
+
+## Alerts and status
+
+The scheduler writes a `runnerStatus` row to Convex after heartbeat attempts
+when `CONVEX_URL` and `INDEXER_SECRET` are configured. Telegram alerting is
+best-effort and never crashes the loop.
+
+| Variable | Description |
+|---|---|
+| `RUNNER_ID` | Stable `runnerStatus` id. Defaults to `clanworld-runner` in the full runner and `clanworld-heartbeat-loop` in the standalone loop. |
+| `TELEGRAM_BOT_TOKEN` | Bot token used for heartbeat retry-exhaustion alerts. If unset, the runner logs locally and keeps running. |
+| `TELEGRAM_ALERT_CHAT_ID` | Alert target chat. Defaults to do-crew group `-1003806628027`. |
+| `TELEGRAM_ALERT_THREAD_ID` | Optional Telegram forum topic id. If unset, alerts post to the main group. |
+
 ## Run it
 
 ```bash
@@ -37,6 +64,8 @@ export RUNNER_PRIVATE_KEY=0x...
 export CLAN_WORLD_CONTRACT_ADDRESS=0xC012275376b867944cd874FB2d600d6dA3B4A56e
 export RPC_URL_PRIMARY=https://base-sepolia.g.alchemy.com/v2/...
 export CONVEX_URL=https://...convex.cloud   # optional; runner idles without it
+export INDEXER_SECRET=...                    # optional; enables runnerStatus writes
+export TELEGRAM_BOT_TOKEN=...                # optional; enables heartbeat failure alerts
 
 # 2. Make sure 4 tmux sessions exist with Elder Claude Code already attached:
 #    elder-1, elder-2, elder-3, elder-4

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "tsx watch src/main.ts",
     "start": "tsx --env-file=../../.env.local src/main.ts",
+    "heartbeat": "tsx --env-file=../../.env.local src/heartbeatLoopMain.ts",
     "build": "echo 'uses tsx at runtime; no emit build needed'",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/runner/src/convexSnapshotSettleLatch.ts
+++ b/packages/runner/src/convexSnapshotSettleLatch.ts
@@ -42,6 +42,19 @@ export function makeConvexSnapshotSettleLatch(args: {
   };
 }
 
+export function makeHeartbeatLoopSettleLatch(args: {
+  convex: Pick<IConvexClient, 'getSnapshot' | 'isStub'>;
+  signal: AbortSignal;
+  log?: Pick<Console, 'warn'>;
+  pollMs?: number;
+}): SettleLatch | undefined {
+  if (args.convex.isStub) {
+    args.log?.warn('[heartbeatLoopMain] stub Convex detected — running without settle latch');
+    return undefined;
+  }
+  return makeConvexSnapshotSettleLatch(args);
+}
+
 async function sleepWithSignal(ms: number, signal: AbortSignal): Promise<void> {
   if (ms <= 0) return;
   await new Promise<void>(resolve => {

--- a/packages/runner/src/convexSnapshotSettleLatch.ts
+++ b/packages/runner/src/convexSnapshotSettleLatch.ts
@@ -1,0 +1,63 @@
+import type { IConvexClient } from '@clan-world/shared/adapters';
+import type { SettleLatch } from './settleLatch';
+
+const SNAPSHOT_LATCH_POLL_MS = 1_000;
+
+/**
+ * Standalone heartbeat-loop latch.
+ *
+ * The full runner has Cycle B call markSettled() after it has processed the
+ * new tick. The standalone heartbeat launcher has no Cycle B, so it gates on
+ * Convex ingest instead: each heartbeat is allowed only after worldSnapshot.tick
+ * has advanced beyond the tick used for the previous heartbeat.
+ */
+export function makeConvexSnapshotSettleLatch(args: {
+  convex: Pick<IConvexClient, 'getSnapshot'>;
+  signal: AbortSignal;
+  log?: Pick<Console, 'warn'>;
+  pollMs?: number;
+}): SettleLatch {
+  let lastSeenTick = -1;
+  const pollMs = args.pollMs ?? SNAPSHOT_LATCH_POLL_MS;
+
+  const poll = async (): Promise<void> => {
+    while (!args.signal.aborted) {
+      try {
+        const snapshot = await args.convex.getSnapshot();
+        if (snapshot.tick > lastSeenTick) lastSeenTick = snapshot.tick;
+      } catch (err) {
+        args.log?.warn('[heartbeat-loop] worldSnapshot.tick read failed:', err);
+      }
+      await sleepWithSignal(pollMs, args.signal);
+    }
+  };
+
+  void poll();
+
+  return {
+    lastSettledTick: () => lastSeenTick,
+    markSettled: (tick) => {
+      if (tick > lastSeenTick) lastSeenTick = tick;
+    },
+  };
+}
+
+async function sleepWithSignal(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise<void>(resolve => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    };
+    signal.addEventListener('abort', onAbort);
+  });
+}

--- a/packages/runner/src/heartbeatLoopMain.ts
+++ b/packages/runner/src/heartbeatLoopMain.ts
@@ -1,5 +1,6 @@
 import { createConvexClient } from '@clan-world/shared/adapters';
 import { startHeartbeatScheduler } from './heartbeatScheduler';
+import { makeConvexSnapshotSettleLatch } from './convexSnapshotSettleLatch';
 import { configFromEnv, RunnerCastHeartbeat } from './runnerCastHeartbeat';
 
 async function main(): Promise<void> {
@@ -15,10 +16,18 @@ async function main(): Promise<void> {
   process.on('SIGTERM', () => onSignal('SIGTERM'));
   process.on('SIGINT', () => onSignal('SIGINT'));
 
+  const convex = createConvexClient();
+  const settleLatch = makeConvexSnapshotSettleLatch({
+    convex,
+    signal: abort.signal,
+    log: console,
+  });
+
   startHeartbeatScheduler({
     heartbeatCaller: new RunnerCastHeartbeat(configFromEnv()),
-    convex: createConvexClient(),
+    convex,
     signal: abort.signal,
+    settleLatch,
     runnerId: process.env['RUNNER_ID'] ?? 'clanworld-heartbeat-loop',
   });
 

--- a/packages/runner/src/heartbeatLoopMain.ts
+++ b/packages/runner/src/heartbeatLoopMain.ts
@@ -1,6 +1,6 @@
 import { createConvexClient } from '@clan-world/shared/adapters';
 import { startHeartbeatScheduler } from './heartbeatScheduler';
-import { makeConvexSnapshotSettleLatch } from './convexSnapshotSettleLatch';
+import { makeHeartbeatLoopSettleLatch } from './convexSnapshotSettleLatch';
 import { configFromEnv, RunnerCastHeartbeat } from './runnerCastHeartbeat';
 
 async function main(): Promise<void> {
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
   process.on('SIGINT', () => onSignal('SIGINT'));
 
   const convex = createConvexClient();
-  const settleLatch = makeConvexSnapshotSettleLatch({
+  const settleLatch = makeHeartbeatLoopSettleLatch({
     convex,
     signal: abort.signal,
     log: console,

--- a/packages/runner/src/heartbeatLoopMain.ts
+++ b/packages/runner/src/heartbeatLoopMain.ts
@@ -1,0 +1,37 @@
+import { createConvexClient } from '@clan-world/shared/adapters';
+import { startHeartbeatScheduler } from './heartbeatScheduler';
+import { configFromEnv, RunnerCastHeartbeat } from './runnerCastHeartbeat';
+
+async function main(): Promise<void> {
+  console.log(`[heartbeat-loop] starting at ${new Date().toISOString()}`);
+  const abort = new AbortController();
+  let shuttingDown = false;
+  const onSignal = (sig: string): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`[heartbeat-loop] ${sig} received — shutting down cleanly`);
+    abort.abort();
+  };
+  process.on('SIGTERM', () => onSignal('SIGTERM'));
+  process.on('SIGINT', () => onSignal('SIGINT'));
+
+  startHeartbeatScheduler({
+    heartbeatCaller: new RunnerCastHeartbeat(configFromEnv()),
+    convex: createConvexClient(),
+    signal: abort.signal,
+    runnerId: process.env['RUNNER_ID'] ?? 'clanworld-heartbeat-loop',
+  });
+
+  await new Promise<void>(resolve => {
+    if (abort.signal.aborted) {
+      resolve();
+      return;
+    }
+    abort.signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}
+
+main().catch(err => {
+  console.error('[heartbeat-loop] fatal:', err);
+  process.exit(1);
+});

--- a/packages/runner/src/heartbeatScheduler.ts
+++ b/packages/runner/src/heartbeatScheduler.ts
@@ -89,7 +89,7 @@ async function runHeartbeatScheduler(
   let heartbeatIntervalSeconds: number | undefined;
   let lastHeartbeatForTick = -1;
   let consecutiveReadFailures = 0;
-  let lastAlertAtMs: number | undefined;
+  const lastAlertAtMs = new Map<string, number>();
 
   try {
     heartbeatIntervalSeconds = await deps.heartbeatCaller.readHeartbeatIntervalSeconds();
@@ -148,7 +148,7 @@ async function runHeartbeatScheduler(
     });
     if (result.success) {
       if (deps.settleLatch) lastHeartbeatForTick = settledSnapshot;
-      if (!result.rateLimited) lastAlertAtMs = undefined;
+      if (!result.rateLimited) lastAlertAtMs.clear();
       const nextAfterSuccess = await deps.heartbeatCaller
         .readNextHeartbeatAtTs()
         .catch(() => undefined);
@@ -163,11 +163,16 @@ async function runHeartbeatScheduler(
 
     if (result.aborted || result.lastFireResult === 'rate-limited') continue;
     const currentMs = nowMs();
-    if (lastAlertAtMs !== undefined && currentMs - lastAlertAtMs < ALERT_DEDUP_WINDOW_MS) {
+    const alertClass = result.lastFireResult;
+    const lastAlertForClassAtMs = lastAlertAtMs.get(alertClass);
+    if (
+      lastAlertForClassAtMs !== undefined &&
+      currentMs - lastAlertForClassAtMs < ALERT_DEDUP_WINDOW_MS
+    ) {
       deps.log.warn(`suppressing duplicate heartbeat alert: ${result.message}`);
       continue;
     }
-    lastAlertAtMs = currentMs;
+    lastAlertAtMs.set(alertClass, currentMs);
     const alertMessage =
       `ClanWorld heartbeat failed after retries: ${result.message}`;
     const alertResult = await alert(alertMessage);
@@ -209,7 +214,7 @@ async function attemptHeartbeatWithBackoff(
         runnerId: deps.runnerId,
         lastFireAt: nowMs(),
         lastFireResult: 'success',
-        lastFailureMessage: undefined,
+        lastFailureMessage: '',
         heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
         nextHeartbeatAtTs: deps.nextHeartbeatAtTs,
       });
@@ -240,7 +245,7 @@ async function attemptHeartbeatWithBackoff(
             runnerId: deps.runnerId,
             lastFireAt: nowMs(),
             lastFireResult: 'success',
-            lastFailureMessage: undefined,
+            lastFailureMessage: '',
             heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
             nextHeartbeatAtTs: nextAfterTimeout,
           });

--- a/packages/runner/src/heartbeatScheduler.ts
+++ b/packages/runner/src/heartbeatScheduler.ts
@@ -1,12 +1,14 @@
 import { HeartbeatRateLimitedError, type IHeartbeatCaller } from '@clan-world/agents/seams';
+import type { IConvexClient, RunnerStatusUpdate } from '@clan-world/shared/adapters';
 import type { SettleLatch } from './settleLatch';
+import { sendTelegramAlert } from './telegramAlert';
+
+export type HeartbeatFireResult = RunnerStatusUpdate['lastFireResult'];
 
 export interface HeartbeatSchedulerDeps {
   heartbeatCaller: IHeartbeatCaller;
   /** AbortSignal for clean shutdown. */
   signal: AbortSignal;
-  /** How often to check isHeartbeatDue (ms). Defaults to 30_000. */
-  checkIntervalMs?: number;
   /** Logger — defaults to console. Tests pass a recorder. */
   log?: {
     info: (...args: unknown[]) => void;
@@ -15,18 +17,33 @@ export interface HeartbeatSchedulerDeps {
   };
   /**
    * Shared latch — Cycle A only fires heartbeat after Cycle B settles a new tick.
-   * Compared against an internal `lastHeartbeatForTick` counter so no Convex
-   * poll is needed here (avoids stale-snapshot / error-path races).
+   * This can intentionally delay a heartbeat past nextHeartbeatAtTs + jitter
+   * while Elders are still in their settle window; liveness beats interrupting
+   * the order-submission phase.
    */
   settleLatch?: SettleLatch;
+  /** Convex status sink. Missing/failed writes are logged but non-fatal. */
+  convex?: Pick<IConvexClient, 'postRunnerStatus'>;
+  /** Stable id for the runnerStatus row. */
+  runnerId?: string;
+  /** Override alert sender for tests. */
+  alert?: (message: string) => Promise<{ ok: boolean; error?: string }>;
+  /** Override current time for tests. */
+  nowMs?: () => number;
 }
+
+export const HEARTBEAT_JITTER_MS = 500;
+export const HEARTBEAT_RETRY_BACKOFF_MS = [1_000, 2_000, 5_000, 10_000] as const;
+const SETTLE_LATCH_RECHECK_MS = 1_000;
+const HOT_LOOP_GUARD_MS = 1_000;
 
 /**
  * Cycle A — heartbeat driver (independent of Elder activity).
  *
- * Polls isHeartbeatDue() on a fixed interval. When due, fires callHeartbeat().
- * HeartbeatRateLimitedError is caught and logged — the next interval will
- * re-check isHeartbeatDue() and retry naturally when the window elapses.
+ * Schedules from on-chain getWorldState().nextHeartbeatAtTs instead of a local
+ * fixed interval. The owner-configured heartbeatIntervalSeconds is read once
+ * at boot for observability; cadence changes are applied operationally by
+ * updating the chain value and restarting this process.
  */
 export function startHeartbeatScheduler(deps: HeartbeatSchedulerDeps): void {
   const log = deps.log ?? {
@@ -34,49 +51,201 @@ export function startHeartbeatScheduler(deps: HeartbeatSchedulerDeps): void {
     warn: (...a: unknown[]) => console.warn('[heartbeat]', ...a),
     error: (...a: unknown[]) => console.error('[heartbeat]', ...a),
   };
-  const checkMs = deps.checkIntervalMs ?? 30_000;
-  let inFlight = false;
-  // Tracks the lastSettledTick value at the time of the last successful heartbeat.
-  // Cycle A only fires when Cycle B has settled a tick NEWER than the last one
-  // we heartbeated for — no Convex poll needed, no stale-snapshot race.
+
+  if (deps.signal.aborted) return;
+
+  void runHeartbeatScheduler({ ...deps, log }).catch(err => {
+    if (deps.signal.aborted) return;
+    log.error('heartbeat scheduler exited:', err);
+  });
+}
+
+export function computeHeartbeatDelayMs(
+  nextHeartbeatAtTs: number,
+  nowMs: number,
+  jitterMs = HEARTBEAT_JITTER_MS,
+): number {
+  return Math.max(0, nextHeartbeatAtTs * 1000 - nowMs) + jitterMs;
+}
+
+export function classifyHeartbeatError(err: unknown): HeartbeatFireResult {
+  if (err instanceof HeartbeatRateLimitedError) return 'revert';
+  if (err instanceof Error) {
+    if (err.name === 'HeartbeatTimeoutError' || err.name.includes('Timeout')) return 'timeout';
+    if (err.name.includes('Revert') || /revert|rate[- ]limited/i.test(err.message)) return 'revert';
+  }
+  return 'error';
+}
+
+async function runHeartbeatScheduler(
+  deps: HeartbeatSchedulerDeps & {
+    log: NonNullable<HeartbeatSchedulerDeps['log']>;
+  },
+): Promise<void> {
+  const runnerId = deps.runnerId ?? 'clanworld-runner';
+  const nowMs = deps.nowMs ?? (() => Date.now());
+  const alert = deps.alert ?? sendTelegramAlert;
+  let heartbeatIntervalSeconds: number | undefined;
   let lastHeartbeatForTick = -1;
 
-  if (deps.signal.aborted) return; // LOW: don't create timer if already shut down
+  try {
+    heartbeatIntervalSeconds = await deps.heartbeatCaller.readHeartbeatIntervalSeconds();
+    deps.log.info(`on-chain heartbeat interval: ${heartbeatIntervalSeconds}s`);
+  } catch (err) {
+    deps.log.error('failed to read heartbeatIntervalSeconds at boot:', err);
+    await postRunnerStatus(deps, {
+      runnerId,
+      lastFireResult: 'error',
+      lastFailureMessage: `boot interval read failed: ${messageFrom(err)}`,
+    });
+  }
 
-  const timer = setInterval(() => {
-    void (async () => {
-      if (deps.signal.aborted) return;
-      if (inFlight) return;
-      inFlight = true;
-      try {
-        const due = await deps.heartbeatCaller.isHeartbeatDue();
-        if (!due) return;
-        if (deps.signal.aborted) return;
-        // Only fire after Cycle B has settled a tick newer than our last heartbeat.
-        // Snapshot settled BEFORE callHeartbeat() — a slow tx can take long enough
-        // for Cycle B to settle the next tick; reading after the call would mark
-        // the newer tick as already-heartbeated and permanently skip it.
-        const settledSnapshot = deps.settleLatch ? deps.settleLatch.lastSettledTick() : -1;
-        if (deps.settleLatch && settledSnapshot <= lastHeartbeatForTick) {
-          log.info(`waiting for Cycle B to settle (last settled: ${settledSnapshot}, last heartbeat for: ${lastHeartbeatForTick})`);
-          return;
-        }
-        const { txHash } = await deps.heartbeatCaller.callHeartbeat();
-        log.info(`heartbeat tx confirmed: ${txHash}`);
-        if (deps.settleLatch) lastHeartbeatForTick = settledSnapshot;
-      } catch (err) {
-        if (err instanceof HeartbeatRateLimitedError) {
-          log.warn(
-            `heartbeat rate-limited until ${new Date(err.nextAllowedAt * 1000).toISOString()} — will retry on next check`,
-          );
-          return;
-        }
-        log.error('heartbeat failed:', err);
-      } finally {
-        inFlight = false;
+  while (!deps.signal.aborted) {
+    let nextHeartbeatAtTs: number;
+    try {
+      nextHeartbeatAtTs = await deps.heartbeatCaller.readNextHeartbeatAtTs();
+    } catch (err) {
+      deps.log.error('failed to read nextHeartbeatAtTs:', err);
+      await postRunnerStatus(deps, {
+        runnerId,
+        lastFireResult: 'error',
+        lastFailureMessage: `nextHeartbeatAtTs read failed: ${messageFrom(err)}`,
+        heartbeatIntervalSeconds,
+      });
+      await sleepWithSignal(HEARTBEAT_RETRY_BACKOFF_MS[0], deps.signal);
+      continue;
+    }
+
+    await sleepWithSignal(
+      computeHeartbeatDelayMs(nextHeartbeatAtTs, nowMs()),
+      deps.signal,
+    );
+    if (deps.signal.aborted) break;
+
+    const settledSnapshot = deps.settleLatch ? deps.settleLatch.lastSettledTick() : -1;
+    if (deps.settleLatch && settledSnapshot <= lastHeartbeatForTick) {
+      deps.log.info(
+        `waiting for Cycle B to settle (last settled: ${settledSnapshot}, last heartbeat for: ${lastHeartbeatForTick})`,
+      );
+      await sleepWithSignal(SETTLE_LATCH_RECHECK_MS, deps.signal);
+      continue;
+    }
+
+    const result = await attemptHeartbeatWithBackoff({
+      ...deps,
+      runnerId,
+      heartbeatIntervalSeconds,
+      nextHeartbeatAtTs,
+      settledSnapshot,
+    });
+    if (result.success) {
+      if (deps.settleLatch) lastHeartbeatForTick = settledSnapshot;
+      const nextAfterSuccess = await deps.heartbeatCaller
+        .readNextHeartbeatAtTs()
+        .catch(() => undefined);
+      if (nextAfterSuccess !== undefined && nextAfterSuccess * 1000 <= nowMs()) {
+        deps.log.warn(
+          `heartbeat succeeded but nextHeartbeatAtTs (${nextAfterSuccess}) is still in the past; sleeping ${HOT_LOOP_GUARD_MS}ms before retry`,
+        );
+        await sleepWithSignal(HOT_LOOP_GUARD_MS, deps.signal);
       }
-    })();
-  }, checkMs);
+      continue;
+    }
 
-  deps.signal.addEventListener('abort', () => clearInterval(timer), { once: true });
+    const alertMessage =
+      `ClanWorld heartbeat failed after retries: ${result.message}`;
+    const alertResult = await alert(alertMessage);
+    if (!alertResult.ok) {
+      const msg = `Telegram alert failed: ${alertResult.error ?? 'unknown error'}`;
+      deps.log.error(msg);
+      await postRunnerStatus(deps, {
+        runnerId,
+        lastFireResult: 'error',
+        lastFailureMessage: msg,
+        heartbeatIntervalSeconds,
+        nextHeartbeatAtTs,
+      });
+    }
+  }
+}
+
+async function attemptHeartbeatWithBackoff(
+  deps: HeartbeatSchedulerDeps & {
+    log: NonNullable<HeartbeatSchedulerDeps['log']>;
+    runnerId: string;
+    heartbeatIntervalSeconds?: number;
+    nextHeartbeatAtTs?: number;
+    settledSnapshot: number;
+  },
+): Promise<{ success: true } | { success: false; message: string }> {
+  for (let attempt = 0; attempt <= HEARTBEAT_RETRY_BACKOFF_MS.length; attempt++) {
+    try {
+      const { txHash } = await deps.heartbeatCaller.callHeartbeat();
+      deps.log.info(`heartbeat tx confirmed: ${txHash}`);
+      await postRunnerStatus(deps, {
+        runnerId: deps.runnerId,
+        lastFireAt: Date.now(),
+        lastFireResult: 'success',
+        lastFailureMessage: undefined,
+        heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
+        nextHeartbeatAtTs: deps.nextHeartbeatAtTs,
+      });
+      return { success: true };
+    } catch (err) {
+      const lastFireResult = classifyHeartbeatError(err);
+      const lastFailureMessage = messageFrom(err);
+      deps.log.warn(`heartbeat attempt ${attempt + 1} failed (${lastFireResult}): ${lastFailureMessage}`);
+      await postRunnerStatus(deps, {
+        runnerId: deps.runnerId,
+        lastFireResult,
+        lastFailureMessage,
+        heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
+        nextHeartbeatAtTs: deps.nextHeartbeatAtTs,
+      });
+
+      if (attempt === HEARTBEAT_RETRY_BACKOFF_MS.length) {
+        return { success: false, message: lastFailureMessage };
+      }
+      const backoffMs = HEARTBEAT_RETRY_BACKOFF_MS[attempt] ?? HEARTBEAT_RETRY_BACKOFF_MS[0];
+      await sleepWithSignal(backoffMs, deps.signal);
+      if (deps.signal.aborted) return { success: false, message: 'aborted' };
+    }
+  }
+  return { success: false, message: 'retry loop exhausted' };
+}
+
+async function postRunnerStatus(
+  deps: Pick<HeartbeatSchedulerDeps, 'convex' | 'log'>,
+  status: RunnerStatusUpdate,
+): Promise<void> {
+  if (!deps.convex) return;
+  try {
+    await deps.convex.postRunnerStatus(status);
+  } catch (err) {
+    deps.log?.warn('runnerStatus update failed:', err);
+  }
+}
+
+function messageFrom(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function sleepWithSignal(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise<void>(resolve => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    };
+    signal.addEventListener('abort', onAbort);
+  });
 }

--- a/packages/runner/src/heartbeatScheduler.ts
+++ b/packages/runner/src/heartbeatScheduler.ts
@@ -36,6 +36,7 @@ export const HEARTBEAT_JITTER_MS = 500;
 export const HEARTBEAT_RETRY_BACKOFF_MS = [1_000, 2_000, 5_000, 10_000] as const;
 const SETTLE_LATCH_RECHECK_MS = 1_000;
 const HOT_LOOP_GUARD_MS = 1_000;
+const ALERT_DEDUP_WINDOW_MS = 5 * 60 * 1_000;
 
 /**
  * Cycle A — heartbeat driver (independent of Elder activity).
@@ -69,7 +70,7 @@ export function computeHeartbeatDelayMs(
 }
 
 export function classifyHeartbeatError(err: unknown): HeartbeatFireResult {
-  if (err instanceof HeartbeatRateLimitedError) return 'revert';
+  if (err instanceof HeartbeatRateLimitedError) return 'rate-limited';
   if (err instanceof Error) {
     if (err.name === 'HeartbeatTimeoutError' || err.name.includes('Timeout')) return 'timeout';
     if (err.name.includes('Revert') || /revert|rate[- ]limited/i.test(err.message)) return 'revert';
@@ -87,6 +88,8 @@ async function runHeartbeatScheduler(
   const alert = deps.alert ?? sendTelegramAlert;
   let heartbeatIntervalSeconds: number | undefined;
   let lastHeartbeatForTick = -1;
+  let consecutiveReadFailures = 0;
+  let lastAlertAtMs: number | undefined;
 
   try {
     heartbeatIntervalSeconds = await deps.heartbeatCaller.readHeartbeatIntervalSeconds();
@@ -95,7 +98,7 @@ async function runHeartbeatScheduler(
     deps.log.error('failed to read heartbeatIntervalSeconds at boot:', err);
     await postRunnerStatus(deps, {
       runnerId,
-      lastFireResult: 'error',
+      lastFireResult: 'boot-error',
       lastFailureMessage: `boot interval read failed: ${messageFrom(err)}`,
     });
   }
@@ -104,6 +107,7 @@ async function runHeartbeatScheduler(
     let nextHeartbeatAtTs: number;
     try {
       nextHeartbeatAtTs = await deps.heartbeatCaller.readNextHeartbeatAtTs();
+      consecutiveReadFailures = 0;
     } catch (err) {
       deps.log.error('failed to read nextHeartbeatAtTs:', err);
       await postRunnerStatus(deps, {
@@ -112,7 +116,11 @@ async function runHeartbeatScheduler(
         lastFailureMessage: `nextHeartbeatAtTs read failed: ${messageFrom(err)}`,
         heartbeatIntervalSeconds,
       });
-      await sleepWithSignal(HEARTBEAT_RETRY_BACKOFF_MS[0], deps.signal);
+      const backoffMs = HEARTBEAT_RETRY_BACKOFF_MS[
+        Math.min(consecutiveReadFailures, HEARTBEAT_RETRY_BACKOFF_MS.length - 1)
+      ] ?? HEARTBEAT_RETRY_BACKOFF_MS[0];
+      consecutiveReadFailures++;
+      await sleepWithSignal(backoffMs, deps.signal);
       continue;
     }
 
@@ -140,6 +148,7 @@ async function runHeartbeatScheduler(
     });
     if (result.success) {
       if (deps.settleLatch) lastHeartbeatForTick = settledSnapshot;
+      if (!result.rateLimited) lastAlertAtMs = undefined;
       const nextAfterSuccess = await deps.heartbeatCaller
         .readNextHeartbeatAtTs()
         .catch(() => undefined);
@@ -152,6 +161,13 @@ async function runHeartbeatScheduler(
       continue;
     }
 
+    if (result.aborted || result.lastFireResult === 'rate-limited') continue;
+    const currentMs = nowMs();
+    if (lastAlertAtMs !== undefined && currentMs - lastAlertAtMs < ALERT_DEDUP_WINDOW_MS) {
+      deps.log.warn(`suppressing duplicate heartbeat alert: ${result.message}`);
+      continue;
+    }
+    lastAlertAtMs = currentMs;
     const alertMessage =
       `ClanWorld heartbeat failed after retries: ${result.message}`;
     const alertResult = await alert(alertMessage);
@@ -177,7 +193,12 @@ async function attemptHeartbeatWithBackoff(
     nextHeartbeatAtTs?: number;
     settledSnapshot: number;
   },
-): Promise<{ success: true } | { success: false; message: string }> {
+): Promise<
+  | { success: true; rateLimited?: false }
+  | { success: true; rateLimited: true }
+  | { success: false; aborted: true; message: string; lastFireResult?: HeartbeatFireResult }
+  | { success: false; aborted: false; message: string; lastFireResult: HeartbeatFireResult }
+> {
   for (let attempt = 0; attempt <= HEARTBEAT_RETRY_BACKOFF_MS.length; attempt++) {
     try {
       const { txHash } = await deps.heartbeatCaller.callHeartbeat();
@@ -192,6 +213,38 @@ async function attemptHeartbeatWithBackoff(
       });
       return { success: true };
     } catch (err) {
+      if (err instanceof HeartbeatRateLimitedError) {
+        const lastFailureMessage = messageFrom(err);
+        deps.log.warn(`heartbeat rate-limited: ${lastFailureMessage}`);
+        await postRunnerStatus(deps, {
+          runnerId: deps.runnerId,
+          lastFireResult: 'rate-limited',
+          lastFailureMessage,
+          heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
+          nextHeartbeatAtTs: deps.nextHeartbeatAtTs,
+        });
+        return { success: true, rateLimited: true };
+      }
+      if (deps.signal.aborted) return { success: false, aborted: true, message: 'aborted' };
+      if (isHeartbeatTimeoutError(err) && deps.nextHeartbeatAtTs !== undefined) {
+        const nextAfterTimeout = await deps.heartbeatCaller
+          .readNextHeartbeatAtTs()
+          .catch(() => undefined);
+        if (nextAfterTimeout !== undefined && nextAfterTimeout > deps.nextHeartbeatAtTs) {
+          deps.log.info(
+            `heartbeat receipt timed out, but nextHeartbeatAtTs advanced from ${deps.nextHeartbeatAtTs} to ${nextAfterTimeout}`,
+          );
+          await postRunnerStatus(deps, {
+            runnerId: deps.runnerId,
+            lastFireAt: Date.now(),
+            lastFireResult: 'success',
+            lastFailureMessage: undefined,
+            heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
+            nextHeartbeatAtTs: nextAfterTimeout,
+          });
+          return { success: true };
+        }
+      }
       const lastFireResult = classifyHeartbeatError(err);
       const lastFailureMessage = messageFrom(err);
       deps.log.warn(`heartbeat attempt ${attempt + 1} failed (${lastFireResult}): ${lastFailureMessage}`);
@@ -204,14 +257,14 @@ async function attemptHeartbeatWithBackoff(
       });
 
       if (attempt === HEARTBEAT_RETRY_BACKOFF_MS.length) {
-        return { success: false, message: lastFailureMessage };
+        return { success: false, aborted: false, message: lastFailureMessage, lastFireResult };
       }
       const backoffMs = HEARTBEAT_RETRY_BACKOFF_MS[attempt] ?? HEARTBEAT_RETRY_BACKOFF_MS[0];
       await sleepWithSignal(backoffMs, deps.signal);
-      if (deps.signal.aborted) return { success: false, message: 'aborted' };
+      if (deps.signal.aborted) return { success: false, aborted: true, message: 'aborted' };
     }
   }
-  return { success: false, message: 'retry loop exhausted' };
+  return { success: false, aborted: false, message: 'retry loop exhausted', lastFireResult: 'error' };
 }
 
 async function postRunnerStatus(
@@ -228,6 +281,10 @@ async function postRunnerStatus(
 
 function messageFrom(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function isHeartbeatTimeoutError(err: unknown): boolean {
+  return err instanceof Error && (err.name === 'HeartbeatTimeoutError' || err.name.includes('Timeout'));
 }
 
 async function sleepWithSignal(ms: number, signal: AbortSignal): Promise<void> {

--- a/packages/runner/src/heartbeatScheduler.ts
+++ b/packages/runner/src/heartbeatScheduler.ts
@@ -199,13 +199,15 @@ async function attemptHeartbeatWithBackoff(
   | { success: false; aborted: true; message: string; lastFireResult?: HeartbeatFireResult }
   | { success: false; aborted: false; message: string; lastFireResult: HeartbeatFireResult }
 > {
+  const nowMs = deps.nowMs ?? (() => Date.now());
+
   for (let attempt = 0; attempt <= HEARTBEAT_RETRY_BACKOFF_MS.length; attempt++) {
     try {
       const { txHash } = await deps.heartbeatCaller.callHeartbeat();
       deps.log.info(`heartbeat tx confirmed: ${txHash}`);
       await postRunnerStatus(deps, {
         runnerId: deps.runnerId,
-        lastFireAt: Date.now(),
+        lastFireAt: nowMs(),
         lastFireResult: 'success',
         lastFailureMessage: undefined,
         heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
@@ -236,7 +238,7 @@ async function attemptHeartbeatWithBackoff(
           );
           await postRunnerStatus(deps, {
             runnerId: deps.runnerId,
-            lastFireAt: Date.now(),
+            lastFireAt: nowMs(),
             lastFireResult: 'success',
             lastFailureMessage: undefined,
             heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,

--- a/packages/runner/src/heartbeatScheduler.ts
+++ b/packages/runner/src/heartbeatScheduler.ts
@@ -147,6 +147,11 @@ async function runHeartbeatScheduler(
       settledSnapshot,
     });
     if (result.success && !result.rateLimited) {
+      // First-fire (lastHeartbeatForTick === -1) is allowed to bypass the latch to avoid
+      // boot-deadlock when Convex is unreachable. Subsequent iterations only require
+      // settledSnapshot > Math.max(0, prev). This trades strict "wait for prior tick to
+      // settle in Convex" for liveness -- acceptable for hackathon scope, but should
+      // be hardened with an "expected next tick" watermark for production. See follow-up.
       if (deps.settleLatch) lastHeartbeatForTick = Math.max(0, settledSnapshot);
       lastAlertAtMs.clear();
     }
@@ -180,15 +185,7 @@ async function runHeartbeatScheduler(
     if (alertResult.ok) {
       lastAlertAtMs.set(alertClass, currentMs);
     } else {
-      const msg = `Telegram alert failed: ${alertResult.error ?? 'unknown error'}`;
-      deps.log.error(msg);
-      await postRunnerStatus(deps, {
-        runnerId,
-        lastFireResult: 'error',
-        lastFailureMessage: msg,
-        heartbeatIntervalSeconds,
-        nextHeartbeatAtTs,
-      });
+      deps.log.error('[heartbeatScheduler] Telegram alert failed:', alertResult.error);
     }
   }
 }

--- a/packages/runner/src/heartbeatScheduler.ts
+++ b/packages/runner/src/heartbeatScheduler.ts
@@ -131,7 +131,7 @@ async function runHeartbeatScheduler(
     if (deps.signal.aborted) break;
 
     const settledSnapshot = deps.settleLatch ? deps.settleLatch.lastSettledTick() : -1;
-    if (deps.settleLatch && settledSnapshot <= lastHeartbeatForTick) {
+    if (deps.settleLatch && lastHeartbeatForTick >= 0 && settledSnapshot <= lastHeartbeatForTick) {
       deps.log.info(
         `waiting for Cycle B to settle (last settled: ${settledSnapshot}, last heartbeat for: ${lastHeartbeatForTick})`,
       );
@@ -146,9 +146,11 @@ async function runHeartbeatScheduler(
       nextHeartbeatAtTs,
       settledSnapshot,
     });
+    if (result.success && !result.rateLimited) {
+      if (deps.settleLatch) lastHeartbeatForTick = Math.max(0, settledSnapshot);
+      lastAlertAtMs.clear();
+    }
     if (result.success) {
-      if (deps.settleLatch) lastHeartbeatForTick = settledSnapshot;
-      if (!result.rateLimited) lastAlertAtMs.clear();
       const nextAfterSuccess = await deps.heartbeatCaller
         .readNextHeartbeatAtTs()
         .catch(() => undefined);
@@ -172,11 +174,12 @@ async function runHeartbeatScheduler(
       deps.log.warn(`suppressing duplicate heartbeat alert: ${result.message}`);
       continue;
     }
-    lastAlertAtMs.set(alertClass, currentMs);
     const alertMessage =
       `ClanWorld heartbeat failed after retries: ${result.message}`;
     const alertResult = await alert(alertMessage);
-    if (!alertResult.ok) {
+    if (alertResult.ok) {
+      lastAlertAtMs.set(alertClass, currentMs);
+    } else {
       const msg = `Telegram alert failed: ${alertResult.error ?? 'unknown error'}`;
       deps.log.error(msg);
       await postRunnerStatus(deps, {

--- a/packages/runner/src/heartbeatScheduler.ts
+++ b/packages/runner/src/heartbeatScheduler.ts
@@ -151,7 +151,7 @@ async function runHeartbeatScheduler(
       // boot-deadlock when Convex is unreachable. Subsequent iterations only require
       // settledSnapshot > Math.max(0, prev). This trades strict "wait for prior tick to
       // settle in Convex" for liveness -- acceptable for hackathon scope, but should
-      // be hardened with an "expected next tick" watermark for production. See follow-up.
+      // be hardened with an "expected next tick" watermark for production. See #511.
       if (deps.settleLatch) lastHeartbeatForTick = Math.max(0, settledSnapshot);
       lastAlertAtMs.clear();
     }

--- a/packages/runner/src/main.ts
+++ b/packages/runner/src/main.ts
@@ -44,7 +44,6 @@ function loadConfig(env: NodeJS.ProcessEnv = process.env): RunnerConfig {
   const settleWindowSec = parseIntEnv(env, 'RUNNER_SETTLE_WINDOW_SEC', 90);
   const deliveryTimeoutMs = parseIntEnv(env, 'RUNNER_DELIVERY_TIMEOUT_MS', 10_000);
   const ackTimeoutMs = parseIntEnv(env, 'RUNNER_ACK_TIMEOUT_MS', 30_000);
-  const heartbeatCheckIntervalMs = parseIntEnv(env, 'RUNNER_HEARTBEAT_CHECK_INTERVAL_MS', 30_000);
   const tmuxSessionPrefix = env['RUNNER_TMUX_SESSION_PREFIX'] ?? 'elder';
   const elderToClanId: Record<ElderId, string> = {
     1: env['ELDER_1_CLAN_ID'] ?? '1',
@@ -57,7 +56,6 @@ function loadConfig(env: NodeJS.ProcessEnv = process.env): RunnerConfig {
     settleWindowSec,
     deliveryTimeoutMs,
     ackTimeoutMs,
-    heartbeatCheckIntervalMs,
     stateDir,
     tmuxSessionPrefix,
     elderToClanId,
@@ -142,8 +140,9 @@ async function main(): Promise<void> {
   startHeartbeatScheduler({
     heartbeatCaller,
     signal: abort.signal,
-    checkIntervalMs: config.heartbeatCheckIntervalMs,
     settleLatch,
+    convex,
+    runnerId: process.env['RUNNER_ID'] ?? 'clanworld-runner',
   });
 
   try {

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -49,11 +49,24 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): RunnerHeart
       `CLAN_WORLD_CONTRACT_ADDRESS missing or invalid; expected 0x-prefixed 40-hex-char address, got ${String(contractAddress)}`,
     );
   }
-  const convexWebhookUrl = env['CONVEX_WEBHOOK_URL'] || deriveConvexWebhookUrl(env['CONVEX_DEPLOY_URL']);
-  if (!env['CONVEX_WEBHOOK_URL'] && convexWebhookUrl) {
-    console.warn(
-      'Deriving CONVEX_WEBHOOK_URL from CONVEX_DEPLOY_URL — set CONVEX_WEBHOOK_URL explicitly in env',
-    );
+  const hasExplicitWebhookUrl = Object.prototype.hasOwnProperty.call(env, 'CONVEX_WEBHOOK_URL');
+  let convexWebhookUrl: string | undefined;
+  if (hasExplicitWebhookUrl) {
+    convexWebhookUrl = env['CONVEX_WEBHOOK_URL'] || undefined;
+    if (env['CONVEX_WEBHOOK_URL'] === '') {
+      console.info('CONVEX_WEBHOOK_URL is empty; heartbeat webhook disabled');
+    }
+  } else {
+    convexWebhookUrl = deriveConvexWebhookUrl(env['CONVEX_DEPLOY_URL']);
+    if (convexWebhookUrl) {
+      console.warn(
+        'Deriving CONVEX_WEBHOOK_URL from CONVEX_DEPLOY_URL — set CONVEX_WEBHOOK_URL explicitly in env',
+      );
+    } else if (env['CONVEX_DEPLOY_URL']) {
+      console.warn(
+        'CONVEX_DEPLOY_URL is non-standard; CONVEX_WEBHOOK_URL required for webhook ingest',
+      );
+    }
   }
   return {
     privateKey: pk,
@@ -226,5 +239,6 @@ function normalizePk(pk: string): `0x${string}` {
 
 function deriveConvexWebhookUrl(convexDeployUrl?: string): string | undefined {
   if (!convexDeployUrl) return undefined;
+  if (!convexDeployUrl.includes('.convex.cloud')) return undefined;
   return convexDeployUrl.replace('.convex.cloud', '.convex.site');
 }

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -3,6 +3,7 @@ import {
   createPublicClient,
   createWalletClient,
   http,
+  WaitForTransactionReceiptTimeoutError,
   type Account,
   type PublicClient,
   type WalletClient,
@@ -21,6 +22,8 @@ export interface RunnerHeartbeatConfig {
   rpcUrl?: string;
   /** ClanWorld contract address. */
   contractAddress: `0x${string}`;
+  /** Wait time for heartbeat receipt confirmation. */
+  receiptTimeoutMs?: number;
 }
 
 /**
@@ -63,6 +66,7 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
   private readonly walletClient: WalletClient;
   private readonly account: Account;
   private readonly contractAddress: `0x${string}`;
+  private readonly receiptTimeoutMs: number;
 
   constructor(cfg: RunnerHeartbeatConfig) {
     const pk = normalizePk(cfg.privateKey);
@@ -75,6 +79,7 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
       transport,
     });
     this.contractAddress = cfg.contractAddress;
+    this.receiptTimeoutMs = cfg.receiptTimeoutMs ?? 15_000;
   }
 
   async callHeartbeat(): Promise<{ txHash: string }> {
@@ -88,12 +93,15 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
         args: [],
       });
       // Wait for confirmation per the seam contract ("not fire-and-forget").
-      const receipt = await this.publicClient.waitForTransactionReceipt({ hash });
+      const receipt = await this.publicClient.waitForTransactionReceipt({
+        hash,
+        timeout: this.receiptTimeoutMs,
+      });
       if (receipt.status !== 'success') {
         // Mined-but-reverted. Most common cause is the rate-limit window
         // hadn't elapsed yet (when simulation succeeded but execution didn't).
         // Re-read state to upgrade to HeartbeatRateLimitedError when applicable.
-        const next = await this.readNextHeartbeatAt().catch(() => undefined);
+        const next = await this.readNextHeartbeatAtTs().catch(() => undefined);
         if (next !== undefined && next > Math.floor(Date.now() / 1000)) {
           throw new HeartbeatRateLimitedError(next);
         }
@@ -103,10 +111,15 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     } catch (err) {
       // Already a rate-limit error — rethrow immediately; no second RPC read.
       if (err instanceof HeartbeatRateLimitedError) throw err;
+      if (err instanceof WaitForTransactionReceiptTimeoutError) {
+        throw new HeartbeatTimeoutError(
+          `heartbeat tx receipt timed out after ${this.receiptTimeoutMs}ms`,
+        );
+      }
       // Attempt to upgrade only simulation-level contract reverts to
       // HeartbeatRateLimitedError; pre-flight/RPC errors must surface unchanged.
       if (!(err instanceof ContractFunctionRevertedError)) throw err;
-      const next = await this.readNextHeartbeatAt().catch(() => undefined);
+      const next = await this.readNextHeartbeatAtTs().catch(() => undefined);
       if (next !== undefined && next > Math.floor(Date.now() / 1000)) {
         throw new HeartbeatRateLimitedError(next);
       }
@@ -114,12 +127,17 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     }
   }
 
-  async isHeartbeatDue(): Promise<boolean> {
-    const next = await this.readNextHeartbeatAt();
-    return next <= Math.floor(Date.now() / 1000);
+  async readHeartbeatIntervalSeconds(): Promise<number> {
+    const interval = await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: CLAN_WORLD_ABI,
+      functionName: 'heartbeatIntervalSeconds',
+      args: [],
+    });
+    return Number(interval);
   }
 
-  private async readNextHeartbeatAt(): Promise<number> {
+  async readNextHeartbeatAtTs(): Promise<number> {
     const state = await this.publicClient.readContract({
       address: this.contractAddress,
       abi: CLAN_WORLD_ABI,
@@ -128,6 +146,13 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     });
     // viem decodes the named tuple into an object with the same field names.
     return Number((state as { nextHeartbeatAtTs: bigint }).nextHeartbeatAtTs);
+  }
+}
+
+export class HeartbeatTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HeartbeatTimeoutError';
   }
 }
 

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -239,6 +239,17 @@ function normalizePk(pk: string): `0x${string}` {
 
 function deriveConvexWebhookUrl(convexDeployUrl?: string): string | undefined {
   if (!convexDeployUrl) return undefined;
-  if (!convexDeployUrl.includes('.convex.cloud')) return undefined;
-  return convexDeployUrl.replace('.convex.cloud', '.convex.site');
+  // Hostname-suffix check (not substring) so URLs like
+  // `https://attacker.convex.cloud.evil.com` or `https://example.com/.convex.cloud/x`
+  // don't false-positive into a rewritten webhook target. R5 super-swarm hardening.
+  let url: URL;
+  try {
+    url = new URL(convexDeployUrl);
+  } catch {
+    return undefined;
+  }
+  if (!url.hostname.endsWith('.convex.cloud')) return undefined;
+  url.hostname = url.hostname.replace(/\.convex\.cloud$/, '.convex.site');
+  // Preserve protocol/port; strip trailing slash if URL had no explicit path.
+  return url.toString().replace(/\/$/, '');
 }

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -49,11 +49,17 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): RunnerHeart
       `CLAN_WORLD_CONTRACT_ADDRESS missing or invalid; expected 0x-prefixed 40-hex-char address, got ${String(contractAddress)}`,
     );
   }
+  const convexWebhookUrl = env['CONVEX_WEBHOOK_URL'] || deriveConvexWebhookUrl(env['CONVEX_DEPLOY_URL']);
+  if (!env['CONVEX_WEBHOOK_URL'] && convexWebhookUrl) {
+    console.warn(
+      'Deriving CONVEX_WEBHOOK_URL from CONVEX_DEPLOY_URL — set CONVEX_WEBHOOK_URL explicitly in env',
+    );
+  }
   return {
     privateKey: pk,
     rpcUrl: env['RPC_URL_PRIMARY'] || env['RPC_URL_FALLBACK'],
     contractAddress: contractAddress as `0x${string}`,
-    convexWebhookUrl: env['CONVEX_WEBHOOK_URL'],
+    convexWebhookUrl,
     webhookSharedSecret: env['WEBHOOK_SHARED_SECRET'],
   };
 }
@@ -167,10 +173,11 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     blockNumber?: bigint | number | null;
   }): Promise<void> {
     if (!this.convexWebhookUrl) return;
-    const webhookUrl = new URL('/api/heartbeat-webhook', this.convexWebhookUrl);
     try {
+      const webhookUrl = new URL('/api/heartbeat-webhook', this.convexWebhookUrl);
       const response = await fetch(webhookUrl, {
         method: 'POST',
+        signal: AbortSignal.timeout(5_000),
         headers: {
           'content-type': 'application/json',
           ...(this.webhookSharedSecret
@@ -215,4 +222,9 @@ function normalizePk(pk: string): `0x${string}` {
     );
   }
   return withPrefix as `0x${string}`;
+}
+
+function deriveConvexWebhookUrl(convexDeployUrl?: string): string | undefined {
+  if (!convexDeployUrl) return undefined;
+  return convexDeployUrl.replace('.convex.cloud', '.convex.site');
 }

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -24,6 +24,10 @@ export interface RunnerHeartbeatConfig {
   contractAddress: `0x${string}`;
   /** Wait time for heartbeat receipt confirmation. */
   receiptTimeoutMs?: number;
+  /** Convex deployment base URL for best-effort heartbeat webhook pings. */
+  convexWebhookUrl?: string;
+  /** Shared webhook auth secret. */
+  webhookSharedSecret?: string;
 }
 
 /**
@@ -49,6 +53,8 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): RunnerHeart
     privateKey: pk,
     rpcUrl: env['RPC_URL_PRIMARY'] || env['RPC_URL_FALLBACK'],
     contractAddress: contractAddress as `0x${string}`,
+    convexWebhookUrl: env['CONVEX_WEBHOOK_URL'],
+    webhookSharedSecret: env['WEBHOOK_SHARED_SECRET'],
   };
 }
 
@@ -67,6 +73,8 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
   private readonly account: Account;
   private readonly contractAddress: `0x${string}`;
   private readonly receiptTimeoutMs: number;
+  private readonly convexWebhookUrl?: string;
+  private readonly webhookSharedSecret?: string;
 
   constructor(cfg: RunnerHeartbeatConfig) {
     const pk = normalizePk(cfg.privateKey);
@@ -80,6 +88,8 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     });
     this.contractAddress = cfg.contractAddress;
     this.receiptTimeoutMs = cfg.receiptTimeoutMs ?? 15_000;
+    this.convexWebhookUrl = cfg.convexWebhookUrl;
+    this.webhookSharedSecret = cfg.webhookSharedSecret;
   }
 
   async callHeartbeat(): Promise<{ txHash: string }> {
@@ -107,6 +117,10 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
         }
         throw new Error(`heartbeat tx ${hash} reverted on-chain`);
       }
+      await this.postHeartbeatWebhook({
+        txHash: hash,
+        blockNumber: receipt.blockNumber,
+      });
       return { txHash: hash };
     } catch (err) {
       // Already a rate-limit error — rethrow immediately; no second RPC read.
@@ -146,6 +160,42 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     });
     // viem decodes the named tuple into an object with the same field names.
     return Number((state as { nextHeartbeatAtTs: bigint }).nextHeartbeatAtTs);
+  }
+
+  private async postHeartbeatWebhook(args: {
+    txHash: `0x${string}`;
+    blockNumber?: bigint | number | null;
+  }): Promise<void> {
+    if (!this.convexWebhookUrl) return;
+    const webhookUrl = new URL('/api/heartbeat-webhook', this.convexWebhookUrl);
+    try {
+      const response = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...(this.webhookSharedSecret
+            ? { Authorization: `Bearer ${this.webhookSharedSecret}` }
+            : {}),
+        },
+        body: JSON.stringify({
+          chain: baseSepolia.name,
+          engineAddress: this.contractAddress,
+          txHash: args.txHash,
+          blockNumber: args.blockNumber === undefined || args.blockNumber === null
+            ? undefined
+            : Number(args.blockNumber),
+          firedAtTs: Math.floor(Date.now() / 1000),
+          source: 'ts-runner',
+        }),
+      });
+      if (!response.ok) {
+        console.warn(
+          `[RunnerCastHeartbeat] heartbeat webhook POST failed: ${response.status} ${response.statusText}`,
+        );
+      }
+    } catch (err) {
+      console.warn('[RunnerCastHeartbeat] heartbeat webhook POST failed:', err);
+    }
   }
 }
 

--- a/packages/runner/src/telegramAlert.ts
+++ b/packages/runner/src/telegramAlert.ts
@@ -1,0 +1,54 @@
+export interface TelegramAlertConfig {
+  botToken?: string;
+  chatId?: string;
+  threadId?: string;
+}
+
+export interface TelegramAlertResult {
+  ok: boolean;
+  error?: string;
+}
+
+const DEFAULT_DO_CREW_CHAT_ID = '-1003806628027';
+
+export function telegramAlertConfigFromEnv(env: NodeJS.ProcessEnv = process.env): TelegramAlertConfig {
+  return {
+    botToken: env['TELEGRAM_BOT_TOKEN'],
+    chatId: env['TELEGRAM_ALERT_CHAT_ID'] ?? DEFAULT_DO_CREW_CHAT_ID,
+    threadId: env['TELEGRAM_ALERT_THREAD_ID'],
+  };
+}
+
+export async function sendTelegramAlert(
+  text: string,
+  cfg: TelegramAlertConfig = telegramAlertConfigFromEnv(),
+): Promise<TelegramAlertResult> {
+  if (!cfg.botToken) {
+    return { ok: false, error: 'TELEGRAM_BOT_TOKEN is not set' };
+  }
+  const chatId = cfg.chatId ?? DEFAULT_DO_CREW_CHAT_ID;
+  const body = new URLSearchParams({
+    chat_id: chatId,
+    text,
+  });
+  if (cfg.threadId) {
+    body.set('message_thread_id', cfg.threadId);
+  }
+
+  try {
+    const response = await fetch(`https://api.telegram.org/bot${cfg.botToken}/sendMessage`, {
+      method: 'POST',
+      body,
+    });
+    if (!response.ok) {
+      const description = await response.text().catch(() => response.statusText);
+      return { ok: false, error: `Telegram API ${response.status}: ${description}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/runner/src/telegramAlert.ts
+++ b/packages/runner/src/telegramAlert.ts
@@ -38,6 +38,7 @@ export async function sendTelegramAlert(
   try {
     const response = await fetch(`https://api.telegram.org/bot${cfg.botToken}/sendMessage`, {
       method: 'POST',
+      signal: AbortSignal.timeout(5_000),
       body,
     });
     if (!response.ok) {

--- a/packages/runner/src/types.ts
+++ b/packages/runner/src/types.ts
@@ -37,6 +37,4 @@ export interface RunnerConfig {
   tmuxSessionPrefix: string;
   /** Map of Elder id → clan id used for tick-update context + peer routing. */
   elderToClanId: Record<ElderId, string>;
-  /** Milliseconds between isHeartbeatDue() checks in the heartbeat scheduler. */
-  heartbeatCheckIntervalMs: number;
 }

--- a/packages/runner/test/heartbeatScheduler.test.ts
+++ b/packages/runner/test/heartbeatScheduler.test.ts
@@ -4,8 +4,11 @@ import {
   HEARTBEAT_RETRY_BACKOFF_MS,
   startHeartbeatScheduler,
 } from '../src/heartbeatScheduler';
-import { type IHeartbeatCaller } from '@clan-world/agents/seams';
+import { HeartbeatRateLimitedError, type IHeartbeatCaller } from '@clan-world/agents/seams';
 import { makeSettleLatch } from '../src/settleLatch';
+import { makeConvexSnapshotSettleLatch } from '../src/convexSnapshotSettleLatch';
+import { HeartbeatTimeoutError } from '../src/runnerCastHeartbeat';
+import type { WorldSnapshot } from '@clan-world/shared';
 
 function makeHeartbeatCaller(overrides: Partial<IHeartbeatCaller> = {}): IHeartbeatCaller {
   return {
@@ -73,6 +76,149 @@ describe('heartbeatScheduler', () => {
     abort.abort();
   });
 
+  it('treats rate-limited heartbeats as settled without retrying or alerting', async () => {
+    const callHeartbeat = vi.fn().mockRejectedValue(new HeartbeatRateLimitedError(60));
+    const alert = vi.fn().mockResolvedValue({ ok: true });
+    const postRunnerStatus = vi.fn().mockResolvedValue(undefined);
+    let readNextCount = 0;
+    const caller = makeHeartbeatCaller({
+      callHeartbeat,
+      async readNextHeartbeatAtTs() {
+        readNextCount++;
+        return readNextCount === 2 ? 60 : 0;
+      },
+    });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      alert,
+      convex: { postRunnerStatus },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(501);
+
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+    expect(alert).not.toHaveBeenCalled();
+    expect(postRunnerStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ lastFireResult: 'rate-limited' }),
+    );
+
+    abort.abort();
+  });
+
+  it('exits silently when aborted during retry sleep', async () => {
+    const callHeartbeat = vi.fn().mockRejectedValue(new Error('rpc down'));
+    const alert = vi.fn().mockResolvedValue({ ok: true });
+    const caller = makeHeartbeatCaller({ callHeartbeat });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      alert,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(501);
+    abort.abort();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+    expect(alert).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates heartbeat failure alerts for five minutes', async () => {
+    const callHeartbeat = vi.fn().mockRejectedValue(new Error('rpc down'));
+    const alert = vi.fn().mockResolvedValue({ ok: true });
+    const caller = makeHeartbeatCaller({ callHeartbeat });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      alert,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    const failureCycleMs =
+      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
+    await vi.advanceTimersByTimeAsync(failureCycleMs);
+    await vi.advanceTimersByTimeAsync(failureCycleMs);
+
+    expect(callHeartbeat).toHaveBeenCalledTimes((HEARTBEAT_RETRY_BACKOFF_MS.length + 1) * 2);
+    expect(alert).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+  });
+
+  it('backs off repeated nextHeartbeatAtTs read failures', async () => {
+    const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
+    const readNextHeartbeatAtTs = vi.fn()
+      .mockRejectedValueOnce(new Error('rpc read down 1'))
+      .mockRejectedValueOnce(new Error('rpc read down 2'))
+      .mockRejectedValueOnce(new Error('rpc read down 3'))
+      .mockResolvedValue(60);
+    const caller = makeHeartbeatCaller({ callHeartbeat, readNextHeartbeatAtTs });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 60_000,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(readNextHeartbeatAtTs).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(readNextHeartbeatAtTs).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(readNextHeartbeatAtTs).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(readNextHeartbeatAtTs).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(readNextHeartbeatAtTs).toHaveBeenCalledTimes(4);
+
+    abort.abort();
+  });
+
+  it('re-reads nextHeartbeatAtTs after receipt timeout and treats advanced state as success', async () => {
+    const callHeartbeat = vi.fn().mockRejectedValue(new HeartbeatTimeoutError('receipt timed out'));
+    const alert = vi.fn().mockResolvedValue({ ok: true });
+    const postRunnerStatus = vi.fn().mockResolvedValue(undefined);
+    const readNextHeartbeatAtTs = vi.fn()
+      .mockResolvedValueOnce(100)
+      .mockResolvedValueOnce(160)
+      .mockResolvedValue(220);
+    const caller = makeHeartbeatCaller({ callHeartbeat, readNextHeartbeatAtTs });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 100_000,
+      alert,
+      convex: { postRunnerStatus },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(501);
+
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+    expect(alert).not.toHaveBeenCalled();
+    expect(postRunnerStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ lastFireResult: 'success', nextHeartbeatAtTs: 160 }),
+    );
+
+    abort.abort();
+  });
+
   it('swallows runnerStatus write failures and keeps scheduling', async () => {
     const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
     const postRunnerStatus = vi.fn().mockRejectedValue(new Error('convex down'));
@@ -125,6 +271,41 @@ describe('heartbeatScheduler', () => {
     abort.abort();
   });
 
+  it('standalone snapshot latch waits for worldSnapshot.tick to advance before the next fire', async () => {
+    let snapshotTick = 0;
+    const getSnapshot = vi.fn(async () => makeSnapshot(snapshotTick));
+    const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
+    const readNextHeartbeatAtTs = vi.fn().mockResolvedValue(0);
+    const caller = makeHeartbeatCaller({ callHeartbeat, readNextHeartbeatAtTs });
+    const abort = new AbortController();
+    const settleLatch = makeConvexSnapshotSettleLatch({
+      convex: { getSnapshot },
+      signal: abort.signal,
+      log: { warn: vi.fn() },
+      pollMs: 100,
+    });
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      settleLatch,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(501);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+
+    snapshotTick = 1;
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(callHeartbeat).toHaveBeenCalledTimes(2);
+
+    abort.abort();
+  });
+
   it('guards successful no-op heartbeats whose nextHeartbeatAtTs remains in the past', async () => {
     const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
     let nextReads = 0;
@@ -153,3 +334,13 @@ describe('heartbeatScheduler', () => {
     abort.abort();
   });
 });
+
+function makeSnapshot(tick: number): WorldSnapshot {
+  return {
+    tick,
+    heartbeatIntervalSeconds: 60,
+    tickEpoch: { startedAt: 0, durationMs: 60_000 },
+    regions: [],
+    clans: [],
+  };
+}

--- a/packages/runner/test/heartbeatScheduler.test.ts
+++ b/packages/runner/test/heartbeatScheduler.test.ts
@@ -244,6 +244,36 @@ describe('heartbeatScheduler', () => {
     abort.abort();
   });
 
+  it('uses nowMs override for successful runnerStatus lastFireAt', async () => {
+    const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
+    const postRunnerStatus = vi.fn().mockResolvedValue(undefined);
+    let readNextCount = 0;
+    const caller = makeHeartbeatCaller({
+      callHeartbeat,
+      async readNextHeartbeatAtTs() {
+        readNextCount++;
+        return readNextCount === 2 ? 60 : 0;
+      },
+    });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 123_456,
+      convex: { postRunnerStatus },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(501);
+
+    expect(postRunnerStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ lastFireAt: 123_456, lastFireResult: 'success' }),
+    );
+
+    abort.abort();
+  });
+
   it('waits for Cycle B settle latch before firing', async () => {
     const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
     const caller = makeHeartbeatCaller({

--- a/packages/runner/test/heartbeatScheduler.test.ts
+++ b/packages/runner/test/heartbeatScheduler.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { startHeartbeatScheduler } from '../src/heartbeatScheduler';
-import { HeartbeatRateLimitedError, type IHeartbeatCaller } from '@clan-world/agents/seams';
+import {
+  computeHeartbeatDelayMs,
+  HEARTBEAT_RETRY_BACKOFF_MS,
+  startHeartbeatScheduler,
+} from '../src/heartbeatScheduler';
+import { type IHeartbeatCaller } from '@clan-world/agents/seams';
 import { makeSettleLatch } from '../src/settleLatch';
 
 function makeHeartbeatCaller(overrides: Partial<IHeartbeatCaller> = {}): IHeartbeatCaller {
   return {
-    async isHeartbeatDue() { return false; },
     async callHeartbeat() { return { txHash: '0xabc' }; },
+    async readHeartbeatIntervalSeconds() { return 60; },
+    async readNextHeartbeatAtTs() { return 0; },
     ...overrides,
   };
 }
@@ -15,171 +20,135 @@ beforeEach(() => { vi.useFakeTimers(); });
 afterEach(() => { vi.useRealTimers(); });
 
 describe('heartbeatScheduler', () => {
-  it('calls callHeartbeat when isHeartbeatDue returns true', async () => {
-    const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
-    const caller = makeHeartbeatCaller({
-      async isHeartbeatDue() { return true; },
-      callHeartbeat,
-    });
-    const abort = new AbortController();
-
-    startHeartbeatScheduler({ heartbeatCaller: caller, signal: abort.signal, checkIntervalMs: 100 });
-
-    await vi.advanceTimersByTimeAsync(110);
-    expect(callHeartbeat).toHaveBeenCalledTimes(1);
-
-    abort.abort();
+  it('computes delay from nextHeartbeatAtTs with 500ms jitter', () => {
+    expect(computeHeartbeatDelayMs(10, 9_250)).toBe(1_250);
+    expect(computeHeartbeatDelayMs(10, 11_000)).toBe(500);
   });
 
-  it('does NOT call callHeartbeat when isHeartbeatDue returns false', async () => {
+  it('fires heartbeat when on-chain nextHeartbeatAtTs is due', async () => {
     const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
+    let readNextCount = 0;
     const caller = makeHeartbeatCaller({
-      async isHeartbeatDue() { return false; },
       callHeartbeat,
-    });
-    const abort = new AbortController();
-
-    startHeartbeatScheduler({ heartbeatCaller: caller, signal: abort.signal, checkIntervalMs: 100 });
-
-    await vi.advanceTimersByTimeAsync(350);
-    expect(callHeartbeat).not.toHaveBeenCalled();
-
-    abort.abort();
-  });
-
-  it('catches HeartbeatRateLimitedError without crashing, retries on next check', async () => {
-    let callCount = 0;
-    const caller = makeHeartbeatCaller({
-      async isHeartbeatDue() { return true; },
-      async callHeartbeat() {
-        callCount++;
-        if (callCount === 1) {
-          throw new HeartbeatRateLimitedError(Math.floor(Date.now() / 1000) + 60);
-        }
-        return { txHash: '0x2' };
+      async readNextHeartbeatAtTs() {
+        readNextCount++;
+        return readNextCount === 2 ? 60 : 0;
       },
     });
     const abort = new AbortController();
-    const warnLog = vi.fn();
 
     startHeartbeatScheduler({
       heartbeatCaller: caller,
       signal: abort.signal,
-      checkIntervalMs: 100,
-      log: { info: vi.fn(), warn: warnLog, error: vi.fn() },
+      nowMs: () => 0,
     });
 
-    // First interval: throws rate-limited, warn logged
-    await vi.advanceTimersByTimeAsync(110);
-    expect(callCount).toBe(1);
-    expect(warnLog).toHaveBeenCalledTimes(1);
-
-    // Second interval: succeeds
-    await vi.advanceTimersByTimeAsync(110);
-    expect(callCount).toBe(2);
+    await vi.advanceTimersByTimeAsync(501);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
 
     abort.abort();
   });
 
-  it('clears the interval on signal abort', async () => {
+  it('retries failed heartbeats with 1s, 2s, 5s, 10s backoff then alerts', async () => {
+    const callHeartbeat = vi.fn().mockRejectedValue(new Error('rpc down'));
+    const alert = vi.fn().mockResolvedValue({ ok: true });
+    const caller = makeHeartbeatCaller({ callHeartbeat });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      alert,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(
+      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0),
+    );
+
+    expect(callHeartbeat).toHaveBeenCalledTimes(HEARTBEAT_RETRY_BACKOFF_MS.length + 1);
+    expect(alert).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+  });
+
+  it('swallows runnerStatus write failures and keeps scheduling', async () => {
     const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
+    const postRunnerStatus = vi.fn().mockRejectedValue(new Error('convex down'));
     const caller = makeHeartbeatCaller({
-      async isHeartbeatDue() { return true; },
       callHeartbeat,
+      async readNextHeartbeatAtTs() { return 0; },
     });
     const abort = new AbortController();
 
-    startHeartbeatScheduler({ heartbeatCaller: caller, signal: abort.signal, checkIntervalMs: 100 });
-    abort.abort();
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      convex: { postRunnerStatus },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
 
-    await vi.advanceTimersByTimeAsync(350);
-    expect(callHeartbeat).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(2_002);
+
+    expect(postRunnerStatus).toHaveBeenCalled();
+    expect(callHeartbeat).toHaveBeenCalledTimes(2);
+
+    abort.abort();
   });
 
-  it('does not allow overlapping callHeartbeat — second interval fires while first in flight', async () => {
-    let inFlightCount = 0;
-    let maxConcurrent = 0;
-    const callHeartbeat = vi.fn(async () => {
-      inFlightCount++;
-      maxConcurrent = Math.max(maxConcurrent, inFlightCount);
-      await new Promise(resolve => setTimeout(resolve, 250)); // slow
-      inFlightCount--;
-      return { txHash: '0xslow' };
-    });
+  it('waits for Cycle B settle latch before firing', async () => {
+    const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
     const caller = makeHeartbeatCaller({
-      async isHeartbeatDue() { return true; },
       callHeartbeat,
+      async readNextHeartbeatAtTs() { return 0; },
     });
     const abort = new AbortController();
     const settleLatch = makeSettleLatch();
-    settleLatch.markSettled(1); // Cycle B already settled tick 1
 
-    startHeartbeatScheduler({ heartbeatCaller: caller, signal: abort.signal, checkIntervalMs: 100, settleLatch });
-
-    // Fire 3 intervals (0ms, 100ms, 200ms) while first call takes 250ms
-    await vi.advanceTimersByTimeAsync(310);
-    expect(maxConcurrent).toBe(1); // never more than 1 in-flight
-    abort.abort();
-  });
-
-  it('skips heartbeat when Cycle B has not settled the current tick', async () => {
-    const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
-    const caller = makeHeartbeatCaller({
-      async isHeartbeatDue() { return true; },
-      callHeartbeat,
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      settleLatch,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     });
-    const abort = new AbortController();
-    const settleLatch = makeSettleLatch(); // lastSettledTick = -1, Cycle B hasn't settled yet
 
-    startHeartbeatScheduler({ heartbeatCaller: caller, signal: abort.signal, checkIntervalMs: 100, settleLatch });
-
-    await vi.advanceTimersByTimeAsync(350); // 3 intervals — Cycle B unsettled, all skip
+    await vi.advanceTimersByTimeAsync(501);
     expect(callHeartbeat).not.toHaveBeenCalled();
 
-    // Cycle B settles a tick — Cycle A now allowed to fire
     settleLatch.markSettled(1);
-    await vi.advanceTimersByTimeAsync(110);
+    await vi.advanceTimersByTimeAsync(1_501);
     expect(callHeartbeat).toHaveBeenCalledTimes(1);
 
     abort.abort();
   });
 
-  it('slow callHeartbeat + Cycle B advances mid-call does not permanently skip next tick', async () => {
-    // Scenario: Cycle A fires for tick 1. callHeartbeat takes 250ms. During that wait,
-    // Cycle B settles tick 2. Without snapshot-before-call, lastHeartbeatForTick would
-    // be set to 2 after the call, making Cycle A think tick 2 was already heartbeated.
-    const settleLatch = makeSettleLatch();
-    settleLatch.markSettled(1); // Cycle B settled tick 1
-
-    let resolveHeartbeat!: () => void;
-    const callHeartbeat = vi.fn((): Promise<{ txHash: string }> => {
-      return new Promise(resolve => {
-        resolveHeartbeat = () => resolve({ txHash: '0xslow' });
-      });
-    });
+  it('guards successful no-op heartbeats whose nextHeartbeatAtTs remains in the past', async () => {
+    const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
+    let nextReads = 0;
     const caller = makeHeartbeatCaller({
-      async isHeartbeatDue() { return true; },
       callHeartbeat,
+      async readNextHeartbeatAtTs() {
+        nextReads++;
+        return nextReads <= 2 ? 0 : 60;
+      },
     });
     const abort = new AbortController();
 
-    startHeartbeatScheduler({ heartbeatCaller: caller, signal: abort.signal, checkIntervalMs: 100, settleLatch });
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 2_000,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
 
-    // Trigger first interval — starts callHeartbeat for tick 1 (settledSnapshot = 1)
-    await vi.advanceTimersByTimeAsync(110);
+    await vi.advanceTimersByTimeAsync(501);
     expect(callHeartbeat).toHaveBeenCalledTimes(1);
 
-    // Cycle B settles tick 2 WHILE callHeartbeat is still in-flight
-    settleLatch.markSettled(2);
-
-    // Resolve the slow heartbeat
-    resolveHeartbeat();
-    await vi.advanceTimersByTimeAsync(10); // flush microtasks
-
-    // lastHeartbeatForTick should be 1 (the snapshot taken before the call), not 2
-    // So the next interval must fire heartbeat for tick 2
-    await vi.advanceTimersByTimeAsync(110);
-    expect(callHeartbeat).toHaveBeenCalledTimes(2); // fired again for tick 2
+    await vi.advanceTimersByTimeAsync(999);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
 
     abort.abort();
   });

--- a/packages/runner/test/heartbeatScheduler.test.ts
+++ b/packages/runner/test/heartbeatScheduler.test.ts
@@ -6,7 +6,10 @@ import {
 } from '../src/heartbeatScheduler';
 import { HeartbeatRateLimitedError, type IHeartbeatCaller } from '@clan-world/agents/seams';
 import { makeSettleLatch } from '../src/settleLatch';
-import { makeConvexSnapshotSettleLatch } from '../src/convexSnapshotSettleLatch';
+import {
+  makeConvexSnapshotSettleLatch,
+  makeHeartbeatLoopSettleLatch,
+} from '../src/convexSnapshotSettleLatch';
 import { HeartbeatTimeoutError } from '../src/runnerCastHeartbeat';
 import type { WorldSnapshot } from '@clan-world/shared';
 
@@ -152,6 +155,74 @@ describe('heartbeatScheduler', () => {
     await vi.advanceTimersByTimeAsync(failureCycleMs);
 
     expect(callHeartbeat).toHaveBeenCalledTimes((HEARTBEAT_RETRY_BACKOFF_MS.length + 1) * 2);
+    expect(alert).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+  });
+
+  it('does not suppress different heartbeat failure classes inside the dedup window', async () => {
+    vi.setSystemTime(0);
+    const callHeartbeat = vi.fn()
+      .mockRejectedValueOnce(new Error('rpc down'))
+      .mockRejectedValueOnce(new Error('rpc down'))
+      .mockRejectedValueOnce(new Error('rpc down'))
+      .mockRejectedValueOnce(new Error('rpc down'))
+      .mockRejectedValueOnce(new Error('rpc down'))
+      .mockRejectedValueOnce(new Error('execution reverted: paused'))
+      .mockRejectedValueOnce(new Error('execution reverted: paused'))
+      .mockRejectedValueOnce(new Error('execution reverted: paused'))
+      .mockRejectedValueOnce(new Error('execution reverted: paused'))
+      .mockRejectedValueOnce(new Error('execution reverted: paused'));
+    const readNextHeartbeatAtTs = vi.fn()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValue(120);
+    const alert = vi.fn().mockResolvedValue({ ok: true });
+    const caller = makeHeartbeatCaller({ callHeartbeat, readNextHeartbeatAtTs });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      alert,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    const failureCycleMs =
+      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
+    await vi.advanceTimersByTimeAsync(failureCycleMs);
+    await vi.advanceTimersByTimeAsync(120_000 - failureCycleMs);
+    await vi.advanceTimersByTimeAsync(failureCycleMs);
+
+    expect(alert).toHaveBeenCalledTimes(2);
+    expect(alert.mock.calls[0]?.[0]).toContain('rpc down');
+    expect(alert.mock.calls[1]?.[0]).toContain('execution reverted: paused');
+
+    abort.abort();
+  });
+
+  it('suppresses same-class heartbeat failure alerts inside the dedup window', async () => {
+    vi.setSystemTime(0);
+    const callHeartbeat = vi.fn().mockRejectedValue(new Error('rpc down'));
+    const readNextHeartbeatAtTs = vi.fn()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValue(120);
+    const alert = vi.fn().mockResolvedValue({ ok: true });
+    const caller = makeHeartbeatCaller({ callHeartbeat, readNextHeartbeatAtTs });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      alert,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    const failureCycleMs =
+      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
+    await vi.advanceTimersByTimeAsync(failureCycleMs);
+    await vi.advanceTimersByTimeAsync(120_000 - failureCycleMs);
+    await vi.advanceTimersByTimeAsync(failureCycleMs);
+
     expect(alert).toHaveBeenCalledTimes(1);
 
     abort.abort();
@@ -331,6 +402,40 @@ describe('heartbeatScheduler', () => {
 
     snapshotTick = 1;
     await vi.advanceTimersByTimeAsync(2_000);
+    expect(callHeartbeat).toHaveBeenCalledTimes(2);
+
+    abort.abort();
+  });
+
+  it('uses no settle latch for stub Convex so standalone heartbeat does not deadlock', async () => {
+    const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
+    const readNextHeartbeatAtTs = vi.fn().mockResolvedValue(0);
+    const caller = makeHeartbeatCaller({ callHeartbeat, readNextHeartbeatAtTs });
+    const abort = new AbortController();
+    const warn = vi.fn();
+    const settleLatch = makeHeartbeatLoopSettleLatch({
+      convex: {
+        isStub: true,
+        async getSnapshot() { return makeSnapshot(0); },
+      },
+      signal: abort.signal,
+      log: { warn },
+    });
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      settleLatch,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(2_002);
+
+    expect(settleLatch).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      '[heartbeatLoopMain] stub Convex detected — running without settle latch',
+    );
     expect(callHeartbeat).toHaveBeenCalledTimes(2);
 
     abort.abort();

--- a/packages/runner/test/heartbeatScheduler.test.ts
+++ b/packages/runner/test/heartbeatScheduler.test.ts
@@ -113,6 +113,37 @@ describe('heartbeatScheduler', () => {
     abort.abort();
   });
 
+  it('does not advance settle-latch watermark for rate-limited heartbeats', async () => {
+    const callHeartbeat = vi.fn()
+      .mockRejectedValueOnce(new HeartbeatRateLimitedError(60))
+      .mockResolvedValue({ txHash: '0x1' });
+    const alert = vi.fn().mockResolvedValue({ ok: true });
+    const caller = makeHeartbeatCaller({
+      callHeartbeat,
+      async readNextHeartbeatAtTs() { return 0; },
+    });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      alert,
+      settleLatch: {
+        lastSettledTick: () => 0,
+        markSettled: vi.fn(),
+      },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(2_002);
+
+    expect(callHeartbeat).toHaveBeenCalledTimes(2);
+    expect(alert).not.toHaveBeenCalled();
+
+    abort.abort();
+  });
+
   it('exits silently when aborted during retry sleep', async () => {
     const callHeartbeat = vi.fn().mockRejectedValue(new Error('rpc down'));
     const alert = vi.fn().mockResolvedValue({ ok: true });
@@ -156,6 +187,36 @@ describe('heartbeatScheduler', () => {
 
     expect(callHeartbeat).toHaveBeenCalledTimes((HEARTBEAT_RETRY_BACKOFF_MS.length + 1) * 2);
     expect(alert).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+  });
+
+  it('does not deduplicate heartbeat alerts when alert delivery fails', async () => {
+    vi.setSystemTime(0);
+    const callHeartbeat = vi.fn().mockRejectedValue(new Error('rpc down'));
+    const readNextHeartbeatAtTs = vi.fn()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValue(120);
+    const alert = vi.fn()
+      .mockResolvedValueOnce({ ok: false, error: 'telegram down' })
+      .mockResolvedValue({ ok: true });
+    const caller = makeHeartbeatCaller({ callHeartbeat, readNextHeartbeatAtTs });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      alert,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    const failureCycleMs =
+      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
+    await vi.advanceTimersByTimeAsync(failureCycleMs);
+    await vi.advanceTimersByTimeAsync(120_000 - failureCycleMs);
+    await vi.advanceTimersByTimeAsync(failureCycleMs);
+
+    expect(alert).toHaveBeenCalledTimes(2);
 
     abort.abort();
   });
@@ -345,7 +406,7 @@ describe('heartbeatScheduler', () => {
     abort.abort();
   });
 
-  it('waits for Cycle B settle latch before firing', async () => {
+  it('allows the first fire before Cycle B settle latch has observed a tick', async () => {
     const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
     const caller = makeHeartbeatCaller({
       callHeartbeat,
@@ -363,10 +424,41 @@ describe('heartbeatScheduler', () => {
     });
 
     await vi.advanceTimersByTimeAsync(501);
-    expect(callHeartbeat).not.toHaveBeenCalled();
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
 
     settleLatch.markSettled(1);
     await vi.advanceTimersByTimeAsync(1_501);
+    expect(callHeartbeat).toHaveBeenCalledTimes(2);
+
+    abort.abort();
+  });
+
+  it('fires first heartbeat when standalone snapshot latch cannot read Convex', async () => {
+    const getSnapshot = vi.fn().mockRejectedValue(new Error('convex down'));
+    const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
+    const readNextHeartbeatAtTs = vi.fn().mockResolvedValue(0);
+    const caller = makeHeartbeatCaller({ callHeartbeat, readNextHeartbeatAtTs });
+    const abort = new AbortController();
+    const settleLatch = makeConvexSnapshotSettleLatch({
+      convex: { getSnapshot },
+      signal: abort.signal,
+      log: { warn: vi.fn() },
+      pollMs: 100,
+    });
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      settleLatch,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(501);
+
     expect(callHeartbeat).toHaveBeenCalledTimes(1);
 
     abort.abort();

--- a/packages/runner/test/heartbeatScheduler.test.ts
+++ b/packages/runner/test/heartbeatScheduler.test.ts
@@ -221,6 +221,43 @@ describe('heartbeatScheduler', () => {
     abort.abort();
   });
 
+  it('keeps heartbeat failure runnerStatus when Telegram alert delivery fails', async () => {
+    const callHeartbeat = vi.fn().mockRejectedValue(new Error('rpc down'));
+    const alert = vi.fn().mockResolvedValue({ ok: false, error: 'telegram down' });
+    const postRunnerStatus = vi.fn().mockResolvedValue(undefined);
+    const caller = makeHeartbeatCaller({ callHeartbeat });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      alert,
+      convex: { postRunnerStatus },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(
+      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0),
+    );
+
+    expect(alert).toHaveBeenCalledTimes(1);
+    expect(postRunnerStatus).toHaveBeenCalledTimes(HEARTBEAT_RETRY_BACKOFF_MS.length + 1);
+    expect(postRunnerStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        lastFireResult: 'error',
+        lastFailureMessage: 'rpc down',
+      }),
+    );
+    expect(postRunnerStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastFailureMessage: 'Telegram alert failed: telegram down',
+      }),
+    );
+
+    abort.abort();
+  });
+
   it('does not suppress different heartbeat failure classes inside the dedup window', async () => {
     vi.setSystemTime(0);
     const callHeartbeat = vi.fn()

--- a/packages/runner/test/runnerCastHeartbeat.test.ts
+++ b/packages/runner/test/runnerCastHeartbeat.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const viemMocks = vi.hoisted(() => ({
   readContract: vi.fn(),
@@ -35,6 +35,10 @@ beforeEach(() => {
   viemMocks.writeContract.mockReset();
 });
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe('configFromEnv', () => {
   it('falls back to RPC_URL_FALLBACK when RPC_URL_PRIMARY is blank', () => {
     const cfg = configFromEnv({
@@ -65,5 +69,42 @@ describe('RunnerCastHeartbeat', () => {
         args: [],
       }),
     );
+  });
+
+  it('posts a best-effort heartbeat webhook after receipt confirmation', async () => {
+    const hash = `0x${'a'.repeat(64)}` as const;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    viemMocks.writeContract.mockResolvedValue(hash);
+    viemMocks.waitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      blockNumber: 123n,
+    });
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'https://rpc.example',
+      convexWebhookUrl: 'https://convex.example',
+      webhookSharedSecret: 'shared-secret',
+    });
+
+    await expect(heartbeat.callHeartbeat()).resolves.toEqual({ txHash: hash });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toBe('https://convex.example/api/heartbeat-webhook');
+    expect(init).toMatchObject({
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: 'Bearer shared-secret',
+      },
+    });
+    expect(JSON.parse(init.body)).toMatchObject({
+      engineAddress: '0x0000000000000000000000000000000000000001',
+      txHash: hash,
+      blockNumber: 123,
+      source: 'ts-runner',
+    });
   });
 });

--- a/packages/runner/test/runnerCastHeartbeat.test.ts
+++ b/packages/runner/test/runnerCastHeartbeat.test.ts
@@ -1,5 +1,39 @@
-import { describe, expect, it } from 'vitest';
-import { configFromEnv } from '../src/runnerCastHeartbeat';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const viemMocks = vi.hoisted(() => ({
+  readContract: vi.fn(),
+  waitForTransactionReceipt: vi.fn(),
+  writeContract: vi.fn(),
+}));
+
+vi.mock('viem', async () => {
+  const actual = await vi.importActual<typeof import('viem')>('viem');
+  return {
+    ...actual,
+    createPublicClient: vi.fn(() => ({
+      readContract: viemMocks.readContract,
+      waitForTransactionReceipt: viemMocks.waitForTransactionReceipt,
+    })),
+    createWalletClient: vi.fn(() => ({
+      writeContract: viemMocks.writeContract,
+    })),
+    http: vi.fn(() => ({})),
+  };
+});
+
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: vi.fn(() => ({
+    address: '0x0000000000000000000000000000000000000002',
+  })),
+}));
+
+import { configFromEnv, RunnerCastHeartbeat } from '../src/runnerCastHeartbeat';
+
+beforeEach(() => {
+  viemMocks.readContract.mockReset();
+  viemMocks.waitForTransactionReceipt.mockReset();
+  viemMocks.writeContract.mockReset();
+});
 
 describe('configFromEnv', () => {
   it('falls back to RPC_URL_FALLBACK when RPC_URL_PRIMARY is blank', () => {
@@ -11,5 +45,25 @@ describe('configFromEnv', () => {
     });
 
     expect(cfg.rpcUrl).toBe('https://fallback.example');
+  });
+});
+
+describe('RunnerCastHeartbeat', () => {
+  it('reads heartbeatIntervalSeconds from the canonical ABI', async () => {
+    viemMocks.readContract.mockResolvedValue(42n);
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'https://rpc.example',
+    });
+
+    await expect(heartbeat.readHeartbeatIntervalSeconds()).resolves.toBe(42);
+    expect(viemMocks.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: '0x0000000000000000000000000000000000000001',
+        functionName: 'heartbeatIntervalSeconds',
+        args: [],
+      }),
+    );
   });
 });

--- a/packages/runner/test/runnerCastHeartbeat.test.ts
+++ b/packages/runner/test/runnerCastHeartbeat.test.ts
@@ -37,6 +37,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 describe('configFromEnv', () => {
@@ -49,6 +50,22 @@ describe('configFromEnv', () => {
     });
 
     expect(cfg.rpcUrl).toBe('https://fallback.example');
+  });
+
+  it('derives CONVEX_WEBHOOK_URL from CONVEX_DEPLOY_URL when explicit URL is unset', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const cfg = configFromEnv({
+      RUNNER_PRIVATE_KEY: '1'.repeat(64),
+      CLAN_WORLD_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000001',
+      CONVEX_DEPLOY_URL: 'https://oceanic-hound-951.convex.cloud',
+    });
+
+    expect(cfg.convexWebhookUrl).toBe('https://oceanic-hound-951.convex.site');
+    expect(warn).toHaveBeenCalledWith(
+      'Deriving CONVEX_WEBHOOK_URL from CONVEX_DEPLOY_URL — set CONVEX_WEBHOOK_URL explicitly in env',
+    );
+    warn.mockRestore();
   });
 });
 
@@ -106,5 +123,62 @@ describe('RunnerCastHeartbeat', () => {
       blockNumber: 123,
       source: 'ts-runner',
     });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
+
+  it('reports heartbeat success when webhook URL is malformed', async () => {
+    const hash = `0x${'a'.repeat(64)}` as const;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    viemMocks.writeContract.mockResolvedValue(hash);
+    viemMocks.waitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      blockNumber: 123n,
+    });
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'https://rpc.example',
+      convexWebhookUrl: 'not-a-url',
+    });
+
+    await expect(heartbeat.callHeartbeat()).resolves.toEqual({ txHash: hash });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      '[RunnerCastHeartbeat] heartbeat webhook POST failed:',
+      expect.any(TypeError),
+    );
+    warn.mockRestore();
+  });
+
+  it('bounds hung heartbeat webhook POSTs with a timeout', async () => {
+    const hash = `0x${'a'.repeat(64)}` as const;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchMock = vi.fn((_url: URL, init?: RequestInit) => new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    viemMocks.writeContract.mockResolvedValue(hash);
+    viemMocks.waitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      blockNumber: 123n,
+    });
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'https://rpc.example',
+      convexWebhookUrl: 'https://convex.example',
+    });
+
+    const result = heartbeat.callHeartbeat();
+
+    await expect(result).resolves.toEqual({ txHash: hash });
+    expect(warn).toHaveBeenCalledWith(
+      '[RunnerCastHeartbeat] heartbeat webhook POST failed:',
+      expect.any(Error),
+    );
+    warn.mockRestore();
+  }, 7_000);
 });

--- a/packages/runner/test/runnerCastHeartbeat.test.ts
+++ b/packages/runner/test/runnerCastHeartbeat.test.ts
@@ -99,6 +99,35 @@ describe('configFromEnv', () => {
     warn.mockRestore();
   });
 
+  it('rejects hostnames that contain .convex.cloud as a substring (R5 hardening)', () => {
+    // Substring match would incorrectly rewrite https://attacker.convex.cloud.evil.com
+    // to https://attacker.convex.site.evil.com — defeats the security intent.
+    // Hostname-suffix check via URL parsing prevents this.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const cfg = configFromEnv({
+      RUNNER_PRIVATE_KEY: '1'.repeat(64),
+      CLAN_WORLD_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000001',
+      CONVEX_DEPLOY_URL: 'https://attacker.convex.cloud.evil.com',
+    });
+
+    expect(cfg.convexWebhookUrl).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      'CONVEX_DEPLOY_URL is non-standard; CONVEX_WEBHOOK_URL required for webhook ingest',
+    );
+    warn.mockRestore();
+  });
+
+  it('correctly derives webhook URL for legitimate .convex.cloud hostnames', () => {
+    const cfg = configFromEnv({
+      RUNNER_PRIVATE_KEY: '1'.repeat(64),
+      CLAN_WORLD_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000001',
+      CONVEX_DEPLOY_URL: 'https://oceanic-hound-951.convex.cloud',
+    });
+
+    expect(cfg.convexWebhookUrl).toBe('https://oceanic-hound-951.convex.site');
+  });
+
   it('treats explicit empty CONVEX_WEBHOOK_URL as disabled without derivation warning', () => {
     const info = vi.spyOn(console, 'info').mockImplementation(() => {});
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/runner/test/runnerCastHeartbeat.test.ts
+++ b/packages/runner/test/runnerCastHeartbeat.test.ts
@@ -67,6 +67,55 @@ describe('configFromEnv', () => {
     );
     warn.mockRestore();
   });
+
+  it('does not derive webhook URL from non-standard CONVEX_DEPLOY_URL', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const hash = `0x${'a'.repeat(64)}` as const;
+    viemMocks.writeContract.mockResolvedValue(hash);
+    viemMocks.waitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      blockNumber: 123n,
+    });
+
+    const cfg = configFromEnv({
+      RUNNER_PRIVATE_KEY: '1'.repeat(64),
+      CLAN_WORLD_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000001',
+      CONVEX_DEPLOY_URL: 'https://convex.mycompany.com',
+    });
+
+    expect(cfg.convexWebhookUrl).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      'CONVEX_DEPLOY_URL is non-standard; CONVEX_WEBHOOK_URL required for webhook ingest',
+    );
+
+    const heartbeat = new RunnerCastHeartbeat({
+      ...cfg,
+      rpcUrl: 'https://rpc.example',
+    });
+    await expect(heartbeat.callHeartbeat()).resolves.toEqual({ txHash: hash });
+    expect(fetchMock).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('treats explicit empty CONVEX_WEBHOOK_URL as disabled without derivation warning', () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const cfg = configFromEnv({
+      RUNNER_PRIVATE_KEY: '1'.repeat(64),
+      CLAN_WORLD_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000001',
+      CONVEX_WEBHOOK_URL: '',
+      CONVEX_DEPLOY_URL: 'https://oceanic-hound-951.convex.cloud',
+    });
+
+    expect(cfg.convexWebhookUrl).toBeUndefined();
+    expect(info).toHaveBeenCalledWith('CONVEX_WEBHOOK_URL is empty; heartbeat webhook disabled');
+    expect(warn).not.toHaveBeenCalled();
+    info.mockRestore();
+    warn.mockRestore();
+  });
 });
 
 describe('RunnerCastHeartbeat', () => {

--- a/packages/runner/test/telegramAlert.test.ts
+++ b/packages/runner/test/telegramAlert.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { sendTelegramAlert, telegramAlertConfigFromEnv } from '../src/telegramAlert';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('telegramAlert', () => {
+  it('returns a non-fatal error when TELEGRAM_BOT_TOKEN is missing', async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal('fetch', fetch);
+
+    const result = await sendTelegramAlert('heartbeat failed', {
+      chatId: '-1003806628027',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'TELEGRAM_BOT_TOKEN is not set',
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('defaults to the do-crew chat and omits message_thread_id when unset', () => {
+    const cfg = telegramAlertConfigFromEnv({
+      TELEGRAM_BOT_TOKEN: 'token',
+    } as NodeJS.ProcessEnv);
+
+    expect(cfg).toEqual({
+      botToken: 'token',
+      chatId: '-1003806628027',
+      threadId: undefined,
+    });
+  });
+
+  it('posts message_thread_id when TELEGRAM_ALERT_THREAD_ID is set', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+    } satisfies Partial<Response>);
+    vi.stubGlobal('fetch', fetch);
+
+    const result = await sendTelegramAlert('heartbeat failed', {
+      botToken: 'token',
+      chatId: '-1003806628027',
+      threadId: '123',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.telegram.org/bottoken/sendMessage',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const body = fetch.mock.calls[0]?.[1]?.body as URLSearchParams;
+    expect(body.get('chat_id')).toBe('-1003806628027');
+    expect(body.get('text')).toBe('heartbeat failed');
+    expect(body.get('message_thread_id')).toBe('123');
+  });
+
+  it('returns a non-fatal error for non-OK Telegram API responses', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      text: vi.fn().mockResolvedValue('rate limited'),
+    } satisfies Partial<Response>));
+
+    const result = await sendTelegramAlert('heartbeat failed', {
+      botToken: 'token',
+      chatId: '-1003806628027',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Telegram API 429: rate limited',
+    });
+  });
+
+  it('returns a non-fatal error when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+
+    const result = await sendTelegramAlert('heartbeat failed', {
+      botToken: 'token',
+      chatId: '-1003806628027',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'network down',
+    });
+  });
+});

--- a/packages/runner/test/telegramAlert.test.ts
+++ b/packages/runner/test/telegramAlert.test.ts
@@ -48,7 +48,10 @@ describe('telegramAlert', () => {
     expect(result).toEqual({ ok: true });
     expect(fetch).toHaveBeenCalledWith(
       'https://api.telegram.org/bottoken/sendMessage',
-      expect.objectContaining({ method: 'POST' }),
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.any(AbortSignal),
+      }),
     );
     const body = fetch.mock.calls[0]?.[1]?.body as URLSearchParams;
     expect(body.get('chat_id')).toBe('-1003806628027');

--- a/packages/runner/test/tickLoop.test.ts
+++ b/packages/runner/test/tickLoop.test.ts
@@ -29,6 +29,7 @@ function fakeConvex(tick: number): IConvexClient {
       };
     },
     async postLog() {},
+    async postRunnerStatus() {},
     async postWhisper() {},
     async postOrchEvent() {},
     async postHumanSteering() {},
@@ -63,7 +64,6 @@ function config(): RunnerConfig {
     settleWindowSec: 0,
     deliveryTimeoutMs: 100,
     ackTimeoutMs: 100,
-    heartbeatCheckIntervalMs: 100,
     stateDir: '/tmp/clanworld-runner-test',
     tmuxSessionPrefix: 'elder',
     elderToClanId: { 1: '1', 2: '2', 3: '3', 4: '4' },

--- a/packages/sdk/convex/schema.ts
+++ b/packages/sdk/convex/schema.ts
@@ -177,6 +177,8 @@ export default defineSchema({
       v.literal("revert"),
       v.literal("timeout"),
       v.literal("error"),
+      v.literal("rate-limited"),
+      v.literal("boot-error"),
     ),
     lastFailureMessage: v.optional(v.string()),
     heartbeatIntervalSeconds: v.optional(v.number()),

--- a/packages/sdk/convex/schema.ts
+++ b/packages/sdk/convex/schema.ts
@@ -99,6 +99,7 @@ export default defineSchema({
     blockNumber: v.optional(v.number()),
     tickEpochStartedAt: v.number(),
     tickEpochDurationMs: v.number(),
+    heartbeatIntervalSeconds: v.optional(v.number()),
     currentSeasonNumber: v.optional(v.number()),
     seasonStartTick: v.number(),
     seasonEndTick: v.number(),
@@ -109,6 +110,7 @@ export default defineSchema({
     tick: v.number(),
     tickEpochStartedAt: v.number(),
     tickEpochDurationMs: v.number(),
+    heartbeatIntervalSeconds: v.optional(v.number()),
     // Season + winter timers (Phase 4.4)
     currentSeasonNumber: v.optional(v.number()),
     seasonStartTick: v.optional(v.number()),
@@ -167,6 +169,20 @@ export default defineSchema({
       )
     ),
   }).index("by_tick", ["tick"]),
+  runnerStatus: defineTable({
+    runnerId: v.string(),
+    lastFireAt: v.optional(v.number()),
+    lastFireResult: v.union(
+      v.literal("success"),
+      v.literal("revert"),
+      v.literal("timeout"),
+      v.literal("error"),
+    ),
+    lastFailureMessage: v.optional(v.string()),
+    heartbeatIntervalSeconds: v.optional(v.number()),
+    nextHeartbeatAtTs: v.optional(v.number()),
+    updatedAt: v.number(),
+  }).index("by_runnerId", ["runnerId"]),
   chainEvents: defineTable({
     txHash: v.string(),
     logIndex: v.number(),

--- a/packages/sdk/src/convex/index.ts
+++ b/packages/sdk/src/convex/index.ts
@@ -29,6 +29,7 @@ export type SnapshotBandit = {
 
 export type WorldSnapshot = {
   tick: number;
+  heartbeatIntervalSeconds?: number;
   tickEpoch: TickEpoch;
   regions: SnapshotRegion[];
   clans: SnapshotClan[];

--- a/packages/shared/src/adapters/IChainClient.ts
+++ b/packages/shared/src/adapters/IChainClient.ts
@@ -2767,6 +2767,19 @@ export const CLAN_WORLD_ABI = [
   },
   {
     "type": "function",
+    "name": "heartbeatIntervalSeconds",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "initTreasury",
     "inputs": [
       {

--- a/packages/shared/src/adapters/IConvexClient.ts
+++ b/packages/shared/src/adapters/IConvexClient.ts
@@ -1,5 +1,6 @@
 import { ConvexHttpClient } from 'convex/browser';
 import type { ClanFullView, WorldSnapshot } from '../types';
+import { HEARTBEAT_INTERVAL_SECONDS } from '../generated/constants';
 import { readEnv } from './_env';
 import { convexApiRefs } from './convexApiRefs';
 
@@ -22,6 +23,7 @@ export interface IConvexClient {
   getSnapshot(): Promise<WorldSnapshot>;
   getClanFullView(clanId: string): Promise<ClanFullView>;
   postLog(level: 'info' | 'warn' | 'error', message: string): Promise<void>;
+  postRunnerStatus(args: RunnerStatusUpdate): Promise<void>;
 
   // Cockpit Comms write-side. Each method is best-effort: callers wrap in
   // try/catch + treat failures as non-fatal so the cockpit display stays
@@ -56,11 +58,23 @@ export interface IConvexClient {
   }): Promise<void>;
 }
 
+export type RunnerStatusUpdate = {
+  runnerId: string;
+  lastFireAt?: number;
+  lastFireResult: 'success' | 'revert' | 'timeout' | 'error';
+  lastFailureMessage?: string;
+  heartbeatIntervalSeconds?: number;
+  nextHeartbeatAtTs?: number;
+};
+
+const DEFAULT_TICK_DURATION_MS = Number(HEARTBEAT_INTERVAL_SECONDS) * 1000;
+
 class StubConvexClient implements IConvexClient {
   async getSnapshot(): Promise<WorldSnapshot> {
     return {
       tick: 0,
-      tickEpoch: { startedAt: 0, durationMs: 20_000 },
+      heartbeatIntervalSeconds: Number(HEARTBEAT_INTERVAL_SECONDS),
+      tickEpoch: { startedAt: 0, durationMs: DEFAULT_TICK_DURATION_MS },
       regions: [],
       clans: [],
     };
@@ -76,6 +90,9 @@ class StubConvexClient implements IConvexClient {
   async postLog(_level: 'info' | 'warn' | 'error', _message: string): Promise<void> {
     // no-op stub
   }
+  async postRunnerStatus(_args: RunnerStatusUpdate): Promise<void> {
+    // no-op stub
+  }
 
   async postWhisper(_args: { tick: number; fromClanId: number; toClanIds: number[]; body: string; msgId?: string; signal?: AbortSignal }): Promise<void> {}
   async postOrchEvent(_args: { tick: number; kind: 'world_event' | 'directive' | 'narration'; body: string; targetClanId?: number }): Promise<void> {}
@@ -88,6 +105,7 @@ const sendWhisperRef = convexApiRefs.comms.sendWhisper;
 const seedOrchEventRef = convexApiRefs.comms.seedOrchEvent;
 const seedHumanSteeringRef = convexApiRefs.comms.seedHumanSteering;
 const seedBulletinRef = convexApiRefs.bulletins.seedBulletin;
+const updateRunnerStatusRef = convexApiRefs.runnerStatus.updateRunnerStatus;
 
 class RealConvexClient implements IConvexClient {
   private readonly http: ConvexHttpClient;
@@ -117,7 +135,13 @@ class RealConvexClient implements IConvexClient {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes('not found') || msg.includes('Could not find')) {
         console.warn('[RealConvexClient] getSnapshot query not found on server, using stub data');
-        return { tick: 0, tickEpoch: { startedAt: 0, durationMs: 20_000 }, regions: [], clans: [] };
+        return {
+          tick: 0,
+          heartbeatIntervalSeconds: Number(HEARTBEAT_INTERVAL_SECONDS),
+          tickEpoch: { startedAt: 0, durationMs: DEFAULT_TICK_DURATION_MS },
+          regions: [],
+          clans: [],
+        };
       }
       throw err;
     }
@@ -134,6 +158,19 @@ class RealConvexClient implements IConvexClient {
 
   async postLog(_level: 'info' | 'warn' | 'error', _message: string): Promise<void> {
     // Phase 4: postLog via Convex not yet used by CLI path
+  }
+
+  async postRunnerStatus(args: RunnerStatusUpdate): Promise<void> {
+    const secret = this.indexerSecret();
+    if (!secret) {
+      console.warn('[ConvexClient] postRunnerStatus skipped: INDEXER_SECRET not set');
+      return;
+    }
+    try {
+      await this.http.mutation(updateRunnerStatusRef, { secret, ...args });
+    } catch (err) {
+      console.warn('[ConvexClient] postRunnerStatus failed (non-fatal):', err);
+    }
   }
 
   // Cockpit Comms write-side — best-effort, swallow + warn on failure so the

--- a/packages/shared/src/adapters/IConvexClient.ts
+++ b/packages/shared/src/adapters/IConvexClient.ts
@@ -20,6 +20,7 @@ declare module 'convex/browser' {
 }
 
 export interface IConvexClient {
+  readonly isStub?: boolean;
   getSnapshot(): Promise<WorldSnapshot>;
   getClanFullView(clanId: string): Promise<ClanFullView>;
   postLog(level: 'info' | 'warn' | 'error', message: string): Promise<void>;
@@ -70,6 +71,8 @@ export type RunnerStatusUpdate = {
 const DEFAULT_TICK_DURATION_MS = Number(HEARTBEAT_INTERVAL_SECONDS) * 1000;
 
 class StubConvexClient implements IConvexClient {
+  readonly isStub = true;
+
   async getSnapshot(): Promise<WorldSnapshot> {
     return {
       tick: 0,
@@ -108,6 +111,8 @@ const seedBulletinRef = convexApiRefs.bulletins.seedBulletin;
 const updateRunnerStatusRef = convexApiRefs.runnerStatus.updateRunnerStatus;
 
 class RealConvexClient implements IConvexClient {
+  readonly isStub = false;
+
   private readonly http: ConvexHttpClient;
   private readonly url: string;
 

--- a/packages/shared/src/adapters/IConvexClient.ts
+++ b/packages/shared/src/adapters/IConvexClient.ts
@@ -61,7 +61,7 @@ export interface IConvexClient {
 export type RunnerStatusUpdate = {
   runnerId: string;
   lastFireAt?: number;
-  lastFireResult: 'success' | 'revert' | 'timeout' | 'error';
+  lastFireResult: 'success' | 'revert' | 'timeout' | 'error' | 'rate-limited' | 'boot-error';
   lastFailureMessage?: string;
   heartbeatIntervalSeconds?: number;
   nextHeartbeatAtTs?: number;

--- a/packages/shared/src/adapters/convexApiRefs.ts
+++ b/packages/shared/src/adapters/convexApiRefs.ts
@@ -39,6 +39,16 @@ type SeedBulletinArgs = {
   txHash?: string;
 };
 
+type UpdateRunnerStatusArgs = {
+  secret: string;
+  runnerId: string;
+  lastFireAt?: number;
+  lastFireResult: 'success' | 'revert' | 'timeout' | 'error';
+  lastFailureMessage?: string;
+  heartbeatIntervalSeconds?: number;
+  nextHeartbeatAtTs?: number;
+};
+
 type ClanWorldConvexApi = {
   getSnapshot: {
     getSnapshot: PublicQuery<Record<string, never>, WorldSnapshot>;
@@ -50,6 +60,9 @@ type ClanWorldConvexApi = {
   };
   bulletins: {
     seedBulletin: PublicMutation<SeedBulletinArgs>;
+  };
+  runnerStatus: {
+    updateRunnerStatus: PublicMutation<UpdateRunnerStatusArgs, string>;
   };
 };
 

--- a/packages/shared/src/adapters/convexApiRefs.ts
+++ b/packages/shared/src/adapters/convexApiRefs.ts
@@ -43,7 +43,7 @@ type UpdateRunnerStatusArgs = {
   secret: string;
   runnerId: string;
   lastFireAt?: number;
-  lastFireResult: 'success' | 'revert' | 'timeout' | 'error';
+  lastFireResult: 'success' | 'revert' | 'timeout' | 'error' | 'rate-limited' | 'boot-error';
   lastFailureMessage?: string;
   heartbeatIntervalSeconds?: number;
   nextHeartbeatAtTs?: number;

--- a/packages/shared/src/mocks/clanWorldFixture.ts
+++ b/packages/shared/src/mocks/clanWorldFixture.ts
@@ -31,6 +31,7 @@ import type {
   Whisper,
   WorldSnapshot,
 } from '../types';
+import { HEARTBEAT_INTERVAL_SECONDS } from '../generated/constants';
 
 // Local demo-only types. Kept out of types.ts to preserve Wave 0 minimalism.
 
@@ -190,12 +191,15 @@ const SORA: ClanDemoState = {
 
 const CLANS: ClanDemoState[] = [ALDRIC, MIRA, BRENNAN, SORA];
 
-// World snapshot — currentTick = 80, 20s tick window for Submission 1.
+const HEARTBEAT_INTERVAL = Number(HEARTBEAT_INTERVAL_SECONDS);
+
+// World snapshot — currentTick = 80, heartbeat window mirrors the generated contract default.
 const WORLD_SNAPSHOT: WorldSnapshot = {
   tick: 80,
+  heartbeatIntervalSeconds: HEARTBEAT_INTERVAL,
   tickEpoch: {
     startedAt: Math.floor(Date.now() / 1000) - 5, // current tick window opened ~5s ago
-    durationMs: 20_000,
+    durationMs: HEARTBEAT_INTERVAL * 1000,
   },
   regions: REGIONS,
   clans: CLANS, // ClanDemoState extends Clan so this satisfies WorldSnapshot.clans.

--- a/scripts/start-heartbeat-loop.sh
+++ b/scripts/start-heartbeat-loop.sh
@@ -1,101 +1,10 @@
 #!/usr/bin/env bash
-# chmod +x scripts/start-heartbeat-loop.sh
+# Thin compatibility launcher for the TypeScript heartbeat scheduler.
+# The scheduler reads heartbeatIntervalSeconds() once at boot and schedules
+# from getWorldState().nextHeartbeatAtTs; do not add timing logic here.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
-export PATH="$HOME/.foundry/bin:$PATH"
-
-# Source .env.local from repo root if it exists
-if [ -f .env.local ]; then
-  set -a
-  # shellcheck source=/dev/null
-  source .env.local
-  set +a
-fi
-
-# Validate required env vars
-REQUIRED_VARS=(
-  RPC_URL_PRIMARY
-  CONVEX_DEPLOY_URL
-  WEBHOOK_SHARED_SECRET
-  DEPLOYER_PRIVATE_KEY
-  CLAN_WORLD_CONTRACT_ADDRESS
-)
-
-missing=0
-for var in "${REQUIRED_VARS[@]}"; do
-  if [ -z "${!var:-}" ]; then
-    echo "ERROR: required env var $var is not set" >&2
-    missing=1
-  fi
-done
-
-if [ "$missing" -eq 1 ]; then
-  echo ""
-  echo "Usage: set the following env vars before running (or put them in .env.local):"
-  for var in "${REQUIRED_VARS[@]}"; do
-    echo "  $var"
-  done
-  exit 1
-fi
-if ! command -v jq >/dev/null 2>&1; then
-  echo "ERROR: required executable jq is not installed" >&2
-  exit 1
-fi
-
-HEARTBEAT_INTERVAL=$(grep "^export const HEARTBEAT_INTERVAL_SECONDS" packages/sdk/src/generated/constants.ts | grep -oE '[0-9]+')
-HEARTBEAT_SLEEP_SECONDS="${HEARTBEAT_SLEEP_SECONDS:-$((HEARTBEAT_INTERVAL + 5))}"
-CONVEX_WEBHOOK_URL="${CONVEX_WEBHOOK_URL:-${CONVEX_DEPLOY_URL/.convex.cloud/.convex.site}}"
-
-echo "Starting heartbeat loop (interval: ${HEARTBEAT_SLEEP_SECONDS}s; avoids on-chain ${HEARTBEAT_INTERVAL}s heartbeat guard)"
-echo "  engine: $CLAN_WORLD_CONTRACT_ADDRESS"
-echo "  rpc:    $RPC_URL_PRIMARY"
-echo "  convex: $CONVEX_DEPLOY_URL"
-echo "  webhook: $CONVEX_WEBHOOK_URL"
-
-while true; do
-  heartbeat_stderr="$(mktemp)"
-  heartbeat_json="$(mktemp)"
-  if ! cast send "$CLAN_WORLD_CONTRACT_ADDRESS" "heartbeat()" \
-    --rpc-url "$RPC_URL_PRIMARY" \
-    --private-key "$DEPLOYER_PRIVATE_KEY" \
-    --json \
-    > "$heartbeat_json" \
-    2> >(tee "$heartbeat_stderr" >&2); then
-    if grep -qi "RateLimited" "$heartbeat_stderr"; then
-      echo "heartbeat rate-limited; continuing" >&2
-    else
-      rm -f "$heartbeat_stderr" "$heartbeat_json"
-      exit 1
-    fi
-  fi
-  rm -f "$heartbeat_stderr"
-
-  tx_hash="$(jq -r '.. | objects | .transactionHash? // .hash? // empty' "$heartbeat_json" | grep -E '^0x[0-9a-fA-F]{64}$' | tail -1)"
-  block_number_hex="$(jq -r '.. | objects | .blockNumber? // empty' "$heartbeat_json" | tail -1)"
-  rm -f "$heartbeat_json"
-
-  if [ -z "$tx_hash" ]; then
-    echo "heartbeat tx hash unavailable from cast JSON; webhook POST skipped" >&2
-    sleep "$HEARTBEAT_SLEEP_SECONDS"
-    continue
-  fi
-  if [[ "$block_number_hex" =~ ^0x[0-9a-fA-F]+$ ]]; then
-    block_number="$((block_number_hex))"
-  elif [[ "$block_number_hex" =~ ^[0-9]+$ ]]; then
-    block_number="$block_number_hex"
-  else
-    block_number="null"
-  fi
-
-  curl -sS --fail -X POST "$CONVEX_WEBHOOK_URL/api/heartbeat-webhook" \
-    -H "Authorization: Bearer $WEBHOOK_SHARED_SECRET" \
-    -H "Content-Type: application/json" \
-    -d "{\"chain\":\"base-sepolia\",\"engineAddress\":\"$CLAN_WORLD_CONTRACT_ADDRESS\",\"txHash\":\"$tx_hash\",\"blockNumber\":$block_number,\"firedAtTs\":$(date +%s),\"source\":\"foundry-loop\"}" \
-    || echo "webhook POST failed (continuing)" >&2
-
-  # Add a small cushion to avoid rate-limit collisions with the on-chain heartbeat guard.
-  sleep "$HEARTBEAT_SLEEP_SECONDS"
-done
+exec pnpm --filter @clan-world/runner heartbeat


### PR DESCRIPTION
## Goal

Make the on-chain `heartbeatIntervalSeconds` (settable via owner-only `HeartbeatConfigFacet.setHeartbeatIntervalSeconds`) the **single source of truth** for all heartbeat timing across the monorepo. Eliminates the "60 + 5 second buffer" pattern, divergent hardcoded constants, and silent env-var coordination.

Design discussion: voice msg 15450 + heartbeat audit at `~/claudes-world/tmp/heartbeat-timing-seams-audit-20260520.md`.

## What changed

### Convex surface
- Indexer reads `heartbeatIntervalSeconds()` via lens; persists onto `worldSnapshot` + `tickClock` so every subscriber gets the on-chain value (no RPC per client).
- New `runnerStatus` table for off-chain runner observability: `lastFireAt`, `lastFireResult`, `lastFailureMessage`, `heartbeatIntervalSeconds`, `nextHeartbeatAtTs`. Public query for ops visibility.

### Heartbeat runner (`packages/runner/src/heartbeatScheduler.ts`)
- Reads `heartbeatIntervalSeconds()` once at boot from chain.
- Self-schedules using `nextHeartbeatAtTs` (no fixed sleep).
- 500ms jitter buffer for RPC roundtrip variance (Base Sepolia p99 ~300-400ms).
- Retry on failure: **1s → 2s → 5s → 10s**, then Telegram alert to do-crew errors thread.
- Hot-loop guard for season-finalization no-op case (codex catch — sleep ≥1s if `nextHeartbeatAtTs` still in the past after success).
- Posts `runnerStatus` after every attempt; failures swallowed.
- Settle-latch preserved.

### Telegram alert (`packages/runner/src/telegramAlert.ts`)
- `TELEGRAM_BOT_TOKEN` required; `TELEGRAM_ALERT_CHAT_ID` defaults to do-crew (`-1003806628027`); `TELEGRAM_ALERT_THREAD_ID` optional.
- Resilient: missing token/non-OK API/fetch-throw all log and continue. Loop stays alive.

### Canonical ABI
- Added `heartbeatIntervalSeconds()` to canonical `IClanWorld.sol` / `.json` / `.ts`. Function existed on-chain; missing from canonical ABI was a codegen completeness gap.

### Web
- `TopHud.tsx` no longer uses `FALLBACK_TICK_DURATION_MS = 59_000`. Reads from Convex with generated constant as cold-start fallback only.

### Mock + dead constants cleanup
- `apps/server/convex/mock.ts`: derived from generated constant (was hardcoded `20_000`, divergent from real `60_000`).
- `.env.template` + `.env.local` `TICK_DURATION_MS`: **DELETED** (read by nothing).
- `TEAMMATE-SETUP.md` + runbooks updated.

### Heartbeat loop wrapper
- `scripts/start-heartbeat-loop.sh` is now a 1-line launcher invoking the TS scheduler. One tested impl replaces the parallel Bash version.

## Verification

- `pnpm gen:contract-abi` + `pnpm gen:chainclient-abi --check`: PASS
- `pnpm --filter @clan-world/server typecheck` + test: PASS, **79 tests**
- `pnpm --filter @clan-world/runner typecheck` + test: PASS, **130 passed, 1 skipped** (grew from 123 — added telegramAlert, status-failure-swallow, readHeartbeatIntervalSeconds tests)
- `pnpm --filter @clan-world/contract-types typecheck`: PASS

## Known pre-existing issue (NOT introduced here)

`pnpm --filter @clan-world/web typecheck` fails with: missing `vitest` types in `eventTickerFormat.test.ts` (PR #464), missing `@clan-world/contract-types` in `OwnerEditor.tsx`, two implicit `any` in same file.

**Verified pre-existing on `origin/dev`** — only `TopHud.tsx` was changed in apps/web in this branch. Will file as follow-up; do not block merge here.

## Out of scope (follow-ups)

- Cockpit/admin UI readout for `runnerStatus` (ops visibility)
- Env-sync automation (local .env → Vercel + Convex) — recommended in audit
- Deployment config-drift watchdog (GH Action diffing local vs deployed env)
- Web typecheck pre-existing failures

## Process

Built via codex 5-stage pattern (plan → implement → critique → polish → final) with xhigh reasoning throughout. Stage 3 critique caught the season-finalization hot-loop edge case + verified web typecheck failures are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Codex 5.5](https://chatgpt.com/codex)