### PR TITLE
feat(command-bus): agentCommands + elderHeartbeat schema + mutations (#351)

### DIFF
--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as agentLogs from "../agentLogs.js";
 import type * as authShared from "../authShared.js";
 import type * as bulletins from "../bulletins.js";
 import type * as clansmen from "../clansmen.js";
+import type * as commandBus from "../commandBus.js";
 import type * as comms from "../comms.js";
 import type * as crons from "../crons.js";
 import type * as events from "../events.js";
@@ -50,6 +51,7 @@ declare const fullApi: ApiFromModules<{
   authShared: typeof authShared;
   bulletins: typeof bulletins;
   clansmen: typeof clansmen;
+  commandBus: typeof commandBus;
   comms: typeof comms;
   crons: typeof crons;
   events: typeof events;

--- a/apps/server/convex/commandBus.test.ts
+++ b/apps/server/convex/commandBus.test.ts
@@ -1,0 +1,563 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  enqueueCommand,
+  claimNext,
+  ackCommand,
+  completeCommand,
+  failCommand,
+  getQueuedFor,
+  sweepStaleDelivered,
+  heartbeat,
+} from "./commandBus";
+
+vi.stubEnv("BUS_OPERATOR_SECRET", "op-secret");
+vi.stubEnv("BUS_ELDER_SECRET_1", "elder-1-secret");
+vi.stubEnv("BUS_ELDER_SECRET_2", "elder-2-secret");
+
+function createDb(tables: Record<string, any[]> = {}) {
+  return {
+    tables,
+    db: {
+      async get(id: string) {
+        for (const rows of Object.values(tables)) {
+          const row = rows.find((r) => r._id === id);
+          if (row) return row;
+        }
+        return null;
+      },
+      async insert(table: string, value: Record<string, unknown>) {
+        tables[table] ??= [];
+        const doc = {
+          ...value,
+          _id: `${table}:${tables[table].length}`,
+          _creationTime: tables[table].length,
+        };
+        tables[table].push(doc);
+        return doc._id;
+      },
+      async patch(id: string, value: Record<string, unknown>) {
+        for (const rows of Object.values(tables)) {
+          const index = rows.findIndex((row) => row._id === id);
+          if (index >= 0) {
+            const updated = { ...rows[index] };
+            for (const [k, v] of Object.entries(value)) {
+              if (v === undefined) delete (updated as any)[k];
+              else (updated as any)[k] = v;
+            }
+            rows[index] = updated;
+          }
+        }
+      },
+      query(table: string) {
+        let rows = [...(tables[table] ?? [])];
+        const builder = {
+          withIndex(_name: string, apply?: (q: any) => unknown) {
+            if (apply) {
+              const eqClauses: Array<{ field: string; value: unknown }> = [];
+              const ltClauses: Array<{ field: string; value: unknown }> = [];
+              const q = {
+                eq(field: string, value: unknown) {
+                  eqClauses.push({ field, value });
+                  return q;
+                },
+                lt(field: string, value: unknown) {
+                  ltClauses.push({ field, value });
+                  return q;
+                },
+              };
+              apply(q);
+              rows = rows.filter((row) =>
+                eqClauses.every((clause) => row[clause.field] === clause.value) &&
+                ltClauses.every((clause) => (row[clause.field] as number) < (clause.value as number)),
+              );
+            }
+            return builder;
+          },
+          filter(predicate: (q: any) => boolean) {
+            rows = rows.filter((row) => {
+              const rowQ = {
+                eq(a: unknown, b: unknown) {
+                  const aVal = typeof a === "function" ? (a as any)(row) : a;
+                  const bVal = typeof b === "function" ? (b as any)(row) : b;
+                  return aVal === bVal;
+                },
+                field(name: string) {
+                  return row[name];
+                },
+              };
+              return predicate(rowQ);
+            });
+            return builder;
+          },
+          order(direction: "asc" | "desc") {
+            rows = [...rows].sort((a, b) =>
+              direction === "desc"
+                ? b._creationTime - a._creationTime
+                : a._creationTime - b._creationTime,
+            );
+            return builder;
+          },
+          async first() {
+            return rows[0] ?? null;
+          },
+          async collect() {
+            return [...rows];
+          },
+        };
+        return builder;
+      },
+    },
+  };
+}
+
+describe("enqueueCommand", () => {
+  it("inserts a command at status=queued", async () => {
+    const { db, tables } = createDb();
+    await (enqueueCommand as any)._handler(
+      { db },
+      {
+        secret: "op-secret",
+        targetAgentId: "elder-1",
+        kind: "user_message",
+        payload: { text: "hello" },
+        source: "orchestrator",
+      },
+    );
+    expect(tables.agentCommands).toHaveLength(1);
+    expect(tables.agentCommands![0].status).toBe("queued");
+    expect(tables.agentCommands![0].retryCount).toBe(0);
+    expect(tables.agentCommands![0].payloadVersion).toBe(1);
+  });
+
+  it("throws on wrong operator secret", async () => {
+    const { db } = createDb();
+    await expect(
+      (enqueueCommand as any)._handler(
+        { db },
+        {
+          secret: "wrong-secret",
+          targetAgentId: "elder-1",
+          kind: "user_message",
+          payload: {},
+          source: "orchestrator",
+        },
+      ),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("throws on invalid targetAgentId", async () => {
+    const { db } = createDb();
+    await expect(
+      (enqueueCommand as any)._handler(
+        { db },
+        { secret: "op-secret", targetAgentId: "elder-99", kind: "reset", payload: {}, source: "orchestrator" },
+      ),
+    ).rejects.toThrow("Invalid targetAgentId");
+  });
+
+  it("fan-out: inserts one row per elder for targetAgentId='*'", async () => {
+    vi.stubEnv("ELDER_IDS", "elder-1,elder-2,elder-3,elder-4");
+    const { db, tables } = createDb();
+    const result = await (enqueueCommand as any)._handler(
+      { db },
+      {
+        secret: "op-secret",
+        targetAgentId: "*",
+        kind: "system_message",
+        payload: { text: "freeze" },
+        source: "orchestrator",
+      },
+    );
+    expect(Array.isArray(result)).toBe(true);
+    expect(tables.agentCommands).toHaveLength(4);
+    const targets = tables.agentCommands!.map((c: any) => c.targetAgentId);
+    expect(targets).toEqual(["elder-1", "elder-2", "elder-3", "elder-4"]);
+    const seqs = tables.agentCommands!.map((c: any) => c.broadcastSequence);
+    expect(new Set(seqs).size).toBe(1); // all same broadcastSequence
+  });
+});
+
+describe("claimNext", () => {
+  it("claims oldest queued command for targetAgentId", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "queued",
+          createdAt: 1000,
+          retryCount: 0,
+        },
+        {
+          _id: "agentCommands:1",
+          _creationTime: 1,
+          targetAgentId: "elder-1",
+          status: "queued",
+          createdAt: 2000,
+          retryCount: 0,
+        },
+      ],
+    });
+    const claimedId = await (claimNext as any)._handler(
+      { db },
+      { secret: "elder-1-secret", agentId: "elder-1" },
+    );
+    expect(claimedId).toBe("agentCommands:0");
+    expect(tables.agentCommands![0].status).toBe("leased");
+    expect(tables.agentCommands![0].leaseOwner).toBe("elder-1");
+  });
+
+  it("returns null on empty queue", async () => {
+    const { db } = createDb({ agentCommands: [] });
+    const result = await (claimNext as any)._handler(
+      { db },
+      { secret: "elder-1-secret", agentId: "elder-1" },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("claims fan-out broadcast row targeted at this elder", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "queued",
+          createdAt: 1000,
+          retryCount: 0,
+          broadcastSequence: 1,
+        },
+      ],
+    });
+    const claimedId = await (claimNext as any)._handler(
+      { db },
+      { secret: "elder-1-secret", agentId: "elder-1" },
+    );
+    expect(claimedId).toBe("agentCommands:0");
+    expect(tables.agentCommands![0].status).toBe("leased");
+  });
+});
+
+describe("ackCommand", () => {
+  it("transitions leased to acked", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    await (ackCommand as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        commandId: "agentCommands:0",
+      },
+    );
+    expect(tables.agentCommands![0].status).toBe("acked");
+    expect(tables.agentCommands![0].ackedAt).toBeDefined();
+  });
+});
+
+describe("completeCommand", () => {
+  it("transitions acked to completed and writes commandResults row", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "acked",
+          leaseOwner: "elder-1",
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    await (completeCommand as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        commandId: "agentCommands:0",
+        resultPayload: { ok: true },
+        tookMs: 42,
+      },
+    );
+    expect(tables.agentCommands![0].status).toBe("completed");
+    expect(tables.agentCommands![0].completedAt).toBeDefined();
+    expect(tables.commandResults).toHaveLength(1);
+    expect(tables.commandResults![0].tookMs).toBe(42);
+    expect(tables.commandResults![0].commandId).toBe("agentCommands:0");
+  });
+});
+
+describe("completeCommand (lease-expiry)", () => {
+  it("throws on expired lease when completing", async () => {
+    const { db } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "acked",
+          leaseOwner: "elder-1",
+          leaseExpiresAt: Date.now() - 1000, // expired
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    await expect(
+      (completeCommand as any)._handler(
+        { db },
+        {
+          secret: "elder-1-secret",
+          agentId: "elder-1",
+          commandId: "agentCommands:0",
+          resultPayload: { ok: true },
+          tookMs: 42,
+        },
+      ),
+    ).rejects.toThrow("Lease expired");
+  });
+});
+
+describe("failCommand", () => {
+  it("increments retryCount and re-queues if < MAX_RETRIES", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          ackedAt: 999,
+          createdAt: 1000,
+          retryCount: 1,
+        },
+      ],
+      commandResults: [],
+    });
+    await (failCommand as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        commandId: "agentCommands:0",
+        reason: "timeout",
+      },
+    );
+    expect(tables.agentCommands![0].status).toBe("queued");
+    expect(tables.agentCommands![0].retryCount).toBe(2);
+    expect(tables.agentCommands![0].leaseOwner).toBeUndefined();
+    expect(tables.agentCommands![0].ackedAt).toBeUndefined();
+    expect(tables.commandResults).toHaveLength(1);
+    expect(tables.commandResults![0].resultPayload.reason).toBe("timeout");
+  });
+
+  it("marks failed if retryCount reaches MAX_RETRIES (3)", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          createdAt: 1000,
+          retryCount: 2,
+        },
+      ],
+    });
+    await (failCommand as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        commandId: "agentCommands:0",
+        reason: "timeout",
+      },
+    );
+    expect(tables.agentCommands![0].status).toBe("failed");
+    expect(tables.agentCommands![0].retryCount).toBe(3);
+  });
+
+  it("throws on expired lease when failing", async () => {
+    const { db } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          leaseExpiresAt: Date.now() - 1000, // expired
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    await expect(
+      (failCommand as any)._handler(
+        { db },
+        {
+          secret: "elder-1-secret",
+          agentId: "elder-1",
+          commandId: "agentCommands:0",
+          reason: "timeout",
+        },
+      ),
+    ).rejects.toThrow("Lease expired");
+  });
+});
+
+describe("sweepStaleDelivered", () => {
+  it("re-queues expired leases", async () => {
+    const now = Date.now();
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          leaseExpiresAt: now - 1000, // expired
+          createdAt: 1000,
+          retryCount: 0,
+        },
+        {
+          _id: "agentCommands:1",
+          _creationTime: 1,
+          targetAgentId: "elder-2",
+          status: "leased",
+          leaseOwner: "elder-2",
+          leaseExpiresAt: now + 999999, // not expired
+          createdAt: 2000,
+          retryCount: 0,
+        },
+      ],
+    });
+    const result = await (sweepStaleDelivered as any)._handler({ db }, {});
+    expect(result.swept).toBe(1);
+    expect(tables.agentCommands![0].status).toBe("queued");
+    expect(tables.agentCommands![1].status).toBe("leased"); // untouched
+  });
+
+  it("re-queues expired acked commands (stuck after elder crash)", async () => {
+    const now = Date.now();
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "acked",
+          leaseOwner: "elder-1",
+          leaseExpiresAt: now - 1000,
+          ackedAt: now - 2000,
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    const result = await (sweepStaleDelivered as any)._handler({ db }, {});
+    expect(result.swept).toBe(1);
+    expect(tables.agentCommands![0].status).toBe("queued");
+    expect(tables.agentCommands![0].leaseOwner).toBeUndefined();
+    expect(tables.agentCommands![0].ackedAt).toBeUndefined();
+  });
+});
+
+describe("getQueuedFor", () => {
+  it("returns queued commands for agentId", async () => {
+    const { db } = createDb({
+      agentCommands: [
+        { _id: "agentCommands:0", _creationTime: 0, targetAgentId: "elder-1", status: "queued", createdAt: 1000, retryCount: 0 },
+      ],
+    });
+    const result = await (getQueuedFor as any)._handler(
+      { db },
+      { secret: "elder-1-secret", agentId: "elder-1" },
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("rejects wrong secret", async () => {
+    const { db } = createDb();
+    await expect(
+      (getQueuedFor as any)._handler({ db }, { secret: "wrong", agentId: "elder-1" }),
+    ).rejects.toThrow("Unauthorized");
+  });
+});
+
+describe("heartbeat", () => {
+  it("inserts a new row on first call", async () => {
+    const { db, tables } = createDb();
+    await (heartbeat as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        lastTickProcessed: 42,
+        health: "green",
+      },
+    );
+    expect(tables.elderHeartbeat).toHaveLength(1);
+    expect(tables.elderHeartbeat![0].agentId).toBe("elder-1");
+    expect(tables.elderHeartbeat![0].health).toBe("green");
+  });
+
+  it("patches existing row on second call", async () => {
+    const { db, tables } = createDb();
+    await (heartbeat as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        lastTickProcessed: 42,
+        health: "green",
+      },
+    );
+    await (heartbeat as any)._handler(
+      { db },
+      {
+        secret: "elder-1-secret",
+        agentId: "elder-1",
+        lastTickProcessed: 43,
+        health: "yellow",
+      },
+    );
+    expect(tables.elderHeartbeat).toHaveLength(1);
+    expect(tables.elderHeartbeat![0].lastTickProcessed).toBe(43);
+    expect(tables.elderHeartbeat![0].health).toBe("yellow");
+  });
+});
+
+describe("auth", () => {
+  it("throws on wrong elder secret", async () => {
+    const { db } = createDb();
+    await expect(
+      (heartbeat as any)._handler(
+        { db },
+        {
+          secret: "wrong-secret",
+          agentId: "elder-1",
+          lastTickProcessed: 1,
+          health: "green",
+        },
+      ),
+    ).rejects.toThrow("Unauthorized");
+  });
+});

--- a/apps/server/convex/commandBus.test.ts
+++ b/apps/server/convex/commandBus.test.ts
@@ -266,6 +266,37 @@ describe("ackCommand", () => {
     expect(tables.agentCommands![0].status).toBe("acked");
     expect(tables.agentCommands![0].ackedAt).toBeDefined();
   });
+
+  it("throws on expired lease when acking", async () => {
+    // Symmetric guard with complete/fail (added round-1 fix from swarm
+    // review PR #538): an elder cannot transition leased→acked once the
+    // lease has expired — otherwise the work later fails complete/fail
+    // and the sweeper retries the same command.
+    const { db } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          leaseExpiresAt: Date.now() - 1000, // expired
+          createdAt: 1000,
+          retryCount: 0,
+        },
+      ],
+    });
+    await expect(
+      (ackCommand as any)._handler(
+        { db },
+        {
+          secret: "elder-1-secret",
+          agentId: "elder-1",
+          commandId: "agentCommands:0",
+        },
+      ),
+    ).rejects.toThrow("Lease expired");
+  });
 });
 
 describe("completeCommand", () => {

--- a/apps/server/convex/commandBus.ts
+++ b/apps/server/convex/commandBus.ts
@@ -1,0 +1,252 @@
+import { mutation, query, internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+
+const LEASE_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_RETRIES = 3;
+
+function checkOperatorAuth(secret: string) {
+  if (!process.env.BUS_OPERATOR_SECRET || secret !== process.env.BUS_OPERATOR_SECRET) {
+    throw new Error("Unauthorized: BUS_OPERATOR_SECRET required");
+  }
+}
+
+function checkElderAuth(secret: string, agentId: string) {
+  const m = agentId.match(/^elder-(\d+)$/);
+  if (!m) throw new Error("Invalid agentId format");
+  const expected = process.env[`BUS_ELDER_SECRET_${m[1]}`];
+  if (!expected || secret !== expected) {
+    throw new Error(`Unauthorized: BUS_ELDER_SECRET_${m[1]} required`);
+  }
+}
+
+// 1. enqueueCommand — operator enqueues a command
+export const enqueueCommand = mutation({
+  args: {
+    secret: v.string(),
+    targetAgentId: v.string(),
+    kind: v.union(
+      v.literal("user_message"), v.literal("system_message"),
+      v.literal("snapshot_request"), v.literal("reset"),
+      v.literal("freeze"), v.literal("unfreeze"),
+    ),
+    payload: v.any(),
+    source: v.string(),
+  },
+  handler: async (ctx, args) => {
+    checkOperatorAuth(args.secret);
+    const validElderIds = (process.env.ELDER_IDS ?? "elder-1,elder-2,elder-3,elder-4")
+      .split(",").map(s => s.trim()).filter(Boolean);
+    if (args.targetAgentId !== "*" && !validElderIds.includes(args.targetAgentId)) {
+      throw new Error(`Invalid targetAgentId: ${args.targetAgentId}`);
+    }
+    let broadcastSequence: number | undefined;
+    if (args.targetAgentId === "*") {
+      const last = await ctx.db.query("agentCommands")
+        .withIndex("by_broadcast_sequence")
+        .order("desc")
+        .first();
+      broadcastSequence = (last?.broadcastSequence ?? 0) + 1;
+      const ids: string[] = [];
+      for (const elderId of validElderIds) {
+        ids.push(await ctx.db.insert("agentCommands", {
+          targetAgentId: elderId,
+          kind: args.kind,
+          payload: args.payload,
+          payloadVersion: 1,
+          source: args.source,
+          createdAt: Date.now(),
+          status: "queued",
+          retryCount: 0,
+          broadcastSequence,
+        }));
+      }
+      return ids;
+    }
+    return await ctx.db.insert("agentCommands", {
+      targetAgentId: args.targetAgentId,
+      kind: args.kind,
+      payload: args.payload,
+      payloadVersion: 1,
+      source: args.source,
+      createdAt: Date.now(),
+      status: "queued",
+      retryCount: 0,
+      broadcastSequence,
+    });
+  },
+});
+
+// 2. claimNext — elder claims oldest queued command
+export const claimNext = mutation({
+  args: { secret: v.string(), agentId: v.string() },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    const cmd = await ctx.db.query("agentCommands")
+      .withIndex("by_target_status", q =>
+        q.eq("targetAgentId", args.agentId).eq("status", "queued"),
+      )
+      .order("asc")
+      .first();
+    if (!cmd) return null;
+    const now = Date.now();
+    await ctx.db.patch(cmd._id, {
+      status: "leased",
+      leaseOwner: args.agentId,
+      leaseExpiresAt: now + LEASE_MS,
+    });
+    return cmd._id;
+  },
+});
+
+// 3. ackCommand — elder acks receipt
+export const ackCommand = mutation({
+  args: { secret: v.string(), agentId: v.string(), commandId: v.id("agentCommands") },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    const cmd = await ctx.db.get(args.commandId);
+    if (!cmd || cmd.status !== "leased" || cmd.leaseOwner !== args.agentId) {
+      throw new Error("Command not found or not leased by this elder");
+    }
+    await ctx.db.patch(args.commandId, { status: "acked", ackedAt: Date.now() });
+  },
+});
+
+// 4. completeCommand — elder marks done + writes result
+export const completeCommand = mutation({
+  args: {
+    secret: v.string(),
+    agentId: v.string(),
+    commandId: v.id("agentCommands"),
+    resultPayload: v.any(),
+    tookMs: v.number(),
+  },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    const cmd = await ctx.db.get(args.commandId);
+    if (!cmd || (cmd.status !== "acked" && cmd.status !== "leased") || cmd.leaseOwner !== args.agentId) {
+      throw new Error("Command not found or not owned by this elder");
+    }
+    if (cmd.leaseExpiresAt !== undefined && cmd.leaseExpiresAt <= Date.now()) {
+      throw new Error("Lease expired — re-claim the command before completing");
+    }
+    const now = Date.now();
+    await ctx.db.patch(args.commandId, { status: "completed", completedAt: now, leaseOwner: undefined, leaseExpiresAt: undefined });
+    await ctx.db.insert("commandResults", {
+      commandId: args.commandId,
+      agentId: args.agentId,
+      resultPayload: args.resultPayload,
+      tookMs: args.tookMs,
+      createdAt: now,
+    });
+  },
+});
+
+// 5. failCommand — elder gives up; retry or mark failed
+export const failCommand = mutation({
+  args: {
+    secret: v.string(),
+    agentId: v.string(),
+    commandId: v.id("agentCommands"),
+    reason: v.string(),
+  },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    const cmd = await ctx.db.get(args.commandId);
+    if (!cmd || (cmd.status !== "leased" && cmd.status !== "acked") || cmd.leaseOwner !== args.agentId) {
+      throw new Error("Command not found or not owned by this elder");
+    }
+    if (cmd.leaseExpiresAt !== undefined && cmd.leaseExpiresAt <= Date.now()) {
+      throw new Error("Lease expired — re-claim the command before failing");
+    }
+    const newRetryCount = cmd.retryCount + 1;
+    const now = Date.now();
+    await ctx.db.insert("commandResults", {
+      commandId: args.commandId,
+      agentId: args.agentId,
+      resultPayload: { reason: args.reason, retryCount: newRetryCount },
+      tookMs: 0,
+      createdAt: now,
+    });
+    await ctx.db.patch(args.commandId, {
+      status: newRetryCount >= MAX_RETRIES ? "failed" : "queued",
+      retryCount: newRetryCount,
+      leaseOwner: undefined,
+      leaseExpiresAt: undefined,
+      ackedAt: undefined,
+    });
+  },
+});
+
+// 6. getQueuedFor — reactive query for elder's queue
+export const getQueuedFor = query({
+  args: { secret: v.string(), agentId: v.string() },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    return await ctx.db.query("agentCommands")
+      .withIndex("by_target_status", q =>
+        q.eq("targetAgentId", args.agentId).eq("status", "queued"),
+      )
+      .collect();
+  },
+});
+
+// 7. sweepStaleDelivered — cron: re-queue expired leases
+export const sweepStaleDelivered = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const expiredLeased = await ctx.db.query("agentCommands")
+      .withIndex("by_status_lease", q =>
+        q.eq("status", "leased").lt("leaseExpiresAt", now)
+      )
+      .collect();
+    const expiredAcked = await ctx.db.query("agentCommands")
+      .withIndex("by_status_lease", q =>
+        q.eq("status", "acked").lt("leaseExpiresAt", now)
+      )
+      .collect();
+    const expired = [...expiredLeased, ...expiredAcked];
+    let swept = 0;
+    for (const cmd of expired) {
+      const newRetryCount = cmd.retryCount + 1;
+      await ctx.db.patch(cmd._id, {
+        status: newRetryCount >= MAX_RETRIES ? "failed" : "queued",
+        retryCount: newRetryCount,
+        leaseOwner: undefined,
+        leaseExpiresAt: undefined,
+        ackedAt: undefined,
+      });
+      swept++;
+    }
+    return { swept };
+  },
+});
+
+// 8. heartbeat — elder-runtime upserts heartbeat row
+export const heartbeat = mutation({
+  args: {
+    secret: v.string(),
+    agentId: v.string(),
+    lastTickProcessed: v.number(),
+    currentStrategy: v.optional(v.string()),
+    health: v.union(v.literal("green"), v.literal("yellow"), v.literal("red")),
+  },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    const existing = await ctx.db.query("elderHeartbeat")
+      .withIndex("by_agentId", q => q.eq("agentId", args.agentId))
+      .first();
+    const data = {
+      agentId: args.agentId,
+      lastSeenAt: Date.now(),
+      lastTickProcessed: args.lastTickProcessed,
+      currentStrategy: args.currentStrategy,
+      health: args.health,
+    };
+    if (existing) {
+      await ctx.db.patch(existing._id, data);
+    } else {
+      await ctx.db.insert("elderHeartbeat", data);
+    }
+  },
+});

