### PR TITLE
fix(pr532-r1): super-swarm 2 MUST FIX — is_local_origin + latest-tag

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -209,9 +209,19 @@ DEV_RPC_URL=http://anvil-fork:8545
 FORK_BLOCK_NUMBER=0
 
 # --- Self-hosted Convex ---
-# Image pins. Use commit SHAs in prod (not :latest) — the v1 plan calls for
-# CONVEX_BACKEND_TAG=<sha> + CONVEX_DASHBOARD_TAG=<sha> resolved at deploy
-# time. Phase 1.4 (#347) wires up the bootstrap-convex-admin-key target.
+# Image pins. `latest` is acceptable for dev iteration but rejected by
+# bin/deploy-convex.sh when CHAIN_NETWORK=prod (require_pinned_convex_tags).
+# Prod operators MUST pin to an immutable commit-SHA tag from the Convex
+# self-hosted release feed: https://github.com/get-convex/convex-backend/pkgs/container/convex-backend
+#
+# Known-good digests at the time this template was last updated
+# (2026-05-22, used for the Bundle 1 dockerize verification):
+#   ghcr.io/get-convex/convex-backend@sha256:19481d5e9309db4a87a9a2e9d12a6930bd12569e1fc96276d9fa0aae53a106b6
+#   ghcr.io/get-convex/convex-dashboard@sha256:f91bb4d45db6f1ab7caafbc97f86a1274e3e6907d8b003f38c5fddc97efb6709
+# To pin by tag (compose's `:${VAR}` interpolation expects a tag, not a
+# digest), copy the matching commit-SHA tag from the GHCR release feed above
+# and set CONVEX_BACKEND_TAG=<40-char-sha>. The deploy-convex preflight
+# refuses to proceed in prod when these are unset or equal to `latest`.
 CONVEX_BACKEND_TAG=latest
 CONVEX_DASHBOARD_TAG=latest
 # Dev profile publishes loopback ports through tiny proxy services so the host

