### PR TITLE
fix(agents): R2+R3 swarm follow-up to merged #533 — symlinks, firewall override, healthcheck self-match

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -85,9 +85,13 @@ ENV HOME=/home/elder
 ENV CLAUDE_CONFIG_DIR=/home/elder/.claude
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# Healthcheck — tmux daemon alive AND ttyd accepting connections on 7681.
+# Healthcheck — v1 elder claude process alive. Tmux + ttyd are installed in the
+# image but NOT started by entrypoint.sh / run.sh in v1 (those are #353 Phase
+# 1.9 supervisor scope). The compose-level healthcheck on each elder-N service
+# block matches this image-level default; when #353 lands, both will tighten
+# to also verify the supervisor process + ttyd port 7681 .
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD pgrep -f tmux >/dev/null && curl -sf http://localhost:7681 >/dev/null || exit 1
+    CMD pgrep -f 'claude --' >/dev/null || exit 1
 
 # tini = PID 1; reaps zombies and forwards signals to entrypoint.sh, which
 # applies the firewall and execs run.sh from the bind-mounted shared tree.

--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -90,8 +90,12 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # 1.9 supervisor scope). The compose-level healthcheck on each elder-N service
 # block matches this image-level default; when #353 lands, both will tighten
 # to also verify the supervisor process + ttyd port 7681 .
+#
+# `pgrep claude` (without -f) matches by comm name only, so the healthcheck's
+# own shell command line doesn't self-match — `pgrep -f 'claude --'` would
+# false-positive because the pattern appears in /bin/sh -c "pgrep -f 'claude --'..."
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD pgrep -f 'claude --' >/dev/null || exit 1
+    CMD pgrep -x claude >/dev/null || exit 1
 
 # tini = PID 1; reaps zombies and forwards signals to entrypoint.sh, which
 # applies the firewall and execs run.sh from the bind-mounted shared tree.

--- a/agents/entrypoint.sh
+++ b/agents/entrypoint.sh
@@ -15,24 +15,19 @@ set -euo pipefail
 # autonomous elders MUST run with egress restrictions. The operator can
 # explicitly opt out of the firewall (for missing-cap local debugging or for
 # dev containers without iptables modules in the kernel) by setting
-# `ALLOW_UNRESTRICTED_EGRESS=1` in the container environment.
-if [[ -x /opt/clan-world/init-firewall.sh ]]; then
+# `ALLOW_UNRESTRICTED_EGRESS=1` in the container environment. The override is
+# checked BEFORE invoking the firewall script — so debug operators don't get
+# the firewall applied even when iptables would have succeeded.
+if [[ "${ALLOW_UNRESTRICTED_EGRESS:-0}" = "1" ]]; then
+  echo "[entrypoint] WARNING: ALLOW_UNRESTRICTED_EGRESS=1 — skipping init-firewall.sh entirely. Container will have UNRESTRICTED egress. DO NOT use in production." >&2
+elif [[ -x /opt/clan-world/init-firewall.sh ]]; then
   if ! sudo /opt/clan-world/init-firewall.sh; then
-    if [[ "${ALLOW_UNRESTRICTED_EGRESS:-0}" = "1" ]]; then
-      echo "[entrypoint] WARNING: init-firewall.sh failed but ALLOW_UNRESTRICTED_EGRESS=1 — continuing without egress lockdown. DO NOT use in production." >&2
-    else
-      echo "[entrypoint] FATAL: init-firewall.sh failed (likely missing CAP_NET_ADMIN). Set ALLOW_UNRESTRICTED_EGRESS=1 to override for local debugging." >&2
-      exit 3
-    fi
-  fi
-else
-  # No firewall script available at all — same fail-closed posture.
-  if [[ "${ALLOW_UNRESTRICTED_EGRESS:-0}" = "1" ]]; then
-    echo "[entrypoint] WARNING: /opt/clan-world/init-firewall.sh missing but ALLOW_UNRESTRICTED_EGRESS=1 — continuing without egress lockdown." >&2
-  else
-    echo "[entrypoint] FATAL: /opt/clan-world/init-firewall.sh missing and ALLOW_UNRESTRICTED_EGRESS not set. Image misbuild?" >&2
+    echo "[entrypoint] FATAL: init-firewall.sh failed (likely missing CAP_NET_ADMIN). Set ALLOW_UNRESTRICTED_EGRESS=1 to override for local debugging." >&2
     exit 3
   fi
