### PR TITLE
fix(heartbeat): PR #525 cloud-review followups (3 fixes)

### DIFF
--- a/agents/heartbeat/README.md
+++ b/agents/heartbeat/README.md
@@ -51,7 +51,7 @@ compose `anvil-fork` service and viem's `baseSepolia` chain config.
 ## Healthcheck
 
 The compose healthcheck reads `/tmp/last-heartbeat-success` (path configurable
-via `HEARTBEAT_SUCCESS_FILE`). The runner writes the current Unix timestamp
+via `HEARTBEAT_SUCCESS_FILE_OVERRIDE`). The runner writes the current Unix timestamp
 there after either (a) a confirmed heartbeat transaction with a successful
 webhook POST, OR (b) the receipt-timeout recovery path when on-chain
 `nextHeartbeatAtTs` is observed to have advanced (no confirmed receipt, no

--- a/agents/heartbeat/README.md
+++ b/agents/heartbeat/README.md
@@ -50,10 +50,15 @@ compose `anvil-fork` service and viem's `baseSepolia` chain config.
 
 ## Healthcheck
 
-The compose healthcheck reads `/tmp/last-heartbeat-success`. The runner writes
-the current Unix timestamp there after a confirmed heartbeat transaction and
-webhook attempt. A timestamp younger than `HEARTBEAT_HEALTH_THRESHOLD_S` seconds
-means the heartbeat caller is making progress.
+The compose healthcheck reads `/tmp/last-heartbeat-success` (path configurable
+via `HEARTBEAT_SUCCESS_FILE`). The runner writes the current Unix timestamp
+there after either (a) a confirmed heartbeat transaction with a successful
+webhook POST, OR (b) the receipt-timeout recovery path when on-chain
+`nextHeartbeatAtTs` is observed to have advanced (no confirmed receipt, no
+webhook POST). The marker indicates the scheduler is making forward progress,
+NOT that the most recent transaction was confirmed end-to-end. A timestamp
+younger than `HEARTBEAT_HEALTH_THRESHOLD_S` seconds means the heartbeat caller
+is making progress.
 
 Keep `HEARTBEAT_HEALTH_THRESHOLD_S` wider than the on-chain
 `heartbeatIntervalSeconds()` cadence plus restart/RPC slack. If the owner widens

--- a/agents/heartbeat/entrypoint.sh
+++ b/agents/heartbeat/entrypoint.sh
@@ -40,7 +40,21 @@ fi
 
 if [ -n "${WEBHOOK_SHARED_SECRET_FILE:-}" ]; then
   [ -f "$WEBHOOK_SHARED_SECRET_FILE" ] || fail "WEBHOOK_SHARED_SECRET_FILE does not exist: $WEBHOOK_SHARED_SECRET_FILE"
+  # Read secret. Command substitution already strips trailing newlines, but a
+  # paste-error could leave trailing spaces/tabs or embedded newlines; either
+  # would corrupt the Authorization header. Trim trailing whitespace, then
+  # reject any remaining embedded newlines outright.
   WEBHOOK_SHARED_SECRET="$(cat "$WEBHOOK_SHARED_SECRET_FILE")"
+  WEBHOOK_SHARED_SECRET="$(printf '%s' "$WEBHOOK_SHARED_SECRET" | sed 's/[[:space:]]*$//')"
+  # Detect embedded newlines: compare raw byte count to single-line byte count
+  # (command substitution would strip a newline literal in a `case` pattern).
+  _secret_raw_bytes="$(printf '%s' "$WEBHOOK_SHARED_SECRET" | wc -c | tr -d '[:space:]')"
+  _secret_first_line_bytes="$(printf '%s' "$WEBHOOK_SHARED_SECRET" | head -n 1 | wc -c | tr -d '[:space:]')"
+  if [ "$_secret_raw_bytes" != "$_secret_first_line_bytes" ]; then
+    unset _secret_raw_bytes _secret_first_line_bytes
+    fail "WEBHOOK_SHARED_SECRET_FILE contains embedded newlines; secret must be a single line: $WEBHOOK_SHARED_SECRET_FILE"
+  fi
+  unset _secret_raw_bytes _secret_first_line_bytes
   [ -n "$WEBHOOK_SHARED_SECRET" ] || fail "WEBHOOK_SHARED_SECRET_FILE is empty: $WEBHOOK_SHARED_SECRET_FILE"
   export WEBHOOK_SHARED_SECRET
 fi

--- a/agents/heartbeat/entrypoint.sh
+++ b/agents/heartbeat/entrypoint.sh
@@ -55,6 +55,17 @@ if [ -n "${WEBHOOK_SHARED_SECRET_FILE:-}" ]; then
     fail "WEBHOOK_SHARED_SECRET_FILE contains embedded newlines; secret must be a single line: $WEBHOOK_SHARED_SECRET_FILE"
   fi
   unset _secret_raw_bytes _secret_first_line_bytes
+  # head -n 1 only splits on LF, so an embedded CR would slip through the check
+  # above and corrupt the Authorization header. Reject CR explicitly via a
+  # literal-CR pattern (BusyBox ash does not support $'\r').
+  _cr="$(printf '\r')"
+  case "$WEBHOOK_SHARED_SECRET" in
+    *"$_cr"*)
+      unset _cr
+      fail "WEBHOOK_SHARED_SECRET_FILE contains an embedded carriage return; secret must be a single line without CR or LF: $WEBHOOK_SHARED_SECRET_FILE"
+      ;;
+  esac
+  unset _cr
   [ -n "$WEBHOOK_SHARED_SECRET" ] || fail "WEBHOOK_SHARED_SECRET_FILE is empty: $WEBHOOK_SHARED_SECRET_FILE"
   export WEBHOOK_SHARED_SECRET
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,9 +177,11 @@ services:
       # — no cross-env fallback). Entrypoint picks based on CHAIN_NETWORK and
       # aborts if the selected URL is empty.
       DEV_RPC_URL: ${DEV_RPC_URL:-}
