### PR TITLE
fix(agents): land PR #533 R2+R3 stranded swarm fixes (closes #535)

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -85,9 +85,13 @@ ENV HOME=/home/elder
 ENV CLAUDE_CONFIG_DIR=/home/elder/.claude
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# Healthcheck — tmux daemon alive AND ttyd accepting connections on 7681.
+# Healthcheck — v1 elder claude process alive. Tmux + ttyd are installed in the
+# image but NOT started by entrypoint.sh / run.sh in v1 (those are #353 Phase
+# 1.9 supervisor scope). The compose-level healthcheck on each elder-N service
+# block matches this image-level default; when #353 lands, both will tighten
+# to also verify the supervisor process + ttyd port 7681 .
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD pgrep -f tmux >/dev/null && curl -sf http://localhost:7681 >/dev/null || exit 1
+    CMD pgrep -f 'claude --' >/dev/null || exit 1
 
 # tini = PID 1; reaps zombies and forwards signals to entrypoint.sh, which
 # applies the firewall and execs run.sh from the bind-mounted shared tree.

--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -90,8 +90,12 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # 1.9 supervisor scope). The compose-level healthcheck on each elder-N service
 # block matches this image-level default; when #353 lands, both will tighten
 # to also verify the supervisor process + ttyd port 7681 .
+#
+# `pgrep claude` (without -f) matches by comm name only, so the healthcheck's
+# own shell command line doesn't self-match — `pgrep -f 'claude --'` would
+# false-positive because the pattern appears in /bin/sh -c "pgrep -f 'claude --'..."
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD pgrep -f 'claude --' >/dev/null || exit 1
+    CMD pgrep -x claude >/dev/null || exit 1
 
 # tini = PID 1; reaps zombies and forwards signals to entrypoint.sh, which
 # applies the firewall and execs run.sh from the bind-mounted shared tree.

--- a/agents/entrypoint.sh
+++ b/agents/entrypoint.sh
@@ -15,24 +15,19 @@ set -euo pipefail
 # autonomous elders MUST run with egress restrictions. The operator can
 # explicitly opt out of the firewall (for missing-cap local debugging or for
 # dev containers without iptables modules in the kernel) by setting
-# `ALLOW_UNRESTRICTED_EGRESS=1` in the container environment.
-if [[ -x /opt/clan-world/init-firewall.sh ]]; then
+# `ALLOW_UNRESTRICTED_EGRESS=1` in the container environment. The override is
+# checked BEFORE invoking the firewall script — so debug operators don't get
+# the firewall applied even when iptables would have succeeded.
+if [[ "${ALLOW_UNRESTRICTED_EGRESS:-0}" = "1" ]]; then
+  echo "[entrypoint] WARNING: ALLOW_UNRESTRICTED_EGRESS=1 — skipping init-firewall.sh entirely. Container will have UNRESTRICTED egress. DO NOT use in production." >&2
+elif [[ -x /opt/clan-world/init-firewall.sh ]]; then
   if ! sudo /opt/clan-world/init-firewall.sh; then
-    if [[ "${ALLOW_UNRESTRICTED_EGRESS:-0}" = "1" ]]; then
-      echo "[entrypoint] WARNING: init-firewall.sh failed but ALLOW_UNRESTRICTED_EGRESS=1 — continuing without egress lockdown. DO NOT use in production." >&2
-    else
-      echo "[entrypoint] FATAL: init-firewall.sh failed (likely missing CAP_NET_ADMIN). Set ALLOW_UNRESTRICTED_EGRESS=1 to override for local debugging." >&2
-      exit 3
-    fi
-  fi
-else
-  # No firewall script available at all — same fail-closed posture.
-  if [[ "${ALLOW_UNRESTRICTED_EGRESS:-0}" = "1" ]]; then
-    echo "[entrypoint] WARNING: /opt/clan-world/init-firewall.sh missing but ALLOW_UNRESTRICTED_EGRESS=1 — continuing without egress lockdown." >&2
-  else
-    echo "[entrypoint] FATAL: /opt/clan-world/init-firewall.sh missing and ALLOW_UNRESTRICTED_EGRESS not set. Image misbuild?" >&2
+    echo "[entrypoint] FATAL: init-firewall.sh failed (likely missing CAP_NET_ADMIN). Set ALLOW_UNRESTRICTED_EGRESS=1 to override for local debugging." >&2
     exit 3
   fi