+else
+  echo "[entrypoint] FATAL: /opt/clan-world/init-firewall.sh missing and ALLOW_UNRESTRICTED_EGRESS not set. Image misbuild?" >&2
+  exit 3
 fi
 
 # Hand off to run.sh from the shared bind-mount. run.sh is owned by Phase 1.7

--- a/agents/shared/run.sh
+++ b/agents/shared/run.sh
@@ -58,20 +58,49 @@ fi
 export HOME=/home/elder
 export CLAUDE_CONFIG_DIR=/home/elder/.claude
 
-# --- bootstrap shared symlinks --------------------------------------------
+# --- bootstrap shared CC harness state ------------------------------------
 
-# Shared CC harness state (settings.json + CLAUDE.md + skills/) is bind-mounted
-# R/O at /opt/clan-world/shared/home-claude/. We symlink it into the per-elder
-# /home/elder/.claude/ R/W volume so claude picks it up at the canonical path.
-# Symlinks are re-created on every start (idempotent) so host-side edits take
-# effect on container restart.
+# Shared CC harness state lives at /opt/clan-world/shared/home-claude/ (R/O
+# bind-mount). We bootstrap it into the per-elder /home/elder/.claude/ R/W
+# named volume in two modes:
+#
+#   - settings.json + CLAUDE.md → SYMLINK to the bind-mounted source. Edits on
+#     the host are picked up at the next container restart. Writes are denied
+#     by the R/O source filesystem (defense-in-depth on top of settings.json's
+#     own deny rules for Write(CLAUDE.md) / Edit(settings.json)).
+#
+#   - skills/ → COPY with no-clobber on first boot. Shared base skills land in
+#     /home/elder/.claude/skills/ as real files (R/W) so the agent can add
+#     per-elder runtime skills alongside the shared base, per the Phase 1.7
+#     contract documented in agents/shared/home-claude/skills/README.md
+#     ("Per-elder runtime skills authored by the agent itself live in
+#     /home/elder/.claude/skills/ (R/W)"). On subsequent boots, no-clobber
+#     preserves agent-authored skills; updated shared skills can be picked up
+#     by `make wipe-elder-N` clearing the named volume.
 SHARED_HOME=/opt/clan-world/shared/home-claude
 if [ -d "$SHARED_HOME" ]; then
   mkdir -p "$CLAUDE_CONFIG_DIR"
-  for f in settings.json CLAUDE.md skills; do
-    # ln -sfn replaces existing symlink or empty dir target atomically.
-    ln -sfn "$SHARED_HOME/$f" "$CLAUDE_CONFIG_DIR/$f"
+
+  # File-level symlinks for settings.json + CLAUDE.md. Use `ln -sfn` which is
+  # safe against an existing symlink, but `ln` cannot replace an existing real
+  # file or directory — so we explicitly `rm -f` first (file-only; will refuse
+  # to remove a directory, surfacing the misconfig if one exists).
+  for f in settings.json CLAUDE.md; do
+    target="$CLAUDE_CONFIG_DIR/$f"
+    if [ -e "$target" ] && [ ! -L "$target" ]; then
+      # Pre-existing real file (operator override?) — preserve it, log warning.
+      echo "[run.sh] WARNING: $target exists as a real file, not symlinking to shared. Operator override or stale state from earlier image version." >&2
+      continue
+    fi
+    rm -f "$target"
+    ln -s "$SHARED_HOME/$f" "$target"
   done
+
+  # Skills: copy with no-clobber so per-elder runtime additions coexist with
+  # the shared base. `cp -rn` skips existing targets, so on container restart
+  # we don't trample agent-authored skills.
+  mkdir -p "$CLAUDE_CONFIG_DIR/skills"
+  cp -rn "$SHARED_HOME/skills/." "$CLAUDE_CONFIG_DIR/skills/"
 else
   echo "[run.sh] WARNING: $SHARED_HOME not found — shared config not bind-mounted? Container will run without shared CLAUDE.md/settings.json/skills." >&2
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,7 +292,7 @@ services:
       # alive. Tmux + ttyd are installed in the image but not started in v1
       # (no supervisor). #353 (Phase 1.9 supervisor) will start tmux+ttyd and
       # tighten this to also verify the ttyd web port + supervisor process.