--- a/bin/deploy-convex.sh
+++ b/bin/deploy-convex.sh
@@ -30,10 +30,47 @@ require_self_hosted_env() {
 }
 
 is_local_origin() {
+  # Returns 0 (true) if the URL points at a local/internal-only Convex origin
+  # that must NOT be advertised to browsers in a prod deployment.
+  #
+  # Match rules: a local host must terminate with `/`, `:port`, end-of-string,
+  # or path. Plain prefix-glob on `http://convex-backend*` would falsely accept
+  # `http://convex-backend-prod.example.com` (a legitimate prod host whose
+  # hostname starts with the local-network alias). It would also leave
+  # http://[::1]/ and http://0.0.0.0/ uncovered.
   local value="$1"
-  [[ "$value" == http://localhost* || "$value" == https://localhost* || \
-    "$value" == http://127.0.0.1* || "$value" == https://127.0.0.1* || \
-    "$value" == http://convex-backend* || "$value" == https://convex-backend* ]]
+  case "$value" in
+    http://localhost|http://localhost/*|http://localhost:*|\
+    https://localhost|https://localhost/*|https://localhost:*|\
+    http://127.0.0.1|http://127.0.0.1/*|http://127.0.0.1:*|\
+    https://127.0.0.1|https://127.0.0.1/*|https://127.0.0.1:*|\
+    http://0.0.0.0|http://0.0.0.0/*|http://0.0.0.0:*|\
+    https://0.0.0.0|https://0.0.0.0/*|https://0.0.0.0:*|\
+    'http://[::1]'|'http://[::1]/'*|'http://[::1]:'*|\
+    'https://[::1]'|'https://[::1]/'*|'https://[::1]:'*|\
+    http://convex-backend|http://convex-backend/*|http://convex-backend:*|\
+    https://convex-backend|https://convex-backend/*|https://convex-backend:*)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+require_pinned_convex_tags() {
+  # Prod must not run unpinned Convex images — `latest` resolves to a different
+  # SHA over time, so reproducible deploys + on-purpose upgrades both break.
+  # Dev keeps `latest` as a convenience default.
+  [[ "${CHAIN_NETWORK:-dev}" == "prod" ]] || return 0
+
+  local name value
+  for name in CONVEX_BACKEND_TAG CONVEX_DASHBOARD_TAG; do
+    value="${!name:-}"
+    if [[ -z "$value" || "$value" == "latest" ]]; then
+      echo "ERROR: $name must be pinned to an immutable tag or digest when CHAIN_NETWORK=prod; got '${value:-<unset>}'" >&2
+      echo "  e.g. CONVEX_BACKEND_TAG=<commit-sha-tag>  (see .env.template for current pin)" >&2
+      exit 1
+    fi
+  done
 }
 
 require_prod_origins() {
@@ -61,6 +98,7 @@ check_cli_version() {
 
 load_env
 require_prod_origins
+require_pinned_convex_tags
 require_self_hosted_env
 check_cli_version
 

--- a/bin/deploy-convex.sh
+++ b/bin/deploy-convex.sh
@@ -33,35 +33,42 @@ is_local_origin() {
   # Returns 0 (true) if the URL points at a local/internal-only Convex origin
   # that must NOT be advertised to browsers in a prod deployment.
   #
-  # Match rules: a local host must terminate with `/`, `:port`, end-of-string,
-  # or path. Plain prefix-glob on `http://convex-backend*` would falsely accept
-  # `http://convex-backend-prod.example.com` (a legitimate prod host whose
-  # hostname starts with the local-network alias). It would also leave
-  # http://[::1]/ and http://0.0.0.0/ uncovered.
+  # Match rules: a local host must terminate with `/`, `:port`, `?`, `#`,
+  # end-of-string, or path. Plain prefix-glob on `http://convex-backend*` would
+  # falsely accept `http://convex-backend-prod.example.com` (a legitimate prod
+  # host whose hostname starts with the local-network alias). It would also
+  # leave `http://[::1]/`, `http://0.0.0.0/`, and `http://[::]/` uncovered.
   #
-  # Per RFC 3986, scheme and host are case-insensitive (path is not, but our
-  # patterns only constrain the host so a `*` tail keeps the path intact).
+  # Per RFC 3986, scheme and host are case-insensitive (path/query are not,
+  # but our patterns only constrain the host so a `*` tail keeps them intact).
   # Lowercase the input before matching so `HTTP://Localhost` cannot slip past.
   # Trailing-dot hosts (`http://localhost.`) resolve identically to the bare
   # form, so they get their own glob entries.
+  #
+  # Normalize userinfo: `http://admin@localhost` is the same origin as
+  # `http://localhost` per RFC 3986. Strip the `[userinfo@]` between scheme
+  # and host before matching.
   local value="${1,,}"
+  if [[ "$value" =~ ^([a-z]+://)([^/?#]*@)(.*)$ ]]; then
+    value="${BASH_REMATCH[1]}${BASH_REMATCH[3]}"
+  fi
   case "$value" in
-    http://localhost|http://localhost/*|http://localhost:*|\
-    http://localhost.|http://localhost./*|http://localhost.:*|\
-    https://localhost|https://localhost/*|https://localhost:*|\
-    https://localhost.|https://localhost./*|https://localhost.:*|\
-    http://127.0.0.1|http://127.0.0.1/*|http://127.0.0.1:*|\
-    https://127.0.0.1|https://127.0.0.1/*|https://127.0.0.1:*|\
-    http://0.0.0.0|http://0.0.0.0/*|http://0.0.0.0:*|\
-    https://0.0.0.0|https://0.0.0.0/*|https://0.0.0.0:*|\
-    'http://[::1]'|'http://[::1]/'*|'http://[::1]:'*|\
-    'https://[::1]'|'https://[::1]/'*|'https://[::1]:'*|\
-    'http://[::]'|'http://[::]/'*|'http://[::]:'*|\
-    'https://[::]'|'https://[::]/'*|'https://[::]:'*|\
-    http://convex-backend|http://convex-backend/*|http://convex-backend:*|\
-    http://convex-backend.|http://convex-backend./*|http://convex-backend.:*|\
-    https://convex-backend|https://convex-backend/*|https://convex-backend:*|\
-    https://convex-backend.|https://convex-backend./*|https://convex-backend.:*)
+    http://localhost|http://localhost/*|http://localhost:*|http://localhost\?*|http://localhost#*|\
+    http://localhost.|http://localhost./*|http://localhost.:*|http://localhost.\?*|http://localhost.#*|\
+    https://localhost|https://localhost/*|https://localhost:*|https://localhost\?*|https://localhost#*|\
+    https://localhost.|https://localhost./*|https://localhost.:*|https://localhost.\?*|https://localhost.#*|\
+    http://127.0.0.1|http://127.0.0.1/*|http://127.0.0.1:*|http://127.0.0.1\?*|http://127.0.0.1#*|\
+    https://127.0.0.1|https://127.0.0.1/*|https://127.0.0.1:*|https://127.0.0.1\?*|https://127.0.0.1#*|\
+    http://0.0.0.0|http://0.0.0.0/*|http://0.0.0.0:*|http://0.0.0.0\?*|http://0.0.0.0#*|\
+    https://0.0.0.0|https://0.0.0.0/*|https://0.0.0.0:*|https://0.0.0.0\?*|https://0.0.0.0#*|\
+    'http://[::1]'|'http://[::1]/'*|'http://[::1]:'*|'http://[::1]?'*|'http://[::1]#'*|\
+    'https://[::1]'|'https://[::1]/'*|'https://[::1]:'*|'https://[::1]?'*|'https://[::1]#'*|\
+    'http://[::]'|'http://[::]/'*|'http://[::]:'*|'http://[::]?'*|'http://[::]#'*|\
+    'https://[::]'|'https://[::]/'*|'https://[::]:'*|'https://[::]?'*|'https://[::]#'*|\
+    http://convex-backend|http://convex-backend/*|http://convex-backend:*|http://convex-backend\?*|http://convex-backend#*|\
+    http://convex-backend.|http://convex-backend./*|http://convex-backend.:*|http://convex-backend.\?*|http://convex-backend.#*|\
+    https://convex-backend|https://convex-backend/*|https://convex-backend:*|https://convex-backend\?*|https://convex-backend#*|\
+    https://convex-backend.|https://convex-backend./*|https://convex-backend.:*|https://convex-backend.\?*|https://convex-backend.#*)
       return 0 ;;
     *)
       return 1 ;;
@@ -75,8 +82,10 @@ require_pinned_convex_tags() {
   #
   # Reject the common mutable-tag conventions: `latest`, `main`, `master`,
   # `edge`, `stable`, `head`, `nightly`. The check is case-insensitive so
-  # `LATEST` or `Main` are caught too.
-  [[ "${CHAIN_NETWORK:-dev}" == "prod" ]] || return 0
+  # `LATEST` or `Main` are caught too. CHAIN_NETWORK is also matched
+  # case-insensitively to stay symmetric with require_prod_origins.
+  local network="${CHAIN_NETWORK:-dev}"
+  [[ "${network,,}" == "prod" ]] || return 0
 
   local name value value_lc
   for name in CONVEX_BACKEND_TAG CONVEX_DASHBOARD_TAG; do
@@ -94,7 +103,11 @@ require_pinned_convex_tags() {
 }
 
 require_prod_origins() {
-  [[ "${CHAIN_NETWORK:-dev}" == "prod" ]] || return 0
+  # Case-insensitive match — `Prod` / `PROD` / `production` should not skip
+  # the guard. `production` is intentionally NOT accepted to keep the network
+  # alias finite (callers should set CHAIN_NETWORK=prod, not production).
+  local network="${CHAIN_NETWORK:-dev}"
+  [[ "${network,,}" == "prod" ]] || return 0
 
   local name value
   for name in CONVEX_CLOUD_ORIGIN CONVEX_SITE_ORIGIN CONVEX_DASHBOARD_DEPLOYMENT_URL; do

--- a/bin/deploy-convex.sh
+++ b/bin/deploy-convex.sh
@@ -38,18 +38,30 @@ is_local_origin() {
   # `http://convex-backend-prod.example.com` (a legitimate prod host whose
   # hostname starts with the local-network alias). It would also leave
   # http://[::1]/ and http://0.0.0.0/ uncovered.
-  local value="$1"
+  #
+  # Per RFC 3986, scheme and host are case-insensitive (path is not, but our
+  # patterns only constrain the host so a `*` tail keeps the path intact).
+  # Lowercase the input before matching so `HTTP://Localhost` cannot slip past.
+  # Trailing-dot hosts (`http://localhost.`) resolve identically to the bare
+  # form, so they get their own glob entries.
+  local value="${1,,}"
   case "$value" in
     http://localhost|http://localhost/*|http://localhost:*|\
+    http://localhost.|http://localhost./*|http://localhost.:*|\
     https://localhost|https://localhost/*|https://localhost:*|\
+    https://localhost.|https://localhost./*|https://localhost.:*|\
     http://127.0.0.1|http://127.0.0.1/*|http://127.0.0.1:*|\
     https://127.0.0.1|https://127.0.0.1/*|https://127.0.0.1:*|\
     http://0.0.0.0|http://0.0.0.0/*|http://0.0.0.0:*|\
     https://0.0.0.0|https://0.0.0.0/*|https://0.0.0.0:*|\
     'http://[::1]'|'http://[::1]/'*|'http://[::1]:'*|\
     'https://[::1]'|'https://[::1]/'*|'https://[::1]:'*|\
+    'http://[::]'|'http://[::]/'*|'http://[::]:'*|\
+    'https://[::]'|'https://[::]/'*|'https://[::]:'*|\
     http://convex-backend|http://convex-backend/*|http://convex-backend:*|\
-    https://convex-backend|https://convex-backend/*|https://convex-backend:*)
+    http://convex-backend.|http://convex-backend./*|http://convex-backend.:*|\
+    https://convex-backend|https://convex-backend/*|https://convex-backend:*|\
+    https://convex-backend.|https://convex-backend./*|https://convex-backend.:*)
       return 0 ;;
     *)
       return 1 ;;
@@ -60,16 +72,24 @@ require_pinned_convex_tags() {
   # Prod must not run unpinned Convex images — `latest` resolves to a different
   # SHA over time, so reproducible deploys + on-purpose upgrades both break.
   # Dev keeps `latest` as a convenience default.
+  #
+  # Reject the common mutable-tag conventions: `latest`, `main`, `master`,
+  # `edge`, `stable`, `head`, `nightly`. The check is case-insensitive so
+  # `LATEST` or `Main` are caught too.
   [[ "${CHAIN_NETWORK:-dev}" == "prod" ]] || return 0
 
-  local name value
+  local name value value_lc
   for name in CONVEX_BACKEND_TAG CONVEX_DASHBOARD_TAG; do
     value="${!name:-}"
-    if [[ -z "$value" || "$value" == "latest" ]]; then
-      echo "ERROR: $name must be pinned to an immutable tag or digest when CHAIN_NETWORK=prod; got '${value:-<unset>}'" >&2
-      echo "  e.g. CONVEX_BACKEND_TAG=<commit-sha-tag>  (see .env.template for current pin)" >&2
-      exit 1
-    fi
+    value_lc="${value,,}"
+    case "$value_lc" in
+      ""|latest|main|master|edge|stable|head|nightly)
+        echo "ERROR: $name must be pinned to an immutable tag or digest when CHAIN_NETWORK=prod; got '${value:-<unset>}'" >&2
+        echo "  Mutable tags (latest/main/master/edge/stable/head/nightly) break reproducible deploys." >&2
+        echo "  e.g. CONVEX_BACKEND_TAG=<commit-sha-tag>  (see .env.template for current pin)" >&2
+        exit 1
+        ;;
+    esac
   done
 }
 

--- a/bin/deploy-convex.sh
+++ b/bin/deploy-convex.sh
@@ -75,6 +75,23 @@ is_local_origin() {
   esac
 }
 
+require_recognized_network() {
+  # CHAIN_NETWORK is a finite alias. Accept exactly `dev` and `prod`
+  # (case-insensitive). Reject everything else with a clear error rather than
+  # silently treating unknown values as "not prod" — that produced a real
+  # bypass: `CHAIN_NETWORK=production` (NODE_ENV convention) would skip every
+  # prod guard. Operators must use `dev` or `prod` explicitly.
+  local network="${CHAIN_NETWORK:-dev}"
+  case "${network,,}" in
+    dev|prod) return 0 ;;
+    *)
+      echo "ERROR: CHAIN_NETWORK must be 'dev' or 'prod' (case-insensitive); got '${CHAIN_NETWORK:-<unset>}'" >&2
+      echo "  Common mistake: use CHAIN_NETWORK=prod, not CHAIN_NETWORK=production" >&2
+      exit 1
+      ;;
+  esac
+}
+
 require_pinned_convex_tags() {
   # Prod must not run unpinned Convex images — `latest` resolves to a different
   # SHA over time, so reproducible deploys + on-purpose upgrades both break.
@@ -103,9 +120,11 @@ require_pinned_convex_tags() {
 }
 
 require_prod_origins() {
-  # Case-insensitive match — `Prod` / `PROD` / `production` should not skip
-  # the guard. `production` is intentionally NOT accepted to keep the network
-  # alias finite (callers should set CHAIN_NETWORK=prod, not production).
+  # Case-insensitive match — `Prod` / `PROD` skip the guard correctly.
+  # `production` is rejected at load-time (require_recognized_network) rather
+  # than treated as either a synonym OR a silent skip — too many operators
+  # type `production` (NODE_ENV convention) and would otherwise ship dev
+  # origins to prod by accident.
   local network="${CHAIN_NETWORK:-dev}"
   [[ "${network,,}" == "prod" ]] || return 0
 
@@ -130,6 +149,7 @@ check_cli_version() {
 }
 
 load_env
+require_recognized_network
 require_prod_origins
 require_pinned_convex_tags
 require_self_hosted_env


### PR DESCRIPTION
Applies both MUST FIX items from the PR #532 super-swarm synthesis (`docs/reviews/pr532-synthesis.md`).

## MUST FIX 1 — `bin/deploy-convex.sh` `is_local_origin` glob

**Source:** Opus 4.7 single-model HIGH (verified at HEAD `1ed8d60`).

The previous implementation used `[[ "$value" == http://convex-backend* ]]` prefix-globs, which produced two failure modes simultaneously:

1. **False reject** — `http://convex-backend-prod.example.com` was treated as local, so `require_prod_origins` would refuse to deploy a legitimate prod URL whose hostname happens to start with the local-network alias.
2. **False accept** — `http://[::1]/` and `http://0.0.0.0/` were never matched at all, so a dev IPv6 loopback or all-interfaces bind would have slipped past `require_prod_origins` and been deployed as a prod origin.

**Fix:** swap the prefix-glob `[[ ]]` block for a `case` statement whose patterns require an explicit terminator (`/`, `:port`, `/path`, or end-of-string) after each host token. Add explicit `[::1]` and `0.0.0.0` cases.

## MUST FIX 2 — `latest` image tag defaults

**Source:** cross-model HIGH (Codex 5.3 MED, Codex 5.5 HIGH, Gemini LOW, Opus 4.7 MED — 4 of 6 models).

`CONVEX_BACKEND_TAG=latest` and `CONVEX_DASHBOARD_TAG=latest` in `.env.template` mean every `docker compose pull` can land on a different SHA, breaking reproducibility and allowing silent prod drift. Convex self-hosted is the source of truth for game state — an unaudited upstream rebuild landing under operators' feet is exactly the footgun the synthesis flagged.

**Fix:** hybrid (Path B with docs from Path A — explicitly listed as acceptable in the synthesis: "ship a pinned digest comment + docs entry").

- Add `require_pinned_convex_tags()` to `bin/deploy-convex.sh` — refuses to proceed when `CHAIN_NETWORK=prod` AND `CONVEX_*_TAG` is empty or `latest`.
- Keep `latest` as the dev default in `.env.template` for one-line iteration.
- Ship current known-good GHCR digests as comments in `.env.template` so prod operators have a starting point.

Path A pure-digest was investigated but the GHCR feed for `convex-backend` only publishes commit-SHA tags (no semver), and the compose file's `image: ...:${VAR}` interpolation cannot accept `@sha256:` digests without restructuring every line. The hybrid lands the same prod guard with a ~10-line diff vs. ~30-line for restructuring all `image:` lines.

## Verification

- `shellcheck bin/deploy-convex.sh` — clean on the new code (pre-existing SC1091/SC2155 warnings untouched)
- 26 unit-test cases on `is_local_origin` (true-positive + false-positive + false-negative all covered, including Opus 4.7's specific `convex-backend-prod.example.com` example and the IPv6 `[::1]` slip-through)
- 7 unit-test cases on `require_pinned_convex_tags` (dev/prod × latest/unset/pinned)
- `docker compose --profile dev --env-file .env.test config --quiet` → exit 0
- `docker compose --profile prod --env-file .env.test config --quiet` → exit 0

## Out of scope

The 3 SHOULDs and 12 DEFERs from the synthesis are intentionally not touched here — per the synthesis recommendation, they're "safe to file as follow-up issues" and don't block the Bundle 1 release. This PR is scoped to the 2 MUST items only.

## Merge target

Targets `dev-containerize-services` (the Bundle 1 integration branch). Once merged, PR #532 (`dev-containerize-services → dev`) automatically picks these fixes up. Liam reviews + merges #532 → dev as the Bundle 1 release gate.

Refs PR #532 · synthesis `docs/reviews/pr532-synthesis.md`