--- a/apps/server/convex/commandBus.ts
+++ b/apps/server/convex/commandBus.ts
@@ -107,6 +107,13 @@ export const ackCommand = mutation({
     if (!cmd || cmd.status !== "leased" || cmd.leaseOwner !== args.agentId) {
       throw new Error("Command not found or not leased by this elder");
     }
+    if (cmd.leaseExpiresAt !== undefined && cmd.leaseExpiresAt <= Date.now()) {
+      // Symmetric with completeCommand/failCommand: reject ack on an expired
+      // lease so the elder cannot transition leased→acked on work the
+      // sweeper is about to re-queue. Without this guard, complete/fail
+      // would later reject the same stale lease, stranding the work.
+      throw new Error("Lease expired — re-claim the command before acking");
+    }
     await ctx.db.patch(args.commandId, { status: "acked", ackedAt: Date.now() });
   },
 });

--- a/apps/server/convex/crons.ts
+++ b/apps/server/convex/crons.ts
@@ -39,4 +39,9 @@ crons.hourly(
   {},
 );
 
+// Issue #351: command-bus stale-delivered sweeper. Reclaims leases on
+// `leased`/`acked` rows whose `leaseExpiresAt < now()` so retry/fail paths
+// can advance even if the elder runtime crashed mid-delivery.
+crons.interval("bus-sweep-stale-delivered", { seconds: 60 }, internal.commandBus.sweepStaleDelivered, {});
+
 export default crons;