-      test: ["CMD-SHELL", "pgrep -f 'claude --' >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -316,7 +316,7 @@ services:
       - elder-2-home:/home/elder/.claude
       - elder-2-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'claude --' >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -340,7 +340,7 @@ services:
       - elder-3-home:/home/elder/.claude
       - elder-3-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'claude --' >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -364,7 +364,7 @@ services:
       - elder-4-home:/home/elder/.claude
       - elder-4-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'claude --' >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

Follow-up PR with the R2 + R3 swarm-found fixes that were not in scope of PR #533's merge (which landed only the R1 fix-round). These are real bugs caught by local swarm convergence after #533 was merged.

PR #533 merged commit `dc62e8f` (R1 fix-round) at 03:11:41 UTC. The subsequent R2 + R3 rounds of the local 3-tier swarm caught additional verified-real bugs that need to land before elder containers can boot correctly in v1.

## Commits (cherry-picked from the post-merge rebase)

- **`cdbc6e8`** — R2 swarm fix-round: `agents/shared/run.sh` split bootstrap (symlink for settings.json + CLAUDE.md; cp -rn no-clobber for skills/), `agents/entrypoint.sh` ALLOW_UNRESTRICTED_EGRESS=1 checked BEFORE firewall invocation, `agents/Dockerfile` healthcheck aligned to compose-level.
- **`8f7d970`** — R3 swarm fix-round: replaced `pgrep -f 'claude --'` with `pgrep -x claude` in both Dockerfile and 4x compose elder healthchecks. The `-f` form false-positive-matched the shell command line that Docker uses to execute the healthcheck (`/bin/sh -c "pgrep -f 'claude --' ..."` contains literal `claude --`), so a dead elder would always report healthy.

## Why these are not-deferrable

These all break v1 elder boot or healthcheck correctness:

1. **Without R2 symlink-vs-copy split:** Agent cannot author per-elder skills — the symlinked `skills/` directory was R/O, contradicting `agents/shared/home-claude/skills/README.md:18` ("Per-elder runtime skills authored by the agent itself live in /home/elder/.claude/skills/ (R/W)"). Phase 1.7 contract broken.

2. **Without R2 firewall override fix:** `ALLOW_UNRESTRICTED_EGRESS=1` only took effect AFTER iptables failed — a debug operator with NET_ADMIN cap would still get the firewall applied. Documented opt-out semantics broken.

3. **Without R3 healthcheck fix:** `pgrep -f 'claude --'` self-matches its own shell command line. Reproduced:
   ```
   $ docker run --rm --entrypoint /bin/bash clan-world/elder:test \
       -c "pgrep -f 'claude --' >/dev/null && echo SELF-MATCH || echo clean"
   SELF-MATCH    # ← false positive every time
   ```
   Dead elder reports healthy → Docker / compose never restarts unhealthy containers.

## Swarm history on these fixes

R2 swarm (head `dc62e8f` — the just-merged commit):
- Tier 2 (codex): NEEDS_FIXES — 0 HIGH / 2 MED / 1 LOW. All 3 addressed in `cdbc6e8`.
- Tier 3 (gemini): NEEDS_FIXES — 1 HIGH / 1 MED / 3 LOW. Symlink-directory finding converged with codex MED.
- Tier 1 (claude headless): FAILED (process hung at ~3min).

R3 swarm (head `cdbc6e8` after R2 fix-round):
- Tier 2 (codex): NEEDS_FIXES — 1 MED. The pgrep self-match bug.
- Tier 3 (gemini): hallucinated 4 findings on already-fixed code (R2/R3 super-swarm-hallucination pattern). Rejected.

R4 swarm (head `8f7d970` after R3 fix-round):
- Tier 2 (codex): **CLEAN** ✓
- Tier 3 (gemini): **CLEAN** ✓

Original PR #533 swarm comment trail: https://github.com/clan-world/clan-world-game/pull/533

## Test plan

- [x] Cherry-picks landed cleanly on top of merged `dev-containerize-agents`
- [x] `docker build` succeeds
- [x] `docker compose --profile dev config` parses
- [x] Smoke verified: ALLOW_UNRESTRICTED_EGRESS=1 skips firewall entirely; default fail-closed exits 3
- [x] Smoke verified: settings.json/CLAUDE.md = R/O symlinks (writes blocked); skills/ = R/W copy (echo > skills/test.md succeeds)
- [x] Smoke verified: `pgrep -x claude` does NOT self-match the healthcheck shell command
- [ ] Local 3-tier swarm — already done across R2+R3+R4, attaching consolidated triage as initial comment

## Refs

- Follow-up to merged PR #533
- Closes the v1-functional gap for #345 + #350