### PR TITLE
feat(convex): self-hosted backend + dashboard stand-up (#347)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -101,6 +101,7 @@ keys/
 # bus keys / OAuth tokens into the image registry (`docker history --no-trunc`
 # would expose them otherwise).
 agents/secrets/
+agents/backups/
 agents/runtime/
 agents/.docker-mounts/
 agents/elder-*/.env

--- a/.env.template
+++ b/.env.template
@@ -45,9 +45,9 @@ HEARTBEAT_CALLER_ENABLED=false
 # testing and production; v1.1 replaces this with a chain-reader indexer.
 CLANWORLD_USE_FAKE_HEARTBEAT=false
 # Preferred explicit HTTP actions base URL. If UNSET (commented out), the runner
-# derives this from CONVEX_DEPLOY_URL by replacing `.convex.cloud` with
-# `.convex.site`. Set to an explicit URL to override. Set to empty string ("")
-# to intentionally disable the webhook (e.g. local dev without HTTP actions).
+# derives this from hosted Convex URLs by replacing `.convex.cloud` with
+# `.convex.site`. Self-hosted Convex does NOT derive; docker-compose sets this
+# to http://convex-backend:3211 for the heartbeat container.
 # CONVEX_WEBHOOK_URL=
 WEBHOOK_SHARED_SECRET=
 
@@ -211,32 +211,46 @@ FORK_BLOCK_NUMBER=0
 # time. Phase 1.4 (#347) wires up the bootstrap-convex-admin-key target.
 CONVEX_BACKEND_TAG=latest
 CONVEX_DASHBOARD_TAG=latest
-# URL the self-hosted Convex backend is reachable at FROM INSIDE the docker
-# network. Elder containers and the heartbeat container hit this directly.
-# When CHAIN_NETWORK=dev, this also overrides the dev's CONVEX_URL (line ~26)
-# so the dockerized stack uses self-hosted Convex instead of valuable-kudu-985.
-CONVEX_SELF_HOSTED_URL=http://convex-backend:3210
+# Dev profile publishes loopback ports through tiny proxy services so the host
+# can run the Convex CLI and open the dashboard. Prod keeps Convex Docker-
+# internal; expose it through Caddy/Access instead of these dev loopbacks.
+CONVEX_BACKEND_HOST_PORT=3210
+CONVEX_DASHBOARD_HOST_PORT=6791
+# URL the self-hosted Convex backend is reachable at FROM THE HOST running
+# `make deploy-convex`, `make backup-convex`, and `make import-convex-schema`.
+CONVEX_SELF_HOSTED_URL=http://127.0.0.1:3210
+# Dev browser-reachable API origin advertised by the backend.
+CONVEX_CLOUD_ORIGIN=http://localhost:3210
+# Internal HTTP actions origin advertised by the backend and used by heartbeat.
+CONVEX_SITE_ORIGIN=http://convex-backend:3211
+# Browser-reachable deployment URL for the dashboard. Dev uses localhost; prod
+# should override to an admin-routed URL or leave the dashboard unexposed.
+CONVEX_DASHBOARD_DEPLOYMENT_URL=http://localhost:3210
 # CLI version pin (Finding 11 fix). The deploy script aborts if
 # `npx convex --version` does not match this.
-CONVEX_CLI_PINNED_VERSION=1.17.4
+CONVEX_CLI_PINNED_VERSION=1.39.1
 
-# Indexer mode for self-hosted Convex. The webhook + cron paths gate ingestion
-# on these flags (apps/server/convex/heartbeat.ts + crons.ts). The dockerized
-# stack defaults to REAL_INDEXER=true; INDEXER_START_BLOCK is set on the
-# Convex env at deploy time (not pulled from .env). See dockerize-v1-plan
-# alignment note CR-9 for the rationale.
+# --- Indexer flags (set on Convex env via `convex env set`, not in .env) ---
+# After first deploy, export CONVEX_SELF_HOSTED_URL and
+# CONVEX_SELF_HOSTED_ADMIN_KEY, then run:
 #   convex env set CLANWORLD_USE_REAL_INDEXER true
 #   convex env set INDEXER_START_BLOCK <block-at-deploy>
-#   convex env set INDEXER_SECRET ${INDEXER_SECRET}    # reuses .env's value
+#   convex env set INDEXER_SECRET <secret>
+#   convex env set RPC_URL_PRIMARY <base-sepolia-rpc>
+#   convex env set CLAN_WORLD_CONTRACT_ADDRESS <diamond>
+#   convex env set CLAN_WORLD_LENS_ADDRESS <lens>
+#   convex env set WEBHOOK_SHARED_SECRET <secret>
+# Heartbeat webhook fan-out is controlled by the heartbeat container env:
+#   CONVEX_WEBHOOK_URL=http://convex-backend:3211
 
 # --- Secrets (DOCKER SECRETS — file references, not raw bytes) ---
 # These are NOT direct env values. Each variable below names the FILE the
 # Docker secret reads from. `make bootstrap-*` (Phase 1.12) generates the
 # files at the canonical paths and symlinks them into agents/secrets/.
 #
-# Convex backend admin key. File: /etc/clan-world/secrets/convex-admin.key
-# Symlink: agents/secrets/convex-admin.key
-# Generate via: make bootstrap-convex-admin-key
+# Convex admin key for CLI/dashboard access. The backend generates/persists its
+# root instance secret inside the convex_data volume; this file is derived from
+# the running backend by `make bootstrap-convex-admin-key`.
 CONVEX_SELF_HOSTED_ADMIN_KEY_FILE=agents/secrets/convex-admin.key
 # HMAC shared secret for heartbeat -> Convex webhook. File path:
 # /etc/clan-world/secrets/webhook-shared.key

--- a/.env.template
+++ b/.env.template
@@ -219,12 +219,14 @@ CONVEX_DASHBOARD_HOST_PORT=6791
 # URL the self-hosted Convex backend is reachable at FROM THE HOST running
 # `make deploy-convex`, `make backup-convex`, and `make import-convex-schema`.
 CONVEX_SELF_HOSTED_URL=http://127.0.0.1:3210
-# Dev browser-reachable API origin advertised by the backend.
+# Dev browser-reachable API origin advertised by the backend. Prod must set a
+# routed browser-reachable URL; deploy-convex rejects localhost/internal prod values.
 CONVEX_CLOUD_ORIGIN=http://localhost:3210
-# Internal HTTP actions origin advertised by the backend and used by heartbeat.
+# HTTP actions origin advertised by the backend. Dev heartbeat uses the Docker
+# internal origin; prod must set the routed value expected by callers.
 CONVEX_SITE_ORIGIN=http://convex-backend:3211
 # Browser-reachable deployment URL for the dashboard. Dev uses localhost; prod
-# should override to an admin-routed URL or leave the dashboard unexposed.
+# must override to an admin-routed URL if the dashboard is enabled.
 CONVEX_DASHBOARD_DEPLOYMENT_URL=http://localhost:3210
 # CLI version pin (Finding 11 fix). The deploy script aborts if
 # `npx convex --version` does not match this.

--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ docs/planning/V1/
 agents/runtime/
 agents/.env
 agents/.docker-mounts/
+agents/backups/
 agents/secrets/
 agents/elder-*/.env
 !agents/elder-*/.env.example

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /usr/bin/env bash
 PROFILE ?= dev
 CONVEX_SELF_HOSTED_ADMIN_KEY_FILE ?= agents/secrets/convex-admin.key
 
-.PHONY: deploy-convex bootstrap-convex-admin-key import-convex-schema backup-convex reset-anvil
+.PHONY: deploy-convex bootstrap-convex-admin-key import-convex-schema backup-convex check-stack-health reset-anvil
 
 deploy-convex:
 	bash bin/deploy-convex.sh
@@ -13,6 +13,9 @@ import-convex-schema:
 
 backup-convex:
 	bash bin/backup-convex.sh
+
+check-stack-health:
+	bash bin/check-stack-health.sh
 
 bootstrap-convex-admin-key:
 	@mkdir -p "$(dir $(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE))"
@@ -28,12 +31,20 @@ bootstrap-convex-admin-key:
 	  if [[ "$$i" == "30" ]]; then echo "ERROR: convex-backend did not become healthy" >&2; exit 1; fi; \
 	  sleep 1; \
 	done
-	@tmp="$$(mktemp)"; \
-	docker compose --profile "$(PROFILE)" exec -T convex-backend ./generate_admin_key.sh > "$$tmp"; \
-	install -m 600 "$$tmp" "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)"; \
-	rm -f "$$tmp"; \
-	sha256sum "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)" > "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE).sha256"; \
-	echo "Wrote $(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)"; \
+	@if [[ "$(PROFILE)" == "dev" ]]; then \
+	  docker compose --profile "$(PROFILE)" up -d convex-backend-dev-port; \
+	fi
+	@set -euo pipefail; \
+	tmp="$$(mktemp)"; \
+	trap 'rm -f "$$tmp"' EXIT; \
+	docker compose --profile "$(PROFILE)" exec -T convex-backend ./generate_admin_key.sh > "$$tmp" && \
+	if [[ ! -s "$$tmp" ]]; then \
+	  echo "ERROR: Refused to write $(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE): generated admin key was empty" >&2; \
+	  exit 1; \
+	fi && \
+	install -m 600 "$$tmp" "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)" && \
+	sha256sum "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)" > "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE).sha256" && \
+	echo "Wrote $(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)" && \
 	echo "Fingerprint: $$(awk '{print $$1}' "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE).sha256")"
 
 reset-anvil:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+SHELL := /usr/bin/env bash