+else
+  echo "[entrypoint] FATAL: /opt/clan-world/init-firewall.sh missing and ALLOW_UNRESTRICTED_EGRESS not set. Image misbuild?" >&2
+  exit 3
 fi
 
 # Hand off to run.sh from the shared bind-mount. run.sh is owned by Phase 1.7

--- a/agents/shared/run.sh
+++ b/agents/shared/run.sh
@@ -58,20 +58,49 @@ fi
 export HOME=/home/elder
 export CLAUDE_CONFIG_DIR=/home/elder/.claude
 
-# --- bootstrap shared symlinks --------------------------------------------
+# --- bootstrap shared CC harness state ------------------------------------
 
-# Shared CC harness state (settings.json + CLAUDE.md + skills/) is bind-mounted
-# R/O at /opt/clan-world/shared/home-claude/. We symlink it into the per-elder
-# /home/elder/.claude/ R/W volume so claude picks it up at the canonical path.
-# Symlinks are re-created on every start (idempotent) so host-side edits take
-# effect on container restart.
+# Shared CC harness state lives at /opt/clan-world/shared/home-claude/ (R/O
+# bind-mount). We bootstrap it into the per-elder /home/elder/.claude/ R/W
+# named volume in two modes:
+#
+#   - settings.json + CLAUDE.md → SYMLINK to the bind-mounted source. Edits on
+#     the host are picked up at the next container restart. Writes are denied
+#     by the R/O source filesystem (defense-in-depth on top of settings.json's
+#     own deny rules for Write(CLAUDE.md) / Edit(settings.json)).
+#
+#   - skills/ → COPY with no-clobber on first boot. Shared base skills land in
+#     /home/elder/.claude/skills/ as real files (R/W) so the agent can add
+#     per-elder runtime skills alongside the shared base, per the Phase 1.7
+#     contract documented in agents/shared/home-claude/skills/README.md
+#     ("Per-elder runtime skills authored by the agent itself live in
+#     /home/elder/.claude/skills/ (R/W)"). On subsequent boots, no-clobber
+#     preserves agent-authored skills; updated shared skills can be picked up
+#     by `make wipe-elder-N` clearing the named volume.
 SHARED_HOME=/opt/clan-world/shared/home-claude
 if [ -d "$SHARED_HOME" ]; then
   mkdir -p "$CLAUDE_CONFIG_DIR"
-  for f in settings.json CLAUDE.md skills; do
-    # ln -sfn replaces existing symlink or empty dir target atomically.
-    ln -sfn "$SHARED_HOME/$f" "$CLAUDE_CONFIG_DIR/$f"
+
+  # File-level symlinks for settings.json + CLAUDE.md. Use `ln -sfn` which is
+  # safe against an existing symlink, but `ln` cannot replace an existing real
+  # file or directory — so we explicitly `rm -f` first (file-only; will refuse
+  # to remove a directory, surfacing the misconfig if one exists).
+  for f in settings.json CLAUDE.md; do
+    target="$CLAUDE_CONFIG_DIR/$f"
+    if [ -e "$target" ] && [ ! -L "$target" ]; then
+      # Pre-existing real file (operator override?) — preserve it, log warning.
+      echo "[run.sh] WARNING: $target exists as a real file, not symlinking to shared. Operator override or stale state from earlier image version." >&2
+      continue
+    fi
+    rm -f "$target"
+    ln -s "$SHARED_HOME/$f" "$target"
   done
