### PR TITLE
feat(heartbeat): containerize @clan-world/runner heartbeat (Option C, #353)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -50,6 +50,8 @@ CLANWORLD_USE_FAKE_HEARTBEAT=false
 # to intentionally disable the webhook (e.g. local dev without HTTP actions).
 # CONVEX_WEBHOOK_URL=
 WEBHOOK_SHARED_SECRET=
+# Optional heartbeat success marker path override; defaults to /tmp/last-heartbeat-success.
+# HEARTBEAT_SUCCESS_FILE_OVERRIDE=
 
 # ============================================================
 # Browser (Vite) — MUST be VITE_-prefixed to reach the bundle

--- a/agents/heartbeat/Dockerfile
+++ b/agents/heartbeat/Dockerfile
@@ -36,4 +36,7 @@ COPY . .
 RUN touch .env.local \
   && chmod +x agents/heartbeat/entrypoint.sh
 
+RUN chown -R node:node /app
+USER node
+
 ENTRYPOINT ["./agents/heartbeat/entrypoint.sh"]

--- a/agents/heartbeat/Dockerfile
+++ b/agents/heartbeat/Dockerfile
@@ -1,0 +1,39 @@
+FROM ghcr.io/foundry-rs/foundry:v1.2.0 AS foundry
+
+FROM node:22-alpine
+
+RUN apk add --no-cache ca-certificates libgcc libstdc++ \
+  && corepack enable \
+  && corepack prepare pnpm@10.33.2 --activate
+
+COPY --from=foundry /usr/local/bin/cast /usr/local/bin/cast
+RUN cast --version
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY apps/clan-world-mobile/package.json apps/clan-world-mobile/package.json
+COPY apps/dev-ui/package.json apps/dev-ui/package.json
+COPY apps/landing/package.json apps/landing/package.json
+COPY apps/mobile/package.json apps/mobile/package.json
+COPY apps/orchestrator/package.json apps/orchestrator/package.json
+COPY apps/server/package.json apps/server/package.json
+COPY apps/web/package.json apps/web/package.json
+COPY packages/agents/package.json packages/agents/package.json
+COPY packages/contracts/package.json packages/contracts/package.json
+COPY packages/contract-types/package.json packages/contract-types/package.json
+COPY packages/runner/package.json packages/runner/package.json
+COPY packages/sdk/package.json packages/sdk/package.json
+COPY packages/shared/package.json packages/shared/package.json
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+# The @clan-world/runner heartbeat script invokes tsx with
+# --env-file=../../.env.local from packages/runner. Compose supplies runtime
+# env vars, but the file path still needs to exist in the image.
+RUN touch .env.local \
+  && chmod +x agents/heartbeat/entrypoint.sh
+
+ENTRYPOINT ["./agents/heartbeat/entrypoint.sh"]

--- a/agents/heartbeat/README.md
+++ b/agents/heartbeat/README.md
@@ -13,8 +13,9 @@ runner package behavior: on-chain scheduling from `nextHeartbeatAtTs`,
 
 ## Required Runtime Env
 
-Compose passes `.env` into the container and the entrypoint normalizes the
-profile-specific RPC values before Node starts.
+Compose passes an explicit heartbeat-only environment allowlist into the
+container, and the entrypoint normalizes the profile-specific RPC values before
+Node starts.
 
 | Variable | Purpose |
 |---|---|
@@ -27,6 +28,7 @@ profile-specific RPC values before Node starts.
 | `CONVEX_WEBHOOK_URL` | Explicit HTTP actions base URL for `/api/heartbeat-webhook`. |
 | `INDEXER_SECRET` | Secret passed to Convex `runnerStatus.updateRunnerStatus`. |
 | `WEBHOOK_SHARED_SECRET_FILE` | Docker secret file mounted at `/run/secrets/webhook-shared`. |
+| `HEARTBEAT_HEALTH_THRESHOLD_S` | Max age for `/tmp/last-heartbeat-success`; defaults to `180`. |
 | `RUNNER_ID` | Stable row id for `runnerStatus`, e.g. `heartbeat-dev`. |
 
 The entrypoint exports the selected RPC URL as `RPC_URL_PRIMARY` because the
@@ -50,8 +52,13 @@ compose `anvil-fork` service and viem's `baseSepolia` chain config.
 
 The compose healthcheck reads `/tmp/last-heartbeat-success`. The runner writes
 the current Unix timestamp there after a confirmed heartbeat transaction and
-webhook attempt. A timestamp younger than 120 seconds means the heartbeat caller
-is making progress.
+webhook attempt. A timestamp younger than `HEARTBEAT_HEALTH_THRESHOLD_S` seconds
+means the heartbeat caller is making progress.
+
+Keep `HEARTBEAT_HEALTH_THRESHOLD_S` wider than the on-chain
+`heartbeatIntervalSeconds()` cadence plus restart/RPC slack. If the owner widens
+the on-chain interval, update this threshold with it so the container does not
+flap unhealthy between normal ticks.
 
 This file proves heartbeat tx progress. Convex ingest can still fail
 independently; webhook and `runnerStatus` failures are logged by the runner and

--- a/agents/heartbeat/README.md
+++ b/agents/heartbeat/README.md
@@ -1,0 +1,73 @@
+# Heartbeat Container
+
+This container runs the existing TypeScript heartbeat loop:
+
+```bash
+pnpm --filter @clan-world/runner heartbeat
+```
+
+It is intentionally not a shell heartbeat loop. The container preserves the
+runner package behavior: on-chain scheduling from `nextHeartbeatAtTs`,
+`heartbeatIntervalSeconds()` observability, retry/backoff, best-effort Convex
+`runnerStatus` writes, Telegram alerts, and the Convex webhook POST.
+
+## Required Runtime Env
+
+Compose passes `.env` into the container and the entrypoint normalizes the
+profile-specific RPC values before Node starts.
+
+| Variable | Purpose |
+|---|---|
+| `CHAIN_NETWORK` | `dev` or `prod`; selects the RPC URL. |
+| `DEV_RPC_URL` | RPC used when `CHAIN_NETWORK=dev`, normally `http://anvil-fork:8545`. |
+| `PROD_RPC_URL` | RPC used when `CHAIN_NETWORK=prod`, normally `${RPC_URL_PRIMARY}`. |
+| `RUNNER_PRIVATE_KEY` | Dedicated heartbeat wallet. Never reuse an Elder wallet. |
+| `CLAN_WORLD_CONTRACT_ADDRESS` | Diamond address to call. |
+| `CONVEX_URL` | Convex query/mutation base URL for `runnerStatus`. |
+| `CONVEX_WEBHOOK_URL` | Explicit HTTP actions base URL for `/api/heartbeat-webhook`. |
+| `INDEXER_SECRET` | Secret passed to Convex `runnerStatus.updateRunnerStatus`. |
+| `WEBHOOK_SHARED_SECRET_FILE` | Docker secret file mounted at `/run/secrets/webhook-shared`. |
+| `RUNNER_ID` | Stable row id for `runnerStatus`, e.g. `heartbeat-dev`. |
+
+The entrypoint exports the selected RPC URL as `RPC_URL_PRIMARY` because the
+existing runner reads `RPC_URL_PRIMARY`, not `DEV_RPC_URL` or `PROD_RPC_URL`.
+It also reads `WEBHOOK_SHARED_SECRET_FILE` and exports `WEBHOOK_SHARED_SECRET`
+for the bearer-auth webhook contract.
+
+## Preflight
+
+Before starting Node, the entrypoint:
+
+1. Validates `CHAIN_NETWORK`.
+2. Selects the matching RPC URL.
+3. Checks `cast chain-id` against Base Sepolia chain id `84532`.
+4. Verifies `CLAN_WORLD_CONTRACT_ADDRESS` is set.
+
+The dev anvil fork currently also reports chain id `84532`, matching the
+compose `anvil-fork` service and viem's `baseSepolia` chain config.
+
+## Healthcheck
+
+The compose healthcheck reads `/tmp/last-heartbeat-success`. The runner writes
+the current Unix timestamp there after a confirmed heartbeat transaction and
+webhook attempt. A timestamp younger than 120 seconds means the heartbeat caller
+is making progress.
+
+This file proves heartbeat tx progress. Convex ingest can still fail
+independently; webhook and `runnerStatus` failures are logged by the runner and
+treated as non-fatal.
+
+## Restart Policy
+
+Compose uses `restart: on-failure:5`. Fatal process exits, such as missing
+required env or a failed preflight, are retried up to five times and then left
+visible for operator intervention. Plain Docker Compose does not restart a
+container only because it is unhealthy, so stale healthchecks should still be
+watched by external ops tooling or the Convex/dev UI status view.
+
+## Smoke Tests
+
+```bash
+docker compose --profile dev config
+docker build -f agents/heartbeat/Dockerfile -t test-build .
+```

--- a/agents/heartbeat/entrypoint.sh
+++ b/agents/heartbeat/entrypoint.sh
@@ -53,6 +53,17 @@ export RPC_URL_PRIMARY="$SELECTED_RPC_URL"
 
 log "network=${CHAIN_NETWORK} expectedChainId=${EXPECTED_CHAIN_ID} contract=${CLAN_WORLD_CONTRACT_ADDRESS}"
 
+RPC_RETRY_MAX=30
+RPC_RETRY=0
+until cast chain-id --rpc-url "$RPC_URL_PRIMARY" >/dev/null 2>&1; do
+  RPC_RETRY=$((RPC_RETRY + 1))
+  if [ "$RPC_RETRY" -ge "$RPC_RETRY_MAX" ]; then
+    fail "RPC at $RPC_URL_PRIMARY did not respond after ${RPC_RETRY_MAX} attempts"
+  fi
+  log "RPC not ready (attempt ${RPC_RETRY}/${RPC_RETRY_MAX}); retrying in 2s"
+  sleep 2
+done
+
 OBSERVED_CHAIN_ID="$(cast chain-id --rpc-url "$RPC_URL_PRIMARY")" || fail "cast chain-id failed"
 [ "$OBSERVED_CHAIN_ID" = "$EXPECTED_CHAIN_ID" ] || fail "chain id mismatch: expected ${EXPECTED_CHAIN_ID}, got ${OBSERVED_CHAIN_ID}"
 

--- a/agents/heartbeat/entrypoint.sh
+++ b/agents/heartbeat/entrypoint.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -eu
+
+log() {
+  printf '%s\n' "[heartbeat-entrypoint] $*"
+}
+
+fail() {
+  log "ERROR: $*"
+  exit 1
+}
+
+case "${CHAIN_NETWORK:-}" in
+  dev)
+    SELECTED_RPC_URL="${DEV_RPC_URL:-}"
+    EXPECTED_CHAIN_ID="84532"
+    ;;
+  prod)
+    SELECTED_RPC_URL="${PROD_RPC_URL:-}"
+    EXPECTED_CHAIN_ID="84532"
+    ;;
+  "")
+    fail "CHAIN_NETWORK is required (dev|prod)"
+    ;;
+  *)
+    fail "CHAIN_NETWORK must be dev or prod, got '${CHAIN_NETWORK}'"
+    ;;
+esac
+
+[ -n "$SELECTED_RPC_URL" ] || fail "selected RPC URL is empty for CHAIN_NETWORK=${CHAIN_NETWORK}"
+[ -n "${CLAN_WORLD_CONTRACT_ADDRESS:-}" ] || fail "CLAN_WORLD_CONTRACT_ADDRESS is required"
+
+if [ "$CHAIN_NETWORK" = "prod" ]; then
+  case "$SELECTED_RPC_URL" in
+    *anvil-fork*|*localhost*|*127.0.0.1*)
+      fail "prod RPC URL must not point at local/anvil endpoint: $SELECTED_RPC_URL"
+      ;;
+  esac
+fi
+
+if [ -n "${WEBHOOK_SHARED_SECRET_FILE:-}" ]; then
+  [ -f "$WEBHOOK_SHARED_SECRET_FILE" ] || fail "WEBHOOK_SHARED_SECRET_FILE does not exist: $WEBHOOK_SHARED_SECRET_FILE"
+  WEBHOOK_SHARED_SECRET="$(cat "$WEBHOOK_SHARED_SECRET_FILE")"
+  [ -n "$WEBHOOK_SHARED_SECRET" ] || fail "WEBHOOK_SHARED_SECRET_FILE is empty: $WEBHOOK_SHARED_SECRET_FILE"
+  export WEBHOOK_SHARED_SECRET
+fi
+
+[ -n "${WEBHOOK_SHARED_SECRET:-}" ] || fail "WEBHOOK_SHARED_SECRET or WEBHOOK_SHARED_SECRET_FILE is required"
+
+# runnerCastHeartbeat.ts reads RPC_URL_PRIMARY, so export the profile-selected
+# URL under the name the existing runner process already consumes.
+export RPC_URL_PRIMARY="$SELECTED_RPC_URL"
+
+log "network=${CHAIN_NETWORK} expectedChainId=${EXPECTED_CHAIN_ID} contract=${CLAN_WORLD_CONTRACT_ADDRESS}"
+
+OBSERVED_CHAIN_ID="$(cast chain-id --rpc-url "$RPC_URL_PRIMARY")" || fail "cast chain-id failed"
+[ "$OBSERVED_CHAIN_ID" = "$EXPECTED_CHAIN_ID" ] || fail "chain id mismatch: expected ${EXPECTED_CHAIN_ID}, got ${OBSERVED_CHAIN_ID}"
+
+log "preflight passed; starting @clan-world/runner heartbeat"
+exec pnpm --filter @clan-world/runner heartbeat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,7 @@ services:
     build:
       context: .
       dockerfile: agents/heartbeat/Dockerfile
