### PR TITLE
feat(web): URL scheme rename — cockpit → root, map → /map explicit (#354)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           # build.gradle.kts now refuses to fall back to a hardcoded URL —
           # promote these to actual repo secrets when prod URLs change.
-          CLAN_WORLD_MAP_URL: ${{ secrets.CLAN_WORLD_MAP_URL || 'https://app.clan-world.com' }}
+          CLAN_WORLD_MAP_URL: ${{ secrets.CLAN_WORLD_MAP_URL || 'https://app.clan-world.com/map' }}
           CLAN_WORLD_TERMINAL_BASE_URL: ${{ secrets.CLAN_WORLD_TERMINAL_BASE_URL || 'https://cockpit.clan-world.com' }}
           CLAN_WORLD_CONVEX_URL: ${{ secrets.CLAN_WORLD_CONVEX_URL || 'https://valuable-kudu-985.convex.cloud' }}
           CLAN_WORLD_VERSION_NAME: ${{ steps.release.outputs.version_name }}

--- a/apps/clan-world-mobile/README.md
+++ b/apps/clan-world-mobile/README.md
@@ -39,7 +39,7 @@ The full reasoning is in `/home/claude/.claude/plans/my-purpose-here-is-delightf
 # From the worktree root:
 cd apps/clan-world-mobile
 ANDROID_HOME=/opt/android-sdk \
-  CLAN_WORLD_MAP_URL=https://app.clan-world.com \
+  CLAN_WORLD_MAP_URL=https://app.clan-world.com/map \
   CLAN_WORLD_TERMINAL_BASE_URL=https://cockpit.clan-world.com \
   CLAN_WORLD_VERSION_NAME=2.3.3 \
   CLAN_WORLD_VERSION_CODE=2003003 \

--- a/apps/clan-world-mobile/app/build.gradle.kts
+++ b/apps/clan-world-mobile/app/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 // APKs — every project-specific URL should be set explicitly per environment.
 //
 // Local devs can keep these in `~/.gradle/gradle.properties`:
-//   clanWorldMapUrl=https://app.clan-world.com
+//   clanWorldMapUrl=https://app.clan-world.com/map
 //   clanWorldTerminalBaseUrl=https://cockpit.clan-world.com
 //   clanWorldConvexUrl=https://valuable-kudu-985.convex.cloud
 // ─────────────────────────────────────────────────────────────────────────

--- a/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/MapWebView.kt
+++ b/apps/clan-world-mobile/app/src/main/java/world/clan/app/cockpit/MapWebView.kt
@@ -14,12 +14,12 @@ import world.clan.app.BuildConfig
 import world.clan.app.ui.theme.CockpitTokens
 
 /**
- * Loads the full web cockpit route configured by [BuildConfig.MAP_URL]
- * (defaults to https://app.clan-world.com). After issue #326 unified the
- * map across `/`, `/cockpit`, and the Android webview, the root route
- * mounts the same canonical `WorldMap` surface as `/cockpit`, so any URL
- * served by the production web app surfaces the full world map plus
- * shared overlays (version badge, ghost layer, HUD, event ticker).
+ * Loads the canonical world-map surface configured by [BuildConfig.MAP_URL].
+ *
+ * After issue #354 the web cockpit lives at `/`, while the raw map surface
+ * remains at `/map`. Android should point MAP_URL at that explicit map route
+ * (for example, https://app.clan-world.com/map) so the native cockpit's map
+ * region does not accidentally load the full web cockpit chrome.
  *
  * JS + DOM storage are required by the Pixi map; everything else is left
  * at WebView defaults.

--- a/apps/landing/src/pages/LandingPage.tsx
+++ b/apps/landing/src/pages/LandingPage.tsx
@@ -165,7 +165,7 @@ export default function LandingPage() {
             <div className="hook-game">
               <div className="hook-game-frame">
                 <iframe
-                  src="https://app.clan-world.com/"
+                  src="https://app.clan-world.com/map"
                   title="Clan World — live world on Base Sepolia"
                   loading="lazy"
                   allow="fullscreen"

--- a/apps/landing/src/pages/LegacyLandingPage.tsx
+++ b/apps/landing/src/pages/LegacyLandingPage.tsx
@@ -165,7 +165,7 @@ export default function LegacyLandingPage() {
             <div className="hook-game">
               <div className="hook-game-frame">
                 <iframe
-                  src="https://app.clan-world.com/"
+                  src="https://app.clan-world.com/map"
                   title="Clan World — live world on Base Sepolia"
                   loading="lazy"
                   allow="fullscreen"

--- a/apps/mobile/src/screens/CockpitScreen.tsx
+++ b/apps/mobile/src/screens/CockpitScreen.tsx
@@ -7,8 +7,8 @@ import { colors, fonts } from '../theme';
 import { BridgeScreen } from './BridgeScreen';
 
 const COCKPIT_URL =
-  process.env.EXPO_PUBLIC_COCKPIT_URL ?? 'https://app-dev.clan-world.com/cockpit';
-  // process.env.EXPO_PUBLIC_COCKPIT_URL ?? 'https://demo.clan-world.com/cockpit';
+  process.env.EXPO_PUBLIC_COCKPIT_URL ?? 'https://app-dev.clan-world.com/';
+  // process.env.EXPO_PUBLIC_COCKPIT_URL ?? 'https://demo.clan-world.com/';
 
 type Props = {
   inft: Inft;

--- a/apps/web/public/manifest.webmanifest
+++ b/apps/web/public/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "Clan World",
   "short_name": "Clan World",
   "description": "Onchain realm where AI Elders command clans on Base.",
-  "start_url": "/cockpit",
+  "start_url": "/",
   "scope": "/",
   "display": "standalone",
   "orientation": "any",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -69,13 +69,26 @@ export { DEMO_MODE };
 /**
  * Top-level route decision. Lightweight path-based routing avoids a router
  * dep for a single side route. Reading window.location once at render is
- * fine here — the cockpit is a standalone judge view, not a SPA tab inside
- * the main app, so we never need to navigate between them client-side.
+ * fine here — the cockpit is the default surface and the world map lives
+ * on `/map`, so we never need client-side navigation between them.
  */
-function isCockpitRoute(): boolean {
+function isMapRoute(): boolean {
   return (
     typeof window !== 'undefined' &&
-    window.location.pathname.startsWith('/cockpit')
+    (window.location.pathname === '/map' ||
+      window.location.pathname.startsWith('/map/'))
+  );
+}
+
+function isRootRoute(): boolean {
+  return typeof window !== 'undefined' && window.location.pathname === '/';
+}
+
+function isLegacyCockpitRoute(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    (window.location.pathname === '/cockpit' ||
+      window.location.pathname.startsWith('/cockpit/'))
   );
 }
 
@@ -101,12 +114,21 @@ function parseAgentRoute(): number | null {
 }
 
 export function App() {
-  if (isCockpitRoute()) {
+  if (isLegacyCockpitRoute()) {
+    if (typeof window !== 'undefined') {
+      window.location.replace(`/${window.location.search}${window.location.hash}`);
+    }
+    return null;
+  }
+  if (isRootRoute()) {
     return (
       <CockpitErrorBoundary>
         <Cockpit />
       </CockpitErrorBoundary>
     );
+  }
+  if (isMapRoute()) {
+    return <MainApp />;
   }
   const agentId = parseAgentRoute();
   if (agentId !== null) {

--- a/apps/web/src/components/WorldMapEmbed.tsx
+++ b/apps/web/src/components/WorldMapEmbed.tsx
@@ -3,7 +3,7 @@ import { WorldMapBoundary } from './cockpit/shared/WorldMapBoundary';
 
 /**
  * Sanctioned route-level mount for the canonical world map surface.
- * Use this for /, /cockpit, and Android webview-backed cockpit routes.
+ * Use this for the explicit `/map` route and cockpit map cells.
  */
 export function WorldMapEmbed() {
   return (

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -40,8 +40,9 @@ const Provider = ConvexProvider as React.ComponentType<{
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 
-// `/cockpit` is a standalone judge view — always render it, even if Convex
-// env is missing. The Phase-A panels are pure placeholders; the embedded
+// The cockpit (now at `/`), `/map`, `/cockpit`, `/owner`, and `/agents/:id`
+// are standalone surfaces — always render them, even if Convex env is
+// missing. The Phase-A panels are pure placeholders; the embedded
 // WorldMap consumes Convex via useQuery which returns undefined when no
 // data is available, so a stub client is enough to satisfy the provider.
 //
@@ -53,13 +54,18 @@ const root = ReactDOM.createRoot(document.getElementById('root')!);
 const pathname =
   typeof window !== 'undefined' ? window.location.pathname : '';
 // Match the actual route shapes defined in App.tsx:
-//   /cockpit          → isCockpitRoute (startsWith '/cockpit')
+//   /                 → Cockpit
+//   /map              → MainApp / WorldMap
+//   /cockpit          → legacy alias → redirect to /
 //   /owner            → isOwnerRoute   (startsWith '/owner')
 //   /agents/:digits   → parseAgentRoute (regex /^\/agents\/(\d+)\/?$/)
 // Bare `/agents` is NOT a real route in App.tsx — it falls through to
 // MainApp (the WorldMap), which DOES need Convex. So `/agents` must only
 // be treated as standalone when followed by a digit segment.
 const isStandalonePath =
+  pathname === '/' ||
+  pathname === '/map' ||
+  pathname.startsWith('/map/') ||
   pathname === '/cockpit' ||
   pathname.startsWith('/cockpit/') ||
   pathname === '/owner' ||

--- a/apps/web/tests/e2e/00-smoke.spec.ts
+++ b/apps/web/tests/e2e/00-smoke.spec.ts
@@ -39,7 +39,7 @@ test('web app loads with no console errors', async ({ page }) => {
     pageErrors.push({ message: err.message, stack: err.stack });
   });
 
-  await page.goto('/');
+  await page.goto('/map');
 
   // Wait for canvas to mount — WorldMap renders one.
   // 10s gives PIXI v8 + Convex client time to initialize.

--- a/apps/web/tests/e2e/02-demo-mode.spec.ts
+++ b/apps/web/tests/e2e/02-demo-mode.spec.ts
@@ -40,7 +40,7 @@ test.describe('DEMO_MODE flag — mock clans (demo mode ON)', () => {
   );
 
   test('demo mode ON: mock clan names visible in scoreboard panel', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/map');
 
     // Scoreboard pulse panel is rendered only in DEMO_MODE with scoreboardClans > 0.
     // "IG" is the Iron Guard initials rendered in the compact scoreboard.
@@ -59,7 +59,7 @@ test.describe('DEMO_MODE flag — empty world (demo mode OFF)', () => {
   );
 
   test('demo mode OFF: "no chain data yet" placeholder visible', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/map');
 
     // Placeholder overlay is rendered when DEMO_MODE=false and no live snapshot clans.
     const placeholder = page.getByTestId('no-chain-data-placeholder');

--- a/apps/web/tests/e2e/04-cockpit-shell.spec.ts
+++ b/apps/web/tests/e2e/04-cockpit-shell.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test';
  * Phase A — Cockpit layout shell.
  *
  * Verifies the structural skeleton:
- *   - /cockpit route renders without error
+ *   - / route renders the cockpit without error
  *   - 3-col 2-row grid is mounted
  *   - all 4 mini-cockpits visible
  *   - world map cell visible
@@ -39,7 +39,7 @@ test.describe('cockpit shell (Phase A)', () => {
   test('renders 3-col 2-row layout with 4 mini-cockpits + world map', async ({
     page,
   }, testInfo) => {
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     // No error boundary crash.
     const errorBoundary = page.locator('[data-testid="error-boundary"]');
@@ -117,7 +117,7 @@ test.describe('cockpit shell (Phase A)', () => {
       });
     });
 
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     const pill = page.locator('[data-testid="cockpit-connection-pill"]');
     await expect(pill).toBeVisible();
@@ -170,7 +170,7 @@ test.describe('cockpit shell (Phase A)', () => {
       });
     });
 
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     await expect
       .poll(() => documentLoads, { timeout: 8_000 })
@@ -198,7 +198,7 @@ test.describe('cockpit shell (Phase A)', () => {
       });
     });
 
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     await expect(
       page.locator('[data-testid="mini-cockpit-1-content-terminal"]'),

--- a/apps/web/tests/e2e/06-canvas-warmth.spec.ts
+++ b/apps/web/tests/e2e/06-canvas-warmth.spec.ts
@@ -84,9 +84,9 @@ const FOUR_CLAN_PAYLOAD = {
 async function clearSnapshotCache(page: Page): Promise<void> {
   // localStorage is per-origin. We must navigate to the origin first so
   // `page.evaluate` runs with a valid storage context (about:blank has none).
-  // Empty navigation to `/` is the cheapest way to bind the page to the origin
-  // — the page errors are ignored; we only care about establishing storage.
-  await page.goto('/');
+  // Navigate to `/map` to bind the page to the origin without mounting the
+  // root cockpit.
+  await page.goto('/map');
   await page.evaluate(() => {
     const toRemove: string[] = [];
     for (let i = 0; i < localStorage.length; i++) {
@@ -131,7 +131,7 @@ test.describe('canvas warmth state machine (DEMO_MODE=false)', () => {
     // Load fresh — useCachedSnapshot.useState() returns undefined; liveSnapshot
     // also stays undefined (no real Convex backend in e2e); hasClans=false →
     // grace timer arms for 5s.
-    await page.goto('/');
+    await page.goto('/map');
 
     // At t=0 (well within grace) the placeholder MUST NOT be visible. We use
     // a small timeout to ride past any sync mount latency without giving the
@@ -155,7 +155,7 @@ test.describe('canvas warmth state machine (DEMO_MODE=false)', () => {
       ts: Date.now(),
     });
 
-    await page.goto('/');
+    await page.goto('/map');
 
     // Ghost must be in the DOM and visible at first paint — primed cache
     // hydrates synchronously in useState initializer + useMemo, no useEffect
@@ -240,7 +240,7 @@ test.describe('canvas warmth state machine (DEMO_MODE=false)', () => {
     // page.waitForTimeout(4000) + a single post-wait assert would let a
     // mid-window flash slip past (it could appear at t=2s then disappear
     // before t=4s). We sample 8 times across the window to catch a flash.
-    await page.goto('/');
+    await page.goto('/map');
 
     // First, confirm we got past mount with a primed cache by checking the
     // ghost is present AND rendering cache-derived per-clan content. The

--- a/apps/web/tests/e2e/07-cockpit-worldmap-unified.spec.ts
+++ b/apps/web/tests/e2e/07-cockpit-worldmap-unified.spec.ts
@@ -15,25 +15,25 @@ test.describe('unified world map routes', () => {
     await stubTerminalIframes(page);
   });
 
-  test('root and cockpit expose the same version badge text', async ({ page }) => {
-    await page.goto('/');
-    const rootBadge = page.getByTestId('version-badge');
-    await expect(rootBadge).toBeVisible();
+  test('/map and root cockpit expose the same version badge text', async ({ page }) => {
+    await page.goto('/map');
+    const mapBadge = page.getByTestId('version-badge');
+    await expect(mapBadge).toBeVisible();
     await expect(page.locator('canvas')).toHaveCount(1, { timeout: 15_000 });
-    const rootVersion = (await rootBadge.textContent())?.trim();
-    expect(rootVersion).toBeTruthy();
+    const mapVersion = (await mapBadge.textContent())?.trim();
+    expect(mapVersion).toBeTruthy();
 
-    await page.goto('/cockpit');
+    await page.goto('/');
     const cockpitBadge = page.getByTestId('version-badge');
     await expect(cockpitBadge).toBeVisible();
     await expect(page.locator('canvas')).toHaveCount(1, { timeout: 15_000 });
-    await expect(cockpitBadge).toHaveText(rootVersion ?? '');
+    await expect(cockpitBadge).toHaveText(mapVersion ?? '');
   });
 
   test('desktop cockpit mounts one canonical world map', async ({ page }, testInfo) => {
     test.skip(testInfo.project.name.includes('mobile'), 'desktop-only cockpit layout check');
 
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     const mapCell = page.getByTestId('cockpit-worldmap');
     await expect(page.getByTestId('cockpit-root')).toBeVisible();
@@ -47,7 +47,7 @@ test.describe('unified world map routes', () => {
   test('mobile cockpit keeps one map canvas through collapse', async ({ page }, testInfo) => {
     test.skip(!testInfo.project.name.includes('mobile'), 'mobile-only cockpit layout check');
 
-    await page.goto('/cockpit');
+    await page.goto('/');
 
     const layout = page.getByTestId('cockpit-mobile-layout');
     const mapRegion = page.getByTestId('cockpit-mobile-worldmap-region');
@@ -62,5 +62,11 @@ test.describe('unified world map routes', () => {
     await toggle.click();
     await expect(layout).not.toHaveAttribute('data-collapsed', before ?? '');
     await expect(mapRegion.locator('canvas')).toHaveCount(1);
+  });
+
+  test('legacy /cockpit redirects to root cockpit', async ({ page }) => {
+    await page.goto('/cockpit');
+    await expect.poll(() => new URL(page.url()).pathname, { timeout: 5_000 }).toBe('/');
+    await expect(page.getByTestId('cockpit-root')).toBeVisible();
   });
 });

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "redirects": [
+    { "source": "/cockpit", "destination": "/", "permanent": true },
+    { "source": "/cockpit/:path*", "destination": "/", "permanent": true }
+  ],
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }
   ]


### PR DESCRIPTION
## Summary

Re-implementation of PR #418 work on current dev HEAD via codex 5-stage. Avoids the stale `recover/issue-354-url-rename` stack noise (63 files vs this PR's focused 14).

## Changes

- `/` now renders Cockpit (was `/cockpit`)
- `/map*` now renders MainApp explicitly (was implicit via fallthrough)
- `/cockpit` + `/cockpit/*` → permanent 308 redirect to `/` (Vercel-side + client fallback for local-dev)
- **Unknown routes → MainApp** (preserves pre-PR fallthrough behavior — caught by codex Stage 3 critique as a SettleLatch-class drift risk)
- PWA manifest `start_url` → `/`
- E2E tests updated: cockpit shell tests use `/`, map/canvas tests use `/map`, legacy `/cockpit` redirect test added
- Expo mobile cockpit fallback `EXPO_PUBLIC_COCKPIT_URL` → root
- Native Android: `CLAN_WORLD_MAP_URL` docs/examples → `/map`

## Skipped per scope

- `TerminalTab.tsx` + `useConnectionStatus.ts` (dockerized elder-N URL cutover deferred to Bundle 3)
- #398 e2e stub fix (terminal stub URL change `cockpit.clan-world.com/elder-*-tty` → `app.clan-world.com/elder-*` — terminal/Caddy-adjacent, not URL rename; deferred to Bundle 3)

## Tactical decisions (orch-made, Liam can correct)

- `/cockpit` → `/` redirect type: **permanent 308** (community continuity + Liam muscle memory)
- CDN: Vercel-side redirect only + client fallback; no Cloudflare changes

## Test plan

- [x] `pnpm --filter @clan-world/web typecheck` PASS
- [x] `pnpm --filter @clan-world/web build` PASS (with `VITE_CONVEX_URL` set)
- [ ] Playwright on CI (blocked in codex sandbox — port-bind EPERM)
- [ ] Local 3-tier swarm
- [ ] Merge to dev-containerize-agents after swarm clean

## Refs

- Closes #354
- Replaces #418 (stale recover branch, will not merge that one)
- Codex 5-stage session `019e4d7d-bf32-70b2-8d87-b7f24ecc6382` (Stage 3 critique caught the fallthrough regression)