--- a/packages/sdk/convex/schema.ts
+++ b/packages/sdk/convex/schema.ts
@@ -416,4 +416,54 @@ export default defineSchema({
   humanSteeringMessages: defineTable(humanSteeringMessageFields)
     .index("by_target_clan", ["targetClanId", "tick"])
     .index("by_tick", ["tick"]),
+
+  agentCommands: defineTable({
+    targetAgentId: v.string(),
+    kind: v.union(
+      v.literal("user_message"),
+      v.literal("system_message"),
+      v.literal("snapshot_request"),
+      v.literal("reset"),
+      v.literal("freeze"),
+      v.literal("unfreeze"),
+    ),
+    payload: v.any(),
+    payloadVersion: v.number(),
+    source: v.string(),
+    createdAt: v.number(),
+    status: v.union(
+      v.literal("queued"),
+      v.literal("leased"),
+      v.literal("acked"),
+      v.literal("completed"),
+      v.literal("failed"),
+    ),
+    leaseOwner: v.optional(v.string()),
+    leaseExpiresAt: v.optional(v.number()),
+    ackedAt: v.optional(v.number()),
+    completedAt: v.optional(v.number()),
+    retryCount: v.number(),
+    broadcastSequence: v.optional(v.number()),
+  })
+    .index("by_target_status", ["targetAgentId", "status"])
+    .index("by_status_lease", ["status", "leaseExpiresAt"])
+    .index("by_broadcast_sequence", ["broadcastSequence"]),
+
+  elderHeartbeat: defineTable({
+    agentId: v.string(),
+    lastSeenAt: v.number(),
+    lastTickProcessed: v.number(),
+    currentStrategy: v.optional(v.string()),
+    health: v.union(v.literal("green"), v.literal("yellow"), v.literal("red")),
+  })
+    .index("by_agentId", ["agentId"]),
+
+  commandResults: defineTable({
+    commandId: v.id("agentCommands"),
+    agentId: v.string(),
+    resultPayload: v.any(),
+    tookMs: v.number(),
+    createdAt: v.number(),
+  })
+    .index("by_commandId", ["commandId"]),
 });