-    env_file: [.env]
+    init: true
     environment:
       CHAIN_NETWORK: ${CHAIN_NETWORK:?CHAIN_NETWORK required (dev|prod)}
       # Profile-specific overlay sets exactly ONE of these (Finding 9 + 48 fix
@@ -181,6 +181,8 @@ services:
       # missing instead of silently empty (the heartbeat entrypoint aborts
       # anyway, but the compose-level error is faster + clearer).
       PROD_RPC_URL: ${RPC_URL_PRIMARY:-}
+      RUNNER_PRIVATE_KEY: ${RUNNER_PRIVATE_KEY:?RUNNER_PRIVATE_KEY required (dedicated heartbeat wallet)}
+      INDEXER_SECRET: ${INDEXER_SECRET:?INDEXER_SECRET required for runnerStatus writes}
       # createConvexClient() reads CONVEX_URL for runnerStatus writes.
       CONVEX_URL: http://convex-backend:3210
       CONVEX_DEPLOY_URL: http://convex-backend:3210
@@ -188,6 +190,7 @@ services:
       CONVEX_WEBHOOK_URL: ${CONVEX_WEBHOOK_URL:?CONVEX_WEBHOOK_URL required for self-hosted Convex}
       CLAN_WORLD_CONTRACT_ADDRESS: ${CLAN_WORLD_CONTRACT_ADDRESS:?CLAN_WORLD_CONTRACT_ADDRESS required}
       WEBHOOK_SHARED_SECRET_FILE: /run/secrets/webhook-shared