+
+  # Skills: copy with no-clobber so per-elder runtime additions coexist with
+  # the shared base. `cp -rn` skips existing targets, so on container restart
+  # we don't trample agent-authored skills.
+  mkdir -p "$CLAUDE_CONFIG_DIR/skills"
+  cp -rn "$SHARED_HOME/skills/." "$CLAUDE_CONFIG_DIR/skills/"
 else
   echo "[run.sh] WARNING: $SHARED_HOME not found — shared config not bind-mounted? Container will run without shared CLAUDE.md/settings.json/skills." >&2
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,7 +292,7 @@ services:
       # alive. Tmux + ttyd are installed in the image but not started in v1
       # (no supervisor). #353 (Phase 1.9 supervisor) will start tmux+ttyd and
       # tighten this to also verify the ttyd web port + supervisor process.
-      test: ["CMD-SHELL", "pgrep -f 'claude --' >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -316,7 +316,7 @@ services:
       - elder-2-home:/home/elder/.claude
       - elder-2-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'claude --' >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -340,7 +340,7 @@ services:
       - elder-3-home:/home/elder/.claude
       - elder-3-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'claude --' >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -364,7 +364,7 @@ services:
       - elder-4-home:/home/elder/.claude
       - elder-4-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'claude --' >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

PR #533 was merged at R1 (`dc62e8f`) at 03:11:41Z while a parallel orchestrator session was still iterating swarm rounds. The R2 (`0cd554c`) + R3 (`36c5fd5`) fix-round commits landed on the now-closed feature branch and never reached `dev-containerize-agents`. This PR cherry-picks them on top of dev HEAD.

Closes #535.

## Cherry-picked commits

- `cdbc6e8` — R2 fix-round (symlink-vs-copy, firewall override semantics, image healthcheck)
- `8f7d970` — R3 fix-round (`pgrep -f` self-match false-positive)

## Verified-real findings addressed

**R2 [MED, codex+gemini converged]** `agents/shared/run.sh` — `ln -sfn` of `skills/` to R/O bind-mount created `skills/skills` nested symlink when target dir existed, AND broke Phase 1.7 R/W per-elder skills contract. Split bootstrap:
- `settings.json` + `CLAUDE.md` → SYMLINK with `rm -f` first
- `skills/` → COPY with `cp -rn` (no-clobber preserves agent-authored skills)

**R2 [MED, codex]** `agents/entrypoint.sh` — `ALLOW_UNRESTRICTED_EGRESS=1` only applied AFTER firewall failure. Now checked BEFORE invoking script (debug operator with NET_ADMIN no longer gets firewall applied anyway).

**R2 [LOW, codex]** `agents/Dockerfile:88` image-level HEALTHCHECK aligned to compose-level (was still referencing tmux + ttyd:7681).

**R3 [MED, codex]** `pgrep -f 'claude --'` healthcheck self-matches its own shell command line — Docker executes via `/bin/sh -c "pgrep -f 'claude --' >/dev/null"` which contains the literal pattern. Dead elder reported healthy. Switched both Dockerfile + 4× compose elder-N healthchecks to `pgrep -x claude` (exact comm-name, no -f, no self-match risk). Reproduced + fix smoke-verified in fresh container (see commit body).

## Validation

- `pnpm --filter @clan-world/runner typecheck` — clean
- `pnpm --filter @clan-world/sdk typecheck` — clean
- `docker compose --profile dev -f docker-compose.yml config --quiet` — clean (with required env vars stubbed)
- Cherry-pick was clean (no conflicts) since dev-containerize-agents HEAD is the merge commit of the original branch base

## Test plan

- [ ] CI passes (chainclient-abi, contracts, typechain)
- [ ] Local 3-tier swarm review (R1 on this PR's HEAD)
- [ ] Verify the fixes are present in dev-containerize-agents after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)