-      # PROD_RPC_URL reuses RPC_URL_PRIMARY per .env.template — fail-loud on
-      # missing instead of silently empty (the heartbeat entrypoint aborts
-      # anyway, but the compose-level error is faster + clearer).
+      # PROD_RPC_URL reuses RPC_URL_PRIMARY per .env.template. Empty string
+      # passes through compose-parse; the heartbeat entrypoint fails loudly
+      # at container start if the selected RPC URL is empty (entrypoint.sh:30),
+      # so missing values surface at `docker compose up`, not earlier at
+      # `docker compose config`.
       PROD_RPC_URL: ${RPC_URL_PRIMARY:-}
       RUNNER_PRIVATE_KEY: ${RUNNER_PRIVATE_KEY:?RUNNER_PRIVATE_KEY required (dedicated heartbeat wallet)}
       INDEXER_SECRET: ${INDEXER_SECRET:?INDEXER_SECRET required for runnerStatus writes}


### PR DESCRIPTION
## Summary

Three small follow-up fixes addressing cloud-review findings from the post-merge audit on PR #525 (heartbeat containerization). All three are low-severity polish — none were merge blockers.

## Fixes

| # | Severity | File | Issue |
|---|----------|------|-------|
| 1 | MED | agents/heartbeat/README.md | Success-marker accuracy: README claimed only post-confirmed-tx, reality is also receipt-timeout recovery |
| 2 | LOW | docker-compose.yml | Misleading fail-loud comment on RPC_URL_PRIMARY (fail-loud is at entrypoint, not compose-parse) |
| 3 | LOW | agents/heartbeat/entrypoint.sh | WEBHOOK_SHARED_SECRET trim + reject embedded newlines |

## Validation

- `shellcheck -s sh agents/heartbeat/entrypoint.sh` — clean
- `docker compose -f docker-compose.yml config --quiet` — clean
- Local 4-case unit test of the trim/newline-detect logic (single-line, newline-terminated, trailing-spaces, embedded-newline) all behave as designed

## Fix 3 implementation note

Brief suggested bash-specific syntax (`${var%pattern}`, `[[ var == *$'\n'* ]]`) but the entrypoint is `#!/bin/sh` running on Alpine BusyBox ash. Switched to POSIX-compatible approach: `sed 's/[[:space:]]*$//'` for trim, byte-count comparison (`wc -c` raw vs `head -n 1 | wc -c`) for embedded-newline detection. Command-substitution-strips-trailing-newline meant a `case "$secret" in *"$(printf '\n')"*` pattern would have matched everything; byte-count comparison sidesteps that quoting hazard.

## Skipped this PR (filed as separate issues)

- Finding 3 — `writeHeartbeatSuccessFile` extraction refactor (out-of-scope)
- Finding 5 — `CONVEX_WEBHOOK_URL` contract alignment (Liam-input-needed decision)

Source: `~/claudes-world/tmp/20260521-pr525-pr526-cloud-review-audit.md`