+      HEARTBEAT_HEALTH_THRESHOLD_S: ${HEARTBEAT_HEALTH_THRESHOLD_S:-180}
       RUNNER_ID: heartbeat-${CHAIN_NETWORK}
     secrets:
       - webhook-shared
@@ -197,7 +200,7 @@ services:
         condition: service_healthy
     healthcheck:
       # Webhook timestamp file is touched on every successful heartbeat tick.
-      test: ["CMD-SHELL", "test -f /tmp/last-heartbeat-success && [ $$(($$(date +%s) - $$(cat /tmp/last-heartbeat-success))) -lt 120 ]"]
+      test: ["CMD-SHELL", "test -f /tmp/last-heartbeat-success && [ $$(($$(date +%s) - $$(cat /tmp/last-heartbeat-success))) -lt $$HEARTBEAT_HEALTH_THRESHOLD_S ]"]
       interval: 30s
       timeout: 5s
       retries: 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,12 +163,14 @@ services:
     profiles: [dev]
 
   # ---------------------------------------------------------------------------
-  # Heartbeat — calls heartbeat() on the diamond every 60s + posts an HMAC-
-  # signed webhook to Convex. Pre-flight assertions, HMAC signing, and the
-  # single-caller guard land in #353 (Phase 1.10).
+  # Heartbeat — runs the existing @clan-world/runner heartbeat loop in a
+  # container. Pre-flight assertions land in #353 (Phase 1.10).
   # ---------------------------------------------------------------------------
   heartbeat:
-    image: clanworld/heartbeat:dev
+    build:
+      context: .
+      dockerfile: agents/heartbeat/Dockerfile
+    env_file: [.env]
     environment:
       CHAIN_NETWORK: ${CHAIN_NETWORK:?CHAIN_NETWORK required (dev|prod)}
       # Profile-specific overlay sets exactly ONE of these (Finding 9 + 48 fix
@@ -179,16 +181,16 @@ services:
       # missing instead of silently empty (the heartbeat entrypoint aborts
       # anyway, but the compose-level error is faster + clearer).
       PROD_RPC_URL: ${RPC_URL_PRIMARY:-}
+      # createConvexClient() reads CONVEX_URL for runnerStatus writes.
+      CONVEX_URL: http://convex-backend:3210
       CONVEX_DEPLOY_URL: http://convex-backend:3210
+      # Self-hosted Convex cannot be auto-derived from CONVEX_DEPLOY_URL.
+      CONVEX_WEBHOOK_URL: ${CONVEX_WEBHOOK_URL:?CONVEX_WEBHOOK_URL required for self-hosted Convex}
       CLAN_WORLD_CONTRACT_ADDRESS: ${CLAN_WORLD_CONTRACT_ADDRESS:?CLAN_WORLD_CONTRACT_ADDRESS required}
       WEBHOOK_SHARED_SECRET_FILE: /run/secrets/webhook-shared
+      RUNNER_ID: heartbeat-${CHAIN_NETWORK}
     secrets:
       - webhook-shared
-    # NOTE: host crontab mount removed per cloud-reviewer security finding.
-    # Single-caller preflight (Finding 29) now relies on docker compose
-    # `restart: on-failure:0` instead — a second instance can't be started
-    # by compose, and an external single-caller check uses Convex-side
-    # heartbeat state (last successful tick timestamp) for liveness.
     networks: [clan-world-internal]
     depends_on:
       convex-backend:
@@ -200,8 +202,8 @@ services:
       timeout: 5s
       retries: 2
       start_period: 60s
-    # Failed preflight stays failed visibly — operator must intervene.
-    restart: on-failure:0
+    # Retry transient preflight/runtime failures, then leave repeated failures visible.
+    restart: on-failure:5
     profiles: [dev, prod]
 
   # ---------------------------------------------------------------------------

--- a/packages/runner/.env.example
+++ b/packages/runner/.env.example
@@ -29,6 +29,8 @@ RUNNER_DELIVERY_TIMEOUT_MS=10000
 RUNNER_ACK_TIMEOUT_MS=30000
 RUNNER_TMUX_SESSION_PREFIX=elder
 RUNNER_ID=clanworld-runner
+# Optional heartbeat success marker path override; defaults to /tmp/last-heartbeat-success.
+# HEARTBEAT_SUCCESS_FILE_OVERRIDE=
 
 # Optional Telegram alerting for heartbeat retry exhaustion. If the bot token is
 # missing or Telegram fails, the runner logs locally and keeps running.

--- a/packages/runner/src/heartbeatScheduler.ts
+++ b/packages/runner/src/heartbeatScheduler.ts
@@ -1,5 +1,6 @@
 import { HeartbeatRateLimitedError, type IHeartbeatCaller } from '@clan-world/agents/seams';
 import type { IConvexClient, RunnerStatusUpdate } from '@clan-world/shared/adapters';
+import { writeHeartbeatSuccessFile } from './runnerCastHeartbeat';
 import { sendTelegramAlert } from './telegramAlert';
 
 export type HeartbeatFireResult = RunnerStatusUpdate['lastFireResult'];
@@ -228,6 +229,7 @@ async function attemptHeartbeatWithBackoff(
             heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
             nextHeartbeatAtTs: nextAfterTimeout,
           });
+          writeHeartbeatSuccessFile();
           return { success: true };
         }
       }

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -258,11 +258,11 @@ function deriveConvexWebhookUrl(convexDeployUrl?: string): string | undefined {
   return url.toString().replace(/\/$/, '');
 }
 