+
+PROFILE ?= dev
+CONVEX_SELF_HOSTED_ADMIN_KEY_FILE ?= agents/secrets/convex-admin.key
+
+.PHONY: deploy-convex bootstrap-convex-admin-key import-convex-schema backup-convex reset-anvil
+
+deploy-convex:
+	bash bin/deploy-convex.sh
+
+import-convex-schema:
+	bash bin/import-convex-schema.sh
+
+backup-convex:
+	bash bin/backup-convex.sh
+
+bootstrap-convex-admin-key:
+	@mkdir -p "$(dir $(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE))"
+	@if [[ -f "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)" && "$(FORCE)" != "1" ]]; then \
+	  echo "ERROR: $(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE) already exists. Use FORCE=1 to overwrite." >&2; \
+	  exit 1; \
+	fi
+	docker compose --profile "$(PROFILE)" up -d convex-backend
+	@for i in {1..30}; do \
+	  if docker compose --profile "$(PROFILE)" exec -T convex-backend curl -fsS http://localhost:3210/version >/dev/null 2>&1; then \
+	    break; \
+	  fi; \
+	  if [[ "$$i" == "30" ]]; then echo "ERROR: convex-backend did not become healthy" >&2; exit 1; fi; \
+	  sleep 1; \
+	done
+	@tmp="$$(mktemp)"; \
+	docker compose --profile "$(PROFILE)" exec -T convex-backend ./generate_admin_key.sh > "$$tmp"; \
+	install -m 600 "$$tmp" "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)"; \
+	rm -f "$$tmp"; \
+	sha256sum "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)" > "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE).sha256"; \
+	echo "Wrote $(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)"; \
+	echo "Fingerprint: $$(awk '{print $$1}' "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE).sha256")"
+
+reset-anvil:
+	@echo "WARNING: reset-anvil only removes clan-world_anvil_data."
+	@echo "WARNING: NEVER remove clan-world_convex_data without running make backup-convex first;"
+	@echo "         that volume contains the self-hosted Convex instance secret, admin-key root, and all data."
+	docker compose --profile dev stop anvil-fork || true
+	docker compose --profile dev rm -f anvil-fork || true
+	docker volume rm clan-world_anvil_data || true
+	docker compose --profile dev up -d anvil-fork

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -7,6 +7,8 @@
     "dev": "echo 'run: pnpm convex dev'",
     "build": "tsc -b",
     "codegen": "convex codegen --typecheck disable",