### PR DESCRIPTION
## Summary

Surgical extraction from PR #415 (stale recover branch). Adds the Convex command-bus data layer that Bundle 2's elder-runtime supervisor (PR #416, upcoming) will consume.

## Changes

- `apps/server/convex/commandBus.ts` — 252 lines of mutations + queries for the command-bus FSM (enqueue → claim → ack → complete/fail + sweepStaleDelivered + heartbeat)
- `apps/server/convex/commandBus.test.ts` — 563 lines, 10 describe blocks, 20 pure-unit tests (all passing)
- `packages/sdk/convex/schema.ts` — append 3 new tables (`agentCommands`, `elderHeartbeat`, `commandResults`) per ADR 0019 (canonical schema lives in SDK package)
- `apps/server/convex/crons.ts` — 1 new cron line for the 60s `bus-sweep-stale-delivered` retention loop
- `apps/server/convex/_generated/api.d.ts` — regenerated to include `commandBus` module

## Why surgical extraction (not cherry-pick)

PR #415's recover branch carries 11 inherited-stack files from sibling recover/* branches (retention, indexer, events, heartbeat, etc.) that are STALE-BEHIND dev-containerize-agents — re-applying them would regress recent cloud-review-fix work. Surgical extraction from PR head `43a93bf4` gets the clean command-bus code without the noise.

Per exploration audit (`~/claudes-world/tmp/20260521-2240-pr415-redo-guidance.md`):
> "Codex-rebuild offers no advantage — the work already went through 4 fix-rounds super-swarm-clean; we just need to relocate it cleanly into the new SDK-package shape."

## Authentication model

Mutation-arg secrets (NOT HMAC/Bearer):
- `BUS_OPERATOR_SECRET` for `enqueueCommand`
- `BUS_ELDER_SECRET_{N}` per-elder for `claimNext` / `ackCommand` / `completeCommand` / `failCommand` / `heartbeat` / `getQueuedFor`

`.env.template` BUS_* slots already exist on dev-containerize-agents (Bundle 1 pre-provisioned them).

## Closes

- #351

## Test plan

- [x] `pnpm --filter @clan-world/sdk typecheck` PASS
- [x] `pnpm --filter @clan-world/server typecheck` PASS
- [x] `pnpm --filter @clan-world/server test` PASS (139 tests, 13 files; commandBus.test.ts contributes 20 new tests)
- [ ] Local 3-tier swarm review
- [ ] Merge to dev-containerize-agents