-function writeHeartbeatSuccessFile(): void {
+export function writeHeartbeatSuccessFile(successFile = HEARTBEAT_SUCCESS_FILE): void {
   try {
-    const tmpFile = `${HEARTBEAT_SUCCESS_FILE}.${process.pid}.tmp`;
+    const tmpFile = `${successFile}.${process.pid}.tmp`;
     writeFileSync(tmpFile, String(Math.floor(Date.now() / 1000)));
-    renameSync(tmpFile, HEARTBEAT_SUCCESS_FILE);
+    renameSync(tmpFile, successFile);
   } catch (err) {
     console.warn('[RunnerCastHeartbeat] heartbeat success file write failed:', err);
   }

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -1,3 +1,4 @@
+import { renameSync, writeFileSync } from 'node:fs';
 import {
   ContractFunctionRevertedError,
   createPublicClient,
@@ -14,6 +15,8 @@ import {
   HeartbeatRateLimitedError,
   type IHeartbeatCaller,
 } from '@clan-world/agents/seams';
+
+const HEARTBEAT_SUCCESS_FILE = '/tmp/last-heartbeat-success';
 
 export interface RunnerHeartbeatConfig {
   /** Hex-encoded 64-char private key, optionally 0x-prefixed. */
@@ -140,6 +143,7 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
         txHash: hash,
         blockNumber: receipt.blockNumber,
       });
+      writeHeartbeatSuccessFile();
       return { txHash: hash };
     } catch (err) {
       // Already a rate-limit error — rethrow immediately; no second RPC read.
@@ -252,4 +256,14 @@ function deriveConvexWebhookUrl(convexDeployUrl?: string): string | undefined {
   url.hostname = url.hostname.replace(/\.convex\.cloud$/, '.convex.site');
   // Preserve protocol/port; strip trailing slash if URL had no explicit path.
   return url.toString().replace(/\/$/, '');
+}
+
+function writeHeartbeatSuccessFile(): void {
+  try {
+    const tmpFile = `${HEARTBEAT_SUCCESS_FILE}.${process.pid}.tmp`;
+    writeFileSync(tmpFile, String(Math.floor(Date.now() / 1000)));
+    renameSync(tmpFile, HEARTBEAT_SUCCESS_FILE);
+  } catch (err) {
+    console.warn('[RunnerCastHeartbeat] heartbeat success file write failed:', err);
+  }
 }

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -16,7 +16,7 @@ import {
   type IHeartbeatCaller,
 } from '@clan-world/agents/seams';
 
-const HEARTBEAT_SUCCESS_FILE = '/tmp/last-heartbeat-success';
+const DEFAULT_HEARTBEAT_SUCCESS_FILE = '/tmp/last-heartbeat-success';
 
 export interface RunnerHeartbeatConfig {
   /** Hex-encoded 64-char private key, optionally 0x-prefixed. */
@@ -258,7 +258,10 @@ function deriveConvexWebhookUrl(convexDeployUrl?: string): string | undefined {
   return url.toString().replace(/\/$/, '');
 }
 
-export function writeHeartbeatSuccessFile(successFile = HEARTBEAT_SUCCESS_FILE): void {
+export function writeHeartbeatSuccessFile(
+  successFile =
+    process.env['HEARTBEAT_SUCCESS_FILE_OVERRIDE'] ?? DEFAULT_HEARTBEAT_SUCCESS_FILE,
+): void {
   try {
     const tmpFile = `${successFile}.${process.pid}.tmp`;
     writeFileSync(tmpFile, String(Math.floor(Date.now() / 1000)));

--- a/packages/runner/test/heartbeatScheduler.test.ts
+++ b/packages/runner/test/heartbeatScheduler.test.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   computeHeartbeatDelayMs,
@@ -10,6 +11,13 @@ class TestHeartbeatTimeoutError extends Error {
   override name = 'HeartbeatTimeoutError';
 }
 
+const HEARTBEAT_SUCCESS_FILE = '/tmp/last-heartbeat-success';
+
+function cleanupHeartbeatSuccessFile(): void {
+  rmSync(HEARTBEAT_SUCCESS_FILE, { force: true });
+  rmSync(`${HEARTBEAT_SUCCESS_FILE}.${process.pid}.tmp`, { force: true });
+}
+
 function makeHeartbeatCaller(overrides: Partial<IHeartbeatCaller> = {}): IHeartbeatCaller {
   return {
     async callHeartbeat() { return { txHash: '0xabc' }; },
@@ -19,8 +27,14 @@ function makeHeartbeatCaller(overrides: Partial<IHeartbeatCaller> = {}): IHeartb
   };
 }
 
-beforeEach(() => { vi.useFakeTimers(); });
-afterEach(() => { vi.useRealTimers(); });
+beforeEach(() => {
+  cleanupHeartbeatSuccessFile();
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  cleanupHeartbeatSuccessFile();
+  vi.useRealTimers();
+});
 
 describe('heartbeatScheduler', () => {
   it('computes delay from nextHeartbeatAtTs with 500ms jitter', () => {
@@ -324,6 +338,7 @@ describe('heartbeatScheduler', () => {
   });
 
   it('re-reads nextHeartbeatAtTs after receipt timeout and treats advanced state as success', async () => {
+    vi.setSystemTime(100_000);
     const callHeartbeat = vi.fn().mockRejectedValue(new TestHeartbeatTimeoutError('receipt timed out'));
     const alert = vi.fn().mockResolvedValue({ ok: true });
     const postRunnerStatus = vi.fn().mockResolvedValue(undefined);
@@ -350,6 +365,8 @@ describe('heartbeatScheduler', () => {
     expect(postRunnerStatus).toHaveBeenCalledWith(
       expect.objectContaining({ lastFireResult: 'success', nextHeartbeatAtTs: 160 }),
     );
+    expect(existsSync(HEARTBEAT_SUCCESS_FILE)).toBe(true);
+    expect(readFileSync(HEARTBEAT_SUCCESS_FILE, 'utf8')).toBe('100');
 
     abort.abort();
   });

--- a/packages/runner/test/heartbeatScheduler.test.ts
+++ b/packages/runner/test/heartbeatScheduler.test.ts
@@ -1,4 +1,6 @@
-import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   computeHeartbeatDelayMs,
@@ -11,11 +13,13 @@ class TestHeartbeatTimeoutError extends Error {
   override name = 'HeartbeatTimeoutError';
 }
 
-const HEARTBEAT_SUCCESS_FILE = '/tmp/last-heartbeat-success';
+let heartbeatSuccessDir = '';
+let heartbeatSuccessFile = '';
 
 function cleanupHeartbeatSuccessFile(): void {
-  rmSync(HEARTBEAT_SUCCESS_FILE, { force: true });
-  rmSync(`${HEARTBEAT_SUCCESS_FILE}.${process.pid}.tmp`, { force: true });
+  if (!heartbeatSuccessFile) return;
+  rmSync(heartbeatSuccessFile, { force: true });
+  rmSync(`${heartbeatSuccessFile}.${process.pid}.tmp`, { force: true });
 }
 
 function makeHeartbeatCaller(overrides: Partial<IHeartbeatCaller> = {}): IHeartbeatCaller {
@@ -28,11 +32,18 @@ function makeHeartbeatCaller(overrides: Partial<IHeartbeatCaller> = {}): IHeartb
 }
 
 beforeEach(() => {
+  heartbeatSuccessDir = mkdtempSync(join(tmpdir(), 'hb-test-'));
+  heartbeatSuccessFile = join(heartbeatSuccessDir, 'last-heartbeat-success');
+  vi.stubEnv('HEARTBEAT_SUCCESS_FILE_OVERRIDE', heartbeatSuccessFile);
   cleanupHeartbeatSuccessFile();
   vi.useFakeTimers();
 });
 afterEach(() => {
   cleanupHeartbeatSuccessFile();
+  if (heartbeatSuccessDir) rmSync(heartbeatSuccessDir, { recursive: true, force: true });
+  heartbeatSuccessDir = '';
+  heartbeatSuccessFile = '';
+  vi.unstubAllEnvs();
   vi.useRealTimers();
 });
 
@@ -365,8 +376,8 @@ describe('heartbeatScheduler', () => {
     expect(postRunnerStatus).toHaveBeenCalledWith(
       expect.objectContaining({ lastFireResult: 'success', nextHeartbeatAtTs: 160 }),
     );
-    expect(existsSync(HEARTBEAT_SUCCESS_FILE)).toBe(true);
-    expect(readFileSync(HEARTBEAT_SUCCESS_FILE, 'utf8')).toBe('100');
+    expect(existsSync(heartbeatSuccessFile)).toBe(true);
+    expect(readFileSync(heartbeatSuccessFile, 'utf8')).toBe('100');
 
     abort.abort();
   });

--- a/packages/runner/test/runnerCastHeartbeat.test.ts
+++ b/packages/runner/test/runnerCastHeartbeat.test.ts
@@ -36,14 +36,19 @@ import {
   writeHeartbeatSuccessFile,
 } from '../src/runnerCastHeartbeat';
 
-const HEARTBEAT_SUCCESS_FILE = '/tmp/last-heartbeat-success';
+let heartbeatSuccessDir = '';
+let heartbeatSuccessFile = '';
 
 function cleanupHeartbeatSuccessFile(): void {
-  rmSync(HEARTBEAT_SUCCESS_FILE, { force: true });
-  rmSync(`${HEARTBEAT_SUCCESS_FILE}.${process.pid}.tmp`, { force: true });
+  if (!heartbeatSuccessFile) return;
+  rmSync(heartbeatSuccessFile, { force: true });
+  rmSync(`${heartbeatSuccessFile}.${process.pid}.tmp`, { force: true });
 }
 
 beforeEach(() => {
+  heartbeatSuccessDir = mkdtempSync(join(tmpdir(), 'hb-test-'));
+  heartbeatSuccessFile = join(heartbeatSuccessDir, 'last-heartbeat-success');
+  vi.stubEnv('HEARTBEAT_SUCCESS_FILE_OVERRIDE', heartbeatSuccessFile);
   cleanupHeartbeatSuccessFile();
   viemMocks.readContract.mockReset();
   viemMocks.waitForTransactionReceipt.mockReset();
@@ -52,6 +57,10 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanupHeartbeatSuccessFile();
+  if (heartbeatSuccessDir) rmSync(heartbeatSuccessDir, { recursive: true, force: true });
+  heartbeatSuccessDir = '';
+  heartbeatSuccessFile = '';
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
   vi.useRealTimers();
 });
@@ -181,8 +190,8 @@ describe('RunnerCastHeartbeat', () => {
 
     await expect(heartbeat.callHeartbeat()).resolves.toEqual({ txHash: hash });
 
-    expect(existsSync(HEARTBEAT_SUCCESS_FILE)).toBe(true);
-    expect(readFileSync(HEARTBEAT_SUCCESS_FILE, 'utf8')).toBe('123');
+    expect(existsSync(heartbeatSuccessFile)).toBe(true);
+    expect(readFileSync(heartbeatSuccessFile, 'utf8')).toBe('123');
   });
 
   it('swallows EACCES when heartbeat success file cannot be written', () => {

--- a/packages/runner/test/runnerCastHeartbeat.test.ts
+++ b/packages/runner/test/runnerCastHeartbeat.test.ts
@@ -1,3 +1,6 @@
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const viemMocks = vi.hoisted(() => ({
@@ -27,15 +30,28 @@ vi.mock('viem/accounts', () => ({
   })),
 }));
 
-import { configFromEnv, RunnerCastHeartbeat } from '../src/runnerCastHeartbeat';
+import {
+  configFromEnv,
+  RunnerCastHeartbeat,
+  writeHeartbeatSuccessFile,
+} from '../src/runnerCastHeartbeat';
+
+const HEARTBEAT_SUCCESS_FILE = '/tmp/last-heartbeat-success';
+
+function cleanupHeartbeatSuccessFile(): void {
+  rmSync(HEARTBEAT_SUCCESS_FILE, { force: true });
+  rmSync(`${HEARTBEAT_SUCCESS_FILE}.${process.pid}.tmp`, { force: true });
+}
 
 beforeEach(() => {
+  cleanupHeartbeatSuccessFile();
   viemMocks.readContract.mockReset();
   viemMocks.waitForTransactionReceipt.mockReset();
   viemMocks.writeContract.mockReset();
 });
 
 afterEach(() => {
+  cleanupHeartbeatSuccessFile();
   vi.unstubAllGlobals();
   vi.useRealTimers();
 });
@@ -148,6 +164,45 @@ describe('configFromEnv', () => {
 });
 
 describe('RunnerCastHeartbeat', () => {
+  it('writes heartbeat success file after receipt confirmation', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(123_000);
+    const hash = `0x${'a'.repeat(64)}` as const;
+    viemMocks.writeContract.mockResolvedValue(hash);
+    viemMocks.waitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      blockNumber: 123n,
+    });
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'https://rpc.example',
+    });
+
+    await expect(heartbeat.callHeartbeat()).resolves.toEqual({ txHash: hash });
+
+    expect(existsSync(HEARTBEAT_SUCCESS_FILE)).toBe(true);
+    expect(readFileSync(HEARTBEAT_SUCCESS_FILE, 'utf8')).toBe('123');
+  });
+
+  it('swallows EACCES when heartbeat success file cannot be written', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const unwritableDir = mkdtempSync(join(tmpdir(), 'heartbeat-success-'));
+    chmodSync(unwritableDir, 0o500);
+
+    try {
+      expect(() => writeHeartbeatSuccessFile(join(unwritableDir, 'success'))).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        '[RunnerCastHeartbeat] heartbeat success file write failed:',
+        expect.objectContaining({ code: 'EACCES' }),
+      );
+    } finally {
+      chmodSync(unwritableDir, 0o700);
+      rmSync(unwritableDir, { recursive: true, force: true });
+      warn.mockRestore();
+    }
+  });
+
   it('reads heartbeatIntervalSeconds from the canonical ABI', async () => {
     viemMocks.readContract.mockResolvedValue(42n);
     const heartbeat = new RunnerCastHeartbeat({


### PR DESCRIPTION
Closes #353. Option C per Liam directive 2026-05-21 (msg 16006).

## What ships

- `agents/heartbeat/Dockerfile` — multi-stage Node 22-alpine, cast copied from foundry image with `cast --version` self-test, pnpm-install layer cached (manifests first, source after)
- `agents/heartbeat/entrypoint.sh` — pre-flight: CHAIN_NETWORK validation, RPC URL selection, chain-id assertion via cast, reject anvil/localhost URLs in prod profile, require WEBHOOK_SHARED_SECRET
- `agents/heartbeat/README.md` — operator notes
- `docker-compose.yml` — heartbeat service updated from stub to build-based Option C, restart: on-failure:5 (was :0 per opus 4.7 super-swarm M5), CONVEX_WEBHOOK_URL required explicit
- `packages/runner/src/runnerCastHeartbeat.ts` — writes `/tmp/last-heartbeat-success` on each successful heartbeat (atomic temp+rename) for compose healthcheck

## Architecture

NOT a thin shell+foundry caller (that would discard 6 super-swarm rounds of v2.13 hardening). The container IS the existing TypeScript heartbeat scheduler, just in docker. Preserves: `runnerStatus` Convex writes, exponential backoff (1s → 2s → 5s → 10s), Telegram alerts, on-chain interval as source of truth, bearer webhook auth (HMAC deferred to follow-up per Liam directive).

## Bundle assignment

BUNDLE 1 — `dev-containerize-services`. Builds on PR #523 SettleLatch removal — heartbeat now fires every `heartbeatIntervalSeconds()` regardless of Cycle B state.

## Codex 5-stage history

- Stage 1 (xhigh): plan with dep graph + risks
- Stage 2: implement + `pnpm --filter @clan-world/runner test` passes
- Stage 3: 6 critique items (Dockerfile RUN comment fragility, missing cast version self-test, pnpm layer caching, anvil-URL-in-prod check, required webhook secret, atomic timestamp write)
- Stage 4: applied all 6 polish items

## Verification

- `pnpm --filter @clan-world/runner test` passes
- `docker compose --profile {dev,prod} config` parses
- Dockerfile builds successfully (RUN cast --version smoke passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code) + codex 5.5