+    "convex:codegen": "npx -y convex@${CONVEX_CLI_PINNED_VERSION:-1.39.1} codegen --typecheck disable",
+    "convex:deploy": "npx -y convex@${CONVEX_CLI_PINNED_VERSION:-1.39.1} deploy --yes",
     "typecheck": "tsc --noEmit",
     "test": "vitest run convex/*.test.ts",
     "lint": "echo 'lint stub'",

--- a/bin/backup-convex.sh
+++ b/bin/backup-convex.sh
@@ -39,7 +39,8 @@ if [[ -z "${CONVEX_SELF_HOSTED_ADMIN_KEY:-}" ]]; then
 fi
 unset CONVEX_DEPLOYMENT CONVEX_DEPLOY_KEY
 
-mkdir -p agents/backups
+install -d -m 0700 agents/backups
 backup_path="agents/backups/convex-$(date -u +%Y%m%dT%H%M%SZ).zip"
 convex_cli export --path "$backup_path" --include-file-storage
+chmod 0600 "$backup_path"
 echo "Wrote $backup_path"

--- a/bin/backup-convex.sh
+++ b/bin/backup-convex.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+load_env() {
+  set -a
+  [[ -f .env ]] && source .env
+  [[ -f .env.local ]] && source .env.local
+  set +a
+}
+
+convex_cli() {
+  npx -y "convex@${CONVEX_CLI_PINNED_VERSION:?CONVEX_CLI_PINNED_VERSION is required}" "$@"
+}
+
+check_cli_version() {
+  local expected="${CONVEX_CLI_PINNED_VERSION:?CONVEX_CLI_PINNED_VERSION is required}"
+  local actual
+  actual="$(convex_cli --version)"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "ERROR: Convex CLI version mismatch: expected $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+load_env
+check_cli_version
+
+admin_key_file="${CONVEX_SELF_HOSTED_ADMIN_KEY_FILE:-agents/secrets/convex-admin.key}"
+export CONVEX_SELF_HOSTED_URL="${CONVEX_SELF_HOSTED_URL:-http://127.0.0.1:${CONVEX_BACKEND_HOST_PORT:-3210}}"
+if [[ -z "${CONVEX_SELF_HOSTED_ADMIN_KEY:-}" ]]; then
+  if [[ ! -f "$admin_key_file" ]]; then
+    echo "ERROR: missing Convex admin key file: $admin_key_file" >&2
+    exit 1
+  fi
+  export CONVEX_SELF_HOSTED_ADMIN_KEY="$(<"$admin_key_file")"
+fi
+unset CONVEX_DEPLOYMENT CONVEX_DEPLOY_KEY
+
+mkdir -p agents/backups
+backup_path="agents/backups/convex-$(date -u +%Y%m%dT%H%M%SZ).zip"
+convex_cli export --path "$backup_path" --include-file-storage
+echo "Wrote $backup_path"

--- a/bin/check-stack-health.sh
+++ b/bin/check-stack-health.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+load_env() {
+  set -a
+  [[ -f .env ]] && source .env
+  [[ -f .env.local ]] && source .env.local
+  set +a
+}
+
+PROFILE="${PROFILE:-dev}"
+failed=0
+
+check_exec() {
+  local service="$1"
+  local url="$2"
+  if docker compose --profile "$PROFILE" exec -T "$service" curl -fsS "$url" >/dev/null 2>&1; then
+    printf 'GREEN %s %s\n' "$service" "$url"
+  else
+    printf 'RED   %s %s\n' "$service" "$url"
+    failed=1
+  fi
+}
+
+check_host() {
+  local name="$1"
+  local url="$2"
+  if curl -fsS "$url" >/dev/null 2>&1; then
+    printf 'GREEN %s %s\n' "$name" "$url"
+  else
+    printf 'RED   %s %s\n' "$name" "$url"
+    failed=1
+  fi
+}
+
+check_exec_any_status() {
+  local service="$1"
+  local url="$2"
+  if docker compose --profile "$PROFILE" exec -T "$service" curl -sS -o /dev/null --connect-timeout 2 "$url" >/dev/null 2>&1; then
+    printf 'GREEN %s %s\n' "$service" "$url"
+  else
+    printf 'RED   %s %s\n' "$service" "$url"
+    failed=1
+  fi
+}
+
+load_env
+
+check_exec convex-backend http://localhost:3210/version
+check_exec_any_status convex-backend http://localhost:3211/
+check_exec convex-dashboard http://localhost:6791/
+
+if [[ "$PROFILE" == "dev" ]]; then
+  check_host convex-backend-dev-loopback "http://127.0.0.1:${CONVEX_BACKEND_HOST_PORT:-3210}/version"
+  check_host convex-dashboard-dev-loopback "http://127.0.0.1:${CONVEX_DASHBOARD_HOST_PORT:-6791}/"
+fi
+
+exit "$failed"

--- a/bin/deploy-convex.sh
+++ b/bin/deploy-convex.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+load_env() {
+  set -a
+  [[ -f .env ]] && source .env
+  [[ -f .env.local ]] && source .env.local
+  set +a
+}
+
+convex_cli() {
+  npx -y "convex@${CONVEX_CLI_PINNED_VERSION:?CONVEX_CLI_PINNED_VERSION is required}" "$@"
+}
+
+require_self_hosted_env() {
+  local admin_key_file="${CONVEX_SELF_HOSTED_ADMIN_KEY_FILE:-agents/secrets/convex-admin.key}"
+  export CONVEX_SELF_HOSTED_URL="${CONVEX_SELF_HOSTED_URL:-http://127.0.0.1:${CONVEX_BACKEND_HOST_PORT:-3210}}"
+  if [[ -z "${CONVEX_SELF_HOSTED_ADMIN_KEY:-}" ]]; then
+    if [[ ! -f "$admin_key_file" ]]; then
+      echo "ERROR: missing Convex admin key file: $admin_key_file" >&2
+      echo "Run: make bootstrap-convex-admin-key PROFILE=dev" >&2
+      exit 1
+    fi
+    export CONVEX_SELF_HOSTED_ADMIN_KEY="$(<"$admin_key_file")"
+  fi
+  unset CONVEX_DEPLOYMENT CONVEX_DEPLOY_KEY
+}
+
+check_cli_version() {
+  local expected="${CONVEX_CLI_PINNED_VERSION:?CONVEX_CLI_PINNED_VERSION is required}"
+  local actual
+  actual="$(convex_cli --version)"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "ERROR: Convex CLI version mismatch: expected $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+load_env
+require_self_hosted_env
+check_cli_version
+
+pnpm --filter @clan-world/sdk codegen
+pnpm --filter @clan-world/server convex:codegen
+pnpm typecheck
+pnpm --filter @clan-world/server convex:deploy

--- a/bin/deploy-convex.sh
+++ b/bin/deploy-convex.sh
@@ -29,6 +29,26 @@ require_self_hosted_env() {
   unset CONVEX_DEPLOYMENT CONVEX_DEPLOY_KEY
 }
 
+is_local_origin() {
+  local value="$1"
+  [[ "$value" == http://localhost* || "$value" == https://localhost* || \
+    "$value" == http://127.0.0.1* || "$value" == https://127.0.0.1* || \
+    "$value" == http://convex-backend* || "$value" == https://convex-backend* ]]
+}
+
+require_prod_origins() {
+  [[ "${CHAIN_NETWORK:-dev}" == "prod" ]] || return 0
+
+  local name value
+  for name in CONVEX_CLOUD_ORIGIN CONVEX_SITE_ORIGIN CONVEX_DASHBOARD_DEPLOYMENT_URL; do
+    value="${!name:-}"
+    if [[ -z "$value" ]] || is_local_origin "$value"; then
+      echo "ERROR: $name must be set to a browser-routable prod URL when CHAIN_NETWORK=prod; got '${value:-<unset>}'" >&2
+      exit 1
+    fi
+  done
+}
+
 check_cli_version() {
   local expected="${CONVEX_CLI_PINNED_VERSION:?CONVEX_CLI_PINNED_VERSION is required}"
   local actual
@@ -40,10 +60,11 @@ check_cli_version() {
 }
 
 load_env
+require_prod_origins
 require_self_hosted_env
 check_cli_version
 
-pnpm --filter @clan-world/sdk codegen
+pnpm --filter @clan-world/sdk convex:codegen
 pnpm --filter @clan-world/server convex:codegen
 pnpm typecheck
 pnpm --filter @clan-world/server convex:deploy

--- a/bin/import-convex-schema.sh
+++ b/bin/import-convex-schema.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+load_env() {
+  set -a
+  [[ -f .env ]] && source .env
+  [[ -f .env.local ]] && source .env.local
+  set +a
+}
+
+convex_cli() {
+  npx -y "convex@${CONVEX_CLI_PINNED_VERSION:?CONVEX_CLI_PINNED_VERSION is required}" "$@"
+}
+
+check_cli_version() {
+  local expected="${CONVEX_CLI_PINNED_VERSION:?CONVEX_CLI_PINNED_VERSION is required}"
+  local actual
+  actual="$(convex_cli --version)"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "ERROR: Convex CLI version mismatch: expected $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+export_self_hosted_env() {
+  local admin_key_file="${CONVEX_SELF_HOSTED_ADMIN_KEY_FILE:-agents/secrets/convex-admin.key}"
+  export CONVEX_SELF_HOSTED_URL="${CONVEX_SELF_HOSTED_URL:-http://127.0.0.1:${CONVEX_BACKEND_HOST_PORT:-3210}}"
+  if [[ -z "${CONVEX_SELF_HOSTED_ADMIN_KEY:-}" ]]; then
+    if [[ ! -f "$admin_key_file" ]]; then
+      echo "ERROR: missing Convex admin key file: $admin_key_file" >&2
+      exit 1
+    fi
+    export CONVEX_SELF_HOSTED_ADMIN_KEY="$(<"$admin_key_file")"
+  fi
+  unset CONVEX_DEPLOYMENT CONVEX_DEPLOY_KEY
+}
+
+has_hosted_selector() {
+  [[ -n "${CONVEX_DEPLOYMENT:-}" || -n "${CONVEX_DEPLOY_KEY:-}" ]]
+}
+
+load_env
+check_cli_version
+
+mkdir -p agents/backups
+if [[ -n "${HOSTED_CONVEX_EXPORT_ZIP:-}" ]]; then
+  if [[ ! -f "$HOSTED_CONVEX_EXPORT_ZIP" ]]; then
+    echo "ERROR: HOSTED_CONVEX_EXPORT_ZIP points to a missing file: $HOSTED_CONVEX_EXPORT_ZIP" >&2
+    exit 1
+  fi
+  export_zip="$HOSTED_CONVEX_EXPORT_ZIP"
+else
+  if ! has_hosted_selector; then
+    echo "ERROR: set HOSTED_CONVEX_EXPORT_ZIP to an existing export, or set an explicit hosted selector (CONVEX_DEPLOYMENT or CONVEX_DEPLOY_KEY) before export." >&2
+    exit 1
+  fi
+  export_zip="agents/backups/convex-hosted-$(date -u +%Y%m%dT%H%M%SZ).zip"
+fi
+
+schema_sha="$(sha256sum packages/sdk/convex/schema.ts | awk '{print $1}')"
+if [[ -n "${SDK_SCHEMA_SHA256:-}" && "$schema_sha" != "$SDK_SCHEMA_SHA256" ]]; then
+  echo "ERROR: SDK schema fingerprint mismatch: expected $SDK_SCHEMA_SHA256, got $schema_sha" >&2
+  exit 1
+fi
+echo "SDK schema fingerprint: $schema_sha"
+
+if [[ -f "$export_zip" ]]; then
+  echo "Using existing hosted export: $export_zip"
+else
+  echo "Exporting hosted Convex data to $export_zip"
+  unset CONVEX_SELF_HOSTED_URL CONVEX_SELF_HOSTED_ADMIN_KEY
+  convex_cli export --path "$export_zip"
+fi
+
+if [[ "${CONFIRM_REPLACE_ALL:-}" != "1" && "${FRESH_SELF_HOSTED:-}" != "1" ]]; then
+  echo "ERROR: destructive import refused. Set CONFIRM_REPLACE_ALL=1 or FRESH_SELF_HOSTED=1 to replace all self-hosted Convex data." >&2
+  exit 1
+fi
+
+export_self_hosted_env
+echo "WARNING: destructive import will replace all data in self-hosted Convex."
+echo "Importing $export_zip into self-hosted Convex at $CONVEX_SELF_HOSTED_URL"
+convex_cli import --replace-all --yes "$export_zip"

--- a/bin/import-convex-schema.sh
+++ b/bin/import-convex-schema.sh
@@ -45,10 +45,15 @@ has_hosted_selector() {
 load_env
 check_cli_version
 
-mkdir -p agents/backups
+install -d -m 0700 agents/backups
+target_url="${CONVEX_SELF_HOSTED_URL:-http://127.0.0.1:${CONVEX_BACKEND_HOST_PORT:-3210}}"
 if [[ -n "${HOSTED_CONVEX_EXPORT_ZIP:-}" ]]; then
   if [[ ! -f "$HOSTED_CONVEX_EXPORT_ZIP" ]]; then
     echo "ERROR: HOSTED_CONVEX_EXPORT_ZIP points to a missing file: $HOSTED_CONVEX_EXPORT_ZIP" >&2
+    exit 1
+  fi
+  if [[ "${CONFIRM_EXPORT_HAS_FILE_STORAGE:-}" != "1" ]]; then
+    echo "ERROR: external HOSTED_CONVEX_EXPORT_ZIP requires CONFIRM_EXPORT_HAS_FILE_STORAGE=1 because this script cannot verify file storage contents." >&2
     exit 1
   fi
   export_zip="$HOSTED_CONVEX_EXPORT_ZIP"
@@ -72,14 +77,19 @@ if [[ -f "$export_zip" ]]; then
 else
   echo "Exporting hosted Convex data to $export_zip"
   unset CONVEX_SELF_HOSTED_URL CONVEX_SELF_HOSTED_ADMIN_KEY
-  convex_cli export --path "$export_zip"
+  convex_cli export --path "$export_zip" --include-file-storage
 fi
 
 if [[ "${CONFIRM_REPLACE_ALL:-}" != "1" && "${FRESH_SELF_HOSTED:-}" != "1" ]]; then
   echo "ERROR: destructive import refused. Set CONFIRM_REPLACE_ALL=1 or FRESH_SELF_HOSTED=1 to replace all self-hosted Convex data." >&2
   exit 1
 fi
+if [[ "${FRESH_SELF_HOSTED:-}" == "1" && "${CONFIRM_TARGET_URL:-}" != "$target_url" ]]; then
+  echo "ERROR: FRESH_SELF_HOSTED=1 requires CONFIRM_TARGET_URL=$target_url to confirm the target deployment." >&2
+  exit 1
+fi
 
+export CONVEX_SELF_HOSTED_URL="$target_url"
 export_self_hosted_env
 echo "WARNING: destructive import will replace all data in self-hosted Convex."
 echo "Importing $export_zip into self-hosted Convex at $CONVEX_SELF_HOSTED_URL"

--- a/bin/import-convex-schema.sh
+++ b/bin/import-convex-schema.sh
@@ -78,6 +78,7 @@ else
   echo "Exporting hosted Convex data to $export_zip"
   unset CONVEX_SELF_HOSTED_URL CONVEX_SELF_HOSTED_ADMIN_KEY
   convex_cli export --path "$export_zip" --include-file-storage
+  chmod 0600 "$export_zip"
 fi
 
 if [[ "${CONFIRM_REPLACE_ALL:-}" != "1" && "${FRESH_SELF_HOSTED:-}" != "1" ]]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,14 +47,6 @@ volumes:
   elder-4-workspace: {}
 
 secrets:
-  # Plan revision (Finding 10): admin key lives in a file mounted as a Docker
-  # secret, NOT an env var (env vars leak through `docker inspect`).
-  # `make bootstrap-convex-admin-key` (Phase 1.12) materializes these files.
-  # File paths are overridable via .env *_FILE vars — defaults preserve the
-  # canonical bootstrap layout so operators don't have to set anything to get
-  # the standard `make bootstrap-*` workflow.
-  convex-admin-key:
-    file: ${CONVEX_SELF_HOSTED_ADMIN_KEY_FILE:-./agents/secrets/convex-admin.key}
   # Webhook HMAC shared secret for heartbeat → Convex webhook (Finding 30 fix).
   webhook-shared:
     file: ${WEBHOOK_SHARED_SECRET_FILE:-./agents/secrets/webhook-shared.key}
@@ -92,44 +84,81 @@ services:
   # ---------------------------------------------------------------------------
   # Self-hosted Convex backend + dashboard.
   #
-  # Phase 1.1 scaffolds the service definitions only. Image pinning, admin-key
-  # bootstrap, and `npx convex deploy --self-hosted` land in #347.
+  # The backend persists its SQLite database and generated instance secret in
+  # convex_data. `make bootstrap-convex-admin-key` reads a derived admin key
+  # from the running backend; the backend does not consume an admin-key secret.
   # ---------------------------------------------------------------------------
   convex-backend:
     image: ghcr.io/get-convex/convex-backend:${CONVEX_BACKEND_TAG:-latest}
+    stop_grace_period: 10s
+    stop_signal: SIGINT
     environment:
-      CONVEX_INSTANCE_NAME: clan-world-${CHAIN_NETWORK:?CHAIN_NETWORK required (dev|prod)}
-      # Backend reads admin key from a file path, not an env var.
-      CONVEX_ADMIN_KEY_FILE: /run/secrets/convex-admin-key
-    secrets:
-      - convex-admin-key
+      INSTANCE_NAME: clan-world-${CHAIN_NETWORK:?CHAIN_NETWORK required (dev|prod)}
+      CONVEX_CLOUD_ORIGIN: ${CONVEX_CLOUD_ORIGIN:-http://convex-backend:3210}
+      CONVEX_SITE_ORIGIN: ${CONVEX_SITE_ORIGIN:-http://convex-backend:3211}
+      DISABLE_BEACON: ${DISABLE_BEACON:-true}
+      DISABLE_METRICS_ENDPOINT: ${DISABLE_METRICS_ENDPOINT:-true}
+      DO_NOT_REQUIRE_SSL: ${DO_NOT_REQUIRE_SSL:-true}
+      RUST_LOG: ${RUST_LOG:-info}
     volumes:
-      - convex_data:/data
+      - convex_data:/convex/data
     networks: [clan-world-internal]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3210/health"]
-      interval: 10s
+      test: ["CMD", "curl", "-f", "http://localhost:3210/version"]
+      interval: 5s
       timeout: 3s
       retries: 3
-      start_period: 30s
+      start_period: 10s
+    restart: unless-stopped
     profiles: [dev, prod]
 
   convex-dashboard:
     image: ghcr.io/get-convex/convex-dashboard:${CONVEX_DASHBOARD_TAG:-latest}
+    stop_grace_period: 10s
+    stop_signal: SIGINT
     environment:
-      NEXT_PUBLIC_DEPLOYMENT_URL: http://convex-backend:3210
+      # In dev, operators open the dashboard through localhost. In prod this
+      # should be overridden to a routed internal/admin URL or left unexposed.
+      NEXT_PUBLIC_DEPLOYMENT_URL: ${CONVEX_DASHBOARD_DEPLOYMENT_URL:-http://convex-backend:3210}
     networks: [clan-world-internal]
     depends_on:
       convex-backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:6791/"]
+      test: ["CMD", "curl", "-f", "http://localhost:6791/"]
       interval: 10s
       timeout: 3s
       retries: 3
       start_period: 30s
     restart: unless-stopped
     profiles: [dev, prod]
+
+  # Dev-only loopback access for host-run CLI/dashboard. Compose cannot make
+  # a single service's `ports:` conditional on profile, so these tiny proxies
+  # keep prod's canonical services Docker-internal.
+  convex-backend-dev-port:
+    image: alpine/socat:1.7.4.4
+    command: ["TCP-LISTEN:3210,fork,reuseaddr", "TCP:convex-backend:3210"]
+    ports:
+      - "127.0.0.1:${CONVEX_BACKEND_HOST_PORT:-3210}:3210"
+    networks: [clan-world-internal]
+    depends_on:
+      convex-backend:
+        condition: service_healthy
+    restart: unless-stopped
+    profiles: [dev]
+
+  convex-dashboard-dev-port:
+    image: alpine/socat:1.7.4.4
+    command: ["TCP-LISTEN:6791,fork,reuseaddr", "TCP:convex-dashboard:6791"]
+    ports:
+      - "127.0.0.1:${CONVEX_DASHBOARD_HOST_PORT:-6791}:6791"
+    networks: [clan-world-internal]
+    depends_on:
+      convex-dashboard:
+        condition: service_healthy
+    restart: unless-stopped
+    profiles: [dev]
 
   # ---------------------------------------------------------------------------
   # anvil-fork — dev profile ONLY. Forks Base Sepolia at FORK_BLOCK_NUMBER and
@@ -180,6 +209,7 @@ services:
       # anyway, but the compose-level error is faster + clearer).
       PROD_RPC_URL: ${RPC_URL_PRIMARY:-}
       CONVEX_DEPLOY_URL: http://convex-backend:3210
+      CONVEX_WEBHOOK_URL: http://convex-backend:3211
       CLAN_WORLD_CONTRACT_ADDRESS: ${CLAN_WORLD_CONTRACT_ADDRESS:?CLAN_WORLD_CONTRACT_ADDRESS required}
       WEBHOOK_SHARED_SECRET_FILE: /run/secrets/webhook-shared
     secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,8 +94,8 @@ services:
     stop_signal: SIGINT
     environment:
       INSTANCE_NAME: clan-world-${CHAIN_NETWORK:?CHAIN_NETWORK required (dev|prod)}
-      CONVEX_CLOUD_ORIGIN: ${CONVEX_CLOUD_ORIGIN:-http://convex-backend:3210}
-      CONVEX_SITE_ORIGIN: ${CONVEX_SITE_ORIGIN:-http://convex-backend:3211}
+      CONVEX_CLOUD_ORIGIN: ${CONVEX_CLOUD_ORIGIN:?CONVEX_CLOUD_ORIGIN required; set browser-reachable API origin explicitly}
+      CONVEX_SITE_ORIGIN: ${CONVEX_SITE_ORIGIN:?CONVEX_SITE_ORIGIN required; set HTTP actions origin explicitly}
       DISABLE_BEACON: ${DISABLE_BEACON:-true}
       DISABLE_METRICS_ENDPOINT: ${DISABLE_METRICS_ENDPOINT:-true}
       DO_NOT_REQUIRE_SSL: ${DO_NOT_REQUIRE_SSL:-true}
@@ -119,12 +119,13 @@ services:
     environment:
       # In dev, operators open the dashboard through localhost. In prod this
       # should be overridden to a routed internal/admin URL or left unexposed.
-      NEXT_PUBLIC_DEPLOYMENT_URL: ${CONVEX_DASHBOARD_DEPLOYMENT_URL:-http://convex-backend:3210}
+      NEXT_PUBLIC_DEPLOYMENT_URL: ${CONVEX_DASHBOARD_DEPLOYMENT_URL:?CONVEX_DASHBOARD_DEPLOYMENT_URL required; set browser-reachable dashboard deployment URL explicitly}
     networks: [clan-world-internal]
     depends_on:
       convex-backend:
         condition: service_healthy
     healthcheck:
+      # Verified 2026-05-21: ghcr.io/get-convex/convex-dashboard:latest includes /usr/bin/curl.
       test: ["CMD", "curl", "-f", "http://localhost:6791/"]
       interval: 10s
       timeout: 3s

--- a/docs/runbooks/self-hosted-convex.md
+++ b/docs/runbooks/self-hosted-convex.md
@@ -1,0 +1,106 @@
+# Self-Hosted Convex Runbook
+
+Issue #347 stands up Convex backend + dashboard inside the compose stack and
+deploys the existing `apps/server/convex/` functions against the canonical SDK
+schema in `packages/sdk/convex/schema.ts`.
+
+## First Bootstrap
+
+1. Start the backend and generate a CLI/dashboard admin key:
+
+   ```bash
+   make bootstrap-convex-admin-key PROFILE=dev
+   ```
+
+2. Back up `agents/secrets/convex-admin.key` to the operator password manager.
+   The backend does not read this file on boot; it derives the key from the
+   instance secret persisted inside the `convex_data` Docker volume.
+
+3. Deploy code:
+
+   ```bash
+   make deploy-convex
+   ```
+
+## Deploy Sequence
+
+`make deploy-convex` runs:
+
+```bash
+pnpm --filter @clan-world/sdk codegen
+pnpm --filter @clan-world/server convex:codegen
+pnpm typecheck
+pnpm --filter @clan-world/server convex:deploy
+```
+
+The deploy script exports `CONVEX_SELF_HOSTED_URL` and
+`CONVEX_SELF_HOSTED_ADMIN_KEY` for the Convex CLI. There is no `--self-hosted`
+Convex CLI flag in the supported flow.
+
+## Post-Deploy Env
+
+After first deploy, set the indexer env on the self-hosted deployment:
+
+```bash
+export CONVEX_SELF_HOSTED_URL=http://127.0.0.1:3210
+export CONVEX_SELF_HOSTED_ADMIN_KEY="$(cat agents/secrets/convex-admin.key)"
+
+convex env set CLANWORLD_USE_REAL_INDEXER true
+convex env set INDEXER_START_BLOCK <block-at-deploy>
+convex env set INDEXER_SECRET <secret>
+convex env set RPC_URL_PRIMARY <base-sepolia-rpc>
+convex env set CLAN_WORLD_CONTRACT_ADDRESS <diamond>
+convex env set CLAN_WORLD_LENS_ADDRESS <lens>
+convex env set WEBHOOK_SHARED_SECRET <secret>
+```
+
+The heartbeat container posts HTTP actions to
+`CONVEX_WEBHOOK_URL=http://convex-backend:3211`.
+
+## Backup And Restore
+
+Create a pre-migration or pre-reset backup:
+
+```bash
+make backup-convex
+```
+
+Backups are written to `agents/backups/convex-<timestamp>.zip`.
+
+Restore/import into a fresh self-hosted backend:
+
+This is a destructive import. It uses `--replace-all` and is intended only for
+a fresh backend or an explicitly confirmed restore.
+
+```bash
+FRESH_SELF_HOSTED=1 make import-convex-schema
+```
+
+## Do Not Remove `convex_data` Casually
+
+`clan-world_convex_data` contains:
+
+- the SQLite database,
+- file storage,
+- the generated Convex instance secret,
+- the root material used to derive `agents/secrets/convex-admin.key`.
+
+Removing this volume destroys the admin-key root and all self-hosted Convex
+data. Always run `make backup-convex` before any operation that might remove
+`clan-world_convex_data`.
+
+## Health Checks
+
+```bash
+bash bin/check-stack-health.sh
+```
+
+Expected dev endpoints:
+
+- backend API: `http://127.0.0.1:3210/version`
+- dashboard: `http://127.0.0.1:6791/`
+- internal HTTP actions: `http://convex-backend:3211`
+
+If the dashboard loads but cannot authenticate, regenerate or restore
+`agents/secrets/convex-admin.key` from the running backend with
+`make bootstrap-convex-admin-key FORCE=1 PROFILE=dev`.

--- a/docs/runbooks/self-hosted-convex.md
+++ b/docs/runbooks/self-hosted-convex.md
@@ -6,7 +6,8 @@ schema in `packages/sdk/convex/schema.ts`.
 
 ## First Bootstrap
 
-1. Start the backend and generate a CLI/dashboard admin key:
+1. Start the backend, start the dev backend loopback proxy, and generate a
+   CLI/dashboard admin key:
 
    ```bash
    make bootstrap-convex-admin-key PROFILE=dev
@@ -27,7 +28,7 @@ schema in `packages/sdk/convex/schema.ts`.
 `make deploy-convex` runs:
 
 ```bash
-pnpm --filter @clan-world/sdk codegen
+pnpm --filter @clan-world/sdk convex:codegen
 pnpm --filter @clan-world/server convex:codegen
 pnpm typecheck
 pnpm --filter @clan-world/server convex:deploy
@@ -65,7 +66,8 @@ Create a pre-migration or pre-reset backup:
 make backup-convex
 ```
 
-Backups are written to `agents/backups/convex-<timestamp>.zip`.
+Backups are written to `agents/backups/convex-<timestamp>.zip`. The directory
+is created `0700` and backup zips are chmodded `0600`.
 
 Restore/import into a fresh self-hosted backend:
 
@@ -73,8 +75,12 @@ This is a destructive import. It uses `--replace-all` and is intended only for
 a fresh backend or an explicitly confirmed restore.
 
 ```bash
-FRESH_SELF_HOSTED=1 make import-convex-schema
+FRESH_SELF_HOSTED=1 CONFIRM_TARGET_URL=http://127.0.0.1:3210 make import-convex-schema
 ```
+
+If supplying a prebuilt hosted export with `HOSTED_CONVEX_EXPORT_ZIP`, also set
+`CONFIRM_EXPORT_HAS_FILE_STORAGE=1`; the script cannot inspect external zips
+to prove they include Convex file storage.
 
 ## Do Not Remove `convex_data` Casually
 
@@ -92,7 +98,7 @@ data. Always run `make backup-convex` before any operation that might remove
 ## Health Checks
 
 ```bash
-bash bin/check-stack-health.sh
+make check-stack-health
 ```
 
 Expected dev endpoints:

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "build": "tsc --noEmit",
-    "codegen": "npx -y convex@${CONVEX_CLI_PINNED_VERSION:-1.39.1} codegen --typecheck disable",
+    "codegen": "convex codegen --typecheck disable",
+    "convex:codegen": "npx -y convex@${CONVEX_CLI_PINNED_VERSION:-1.39.1} codegen --typecheck disable",
     "deploy": "echo 'SDK is not a Convex deployment target' && exit 1",
     "convex:deploy": "echo 'SDK is not a Convex deployment target' && exit 1",
     "typecheck": "tsc --noEmit",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsc --noEmit",
-    "codegen": "convex codegen --typecheck disable",
+    "codegen": "npx -y convex@${CONVEX_CLI_PINNED_VERSION:-1.39.1} codegen --typecheck disable",
     "deploy": "echo 'SDK is not a Convex deployment target' && exit 1",
     "convex:deploy": "echo 'SDK is not a Convex deployment target' && exit 1",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Closes #347. Phase 1.4 self-host Convex.

## What ships

- 4 new bash scripts under `bin/`: deploy-convex.sh, backup-convex.sh, import-convex-schema.sh, check-stack-health.sh
- Root `Makefile` with deploy-convex / bootstrap-convex-admin-key / backup-convex / import-convex-schema / reset-anvil targets
- `docs/runbooks/self-hosted-convex.md` — operator runbook
- `docker-compose.yml` — convex-backend + convex-dashboard fully wired (was stubs in PR #408)
- `.env.template` updated with Convex self-host vars + indexer-flags Convex env instructions
- Both `apps/server/package.json` + `packages/sdk/package.json` aligned on pinned CLI version (${CONVEX_CLI_PINNED_VERSION:-1.39.1})

## Architecture

- Backend (`ghcr.io/get-convex/convex-backend:${tag}`) generates admin key on first up; bootstrap target reads it back out and writes `agents/secrets/convex-admin.key` 0600 with SHA256 fingerprint
- Dashboard at port 6791 internal, exposed via `alpine/socat:1.7.4.4` loopback proxy on host (dev profile only)
- Heartbeat (PR #525) posts to `CONVEX_WEBHOOK_URL=http://convex-backend:3211` (HTTP actions site origin)
- Destructive operations gated: `make import-convex-schema` requires `FRESH_SELF_HOSTED=1` or `CONFIRM_REPLACE_ALL=1`
- `clan-world_convex_data` volume preservation documented loudly — destroys admin-key root + all data if removed

## Canonical 5-step deploy sequence (Q4 spec, Liam-approved 2026-05-21)

```
# 1. Edit packages/sdk/convex/schema.ts
# 2. pnpm --filter @clan-world/sdk codegen
# 3. pnpm --filter @clan-world/server convex:codegen
# 4. pnpm typecheck
# 5. pnpm --filter @clan-world/server convex:deploy
```

Wrapped by `make deploy-convex`.

## Codex 5-stage history

- Stage 1 (xhigh): dep graph + risks (chicken-and-egg admin key, /version vs /health, convex_data volume warning)
- Stage 2: implement
- Stage 3: 10 critique items
- Stage 4: applied all 10 polish items (SDK CLI version pin, destructive-import gating, health probe for 3211, socat tag pin, var-name alignment, runbook destructive warning)

## Bundle assignment

BUNDLE 1 — `dev-containerize-services`. Pairs with PR #525 heartbeat container.

🤖 Generated with [Claude Code](https://claude.com/claude-code) + codex 5.5