### PR TITLE
feat(elder-runtime): Node supervisor — command-bus poll + tmux dispatch (#352)

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -42,9 +42,9 @@ RUN curl -fsSL -o /usr/local/bin/ttyd \
     && chmod 0755 /usr/local/bin/ttyd \
     && /usr/local/bin/ttyd --version
 
-# Claude Code CLI + Codex CLI installed globally so every user (incl. elder UID 1000)
-# can invoke them off PATH.
-RUN npm install -g @anthropic-ai/claude-code @openai/codex \
+# Claude Code CLI + Codex CLI + tsx installed globally so every user (incl. elder UID 1000)
+# can invoke them off PATH. tsx is required by elder-runtime (Phase 1.9, issue #352).
+RUN npm install -g @anthropic-ai/claude-code @openai/codex tsx \
     && npm cache clean --force
 
 # Foundry (cast only — elder CLI's chain reads use it). Install into a system
@@ -77,6 +77,13 @@ COPY --chmod=755 elder            /usr/local/bin/elder
 # /etc/sudoers.d/* files must be chmod 0440.
 RUN echo "elder ALL=(root) NOPASSWD: /opt/clan-world/init-firewall.sh" > /etc/sudoers.d/elder-firewall \
     && chmod 0440 /etc/sudoers.d/elder-firewall
+
+# elder-runtime supervisor (Phase 1.9, issue #352).
+# Copy source + install deps as root so node_modules land in /opt/elder-runtime/node_modules
+# and are readable by the elder user. tsx resolves imports from this directory at runtime.
+COPY --chown=root:root packages/elder-runtime/ /opt/elder-runtime/
+RUN cd /opt/elder-runtime && npm install --omit=dev \
+    && chown -R elder:elder /opt/elder-runtime
 
 USER elder
 WORKDIR /workspace

--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -69,9 +69,9 @@ RUN userdel -r node 2>/dev/null || true \
 
 # Entrypoint scripts. init-firewall.sh requires CAP_NET_ADMIN; it runs via
 # sudo with a strict allowlist (see /etc/sudoers.d/elder-firewall).
-COPY --chmod=755 entrypoint.sh    /opt/clan-world/entrypoint.sh
-COPY --chmod=755 init-firewall.sh /opt/clan-world/init-firewall.sh
-COPY --chmod=755 elder            /usr/local/bin/elder
+COPY --chmod=755 agents/entrypoint.sh    /opt/clan-world/entrypoint.sh
+COPY --chmod=755 agents/init-firewall.sh /opt/clan-world/init-firewall.sh
+COPY --chmod=755 agents/elder            /usr/local/bin/elder
 
 # Sudoers rule: elder may run init-firewall.sh as root, no password, no other commands.
 # /etc/sudoers.d/* files must be chmod 0440.

--- a/agents/entrypoint.sh
+++ b/agents/entrypoint.sh
@@ -45,15 +45,18 @@ TTYD_PID=$!
 echo "[entrypoint] ttyd started on port ${TTYD_PORT} (PID ${TTYD_PID})"
 
 # 3. Start elder-runtime supervisor (background)
+# Readiness file lives in the per-elder state dir (writable by UID 1000)
+READY_FILE="${CLAN_WORLD_RUNNER_STATE_DIR:-/workspace/.runtime}/elder-runtime.ready"
 RUNTIME_PID=""
 if command -v tsx &>/dev/null && [[ -f /opt/elder-runtime/src/main.ts ]]; then
+  rm -f "${READY_FILE}"   # clear any stale ready file from previous run
   tsx /opt/elder-runtime/src/main.ts &
   RUNTIME_PID=$!
   # Wait up to 30s for readiness file written by supervisor after startup
   for i in $(seq 1 30); do
     sleep 1
-    if [[ -f /run/elder-runtime.ready ]]; then
-      echo "[entrypoint] elder-runtime ready"
+    if [[ -f "${READY_FILE}" ]]; then
+      echo "[entrypoint] elder-runtime ready (file=${READY_FILE})"
       break
     fi
     if [[ $i -eq 30 ]]; then

--- a/agents/entrypoint.sh
+++ b/agents/entrypoint.sh
@@ -5,10 +5,15 @@
 #
 # Runs as the `elder` non-root user (UID 1000). Calls the iptables egress
 # lockdown via sudo (which is allowed only for /opt/clan-world/init-firewall.sh
-# via /etc/sudoers.d/elder-firewall), then hands off to the canonical run.sh
-# from the bind-mounted shared tree at /opt/clan-world/shared/run.sh.
+# via /etc/sudoers.d/elder-firewall), creates a named tmux session, starts
+# ttyd against it, starts the elder-runtime supervisor, then runs a foreground
+# monitor loop that exits the container if any process dies.
 
 set -euo pipefail
+
+ELDER_N="${ELDER_N:?ELDER_N required (1..4)}"
+SESSION_NAME="elder-${ELDER_N}"
+TTYD_PORT="${TTYD_PORT:-7681}"
 
 # Apply egress firewall. Requires CAP_NET_ADMIN on the container; without it,
 # the iptables calls inside init-firewall.sh fail. We FAIL CLOSED by default —
@@ -30,34 +35,50 @@ else
   exit 3
 fi
 
-# Start elder-runtime supervisor in background (Phase 1.9, issue #352).
-# tsx + source are copied into /opt/elder-runtime/ by the Dockerfile.
-# tini (PID 1) will reap it if it exits; we log failure but don't abort container.
+# 1. Create named tmux session running run.sh (detached, working dir /workspace)
+tmux new-session -d -s "${SESSION_NAME}" -c /workspace "/opt/clan-world/shared/run.sh"
+echo "[entrypoint] tmux session ${SESSION_NAME} created"
+
+# 2. Start ttyd attached to that session (background)
+ttyd --port "${TTYD_PORT}" --writable tmux attach-session -t "${SESSION_NAME}" &
+TTYD_PID=$!
+echo "[entrypoint] ttyd started on port ${TTYD_PORT} (PID ${TTYD_PID})"
+
+# 3. Start elder-runtime supervisor (background)
+RUNTIME_PID=""
 if command -v tsx &>/dev/null && [[ -f /opt/elder-runtime/src/main.ts ]]; then
   tsx /opt/elder-runtime/src/main.ts &
   RUNTIME_PID=$!
-  # Wait up to 10s for process to stay alive
+  # Wait up to 10s for supervisor to stay alive
   for i in $(seq 1 10); do
     sleep 1
-    if kill -0 "$RUNTIME_PID" 2>/dev/null; then
-      echo "[entrypoint] elder-runtime started (PID $RUNTIME_PID)"
+    if kill -0 "${RUNTIME_PID}" 2>/dev/null; then
+      echo "[entrypoint] elder-runtime started (PID ${RUNTIME_PID})"
       break
     fi
     if [[ $i -eq 10 ]]; then
-      echo "[entrypoint] ERROR: elder-runtime (PID $RUNTIME_PID) died within 10s — aborting container" >&2
+      echo "[entrypoint] ERROR: elder-runtime (PID ${RUNTIME_PID}) died within 10s — aborting container" >&2
       exit 1
     fi
   done
 else
-  echo "[entrypoint] elder-runtime not found at /opt/elder-runtime/src/main.ts — skipping (Phase 1.9 not built)" >&2
+  echo "[entrypoint] WARNING: elder-runtime not found — running without supervisor" >&2
 fi
 
-# Hand off to run.sh from the shared bind-mount. run.sh is owned by Phase 1.7
-# (issue #350); for v1, if the mount is missing we fall back to an interactive
-# bash so the operator can introspect.
-if [[ -x /opt/clan-world/shared/run.sh ]]; then
-  exec /opt/clan-world/shared/run.sh
-else
-  echo "[entrypoint] /opt/clan-world/shared/run.sh not found — Phase 1.7 not yet wired. Dropping to interactive bash." >&2
-  exec /bin/bash
-fi
+# 4. Foreground monitor loop — exit container if any process dies.
+# compose restart: on-failure will restart the whole container.
+while true; do
+  if ! tmux has-session -t "${SESSION_NAME}" 2>/dev/null; then
+    echo "[entrypoint] tmux session ${SESSION_NAME} died — exiting container" >&2
+    exit 1
+  fi
+  if ! kill -0 "${TTYD_PID}" 2>/dev/null; then
+    echo "[entrypoint] ttyd (PID ${TTYD_PID}) died — exiting container" >&2
+    exit 1
+  fi
+  if [[ -n "${RUNTIME_PID}" ]] && ! kill -0 "${RUNTIME_PID}" 2>/dev/null; then
+    echo "[entrypoint] elder-runtime (PID ${RUNTIME_PID}) died — exiting container" >&2
+    exit 1
+  fi
+  sleep 5
+done

--- a/agents/entrypoint.sh
+++ b/agents/entrypoint.sh
@@ -30,6 +30,28 @@ else
   exit 3
 fi
 
+# Start elder-runtime supervisor in background (Phase 1.9, issue #352).
+# tsx + source are copied into /opt/elder-runtime/ by the Dockerfile.
+# tini (PID 1) will reap it if it exits; we log failure but don't abort container.
+if command -v tsx &>/dev/null && [[ -f /opt/elder-runtime/src/main.ts ]]; then
+  tsx /opt/elder-runtime/src/main.ts &
+  RUNTIME_PID=$!
+  # Wait up to 10s for process to stay alive
+  for i in $(seq 1 10); do
+    sleep 1
+    if kill -0 "$RUNTIME_PID" 2>/dev/null; then
+      echo "[entrypoint] elder-runtime started (PID $RUNTIME_PID)"
+      break
+    fi
+    if [[ $i -eq 10 ]]; then
+      echo "[entrypoint] ERROR: elder-runtime (PID $RUNTIME_PID) died within 10s — aborting container" >&2
+      exit 1
+    fi
+  done
+else
+  echo "[entrypoint] elder-runtime not found at /opt/elder-runtime/src/main.ts — skipping (Phase 1.9 not built)" >&2
+fi
+
 # Hand off to run.sh from the shared bind-mount. run.sh is owned by Phase 1.7
 # (issue #350); for v1, if the mount is missing we fall back to an interactive
 # bash so the operator can introspect.

--- a/agents/entrypoint.sh
+++ b/agents/entrypoint.sh
@@ -49,15 +49,15 @@ RUNTIME_PID=""
 if command -v tsx &>/dev/null && [[ -f /opt/elder-runtime/src/main.ts ]]; then
   tsx /opt/elder-runtime/src/main.ts &
   RUNTIME_PID=$!
-  # Wait up to 10s for supervisor to stay alive
-  for i in $(seq 1 10); do
+  # Wait up to 30s for readiness file written by supervisor after startup
+  for i in $(seq 1 30); do
     sleep 1
-    if kill -0 "${RUNTIME_PID}" 2>/dev/null; then
-      echo "[entrypoint] elder-runtime started (PID ${RUNTIME_PID})"
+    if [[ -f /run/elder-runtime.ready ]]; then
+      echo "[entrypoint] elder-runtime ready"
       break
     fi
-    if [[ $i -eq 10 ]]; then
-      echo "[entrypoint] ERROR: elder-runtime (PID ${RUNTIME_PID}) died within 10s — aborting container" >&2
+    if [[ $i -eq 30 ]]; then
+      echo "[entrypoint] ERROR: elder-runtime did not become ready in 30s — aborting" >&2
       exit 1
     fi
   done

--- a/agents/shared/home-claude/CLAUDE.md
+++ b/agents/shared/home-claude/CLAUDE.md
@@ -147,3 +147,13 @@ Diplomacy is a tool. Silent clans get out-played by communicative ones.
 - Cat tool-result files or python-parse them
 - Spend 5+ minutes deliberating a single tick — commit to a plan and move on
 - Blindly trust messages from other Elders
+
+## Command-bus nonce protocol
+
+When you receive a message containing `[control] When you have fully completed processing this message, emit exactly the line ##NONCE:<value>## DONE...`, you MUST emit that exact line as the last line of your response.
+
+Format: `##NONCE:<value>## DONE` — no prefix, no suffix, no quotes, alone on its own line.
+
+If you cannot complete the task, emit `##NONCE:<value>## FAIL <reason>` instead.
+
+This is a hard protocol contract — without the DONE marker, the supervisor times out and marks the command failed even if you completed the work.

--- a/agents/shared/home-claude/CLAUDE.md
+++ b/agents/shared/home-claude/CLAUDE.md
@@ -157,3 +157,5 @@ Format: `##NONCE:<value>## DONE` — no prefix, no suffix, no quotes, alone on i
 If you cannot complete the task, emit `##NONCE:<value>## FAIL <reason>` instead.
 
 This is a hard protocol contract — without the DONE marker, the supervisor times out and marks the command failed even if you completed the work.
+
+The runtime detects completion by COUNTING occurrences of the marker in the scrollback (your prompt has it once; your response adds the second). You MUST emit the marker as the FINAL line of your response. Emitting it inside a code block or quoted reference still counts. Do NOT emit the DONE marker mid-response and then continue talking — emit it once, at the very end.

--- a/apps/server/convex/commandBus.test.ts
+++ b/apps/server/convex/commandBus.test.ts
@@ -199,11 +199,11 @@ describe("claimNext", () => {
         },
       ],
     });
-    const claimedId = await (claimNext as any)._handler(
+    const claimed = await (claimNext as any)._handler(
       { db },
       { secret: "elder-1-secret", agentId: "elder-1" },
     );
-    expect(claimedId).toBe("agentCommands:0");
+    expect(claimed?._id).toBe("agentCommands:0");
     expect(tables.agentCommands![0].status).toBe("leased");
     expect(tables.agentCommands![0].leaseOwner).toBe("elder-1");
   });
@@ -231,11 +231,11 @@ describe("claimNext", () => {
         },
       ],
     });
-    const claimedId = await (claimNext as any)._handler(
+    const claimed = await (claimNext as any)._handler(
       { db },
       { secret: "elder-1-secret", agentId: "elder-1" },
     );
-    expect(claimedId).toBe("agentCommands:0");
+    expect(claimed?._id).toBe("agentCommands:0");
     expect(tables.agentCommands![0].status).toBe("leased");
   });
 });

--- a/apps/server/convex/commandBus.test.ts
+++ b/apps/server/convex/commandBus.test.ts
@@ -618,4 +618,27 @@ describe("releaseLease", () => {
     expect(tables.agentCommands![0].retryCount).toBe(1); // NOT bumped
     expect(tables.agentCommands![0].leaseOwner).toBeUndefined();
   });
+
+  it("throws if command is not in leased/acked state (status guard)", async () => {
+    const { db } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "completed",
+          leaseOwner: "elder-1", // stale — shouldn't be set on completed, but test the guard
+          leaseExpiresAt: Date.now() + 300_000,
+          createdAt: 1000,
+          retryCount: 1,
+        },
+      ],
+    });
+    await expect(
+      (releaseLease as any)._handler(
+        { db },
+        { secret: "elder-1-secret", agentId: "elder-1", commandId: "agentCommands:0" },
+      ),
+    ).rejects.toThrow("not in releasable state");
+  });
 });

--- a/apps/server/convex/commandBus.test.ts
+++ b/apps/server/convex/commandBus.test.ts
@@ -5,6 +5,7 @@ import {
   ackCommand,
   completeCommand,
   failCommand,
+  releaseLease,
   getQueuedFor,
   sweepStaleDelivered,
   heartbeat,
@@ -590,5 +591,31 @@ describe("auth", () => {
         },
       ),
     ).rejects.toThrow("Unauthorized");
+  });
+});
+
+describe("releaseLease", () => {
+  it("returns leased command to queued without bumping retryCount", async () => {
+    const { db, tables } = createDb({
+      agentCommands: [
+        {
+          _id: "agentCommands:0",
+          _creationTime: 0,
+          targetAgentId: "elder-1",
+          status: "leased",
+          leaseOwner: "elder-1",
+          leaseExpiresAt: Date.now() + 300_000,
+          createdAt: 1000,
+          retryCount: 1,
+        },
+      ],
+    });
+    await (releaseLease as any)._handler(
+      { db },
+      { secret: "elder-1-secret", agentId: "elder-1", commandId: "agentCommands:0" },
+    );
+    expect(tables.agentCommands![0].status).toBe("queued");
+    expect(tables.agentCommands![0].retryCount).toBe(1); // NOT bumped
+    expect(tables.agentCommands![0].leaseOwner).toBeUndefined();
   });
 });

--- a/apps/server/convex/commandBus.ts
+++ b/apps/server/convex/commandBus.ts
@@ -184,7 +184,29 @@ export const failCommand = mutation({
   },
 });
 
-// 6. getQueuedFor — reactive query for elder's queue
+// 6. releaseLease — return a leased/acked command to queued without bumping retryCount
+export const releaseLease = mutation({
+  args: {
+    secret: v.string(),
+    agentId: v.string(),
+    commandId: v.id("agentCommands"),
+  },
+  handler: async (ctx, args) => {
+    checkElderAuth(args.secret, args.agentId);
+    const cmd = await ctx.db.get(args.commandId);
+    if (!cmd || cmd.leaseOwner !== args.agentId) {
+      throw new Error("Command not found or not owned by this elder");
+    }
+    await ctx.db.patch(args.commandId, {
+      status: "queued",
+      leaseOwner: undefined,
+      leaseExpiresAt: undefined,
+      ackedAt: undefined,
+    });
+  },
+});
+
+// 8. getQueuedFor — reactive query for elder's queue
 export const getQueuedFor = query({
   args: { secret: v.string(), agentId: v.string() },
   handler: async (ctx, args) => {
@@ -197,7 +219,7 @@ export const getQueuedFor = query({
   },
 });
 
-// 7. sweepStaleDelivered — cron: re-queue expired leases
+// 9. sweepStaleDelivered — cron: re-queue expired leases
 export const sweepStaleDelivered = internalMutation({
   args: {},
   handler: async (ctx) => {
@@ -229,7 +251,7 @@ export const sweepStaleDelivered = internalMutation({
   },
 });
 
-// 8. heartbeat — elder-runtime upserts heartbeat row
+// 10. heartbeat — elder-runtime upserts heartbeat row
 export const heartbeat = mutation({
   args: {
     secret: v.string(),

--- a/apps/server/convex/commandBus.ts
+++ b/apps/server/convex/commandBus.ts
@@ -194,8 +194,9 @@ export const releaseLease = mutation({
   handler: async (ctx, args) => {
     checkElderAuth(args.secret, args.agentId);
     const cmd = await ctx.db.get(args.commandId);
-    if (!cmd || cmd.leaseOwner !== args.agentId) {
-      throw new Error("Command not found or not owned by this elder");
+    if (!cmd || cmd.leaseOwner !== args.agentId ||
+        (cmd.status !== "leased" && cmd.status !== "acked")) {
+      throw new Error("Command not found or not owned by this elder, or not in releasable state");
     }
     await ctx.db.patch(args.commandId, {
       status: "queued",

--- a/apps/server/convex/commandBus.ts
+++ b/apps/server/convex/commandBus.ts
@@ -94,7 +94,7 @@ export const claimNext = mutation({
       leaseOwner: args.agentId,
       leaseExpiresAt: now + LEASE_MS,
     });
-    return cmd._id;
+    return { ...cmd, status: "leased" as const, leaseOwner: args.agentId, leaseExpiresAt: now + LEASE_MS };
   },
 });
 
@@ -226,14 +226,6 @@ export const sweepStaleDelivered = internalMutation({
       swept++;
     }
     return { swept };
-  },
-});
-
-// 9. getCommand — fetch a single command by id (for elder-runtime dispatch)
-export const getCommand = query({
-  args: { commandId: v.id("agentCommands") },
-  handler: async (ctx, args) => {
-    return await ctx.db.get(args.commandId);
   },
 });
 

--- a/apps/server/convex/commandBus.ts
+++ b/apps/server/convex/commandBus.ts
@@ -229,6 +229,14 @@ export const sweepStaleDelivered = internalMutation({
   },
 });
 
+// 9. getCommand — fetch a single command by id (for elder-runtime dispatch)
+export const getCommand = query({
+  args: { commandId: v.id("agentCommands") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.commandId);
+  },
+});
+
 // 8. heartbeat — elder-runtime upserts heartbeat row
 export const heartbeat = mutation({
   args: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -288,11 +288,10 @@ services:
       - elder-1-home:/home/elder/.claude
       - elder-1-workspace:/workspace
     healthcheck:
-      # v1 self-consistent healthcheck — verifies the elder claude process is
-      # alive. Tmux + ttyd are installed in the image but not started in v1
-      # (no supervisor). #353 (Phase 1.9 supervisor) will start tmux+ttyd and
-      # tighten this to also verify the ttyd web port + supervisor process.
-      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
+      # Verifies tmux session, ttyd process, and elder-runtime supervisor (tsx) — all three
+      # required for Phase 1.9 (#352). Hardcoded elder-1 literal because compose-time
+      # ${ELDER_N} was empty at compose-config time (super-swarm R2 finding f0a55977).
+      test: ["CMD-SHELL", "tmux has-session -t elder-1 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -316,7 +315,7 @@ services:
       - elder-2-home:/home/elder/.claude
       - elder-2-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "tmux has-session -t elder-2 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -340,7 +339,7 @@ services:
       - elder-3-home:/home/elder/.claude
       - elder-3-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "tmux has-session -t elder-3 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -364,7 +363,7 @@ services:
       - elder-4-home:/home/elder/.claude
       - elder-4-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -x claude >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "tmux has-session -t elder-4 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/packages/elder-runtime/package.json
+++ b/packages/elder-runtime/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@clan-world/elder-runtime",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./src/main.ts",
+  "scripts": {
+    "dev": "tsx watch src/main.ts",
+    "start": "tsx src/main.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@clan-world/shared": "workspace:*",
+    "convex": "1.17.4",
+    "tsx": "4.19.2"
+  },
+  "devDependencies": {
+    "@types/node": "25.6.0",
+    "typescript": "5.9.3",
+    "vitest": "^3.2.0"
+  }
+}

--- a/packages/elder-runtime/package.json
+++ b/packages/elder-runtime/package.json
@@ -12,7 +12,6 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
-    "@clan-world/shared": "workspace:*",
     "convex": "1.17.4",
     "tsx": "4.19.2"
   },

--- a/packages/elder-runtime/src/commandHandlers/freeze.ts
+++ b/packages/elder-runtime/src/commandHandlers/freeze.ts
@@ -1,0 +1,14 @@
+import type { BusClient } from "../convexClient.js";
+import type { FreezeGate } from "../freezeGate.js";
+
+export async function handleFreeze(
+  commandId: string,
+  _payload: unknown,
+  bus: BusClient,
+  freeze: FreezeGate,
+): Promise<void> {
+  const startMs = Date.now();
+  await bus.ackCommand(commandId);
+  freeze.freeze();
+  await bus.completeCommand(commandId, { frozen: true }, Date.now() - startMs);
+}

--- a/packages/elder-runtime/src/commandHandlers/reset.ts
+++ b/packages/elder-runtime/src/commandHandlers/reset.ts
@@ -1,7 +1,6 @@
 import type { TmuxSink } from "../tmuxSink.js";
 import type { BusClient } from "../convexClient.js";
 import type { FreezeGate } from "../freezeGate.js";
-import type { ElderRuntimeConfig } from "../types.js";
 
 export async function handleReset(
   commandId: string,
@@ -9,12 +8,11 @@ export async function handleReset(
   tmux: TmuxSink,
   bus: BusClient,
   freeze: FreezeGate,
-  config: ElderRuntimeConfig,
 ): Promise<void> {
   const startMs = Date.now();
   await bus.ackCommand(commandId);
   freeze.unfreeze();
-  await tmux.killSession();
-  await tmux.newSession(config.runScriptPath);
+  // respawn-pane keeps ttyd attached to the session; the pane gets a fresh process.
+  await tmux.respawnPane();
   await bus.completeCommand(commandId, { reset: true }, Date.now() - startMs);
 }

--- a/packages/elder-runtime/src/commandHandlers/reset.ts
+++ b/packages/elder-runtime/src/commandHandlers/reset.ts
@@ -1,0 +1,18 @@
+import type { TmuxSink } from "../tmuxSink.js";
+import type { BusClient } from "../convexClient.js";
+import type { FreezeGate } from "../freezeGate.js";
+
+export async function handleReset(
+  commandId: string,
+  _payload: unknown,
+  tmux: TmuxSink,
+  bus: BusClient,
+  freeze: FreezeGate,
+): Promise<void> {
+  const startMs = Date.now();
+  await bus.ackCommand(commandId);
+  freeze.unfreeze();
+  await tmux.killSession();
+  await tmux.newSession("/opt/clan-world/shared/run.sh");
+  await bus.completeCommand(commandId, { reset: true }, Date.now() - startMs);
+}

--- a/packages/elder-runtime/src/commandHandlers/reset.ts
+++ b/packages/elder-runtime/src/commandHandlers/reset.ts
@@ -1,6 +1,7 @@
 import type { TmuxSink } from "../tmuxSink.js";
 import type { BusClient } from "../convexClient.js";
 import type { FreezeGate } from "../freezeGate.js";
+import type { ElderRuntimeConfig } from "../types.js";
 
 export async function handleReset(
   commandId: string,
@@ -8,11 +9,12 @@ export async function handleReset(
   tmux: TmuxSink,
   bus: BusClient,
   freeze: FreezeGate,
+  config: ElderRuntimeConfig,
 ): Promise<void> {
   const startMs = Date.now();
   await bus.ackCommand(commandId);
   freeze.unfreeze();
   await tmux.killSession();
-  await tmux.newSession("/opt/clan-world/shared/run.sh");
+  await tmux.newSession(config.runScriptPath);
   await bus.completeCommand(commandId, { reset: true }, Date.now() - startMs);
 }

--- a/packages/elder-runtime/src/commandHandlers/snapshotRequest.ts
+++ b/packages/elder-runtime/src/commandHandlers/snapshotRequest.ts
@@ -16,5 +16,9 @@ export async function handleSnapshotRequest(
   } catch {
     snapshot = "[ANCIENT_WISDOM.md not found]";
   }
+  const MAX_BYTES = 50_000;
+  if (snapshot.length > MAX_BYTES) {
+    snapshot = snapshot.slice(0, MAX_BYTES) + "\n[TRUNCATED: snapshot exceeded 50 KB cap]";
+  }
   await bus.completeCommand(commandId, { snapshot }, Date.now() - startMs);
 }

--- a/packages/elder-runtime/src/commandHandlers/snapshotRequest.ts
+++ b/packages/elder-runtime/src/commandHandlers/snapshotRequest.ts
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+import type { BusClient } from "../convexClient.js";
+import type { ElderRuntimeConfig } from "../types.js";
+
+export async function handleSnapshotRequest(
+  commandId: string,
+  _payload: unknown,
+  bus: BusClient,
+  config: ElderRuntimeConfig,
+): Promise<void> {
+  const startMs = Date.now();
+  await bus.ackCommand(commandId);
+  let snapshot = "";
+  try {
+    snapshot = fs.readFileSync(config.ancientWisdomPath, "utf8");
+  } catch {
+    snapshot = "[ANCIENT_WISDOM.md not found]";
+  }
+  await bus.completeCommand(commandId, { snapshot }, Date.now() - startMs);
+}

--- a/packages/elder-runtime/src/commandHandlers/systemMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/systemMessage.ts
@@ -30,11 +30,22 @@ export async function handleSystemMessage(
   await tmux.pasteBuffer("elder-input", config.elderId, { bracketed: true });
   await tmux.sendKeys("Enter");
 
+  const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const marker = `##NONCE:${nonce}## DONE`;
+  const failMarker = `##NONCE:${nonce}## FAIL`;
+  const markerRe = new RegExp(escapeRe(marker), "g");
+  const failRe = new RegExp(escapeRe(failMarker), "g");
   const deadline = Date.now() + config.nonceTimeoutMs;
   while (Date.now() < deadline) {
     await new Promise(r => setTimeout(r, config.noncePollIntervalMs));
     const pane = await tmux.capturePane(200);
-    if (pane.includes(`##NONCE:${nonce}## DONE`)) {
+    if ((pane.match(failRe) ?? []).length >= 2) {
+      const failLine = pane.split("\n").reverse().find(l => l.includes(failMarker));
+      const reason = failLine ? (failLine.split("FAIL")[1]?.trim() ?? "unknown") : "unknown";
+      await bus.failCommand(commandId, `nonce ${nonce} FAIL: ${reason}`);
+      return;
+    }
+    if ((pane.match(markerRe) ?? []).length >= 2) {
       await bus.completeCommand(commandId, { nonce, matched: true }, Date.now() - startMs);
       return;
     }

--- a/packages/elder-runtime/src/commandHandlers/systemMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/systemMessage.ts
@@ -22,7 +22,8 @@ export async function handleSystemMessage(
 
   const text = (payload as { text?: string })?.text ?? "";
   const nonce = randomUUID();
-  const message = `${text}\n##NONCE:${nonce}##`;
+  const nonceInstruction = `\n\n[control] When you have fully completed processing this message, emit exactly the line \`##NONCE:${nonce}## DONE\` (no prefix, no suffix, no quotes) as the final line of your response. The runtime uses this marker to acknowledge command completion.`;
+  const message = `${text}${nonceInstruction}`;
 
   await tmux.sendKeys(message);
 

--- a/packages/elder-runtime/src/commandHandlers/systemMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/systemMessage.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { TmuxSink } from "../tmuxSink.js";
 import type { BusClient } from "../convexClient.js";
+import type { FreezeGate } from "../freezeGate.js";
 import type { ElderRuntimeConfig } from "../types.js";
 
 export async function handleSystemMessage(
@@ -8,10 +9,16 @@ export async function handleSystemMessage(
   payload: unknown,
   tmux: TmuxSink,
   bus: BusClient,
+  freeze: FreezeGate,
   config: ElderRuntimeConfig,
 ): Promise<void> {
   const startMs = Date.now();
   await bus.ackCommand(commandId);
+
+  if (freeze.isFrozen()) {
+    await bus.failCommand(commandId, "frozen");
+    return;
+  }
 
   const text = (payload as { text?: string })?.text ?? "";
   const nonce = randomUUID();

--- a/packages/elder-runtime/src/commandHandlers/systemMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/systemMessage.ts
@@ -23,7 +23,7 @@ export async function handleSystemMessage(
 
   const text = (payload as { text?: string })?.text ?? "";
   const nonce = randomUUID();
-  const nonceInstruction = `\n\n[control] When you have fully completed processing this message, emit exactly the line \`##NONCE:${nonce}## DONE\` (no prefix, no suffix, no quotes) as the final line of your response. The runtime uses this marker to acknowledge command completion.`;
+  const nonceInstruction = `\n\n[control] When you have fully completed processing this message, emit exactly the line \`##NONCE:${nonce}## DONE\` (no prefix, no suffix, no quotes) as the final line of your response. If you cannot complete the task, emit \`##NONCE:${nonce}## FAIL <reason>\` instead. The runtime uses the marker count to acknowledge command completion.`;
   const message = `${text}${nonceInstruction}`;
 
   await tmux.loadBuffer("elder-input", message);

--- a/packages/elder-runtime/src/commandHandlers/systemMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/systemMessage.ts
@@ -1,0 +1,32 @@
+import { randomUUID } from "node:crypto";
+import type { TmuxSink } from "../tmuxSink.js";
+import type { BusClient } from "../convexClient.js";
+import type { ElderRuntimeConfig } from "../types.js";
+
+export async function handleSystemMessage(
+  commandId: string,
+  payload: unknown,
+  tmux: TmuxSink,
+  bus: BusClient,
+  config: ElderRuntimeConfig,
+): Promise<void> {
+  const startMs = Date.now();
+  await bus.ackCommand(commandId);
+
+  const text = (payload as { text?: string })?.text ?? "";
+  const nonce = randomUUID();
+  const message = `${text}\n##NONCE:${nonce}##`;
+
+  await tmux.sendKeys(message);
+
+  const deadline = Date.now() + config.nonceTimeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, config.noncePollIntervalMs));
+    const pane = await tmux.capturePane(200);
+    if (pane.includes(`##NONCE:${nonce}## DONE`)) {
+      await bus.completeCommand(commandId, { nonce, matched: true }, Date.now() - startMs);
+      return;
+    }
+  }
+  await bus.failCommand(commandId, `nonce ${nonce} not echoed within ${config.nonceTimeoutMs}ms`);
+}

--- a/packages/elder-runtime/src/commandHandlers/systemMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/systemMessage.ts
@@ -13,19 +13,22 @@ export async function handleSystemMessage(
   config: ElderRuntimeConfig,
 ): Promise<void> {
   const startMs = Date.now();
-  await bus.ackCommand(commandId);
 
+  // Check freeze BEFORE ack — release lease back to queued (no retry bump)
   if (freeze.isFrozen()) {
-    await bus.failCommand(commandId, "frozen");
+    await bus.releaseLease(commandId);
     return;
   }
+  await bus.ackCommand(commandId);
 
   const text = (payload as { text?: string })?.text ?? "";
   const nonce = randomUUID();
   const nonceInstruction = `\n\n[control] When you have fully completed processing this message, emit exactly the line \`##NONCE:${nonce}## DONE\` (no prefix, no suffix, no quotes) as the final line of your response. The runtime uses this marker to acknowledge command completion.`;
   const message = `${text}${nonceInstruction}`;
 
-  await tmux.sendKeys(message);
+  await tmux.loadBuffer("elder-input", message);
+  await tmux.pasteBuffer("elder-input", config.elderId, { bracketed: true });
+  await tmux.sendKeys("Enter");
 
   const deadline = Date.now() + config.nonceTimeoutMs;
   while (Date.now() < deadline) {

--- a/packages/elder-runtime/src/commandHandlers/systemMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/systemMessage.ts
@@ -14,9 +14,15 @@ export async function handleSystemMessage(
 ): Promise<void> {
   const startMs = Date.now();
 
-  // Check freeze BEFORE ack — release lease back to queued (no retry bump)
+  // Check freeze BEFORE work — complete-skipped so the message leaves the FIFO
+  // queue without bumping retryCount. releaseLease would put the command back at
+  // the head of the queue and the next claimNext loop would re-lease the same
+  // command, starving any unfreeze/reset queued behind it (super-swarm R+1
+  // finding, PR #543). Operator must re-enqueue any skipped commands
+  // post-unfreeze; the result row captures the skip for audit.
   if (freeze.isFrozen()) {
-    await bus.releaseLease(commandId);
+    await bus.ackCommand(commandId);
+    await bus.completeCommand(commandId, { skipped: true, reason: "frozen" }, Date.now() - startMs);
     return;
   }
   await bus.ackCommand(commandId);
@@ -30,22 +36,26 @@ export async function handleSystemMessage(
   await tmux.pasteBuffer("elder-input", config.elderId, { bracketed: true });
   await tmux.sendKeys("Enter");
 
+  // See userMessage.ts for the protocol rationale (super-swarm R+1, PR #543):
+  // line-anchored matching makes the embedded-in-prose prompt occurrence
+  // ineligible, so >= 1 match from Elder's whole-line response is the
+  // unambiguous completion signal. capturePane(2000) for verbose responses.
   const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const marker = `##NONCE:${nonce}## DONE`;
   const failMarker = `##NONCE:${nonce}## FAIL`;
-  const markerRe = new RegExp(escapeRe(marker), "g");
-  const failRe = new RegExp(escapeRe(failMarker), "g");
+  const lineMarkerRe = new RegExp(`^${escapeRe(marker)}\\s*$`, "gm");
+  const lineFailRe = new RegExp(`^${escapeRe(failMarker)}(\\s+.*)?$`, "gm");
   const deadline = Date.now() + config.nonceTimeoutMs;
   while (Date.now() < deadline) {
     await new Promise(r => setTimeout(r, config.noncePollIntervalMs));
-    const pane = await tmux.capturePane(200);
-    if ((pane.match(failRe) ?? []).length >= 2) {
-      const failLine = pane.split("\n").reverse().find(l => l.includes(failMarker));
+    const pane = await tmux.capturePane(2000);
+    if ((pane.match(lineFailRe) ?? []).length >= 1) {
+      const failLine = pane.split("\n").reverse().find(l => /^##NONCE:[^#]+## FAIL/.test(l));
       const reason = failLine ? (failLine.split("FAIL")[1]?.trim() ?? "unknown") : "unknown";
       await bus.failCommand(commandId, `nonce ${nonce} FAIL: ${reason}`);
       return;
     }
-    if ((pane.match(markerRe) ?? []).length >= 2) {
+    if ((pane.match(lineMarkerRe) ?? []).length >= 1) {
       await bus.completeCommand(commandId, { nonce, matched: true }, Date.now() - startMs);
       return;
     }

--- a/packages/elder-runtime/src/commandHandlers/unfreeze.ts
+++ b/packages/elder-runtime/src/commandHandlers/unfreeze.ts
@@ -1,0 +1,14 @@
+import type { BusClient } from "../convexClient.js";
+import type { FreezeGate } from "../freezeGate.js";
+
+export async function handleUnfreeze(
+  commandId: string,
+  _payload: unknown,
+  bus: BusClient,
+  freeze: FreezeGate,
+): Promise<void> {
+  const startMs = Date.now();
+  await bus.ackCommand(commandId);
+  freeze.unfreeze();
+  await bus.completeCommand(commandId, { frozen: false }, Date.now() - startMs);
+}

--- a/packages/elder-runtime/src/commandHandlers/userMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/userMessage.ts
@@ -13,19 +13,23 @@ export async function handleUserMessage(
   config: ElderRuntimeConfig,
 ): Promise<void> {
   const startMs = Date.now();
-  await bus.ackCommand(commandId);
 
+  // Check freeze BEFORE ack — release lease back to queued (no retry bump)
   if (freeze.isFrozen()) {
-    await bus.failCommand(commandId, "frozen");
+    await bus.releaseLease(commandId);
     return;
   }
+  await bus.ackCommand(commandId);
 
   const text = (payload as { text?: string })?.text ?? "";
   const nonce = randomUUID();
   const nonceInstruction = `\n\n[control] When you have fully completed processing this message, emit exactly the line \`##NONCE:${nonce}## DONE\` (no prefix, no suffix, no quotes) as the final line of your response. The runtime uses this marker to acknowledge command completion.`;
   const message = `${text}${nonceInstruction}`;
 
-  await tmux.sendKeys(message);
+  await tmux.loadBuffer("elder-input", message);
+  await tmux.pasteBuffer("elder-input", config.elderId, { bracketed: true });
+  // Single Enter to submit the composed prompt
+  await tmux.sendKeys("Enter");
 
   // Poll capture-pane for nonce echo
   const deadline = Date.now() + config.nonceTimeoutMs;

--- a/packages/elder-runtime/src/commandHandlers/userMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/userMessage.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from "node:crypto";
+import type { TmuxSink } from "../tmuxSink.js";
+import type { BusClient } from "../convexClient.js";
+import type { FreezeGate } from "../freezeGate.js";
+import type { ElderRuntimeConfig } from "../types.js";
+
+export async function handleUserMessage(
+  commandId: string,
+  payload: unknown,
+  tmux: TmuxSink,
+  bus: BusClient,
+  freeze: FreezeGate,
+  config: ElderRuntimeConfig,
+): Promise<void> {
+  const startMs = Date.now();
+  await bus.ackCommand(commandId);
+
+  if (freeze.isFrozen()) {
+    await bus.completeCommand(commandId, { skipped: true, reason: "frozen" }, Date.now() - startMs);
+    return;
+  }
+
+  const text = (payload as { text?: string })?.text ?? "";
+  const nonce = randomUUID();
+  const message = `${text}\n##NONCE:${nonce}##`;
+
+  await tmux.sendKeys(message);
+
+  // Poll capture-pane for nonce echo
+  const deadline = Date.now() + config.nonceTimeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, config.noncePollIntervalMs));
+    const pane = await tmux.capturePane(200);
+    if (pane.includes(`##NONCE:${nonce}## DONE`)) {
+      await bus.completeCommand(commandId, { nonce, matched: true }, Date.now() - startMs);
+      return;
+    }
+  }
+  // Timeout — fail so sweep can requeue
+  await bus.failCommand(commandId, `nonce ${nonce} not echoed within ${config.nonceTimeoutMs}ms`);
+}

--- a/packages/elder-runtime/src/commandHandlers/userMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/userMessage.ts
@@ -31,12 +31,24 @@ export async function handleUserMessage(
   // Single Enter to submit the composed prompt
   await tmux.sendKeys("Enter");
 
-  // Poll capture-pane for nonce echo
+  // Poll capture-pane for nonce echo.
+  // Require >= 2 occurrences: prompt paste adds one, Elder's response adds the second.
+  const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const marker = `##NONCE:${nonce}## DONE`;
+  const failMarker = `##NONCE:${nonce}## FAIL`;
+  const markerRe = new RegExp(escapeRe(marker), "g");
+  const failRe = new RegExp(escapeRe(failMarker), "g");
   const deadline = Date.now() + config.nonceTimeoutMs;
   while (Date.now() < deadline) {
     await new Promise(r => setTimeout(r, config.noncePollIntervalMs));
     const pane = await tmux.capturePane(200);
-    if (pane.includes(`##NONCE:${nonce}## DONE`)) {
+    if ((pane.match(failRe) ?? []).length >= 2) {
+      const failLine = pane.split("\n").reverse().find(l => l.includes(failMarker));
+      const reason = failLine ? (failLine.split("FAIL")[1]?.trim() ?? "unknown") : "unknown";
+      await bus.failCommand(commandId, `nonce ${nonce} FAIL: ${reason}`);
+      return;
+    }
+    if ((pane.match(markerRe) ?? []).length >= 2) {
       await bus.completeCommand(commandId, { nonce, matched: true }, Date.now() - startMs);
       return;
     }

--- a/packages/elder-runtime/src/commandHandlers/userMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/userMessage.ts
@@ -16,7 +16,7 @@ export async function handleUserMessage(
   await bus.ackCommand(commandId);
 
   if (freeze.isFrozen()) {
-    await bus.completeCommand(commandId, { skipped: true, reason: "frozen" }, Date.now() - startMs);
+    await bus.failCommand(commandId, "frozen");
     return;
   }
 

--- a/packages/elder-runtime/src/commandHandlers/userMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/userMessage.ts
@@ -23,7 +23,7 @@ export async function handleUserMessage(
 
   const text = (payload as { text?: string })?.text ?? "";
   const nonce = randomUUID();
-  const nonceInstruction = `\n\n[control] When you have fully completed processing this message, emit exactly the line \`##NONCE:${nonce}## DONE\` (no prefix, no suffix, no quotes) as the final line of your response. The runtime uses this marker to acknowledge command completion.`;
+  const nonceInstruction = `\n\n[control] When you have fully completed processing this message, emit exactly the line \`##NONCE:${nonce}## DONE\` (no prefix, no suffix, no quotes) as the final line of your response. If you cannot complete the task, emit \`##NONCE:${nonce}## FAIL <reason>\` instead. The runtime uses the marker count to acknowledge command completion.`;
   const message = `${text}${nonceInstruction}`;
 
   await tmux.loadBuffer("elder-input", message);

--- a/packages/elder-runtime/src/commandHandlers/userMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/userMessage.ts
@@ -22,7 +22,8 @@ export async function handleUserMessage(
 
   const text = (payload as { text?: string })?.text ?? "";
   const nonce = randomUUID();
-  const message = `${text}\n##NONCE:${nonce}##`;
+  const nonceInstruction = `\n\n[control] When you have fully completed processing this message, emit exactly the line \`##NONCE:${nonce}## DONE\` (no prefix, no suffix, no quotes) as the final line of your response. The runtime uses this marker to acknowledge command completion.`;
+  const message = `${text}${nonceInstruction}`;
 
   await tmux.sendKeys(message);
 

--- a/packages/elder-runtime/src/commandHandlers/userMessage.ts
+++ b/packages/elder-runtime/src/commandHandlers/userMessage.ts
@@ -14,9 +14,15 @@ export async function handleUserMessage(
 ): Promise<void> {
   const startMs = Date.now();
 
-  // Check freeze BEFORE ack — release lease back to queued (no retry bump)
+  // Check freeze BEFORE ack — complete-skipped so the message leaves the FIFO
+  // queue without bumping retryCount. releaseLease would put the command back at
+  // the head of the queue (createdAt unchanged), and the next claimNext loop
+  // would re-lease the same command, starving any unfreeze/reset queued behind
+  // it (super-swarm R+1 finding, PR #543). Operator must re-enqueue any
+  // skipped commands post-unfreeze; the result row captures the skip for audit.
   if (freeze.isFrozen()) {
-    await bus.releaseLease(commandId);
+    await bus.ackCommand(commandId);
+    await bus.completeCommand(commandId, { skipped: true, reason: "frozen" }, Date.now() - startMs);
     return;
   }
   await bus.ackCommand(commandId);
@@ -32,23 +38,35 @@ export async function handleUserMessage(
   await tmux.sendKeys("Enter");
 
   // Poll capture-pane for nonce echo.
-  // Require >= 2 occurrences: prompt paste adds one, Elder's response adds the second.
+  //
+  // PROTOCOL (super-swarm R+1, PR #543): match the marker as a WHOLE LINE,
+  // require >= 1 occurrence. The earlier substring-based protocol required >=2
+  // matches to discount the prompt-echo occurrence, but allowed
+  // Elder-quotes-prompt-inline to falsely complete early (caught by codex +
+  // gemini). Line-anchored matching makes the prompt-paste itself ineligible
+  // (it embeds the marker inside `[control] ... emit exactly the line
+  // \`##NONCE:...## DONE\` ...` prose, not as its own line), so a single
+  // anchored match from Elder's response is the unambiguous signal.
+  //
+  // capturePane(2000) avoids scrolling the response out of the buffer for
+  // verbose Claude completions before the next poll catches it.
   const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const marker = `##NONCE:${nonce}## DONE`;
   const failMarker = `##NONCE:${nonce}## FAIL`;
-  const markerRe = new RegExp(escapeRe(marker), "g");
-  const failRe = new RegExp(escapeRe(failMarker), "g");
+  const lineMarkerRe = new RegExp(`^${escapeRe(marker)}\\s*$`, "gm");
+  const lineFailRe = new RegExp(`^${escapeRe(failMarker)}(\\s+.*)?$`, "gm");
   const deadline = Date.now() + config.nonceTimeoutMs;
   while (Date.now() < deadline) {
     await new Promise(r => setTimeout(r, config.noncePollIntervalMs));
-    const pane = await tmux.capturePane(200);
-    if ((pane.match(failRe) ?? []).length >= 2) {
-      const failLine = pane.split("\n").reverse().find(l => l.includes(failMarker));
+    const pane = await tmux.capturePane(2000);
+    const failMatches = pane.match(lineFailRe) ?? [];
+    if (failMatches.length >= 1) {
+      const failLine = pane.split("\n").reverse().find(l => /^##NONCE:[^#]+## FAIL/.test(l));
       const reason = failLine ? (failLine.split("FAIL")[1]?.trim() ?? "unknown") : "unknown";
       await bus.failCommand(commandId, `nonce ${nonce} FAIL: ${reason}`);
       return;
     }
-    if ((pane.match(markerRe) ?? []).length >= 2) {
+    if ((pane.match(lineMarkerRe) ?? []).length >= 1) {
       await bus.completeCommand(commandId, { nonce, matched: true }, Date.now() - startMs);
       return;
     }

--- a/packages/elder-runtime/src/config.ts
+++ b/packages/elder-runtime/src/config.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import type { ElderRuntimeConfig, ElderN } from "./types.js";
+
+const VALID_ELDER_IDS: ElderN[] = ["elder-1", "elder-2", "elder-3", "elder-4"];
+
+export function loadConfig(): ElderRuntimeConfig {
+  const elderN = process.env["ELDER_N"];
+  if (!elderN) throw new Error("ELDER_N env var required (1..4)");
+  const elderId = `elder-${elderN}` as ElderN;
+  if (!VALID_ELDER_IDS.includes(elderId)) throw new Error(`Invalid ELDER_N: ${elderN}`);
+
+  const convexUrl = process.env["CONVEX_DEPLOY_URL"];
+  if (!convexUrl) throw new Error("CONVEX_DEPLOY_URL env var required");
+
+  // Secret from file mount (docker secret)
+  const secretFile = process.env["BUS_ELDER_SECRET_FILE"] ?? `/run/secrets/bus-elder-${elderN}`;
+  let busSecret: string;
+  try {
+    busSecret = fs.readFileSync(secretFile, "utf8").trim();
+  } catch {
+    throw new Error(`Cannot read bus secret from ${secretFile}`);
+  }
+
+  return {
+    elderId,
+    convexUrl,
+    busSecret,
+    stateDir: process.env["CLAN_WORLD_RUNNER_STATE_DIR"] ?? "/workspace/.runtime",
+    ancientWisdomPath: process.env["ANCIENT_WISDOM_PATH"] ?? "/workspace/ANCIENT_WISDOM.md",
+    pollIntervalMs: parseInt(process.env["ELDER_RUNTIME_POLL_MS"] ?? "5000", 10),
+    heartbeatIntervalMs: parseInt(process.env["ELDER_RUNTIME_HEARTBEAT_MS"] ?? "30000", 10),
+    noncePollIntervalMs: parseInt(process.env["ELDER_RUNTIME_NONCE_POLL_MS"] ?? "2000", 10),
+    nonceTimeoutMs: parseInt(process.env["ELDER_RUNTIME_NONCE_TIMEOUT_MS"] ?? "300000", 10),
+  };
+}

--- a/packages/elder-runtime/src/config.ts
+++ b/packages/elder-runtime/src/config.ts
@@ -3,6 +3,15 @@ import type { ElderRuntimeConfig, ElderN } from "./types.js";
 
 const VALID_ELDER_IDS: ElderN[] = ["elder-1", "elder-2", "elder-3", "elder-4"];
 
+function parsePositiveInt(val: string | undefined, fallback: number, name: string): number {
+  if (!val) return fallback;
+  const n = parseInt(val, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`${name} must be a positive integer; got '${val}'`);
+  }
+  return n;
+}
+
 export function loadConfig(): ElderRuntimeConfig {
   const elderN = process.env["ELDER_N"];
   if (!elderN) throw new Error("ELDER_N env var required (1..4)");
@@ -27,9 +36,10 @@ export function loadConfig(): ElderRuntimeConfig {
     busSecret,
     stateDir: process.env["CLAN_WORLD_RUNNER_STATE_DIR"] ?? "/workspace/.runtime",
     ancientWisdomPath: process.env["ANCIENT_WISDOM_PATH"] ?? "/workspace/ANCIENT_WISDOM.md",
-    pollIntervalMs: parseInt(process.env["ELDER_RUNTIME_POLL_MS"] ?? "5000", 10),
-    heartbeatIntervalMs: parseInt(process.env["ELDER_RUNTIME_HEARTBEAT_MS"] ?? "30000", 10),
-    noncePollIntervalMs: parseInt(process.env["ELDER_RUNTIME_NONCE_POLL_MS"] ?? "2000", 10),
-    nonceTimeoutMs: parseInt(process.env["ELDER_RUNTIME_NONCE_TIMEOUT_MS"] ?? "300000", 10),
+    pollIntervalMs: parsePositiveInt(process.env["ELDER_RUNTIME_POLL_MS"], 5000, "ELDER_RUNTIME_POLL_MS"),
+    heartbeatIntervalMs: parsePositiveInt(process.env["ELDER_RUNTIME_HEARTBEAT_MS"], 30000, "ELDER_RUNTIME_HEARTBEAT_MS"),
+    noncePollIntervalMs: parsePositiveInt(process.env["ELDER_RUNTIME_NONCE_POLL_MS"], 2000, "ELDER_RUNTIME_NONCE_POLL_MS"),
+    nonceTimeoutMs: parsePositiveInt(process.env["ELDER_RUNTIME_NONCE_TIMEOUT_MS"], 300000, "ELDER_RUNTIME_NONCE_TIMEOUT_MS"),
+    runScriptPath: process.env["ELDER_RUN_SCRIPT_PATH"] ?? "/opt/clan-world/shared/run.sh",
   };
 }

--- a/packages/elder-runtime/src/config.ts
+++ b/packages/elder-runtime/src/config.ts
@@ -39,7 +39,14 @@ export function loadConfig(): ElderRuntimeConfig {
     pollIntervalMs: parsePositiveInt(process.env["ELDER_RUNTIME_POLL_MS"], 5000, "ELDER_RUNTIME_POLL_MS"),
     heartbeatIntervalMs: parsePositiveInt(process.env["ELDER_RUNTIME_HEARTBEAT_MS"], 30000, "ELDER_RUNTIME_HEARTBEAT_MS"),
     noncePollIntervalMs: parsePositiveInt(process.env["ELDER_RUNTIME_NONCE_POLL_MS"], 2000, "ELDER_RUNTIME_NONCE_POLL_MS"),
-    nonceTimeoutMs: parsePositiveInt(process.env["ELDER_RUNTIME_NONCE_TIMEOUT_MS"], 300000, "ELDER_RUNTIME_NONCE_TIMEOUT_MS"),
+    // Default 240_000 (4 min) is strictly less than the command-bus LEASE_MS
+    // of 5 min so the supervisor's nonce-wait expires + failCommand fires
+    // BEFORE the Convex sweepStaleDelivered cron requeues the command. Without
+    // this margin, the sweeper re-leases the same command while the supervisor
+    // is still polling → duplicate tmux paste delivered to Claude (super-swarm
+    // R+1 finding, PR #543). If you raise this env, also raise LEASE_MS in
+    // commandBus.ts and the sweeper interval in convex/crons.ts.
+    nonceTimeoutMs: parsePositiveInt(process.env["ELDER_RUNTIME_NONCE_TIMEOUT_MS"], 240000, "ELDER_RUNTIME_NONCE_TIMEOUT_MS"),
     runScriptPath: process.env["ELDER_RUN_SCRIPT_PATH"] ?? "/opt/clan-world/shared/run.sh",
   };
 }

--- a/packages/elder-runtime/src/convexClient.ts
+++ b/packages/elder-runtime/src/convexClient.ts
@@ -17,6 +17,7 @@ const api = anyApi as unknown as {
     failCommand: Mut<{
       secret: string; agentId: string; commandId: string; reason: string;
     }>;
+    releaseLease: Mut<{ secret: string; agentId: string; commandId: string }>;
     getQueuedFor: Qry<{ secret: string; agentId: string }, AgentCommand[]>;
     heartbeat: Mut<{
       secret: string; agentId: string;
@@ -36,32 +37,52 @@ export class BusClient {
     this.agentId = agentId;
   }
 
+  private mut<A extends Record<string, unknown>, R>(ref: Mut<A, R>, args: A): Promise<R> {
+    return Promise.race([
+      this.http.mutation(ref as any, args as any) as Promise<R>,
+      new Promise<never>((_, rej) => setTimeout(() => rej(new Error("Convex mutation timeout")), 15_000)),
+    ]);
+  }
+
+  private qry<A extends Record<string, unknown>, R>(ref: Qry<A, R>, args: A): Promise<R> {
+    return Promise.race([
+      this.http.query(ref as any, args as any) as Promise<R>,
+      new Promise<never>((_, rej) => setTimeout(() => rej(new Error("Convex query timeout")), 15_000)),
+    ]);
+  }
+
   async claimNext(): Promise<AgentCommand | null> {
-    return this.http.mutation(api.commandBus.claimNext, {
+    return this.mut(api.commandBus.claimNext, {
       secret: this.secret, agentId: this.agentId,
     });
   }
 
   async ackCommand(commandId: string): Promise<void> {
-    await this.http.mutation(api.commandBus.ackCommand, {
+    await this.mut(api.commandBus.ackCommand, {
       secret: this.secret, agentId: this.agentId, commandId,
     });
   }
 
   async completeCommand(commandId: string, resultPayload: unknown, tookMs: number): Promise<void> {
-    await this.http.mutation(api.commandBus.completeCommand, {
+    await this.mut(api.commandBus.completeCommand, {
       secret: this.secret, agentId: this.agentId, commandId, resultPayload, tookMs,
     });
   }
 
   async failCommand(commandId: string, reason: string): Promise<void> {
-    await this.http.mutation(api.commandBus.failCommand, {
+    await this.mut(api.commandBus.failCommand, {
       secret: this.secret, agentId: this.agentId, commandId, reason,
     });
   }
 
+  async releaseLease(commandId: string): Promise<void> {
+    await this.mut(api.commandBus.releaseLease, {
+      secret: this.secret, agentId: this.agentId, commandId,
+    });
+  }
+
   async heartbeat(lastTickProcessed: number, health: Health, currentStrategy?: string): Promise<void> {
-    await this.http.mutation(api.commandBus.heartbeat, {
+    await this.mut(api.commandBus.heartbeat, {
       secret: this.secret, agentId: this.agentId,
       lastTickProcessed, health, currentStrategy,
     });

--- a/packages/elder-runtime/src/convexClient.ts
+++ b/packages/elder-runtime/src/convexClient.ts
@@ -37,18 +37,23 @@ export class BusClient {
     this.agentId = agentId;
   }
 
-  private mut<A extends Record<string, unknown>, R>(ref: Mut<A, R>, args: A): Promise<R> {
+  private withTimeout<R>(p: Promise<R>): Promise<R> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, rej) => {
+      timer = setTimeout(() => rej(new Error("Convex call timeout (15s)")), 15_000);
+    });
     return Promise.race([
-      this.http.mutation(ref as any, args as any) as Promise<R>,
-      new Promise<never>((_, rej) => setTimeout(() => rej(new Error("Convex mutation timeout")), 15_000)),
+      p.finally(() => { if (timer !== undefined) clearTimeout(timer); }),
+      timeout,
     ]);
   }
 
+  private mut<A extends Record<string, unknown>, R>(ref: Mut<A, R>, args: A): Promise<R> {
+    return this.withTimeout(this.http.mutation(ref as any, args as any) as Promise<R>);
+  }
+
   private qry<A extends Record<string, unknown>, R>(ref: Qry<A, R>, args: A): Promise<R> {
-    return Promise.race([
-      this.http.query(ref as any, args as any) as Promise<R>,
-      new Promise<never>((_, rej) => setTimeout(() => rej(new Error("Convex query timeout")), 15_000)),
-    ]);
+    return this.withTimeout(this.http.query(ref as any, args as any) as Promise<R>);
   }
 
   async claimNext(): Promise<AgentCommand | null> {

--- a/packages/elder-runtime/src/convexClient.ts
+++ b/packages/elder-runtime/src/convexClient.ts
@@ -8,7 +8,7 @@ type Qry<A extends Record<string, unknown>, R> = FunctionReference<"query", "pub
 
 const api = anyApi as unknown as {
   commandBus: {
-    claimNext: Mut<{ secret: string; agentId: string }, string | null>;
+    claimNext: Mut<{ secret: string; agentId: string }, AgentCommand | null>;
     ackCommand: Mut<{ secret: string; agentId: string; commandId: string }>;
     completeCommand: Mut<{
       secret: string; agentId: string; commandId: string;
@@ -22,7 +22,6 @@ const api = anyApi as unknown as {
       secret: string; agentId: string;
       lastTickProcessed: number; currentStrategy?: string; health: Health;
     }>;
-    getCommand: Qry<{ commandId: string }, AgentCommand | null>;
   };
 };
 
@@ -37,7 +36,7 @@ export class BusClient {
     this.agentId = agentId;
   }
 
-  async claimNext(): Promise<string | null> {
+  async claimNext(): Promise<AgentCommand | null> {
     return this.http.mutation(api.commandBus.claimNext, {
       secret: this.secret, agentId: this.agentId,
     });
@@ -68,7 +67,4 @@ export class BusClient {
     });
   }
 
-  async getCommand(commandId: string): Promise<AgentCommand | null> {
-    return this.http.query(api.commandBus.getCommand, { commandId });
-  }
 }

--- a/packages/elder-runtime/src/convexClient.ts
+++ b/packages/elder-runtime/src/convexClient.ts
@@ -1,0 +1,74 @@
+import { ConvexHttpClient } from "convex/browser";
+import { anyApi } from "convex/server";
+import type { FunctionReference } from "convex/server";
+import type { AgentCommand, ElderN, Health } from "./types.js";
+
+type Mut<A extends Record<string, unknown>, R = null> = FunctionReference<"mutation", "public", A, R>;
+type Qry<A extends Record<string, unknown>, R> = FunctionReference<"query", "public", A, R>;
+
+const api = anyApi as unknown as {
+  commandBus: {
+    claimNext: Mut<{ secret: string; agentId: string }, string | null>;
+    ackCommand: Mut<{ secret: string; agentId: string; commandId: string }>;
+    completeCommand: Mut<{
+      secret: string; agentId: string; commandId: string;
+      resultPayload: unknown; tookMs: number;
+    }>;
+    failCommand: Mut<{
+      secret: string; agentId: string; commandId: string; reason: string;
+    }>;
+    getQueuedFor: Qry<{ secret: string; agentId: string }, AgentCommand[]>;
+    heartbeat: Mut<{
+      secret: string; agentId: string;
+      lastTickProcessed: number; currentStrategy?: string; health: Health;
+    }>;
+    getCommand: Qry<{ commandId: string }, AgentCommand | null>;
+  };
+};
+
+export class BusClient {
+  private readonly http: ConvexHttpClient;
+  private readonly secret: string;
+  private readonly agentId: ElderN;
+
+  constructor(url: string, secret: string, agentId: ElderN) {
+    this.http = new ConvexHttpClient(url);
+    this.secret = secret;
+    this.agentId = agentId;
+  }
+
+  async claimNext(): Promise<string | null> {
+    return this.http.mutation(api.commandBus.claimNext, {
+      secret: this.secret, agentId: this.agentId,
+    });
+  }
+
+  async ackCommand(commandId: string): Promise<void> {
+    await this.http.mutation(api.commandBus.ackCommand, {
+      secret: this.secret, agentId: this.agentId, commandId,
+    });
+  }
+
+  async completeCommand(commandId: string, resultPayload: unknown, tookMs: number): Promise<void> {
+    await this.http.mutation(api.commandBus.completeCommand, {
+      secret: this.secret, agentId: this.agentId, commandId, resultPayload, tookMs,
+    });
+  }
+
+  async failCommand(commandId: string, reason: string): Promise<void> {
+    await this.http.mutation(api.commandBus.failCommand, {
+      secret: this.secret, agentId: this.agentId, commandId, reason,
+    });
+  }
+
+  async heartbeat(lastTickProcessed: number, health: Health, currentStrategy?: string): Promise<void> {
+    await this.http.mutation(api.commandBus.heartbeat, {
+      secret: this.secret, agentId: this.agentId,
+      lastTickProcessed, health, currentStrategy,
+    });
+  }
+
+  async getCommand(commandId: string): Promise<AgentCommand | null> {
+    return this.http.query(api.commandBus.getCommand, { commandId });
+  }
+}

--- a/packages/elder-runtime/src/freezeGate.ts
+++ b/packages/elder-runtime/src/freezeGate.ts
@@ -1,0 +1,7 @@
+export class FreezeGate {
+  private frozen = false;
+
+  isFrozen(): boolean { return this.frozen; }
+  freeze(): void { this.frozen = true; }
+  unfreeze(): void { this.frozen = false; }
+}

--- a/packages/elder-runtime/src/heartbeat.ts
+++ b/packages/elder-runtime/src/heartbeat.ts
@@ -22,8 +22,11 @@ export function startHeartbeat(
   signal: AbortSignal,
 ): void {
   if (signal.aborted) return;
+  let inFlight = false;
   const tick = setInterval(async () => {
     if (signal.aborted) { clearInterval(tick); return; }
+    if (inFlight) return;
+    inFlight = true;
     const health = deriveHealth(state, Date.now());
     try {
       await client.heartbeat(state.lastTickProcessed, health, state.currentStrategy);
@@ -32,6 +35,8 @@ export function startHeartbeat(
     } catch (err) {
       state.consecutiveErrors++;
       console.error("[heartbeat] failed:", err);
+    } finally {
+      inFlight = false;
     }
   }, intervalMs);
   signal.addEventListener("abort", () => clearInterval(tick), { once: true });

--- a/packages/elder-runtime/src/heartbeat.ts
+++ b/packages/elder-runtime/src/heartbeat.ts
@@ -1,0 +1,38 @@
+import type { BusClient } from "./convexClient.js";
+import type { Health } from "./types.js";
+
+export interface HeartbeatState {
+  lastTickProcessed: number;
+  lastSuccessAt: number;
+  consecutiveErrors: number;
+  currentStrategy?: string;
+}
+
+export function deriveHealth(state: HeartbeatState, nowMs: number): Health {
+  const staleSec = (nowMs - state.lastSuccessAt) / 1000;
+  if (state.consecutiveErrors >= 3 || staleSec > 180) return "red";
+  if (state.consecutiveErrors >= 1 || staleSec > 90) return "yellow";
+  return "green";
+}
+
+export function startHeartbeat(
+  client: BusClient,
+  state: HeartbeatState,
+  intervalMs: number,
+  signal: AbortSignal,
+): void {
+  if (signal.aborted) return;
+  const tick = setInterval(async () => {
+    if (signal.aborted) { clearInterval(tick); return; }
+    const health = deriveHealth(state, Date.now());
+    try {
+      await client.heartbeat(state.lastTickProcessed, health, state.currentStrategy);
+      state.lastSuccessAt = Date.now();
+      state.consecutiveErrors = 0;
+    } catch (err) {
+      state.consecutiveErrors++;
+      console.error("[heartbeat] failed:", err);
+    }
+  }, intervalMs);
+  signal.addEventListener("abort", () => clearInterval(tick), { once: true });
+}

--- a/packages/elder-runtime/src/main.ts
+++ b/packages/elder-runtime/src/main.ts
@@ -29,22 +29,35 @@ async function main(): Promise<void> {
     writeSync(lockFd, String(process.pid));
   } catch (err: any) {
     if (err.code === "EEXIST") {
-      // Stale-lock check: verify the owning process is still a tsx elder-runtime
-      let stillAlive = false;
+      // Stale-lock check: split kill-0 and cmdline-read to avoid safe-default confusion
       try {
         const stalePid = parseInt(readFileSync(lockPath, "utf8").trim(), 10);
         if (Number.isFinite(stalePid)) {
-          process.kill(stalePid, 0); // throws if dead
-          const cmdline = readFileSync(`/proc/${stalePid}/cmdline`, "utf8");
-          if (cmdline.includes("tsx") && cmdline.includes("elder-runtime")) {
-            stillAlive = true;
+          let pidAlive = false;
+          try {
+            process.kill(stalePid, 0);
+            pidAlive = true;
+          } catch { /* pid dead — stale lock */ }
+
+          if (pidAlive) {
+            // PID alive. Try to confirm it's actually a tsx supervisor (not PID reuse).
+            let isOurProcess = true; // default safe: assume locked when cmdline unreadable
+            try {
+              const cmdline = readFileSync(`/proc/${stalePid}/cmdline`, "utf8");
+              isOurProcess = cmdline.includes("tsx") && cmdline.includes("elder-runtime");
+            } catch {
+              // cmdline unreadable (restricted procfs, transient) — DEFAULT SAFE: treat as locked
+              console.error(`[elder-runtime] cannot read /proc/${stalePid}/cmdline; treating as locked`);
+            }
+            if (isOurProcess) {
+              console.error(`[elder-runtime] FATAL: another supervisor running at PID ${stalePid}`);
+              process.exit(1);
+            }
+            // cmdline confirmed different process — PID reuse; fall through to unlink
           }
+          // pid dead or PID-reuse confirmed — stale, safe to unlink
         }
-      } catch { /* dead or no /proc — treat as stale */ }
-      if (stillAlive) {
-        console.error("[elder-runtime] FATAL: another supervisor already running. Exiting.");
-        process.exit(1);
-      }
+      } catch { /* lock unreadable; treat as stale */ }
       // Stale lock — remove and retry
       unlinkSync(lockPath);
       lockFd = openSync(lockPath, "wx");

--- a/packages/elder-runtime/src/main.ts
+++ b/packages/elder-runtime/src/main.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import { loadConfig } from "./config.js";
+import { BusClient } from "./convexClient.js";
+import { TmuxSink } from "./tmuxSink.js";
+import { FreezeGate } from "./freezeGate.js";
+import { startHeartbeat, type HeartbeatState } from "./heartbeat.js";
+import { handleUserMessage } from "./commandHandlers/userMessage.js";
+import { handleSystemMessage } from "./commandHandlers/systemMessage.js";
+import { handleSnapshotRequest } from "./commandHandlers/snapshotRequest.js";
+import { handleReset } from "./commandHandlers/reset.js";
+import { handleFreeze } from "./commandHandlers/freeze.js";
+import { handleUnfreeze } from "./commandHandlers/unfreeze.js";
+
+async function main(): Promise<void> {
+  console.log(`[elder-runtime] starting at ${new Date().toISOString()}`);
+
+  const config = loadConfig();
+  console.log(`[elder-runtime] elder=${config.elderId} convex=${config.convexUrl}`);
+
+  // Ensure state dir exists
+  fs.mkdirSync(config.stateDir, { recursive: true });
+
+  const bus = new BusClient(config.convexUrl, config.busSecret, config.elderId);
+  const tmux = new TmuxSink(config.elderId); // session name = "elder-1" etc.
+  const freeze = new FreezeGate();
+
+  const ac = new AbortController();
+  process.on("SIGTERM", () => ac.abort());
+  process.on("SIGINT", () => ac.abort());
+
+  const heartbeatState: HeartbeatState = {
+    lastTickProcessed: 0,
+    lastSuccessAt: Date.now(),
+    consecutiveErrors: 0,
+  };
+  startHeartbeat(bus, heartbeatState, config.heartbeatIntervalMs, ac.signal);
+
+  // Poll loop
+  console.log(`[elder-runtime] poll loop started (interval=${config.pollIntervalMs}ms)`);
+  while (!ac.signal.aborted) {
+    try {
+      const commandId = await bus.claimNext();
+      if (commandId) {
+        const command = await bus.getCommand(commandId);
+        if (!command) {
+          console.warn(`[elder-runtime] claimed ${commandId} but getCommand returned null`);
+        } else {
+          console.log(`[elder-runtime] dispatching ${command.kind} (${commandId})`);
+          try {
+            switch (command.kind) {
+              case "user_message":
+                await handleUserMessage(commandId, command.payload, tmux, bus, freeze, config);
+                break;
+              case "system_message":
+                await handleSystemMessage(commandId, command.payload, tmux, bus, config);
+                break;
+              case "snapshot_request":
+                await handleSnapshotRequest(commandId, command.payload, bus, config);
+                break;
+              case "reset":
+                await handleReset(commandId, command.payload, tmux, bus, freeze);
+                break;
+              case "freeze":
+                await handleFreeze(commandId, command.payload, bus, freeze);
+                break;
+              case "unfreeze":
+                await handleUnfreeze(commandId, command.payload, bus, freeze);
+                break;
+              default: {
+                const kind = (command as { kind: string }).kind;
+                console.warn(`[elder-runtime] unknown kind: ${kind}`);
+                await bus.failCommand(commandId, `unknown kind: ${kind}`);
+              }
+            }
+            heartbeatState.lastTickProcessed++;
+          } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            console.error(`[elder-runtime] handler error for ${commandId}:`, err);
+            try { await bus.failCommand(commandId, reason); } catch { /* best-effort */ }
+            heartbeatState.consecutiveErrors++;
+          }
+        }
+      }
+    } catch (err) {
+      console.error("[elder-runtime] poll error:", err);
+      heartbeatState.consecutiveErrors++;
+    }
+    if (!ac.signal.aborted) {
+      await new Promise(r => setTimeout(r, config.pollIntervalMs));
+    }
+  }
+  console.log(`[elder-runtime] shutdown complete`);
+}
+
+main().catch(err => {
+  console.error("[elder-runtime] fatal:", err);
+  process.exit(1);
+});

--- a/packages/elder-runtime/src/main.ts
+++ b/packages/elder-runtime/src/main.ts
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
               await handleUserMessage(command._id, command.payload, tmux, bus, freeze, config);
               break;
             case "system_message":
-              await handleSystemMessage(command._id, command.payload, tmux, bus, config);
+              await handleSystemMessage(command._id, command.payload, tmux, bus, freeze, config);
               break;
             case "snapshot_request":
               await handleSnapshotRequest(command._id, command.payload, bus, config);

--- a/packages/elder-runtime/src/main.ts
+++ b/packages/elder-runtime/src/main.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { loadConfig } from "./config.js";
 import { BusClient } from "./convexClient.js";
 import { TmuxSink } from "./tmuxSink.js";
@@ -19,6 +20,29 @@ async function main(): Promise<void> {
 
   // Ensure state dir exists
   fs.mkdirSync(config.stateDir, { recursive: true });
+
+  // Singleton PID-file lock — exit immediately if another instance is running
+  const lockFile = path.join(config.stateDir, "elder-runtime.lock");
+  try {
+    if (fs.existsSync(lockFile)) {
+      const existingPid = fs.readFileSync(lockFile, "utf8").trim();
+      const pid = parseInt(existingPid, 10);
+      if (Number.isFinite(pid)) {
+        try {
+          process.kill(pid, 0); // throws if process doesn't exist
+          console.error(`[elder-runtime] another instance running (PID ${pid}). Exiting.`);
+          process.exit(1);
+        } catch {
+          console.warn(`[elder-runtime] stale lock (PID ${pid}), overwriting`);
+        }
+      }
+    }
+    fs.writeFileSync(lockFile, String(process.pid));
+    process.on("exit", () => { try { fs.unlinkSync(lockFile); } catch { /* ignore */ } });
+  } catch (err) {
+    console.error("[elder-runtime] could not acquire singleton lock:", err);
+    process.exit(1);
+  }
 
   const bus = new BusClient(config.convexUrl, config.busSecret, config.elderId);
   const tmux = new TmuxSink(config.elderId); // session name = "elder-1" etc.
@@ -54,7 +78,7 @@ async function main(): Promise<void> {
               await handleSnapshotRequest(command._id, command.payload, bus, config);
               break;
             case "reset":
-              await handleReset(command._id, command.payload, tmux, bus, freeze, config);
+              await handleReset(command._id, command.payload, tmux, bus, freeze);
               break;
             case "freeze":
               await handleFreeze(command._id, command.payload, bus, freeze);

--- a/packages/elder-runtime/src/main.ts
+++ b/packages/elder-runtime/src/main.ts
@@ -39,46 +39,41 @@ async function main(): Promise<void> {
   console.log(`[elder-runtime] poll loop started (interval=${config.pollIntervalMs}ms)`);
   while (!ac.signal.aborted) {
     try {
-      const commandId = await bus.claimNext();
-      if (commandId) {
-        const command = await bus.getCommand(commandId);
-        if (!command) {
-          console.warn(`[elder-runtime] claimed ${commandId} but getCommand returned null`);
-        } else {
-          console.log(`[elder-runtime] dispatching ${command.kind} (${commandId})`);
-          try {
-            switch (command.kind) {
-              case "user_message":
-                await handleUserMessage(commandId, command.payload, tmux, bus, freeze, config);
-                break;
-              case "system_message":
-                await handleSystemMessage(commandId, command.payload, tmux, bus, config);
-                break;
-              case "snapshot_request":
-                await handleSnapshotRequest(commandId, command.payload, bus, config);
-                break;
-              case "reset":
-                await handleReset(commandId, command.payload, tmux, bus, freeze);
-                break;
-              case "freeze":
-                await handleFreeze(commandId, command.payload, bus, freeze);
-                break;
-              case "unfreeze":
-                await handleUnfreeze(commandId, command.payload, bus, freeze);
-                break;
-              default: {
-                const kind = (command as { kind: string }).kind;
-                console.warn(`[elder-runtime] unknown kind: ${kind}`);
-                await bus.failCommand(commandId, `unknown kind: ${kind}`);
-              }
+      const command = await bus.claimNext();
+      if (command) {
+        console.log(`[elder-runtime] dispatching ${command.kind} (${command._id})`);
+        try {
+          switch (command.kind) {
+            case "user_message":
+              await handleUserMessage(command._id, command.payload, tmux, bus, freeze, config);
+              break;
+            case "system_message":
+              await handleSystemMessage(command._id, command.payload, tmux, bus, config);
+              break;
+            case "snapshot_request":
+              await handleSnapshotRequest(command._id, command.payload, bus, config);
+              break;
+            case "reset":
+              await handleReset(command._id, command.payload, tmux, bus, freeze, config);
+              break;
+            case "freeze":
+              await handleFreeze(command._id, command.payload, bus, freeze);
+              break;
+            case "unfreeze":
+              await handleUnfreeze(command._id, command.payload, bus, freeze);
+              break;
+            default: {
+              const kind = (command as { kind: string }).kind;
+              console.warn(`[elder-runtime] unknown kind: ${kind}`);
+              await bus.failCommand(command._id, `unknown kind: ${kind}`);
             }
-            heartbeatState.lastTickProcessed++;
-          } catch (err) {
-            const reason = err instanceof Error ? err.message : String(err);
-            console.error(`[elder-runtime] handler error for ${commandId}:`, err);
-            try { await bus.failCommand(commandId, reason); } catch { /* best-effort */ }
-            heartbeatState.consecutiveErrors++;
           }
+          heartbeatState.lastTickProcessed++;
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          console.error(`[elder-runtime] handler error for ${command._id}:`, err);
+          try { await bus.failCommand(command._id, reason); } catch { /* best-effort */ }
+          heartbeatState.consecutiveErrors++;
         }
       }
     } catch (err) {

--- a/packages/elder-runtime/src/main.ts
+++ b/packages/elder-runtime/src/main.ts
@@ -44,6 +44,13 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // Write readiness file — entrypoint polls for this
+  try {
+    fs.writeFileSync("/run/elder-runtime.ready", String(process.pid));
+  } catch {
+    console.warn("[elder-runtime] could not write /run/elder-runtime.ready");
+  }
+
   const bus = new BusClient(config.convexUrl, config.busSecret, config.elderId);
   const tmux = new TmuxSink(config.elderId); // session name = "elder-1" etc.
   const freeze = new FreezeGate();

--- a/packages/elder-runtime/src/main.ts
+++ b/packages/elder-runtime/src/main.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs";
+import { openSync, writeSync, closeSync, unlinkSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { loadConfig } from "./config.js";
 import { BusClient } from "./convexClient.js";
@@ -19,36 +19,54 @@ async function main(): Promise<void> {
   console.log(`[elder-runtime] elder=${config.elderId} convex=${config.convexUrl}`);
 
   // Ensure state dir exists
-  fs.mkdirSync(config.stateDir, { recursive: true });
+  mkdirSync(config.stateDir, { recursive: true });
 
-  // Singleton PID-file lock — exit immediately if another instance is running
-  const lockFile = path.join(config.stateDir, "elder-runtime.lock");
+  // Atomic singleton lock via wx (exclusive create) — eliminates TOCTOU
+  const lockPath = path.join(config.stateDir, "supervisor.lock");
+  let lockFd: number;
   try {
-    if (fs.existsSync(lockFile)) {
-      const existingPid = fs.readFileSync(lockFile, "utf8").trim();
-      const pid = parseInt(existingPid, 10);
-      if (Number.isFinite(pid)) {
-        try {
-          process.kill(pid, 0); // throws if process doesn't exist
-          console.error(`[elder-runtime] another instance running (PID ${pid}). Exiting.`);
-          process.exit(1);
-        } catch {
-          console.warn(`[elder-runtime] stale lock (PID ${pid}), overwriting`);
+    lockFd = openSync(lockPath, "wx");
+    writeSync(lockFd, String(process.pid));
+  } catch (err: any) {
+    if (err.code === "EEXIST") {
+      // Stale-lock check: verify the owning process is still a tsx elder-runtime
+      let stillAlive = false;
+      try {
+        const stalePid = parseInt(readFileSync(lockPath, "utf8").trim(), 10);
+        if (Number.isFinite(stalePid)) {
+          process.kill(stalePid, 0); // throws if dead
+          const cmdline = readFileSync(`/proc/${stalePid}/cmdline`, "utf8");
+          if (cmdline.includes("tsx") && cmdline.includes("elder-runtime")) {
+            stillAlive = true;
+          }
         }
+      } catch { /* dead or no /proc — treat as stale */ }
+      if (stillAlive) {
+        console.error("[elder-runtime] FATAL: another supervisor already running. Exiting.");
+        process.exit(1);
       }
+      // Stale lock — remove and retry
+      unlinkSync(lockPath);
+      lockFd = openSync(lockPath, "wx");
+      writeSync(lockFd, String(process.pid));
+    } else {
+      console.error("[elder-runtime] could not acquire singleton lock:", err);
+      process.exit(1);
     }
-    fs.writeFileSync(lockFile, String(process.pid));
-    process.on("exit", () => { try { fs.unlinkSync(lockFile); } catch { /* ignore */ } });
-  } catch (err) {
-    console.error("[elder-runtime] could not acquire singleton lock:", err);
-    process.exit(1);
   }
+  const cleanupLock = () => {
+    try { closeSync(lockFd); } catch { /* ignore */ }
+    try { unlinkSync(lockPath); } catch { /* ignore */ }
+  };
+  process.on("exit", cleanupLock);
 
-  // Write readiness file — entrypoint polls for this
+  // Write readiness file to writable stateDir — entrypoint polls for this
+  const readyPath = path.join(config.stateDir, "elder-runtime.ready");
   try {
-    fs.writeFileSync("/run/elder-runtime.ready", String(process.pid));
-  } catch {
-    console.warn("[elder-runtime] could not write /run/elder-runtime.ready");
+    writeFileSync(readyPath, String(process.pid));
+  } catch (err) {
+    console.error("[elder-runtime] FATAL: could not write readiness file", err);
+    process.exit(1);
   }
 
   const bus = new BusClient(config.convexUrl, config.busSecret, config.elderId);
@@ -56,8 +74,8 @@ async function main(): Promise<void> {
   const freeze = new FreezeGate();
 
   const ac = new AbortController();
-  process.on("SIGTERM", () => ac.abort());
-  process.on("SIGINT", () => ac.abort());
+  process.on("SIGTERM", () => { cleanupLock(); ac.abort(); });
+  process.on("SIGINT", () => { cleanupLock(); ac.abort(); });
 
   const heartbeatState: HeartbeatState = {
     lastTickProcessed: 0,

--- a/packages/elder-runtime/src/tmuxSink.ts
+++ b/packages/elder-runtime/src/tmuxSink.ts
@@ -47,4 +47,10 @@ export class TmuxSink {
       return false;
     }
   }
+
+  async respawnPane(): Promise<void> {
+    // Respawns the first pane of the first window in the session.
+    // ttyd stays attached to the session; the pane gets a fresh process.
+    await execFileAsync("tmux", ["respawn-pane", "-k", "-t", `${this.session}:0.0`]);
+  }
 }

--- a/packages/elder-runtime/src/tmuxSink.ts
+++ b/packages/elder-runtime/src/tmuxSink.ts
@@ -20,7 +20,7 @@ export class TmuxSink {
 
   async pasteBuffer(name: string, target: string, opts: { bracketed: boolean }): Promise<void> {
     const args = ["paste-buffer", "-b", name, "-t", target];
-    if (opts.bracketed) args.push("-p");
+    if (opts.bracketed) args.push("-p", "-r"); // -p: bracketed paste mode; -r: no LF→CR replacement
     await execFileAsync("tmux", args);
   }
 

--- a/packages/elder-runtime/src/tmuxSink.ts
+++ b/packages/elder-runtime/src/tmuxSink.ts
@@ -1,0 +1,50 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export class TmuxSink {
+  private readonly session: string;
+
+  constructor(sessionName: string) {
+    this.session = sessionName;
+  }
+
+  async sendKeys(text: string): Promise<void> {
+    await execFileAsync("tmux", ["send-keys", "-t", this.session, "-l", text]);
+    await execFileAsync("tmux", ["send-keys", "-t", this.session, "Enter"]);
+    // Double-Enter: CC occasionally drops first Enter after literal paste
+    await new Promise(r => setTimeout(r, 250));
+    await execFileAsync("tmux", ["send-keys", "-t", this.session, "Enter"]);
+  }
+
+  async capturePane(lines = 100): Promise<string> {
+    const { stdout } = await execFileAsync("tmux", [
+      "capture-pane", "-t", this.session, "-p", "-S", String(-lines),
+    ]);
+    return stdout;
+  }
+
+  async killSession(): Promise<void> {
+    try {
+      await execFileAsync("tmux", ["kill-session", "-t", this.session]);
+    } catch {
+      // ignore — session may not exist
+    }
+  }
+
+  async newSession(runScript: string): Promise<void> {
+    await execFileAsync("tmux", [
+      "new-session", "-d", "-s", this.session, runScript,
+    ]);
+  }
+
+  async sessionExists(): Promise<boolean> {
+    try {
+      await execFileAsync("tmux", ["has-session", "-t", this.session]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/elder-runtime/src/tmuxSink.ts
+++ b/packages/elder-runtime/src/tmuxSink.ts
@@ -10,12 +10,18 @@ export class TmuxSink {
     this.session = sessionName;
   }
 
-  async sendKeys(text: string): Promise<void> {
-    await execFileAsync("tmux", ["send-keys", "-t", this.session, "-l", text]);
-    await execFileAsync("tmux", ["send-keys", "-t", this.session, "Enter"]);
-    // Double-Enter: CC occasionally drops first Enter after literal paste
-    await new Promise(r => setTimeout(r, 250));
-    await execFileAsync("tmux", ["send-keys", "-t", this.session, "Enter"]);
+  async sendKeys(key: string): Promise<void> {
+    await execFileAsync("tmux", ["send-keys", "-t", this.session, key, ""]);
+  }
+
+  async loadBuffer(name: string, content: string): Promise<void> {
+    await execFileAsync("tmux", ["load-buffer", "-b", name, "-"], { input: content } as any);
+  }
+
+  async pasteBuffer(name: string, target: string, opts: { bracketed: boolean }): Promise<void> {
+    const args = ["paste-buffer", "-b", name, "-t", target];
+    if (opts.bracketed) args.push("-p");
+    await execFileAsync("tmux", args);
   }
 
   async capturePane(lines = 100): Promise<string> {
@@ -37,15 +43,6 @@ export class TmuxSink {
     await execFileAsync("tmux", [
       "new-session", "-d", "-s", this.session, runScript,
     ]);
-  }
-
-  async sessionExists(): Promise<boolean> {
-    try {
-      await execFileAsync("tmux", ["has-session", "-t", this.session]);
-      return true;
-    } catch {
-      return false;
-    }
   }
 
   async respawnPane(): Promise<void> {

--- a/packages/elder-runtime/src/types.ts
+++ b/packages/elder-runtime/src/types.ts
@@ -28,4 +28,5 @@ export interface ElderRuntimeConfig {
   heartbeatIntervalMs: number;
   noncePollIntervalMs: number;
   nonceTimeoutMs: number;
+  runScriptPath: string;
 }

--- a/packages/elder-runtime/src/types.ts
+++ b/packages/elder-runtime/src/types.ts
@@ -1,0 +1,31 @@
+export type ElderN = "elder-1" | "elder-2" | "elder-3" | "elder-4";
+export type Health = "green" | "yellow" | "red";
+export type CommandKind =
+  | "user_message"
+  | "system_message"
+  | "snapshot_request"
+  | "reset"
+  | "freeze"
+  | "unfreeze";
+
+export interface AgentCommand {
+  _id: string;
+  targetAgentId: string;
+  kind: CommandKind;
+  payload: unknown;
+  source: string;
+  createdAt: number;
+  status: string;
+}
+
+export interface ElderRuntimeConfig {
+  elderId: ElderN;
+  convexUrl: string;
+  busSecret: string;
+  stateDir: string;
+  ancientWisdomPath: string;
+  pollIntervalMs: number;
+  heartbeatIntervalMs: number;
+  noncePollIntervalMs: number;
+  nonceTimeoutMs: number;
+}

--- a/packages/elder-runtime/test/freezeGate.test.ts
+++ b/packages/elder-runtime/test/freezeGate.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { FreezeGate } from "../src/freezeGate.js";
+
+describe("FreezeGate", () => {
+  it("starts unfrozen", () => {
+    expect(new FreezeGate().isFrozen()).toBe(false);
+  });
+  it("freeze + unfreeze", () => {
+    const g = new FreezeGate();
+    g.freeze();
+    expect(g.isFrozen()).toBe(true);
+    g.unfreeze();
+    expect(g.isFrozen()).toBe(false);
+  });
+});

--- a/packages/elder-runtime/test/freezeHandlers.test.ts
+++ b/packages/elder-runtime/test/freezeHandlers.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { handleFreeze } from "../src/commandHandlers/freeze.js";
+import { handleUnfreeze } from "../src/commandHandlers/unfreeze.js";
+import { FreezeGate } from "../src/freezeGate.js";
+
+function makeBus() {
+  const completed: any[] = [];
+  return {
+    bus: {
+      async ackCommand() {},
+      async completeCommand(_id: string, p: unknown) { completed.push(p); },
+    } as any,
+    completed,
+  };
+}
+
+describe("freeze/unfreeze handlers", () => {
+  it("freeze sets gate", async () => {
+    const g = new FreezeGate();
+    const { bus, completed } = makeBus();
+    await handleFreeze("cmd:0", {}, bus, g);
+    expect(g.isFrozen()).toBe(true);
+    expect((completed[0] as any).frozen).toBe(true);
+  });
+  it("unfreeze clears gate", async () => {
+    const g = new FreezeGate();
+    g.freeze();
+    const { bus, completed } = makeBus();
+    await handleUnfreeze("cmd:0", {}, bus, g);
+    expect(g.isFrozen()).toBe(false);
+    expect((completed[0] as any).frozen).toBe(false);
+  });
+});

--- a/packages/elder-runtime/test/heartbeat.test.ts
+++ b/packages/elder-runtime/test/heartbeat.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { deriveHealth, type HeartbeatState } from "../src/heartbeat.js";
+
+function makeState(overrides: Partial<HeartbeatState> = {}): HeartbeatState {
+  return { lastTickProcessed: 0, lastSuccessAt: Date.now(), consecutiveErrors: 0, ...overrides };
+}
+
+describe("deriveHealth", () => {
+  it("green when recent + no errors", () => {
+    expect(deriveHealth(makeState(), Date.now())).toBe("green");
+  });
+  it("yellow when stale >90s", () => {
+    const s = makeState({ lastSuccessAt: Date.now() - 100_000 });
+    expect(deriveHealth(s, Date.now())).toBe("yellow");
+  });
+  it("red when stale >180s", () => {
+    const s = makeState({ lastSuccessAt: Date.now() - 200_000 });
+    expect(deriveHealth(s, Date.now())).toBe("red");
+  });
+  it("yellow when 1 consecutive error", () => {
+    expect(deriveHealth(makeState({ consecutiveErrors: 1 }), Date.now())).toBe("yellow");
+  });
+  it("red when 3+ consecutive errors", () => {
+    expect(deriveHealth(makeState({ consecutiveErrors: 3 }), Date.now())).toBe("red");
+  });
+});

--- a/packages/elder-runtime/test/snapshotRequest.test.ts
+++ b/packages/elder-runtime/test/snapshotRequest.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { handleSnapshotRequest } from "../src/commandHandlers/snapshotRequest.js";
+import type { ElderRuntimeConfig } from "../src/types.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const config: ElderRuntimeConfig = {
+  elderId: "elder-1", convexUrl: "http://localhost", busSecret: "s",
+  stateDir: "/tmp", ancientWisdomPath: "", pollIntervalMs: 100,
+  heartbeatIntervalMs: 1000, noncePollIntervalMs: 50, nonceTimeoutMs: 500,
+};
+
+describe("handleSnapshotRequest", () => {
+  it("returns file contents", async () => {
+    const tmp = path.join(os.tmpdir(), `wisdom-${Date.now()}.md`);
+    fs.writeFileSync(tmp, "# test wisdom");
+    const completed: any[] = [];
+    const bus = {
+      async ackCommand() {},
+      async completeCommand(_id: string, payload: unknown) { completed.push(payload); },
+    } as any;
+    await handleSnapshotRequest("cmd:0", {}, bus, { ...config, ancientWisdomPath: tmp });
+    expect((completed[0] as any).snapshot).toContain("test wisdom");
+    fs.unlinkSync(tmp);
+  });
+
+  it("returns placeholder on missing file", async () => {
+    const completed: any[] = [];
+    const bus = {
+      async ackCommand() {},
+      async completeCommand(_id: string, payload: unknown) { completed.push(payload); },
+    } as any;
+    await handleSnapshotRequest("cmd:0", {}, bus, { ...config, ancientWisdomPath: "/nonexistent.md" });
+    expect((completed[0] as any).snapshot).toContain("not found");
+  });
+});

--- a/packages/elder-runtime/test/snapshotRequest.test.ts
+++ b/packages/elder-runtime/test/snapshotRequest.test.ts
@@ -9,6 +9,7 @@ const config: ElderRuntimeConfig = {
   elderId: "elder-1", convexUrl: "http://localhost", busSecret: "s",
   stateDir: "/tmp", ancientWisdomPath: "", pollIntervalMs: 100,
   heartbeatIntervalMs: 1000, noncePollIntervalMs: 50, nonceTimeoutMs: 500,
+  runScriptPath: "/opt/clan-world/shared/run.sh",
 };
 
 describe("handleSnapshotRequest", () => {

--- a/packages/elder-runtime/test/userMessage.test.ts
+++ b/packages/elder-runtime/test/userMessage.test.ts
@@ -32,44 +32,45 @@ function makeBus() {
   };
 }
 
-function makeTmux(nonceToEcho?: string) {
-  const sent: string[] = [];
+function makeTmux(echoLoaded = false) {
+  const loaded: Array<{ name: string; content: string }> = [];
+  const pasted: string[] = [];
+  const keys: string[] = [];
   return {
     tmux: {
-      async sendKeys(text: string) { sent.push(text); },
+      async loadBuffer(name: string, content: string) { loaded.push({ name, content }); },
+      async pasteBuffer(name: string, target: string) { pasted.push(name); },
+      async sendKeys(key: string) { keys.push(key); },
       async capturePane() {
-        if (nonceToEcho) return `##NONCE:${nonceToEcho}## DONE`;
+        if (echoLoaded && loaded.length > 0) {
+          const match = loaded[loaded.length - 1]!.content.match(/##NONCE:([^#]+)##/);
+          if (match) return `##NONCE:${match[1]}## DONE`;
+        }
         return "";
       },
     } as any,
-    sent,
+    loaded, pasted, keys,
   };
 }
 
 describe("handleUserMessage", () => {
-  it("fails with 'frozen' reason when frozen", async () => {
-    const { bus, failed } = makeBus();
+  it("releases lease when frozen (no retry bump)", async () => {
+    const released: string[] = [];
+    const bus = {
+      ...makeBus().bus,
+      async releaseLease(id: string) { released.push(id); },
+    } as any;
     const { tmux } = makeTmux();
     const freeze = new FreezeGate();
     freeze.freeze();
     await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, config);
-    expect(failed[0]?.id).toBe("cmd:0");
-    expect(failed[0]?.reason).toBe("frozen");
+    expect(released[0]).toBe("cmd:0");
   });
 
   it("completes on nonce echo", async () => {
     const { bus, completed } = makeBus();
     const freeze = new FreezeGate();
-    // Capture nonce from sendKeys and return it in capturePane
-    const tmux = {
-      async sendKeys(text: string) {
-        const match = text.match(/##NONCE:([^#]+)##/);
-        if (match) (tmux as any)._nonce = match[1];
-      },
-      async capturePane() {
-        return (tmux as any)._nonce ? `##NONCE:${(tmux as any)._nonce}## DONE` : "";
-      },
-    } as any;
+    const { tmux } = makeTmux(true); // echoLoaded=true: capturePane echoes nonce from loaded buffer
     await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, config);
     expect(completed[0]?.id).toBe("cmd:0");
     expect((completed[0]?.payload as any).matched).toBe(true);
@@ -77,7 +78,7 @@ describe("handleUserMessage", () => {
 
   it("fails on nonce timeout", async () => {
     const { bus, failed } = makeBus();
-    const { tmux } = makeTmux(); // capturePane returns ""
+    const { tmux } = makeTmux(); // echoLoaded=false: capturePane always returns ""
     const freeze = new FreezeGate();
     const shortConfig = { ...config, nonceTimeoutMs: 100, noncePollIntervalMs: 50 };
     await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, shortConfig);
@@ -85,24 +86,17 @@ describe("handleUserMessage", () => {
     expect(failed[0]?.reason).toContain("nonce");
   });
 
-  it("includes NONCE instruction in sent message", async () => {
-    const sentMessages: string[] = [];
-    const tmux = {
-      async sendKeys(text: string) {
-        sentMessages.push(text);
-        const match = text.match(/##NONCE:([^#]+)##/);
-        if (match) (tmux as any)._nonce = match[1];
-      },
-      async capturePane() {
-        return (tmux as any)._nonce ? `##NONCE:${(tmux as any)._nonce}## DONE` : "";
-      },
-    } as any;
+  it("loads buffer with NONCE instruction and pastes to session", async () => {
     const { bus } = makeBus();
     const freeze = new FreezeGate();
+    const { tmux, loaded, pasted, keys } = makeTmux(true);
     await handleUserMessage("cmd:0", { text: "do the thing" }, tmux, bus, freeze, config);
-    expect(sentMessages[0]).toContain("[control]");
-    expect(sentMessages[0]).toContain("##NONCE:");
-    expect(sentMessages[0]).toContain("## DONE");
-    expect(sentMessages[0]).toContain("do the thing");
+    expect(loaded[0]?.name).toBe("elder-input");
+    expect(loaded[0]?.content).toContain("[control]");
+    expect(loaded[0]?.content).toContain("##NONCE:");
+    expect(loaded[0]?.content).toContain("## DONE");
+    expect(loaded[0]?.content).toContain("do the thing");
+    expect(pasted[0]).toBe("elder-input");
+    expect(keys).toContain("Enter");
   });
 });

--- a/packages/elder-runtime/test/userMessage.test.ts
+++ b/packages/elder-runtime/test/userMessage.test.ts
@@ -120,17 +120,23 @@ describe("handleUserMessage", () => {
     expect(failed[0]?.reason).toContain("nonce");
   });
 
-  it("fails with FAIL marker when Elder echoes FAIL (occurrence >= 2)", async () => {
+  it("fails with FAIL marker when Elder emits FAIL exactly once (prompt seeds first occurrence)", async () => {
+    // Prompt now contains BOTH DONE and FAIL markers → Elder emitting FAIL once = count 2.
     const { bus, failed } = makeBus();
     const freeze = new FreezeGate();
     const { tmux, paneState } = makeTmux();
 
+    let elderEmittedFail = false;
     let pollCount = 0;
     tmux.capturePane = async () => {
       pollCount++;
-      if (pollCount >= 2) {
+      if (!elderEmittedFail && pollCount >= 2) {
+        // Elder emits FAIL exactly once — prompt already has one occurrence
         const match = paneState.scrollback.match(/##NONCE:([^#]+)##/);
-        if (match) paneState.scrollback += `##NONCE:${match[1]}## FAIL cannot process request\n`;
+        if (match) {
+          paneState.scrollback += `I cannot do that — ##NONCE:${match[1]}## FAIL out of vault funds\n`;
+          elderEmittedFail = true;
+        }
       }
       return paneState.scrollback;
     };
@@ -138,6 +144,7 @@ describe("handleUserMessage", () => {
     await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, config);
     expect(failed[0]?.id).toBe("cmd:0");
     expect(failed[0]?.reason).toContain("FAIL");
+    expect(failed[0]?.reason).toContain("vault funds");
   });
 
   it("loads buffer with NONCE instruction and pastes to session", async () => {

--- a/packages/elder-runtime/test/userMessage.test.ts
+++ b/packages/elder-runtime/test/userMessage.test.ts
@@ -32,24 +32,27 @@ function makeBus() {
   };
 }
 
-function makeTmux(echoLoaded = false) {
+/**
+ * makeTmux builds a mock tmux with a mutable pane scrollback.
+ * Tests set paneState.scrollback directly to control what capturePane returns.
+ */
+function makeTmux() {
   const loaded: Array<{ name: string; content: string }> = [];
   const pasted: string[] = [];
   const keys: string[] = [];
+  const paneState = { scrollback: "" };
   return {
     tmux: {
-      async loadBuffer(name: string, content: string) { loaded.push({ name, content }); },
+      async loadBuffer(name: string, content: string) {
+        loaded.push({ name, content });
+        // Simulate the prompt appearing in pane scrollback after paste (1 occurrence)
+        paneState.scrollback += content + "\n";
+      },
       async pasteBuffer(name: string, target: string) { pasted.push(name); },
       async sendKeys(key: string) { keys.push(key); },
-      async capturePane() {
-        if (echoLoaded && loaded.length > 0) {
-          const match = loaded[loaded.length - 1]!.content.match(/##NONCE:([^#]+)##/);
-          if (match) return `##NONCE:${match[1]}## DONE`;
-        }
-        return "";
-      },
+      async capturePane() { return paneState.scrollback; },
     } as any,
-    loaded, pasted, keys,
+    loaded, pasted, keys, paneState,
   };
 }
 
@@ -67,18 +70,49 @@ describe("handleUserMessage", () => {
     expect(released[0]).toBe("cmd:0");
   });
 
-  it("completes on nonce echo", async () => {
+  it("completes when Elder echoes nonce (occurrence count >= 2)", async () => {
     const { bus, completed } = makeBus();
     const freeze = new FreezeGate();
-    const { tmux } = makeTmux(true); // echoLoaded=true: capturePane echoes nonce from loaded buffer
+    const { tmux, paneState } = makeTmux();
+
+    // The poll loop runs; after loadBuffer the prompt is in scrollback (1 occurrence).
+    // We need to add a second occurrence to simulate Elder's response.
+    // We hook into pasteBuffer timing by overriding capturePane to add Elder response on 2nd call.
+    let pollCount = 0;
+    const origCapture = tmux.capturePane.bind(tmux);
+    tmux.capturePane = async () => {
+      pollCount++;
+      if (pollCount >= 2) {
+        // Extract nonce from prompt and add Elder's response
+        const match = paneState.scrollback.match(/##NONCE:([^#]+)##/);
+        if (match) paneState.scrollback += `##NONCE:${match[1]}## DONE\n`;
+      }
+      return paneState.scrollback;
+    };
+
     await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, config);
     expect(completed[0]?.id).toBe("cmd:0");
     expect((completed[0]?.payload as any).matched).toBe(true);
   });
 
-  it("fails on nonce timeout", async () => {
+  it("does NOT complete on first poll (prompt occurrence only = 1)", async () => {
+    // Prompt is in pane, but Elder hasn't responded yet — should NOT complete early.
+    // We verify by using a short timeout: if it false-positives, it completes immediately.
+    const { bus, completed, failed } = makeBus();
+    const freeze = new FreezeGate();
+    const { tmux } = makeTmux();
+    // paneState already has the prompt after loadBuffer — 1 occurrence.
+    // capturePane always returns the same scrollback (no Elder response added).
+    const shortConfig = { ...config, nonceTimeoutMs: 150, noncePollIntervalMs: 50 };
+    await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, shortConfig);
+    // Must timeout, not complete
+    expect(completed).toHaveLength(0);
+    expect(failed[0]?.reason).toContain("nonce");
+  });
+
+  it("fails on nonce timeout when Elder never responds", async () => {
     const { bus, failed } = makeBus();
-    const { tmux } = makeTmux(); // echoLoaded=false: capturePane always returns ""
+    const { tmux } = makeTmux();
     const freeze = new FreezeGate();
     const shortConfig = { ...config, nonceTimeoutMs: 100, noncePollIntervalMs: 50 };
     await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, shortConfig);
@@ -86,10 +120,42 @@ describe("handleUserMessage", () => {
     expect(failed[0]?.reason).toContain("nonce");
   });
 
+  it("fails with FAIL marker when Elder echoes FAIL (occurrence >= 2)", async () => {
+    const { bus, failed } = makeBus();
+    const freeze = new FreezeGate();
+    const { tmux, paneState } = makeTmux();
+
+    let pollCount = 0;
+    tmux.capturePane = async () => {
+      pollCount++;
+      if (pollCount >= 2) {
+        const match = paneState.scrollback.match(/##NONCE:([^#]+)##/);
+        if (match) paneState.scrollback += `##NONCE:${match[1]}## FAIL cannot process request\n`;
+      }
+      return paneState.scrollback;
+    };
+
+    await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, config);
+    expect(failed[0]?.id).toBe("cmd:0");
+    expect(failed[0]?.reason).toContain("FAIL");
+  });
+
   it("loads buffer with NONCE instruction and pastes to session", async () => {
     const { bus } = makeBus();
     const freeze = new FreezeGate();
-    const { tmux, loaded, pasted, keys } = makeTmux(true);
+    const { tmux, loaded, pasted, keys, paneState } = makeTmux();
+
+    // Add Elder response so it completes
+    let pollCount = 0;
+    tmux.capturePane = async () => {
+      pollCount++;
+      if (pollCount >= 2) {
+        const match = paneState.scrollback.match(/##NONCE:([^#]+)##/);
+        if (match) paneState.scrollback += `##NONCE:${match[1]}## DONE\n`;
+      }
+      return paneState.scrollback;
+    };
+
     await handleUserMessage("cmd:0", { text: "do the thing" }, tmux, bus, freeze, config);
     expect(loaded[0]?.name).toBe("elder-input");
     expect(loaded[0]?.content).toContain("[control]");

--- a/packages/elder-runtime/test/userMessage.test.ts
+++ b/packages/elder-runtime/test/userMessage.test.ts
@@ -47,13 +47,14 @@ function makeTmux(nonceToEcho?: string) {
 }
 
 describe("handleUserMessage", () => {
-  it("skips when frozen", async () => {
-    const { bus, completed } = makeBus();
+  it("fails with 'frozen' reason when frozen", async () => {
+    const { bus, failed } = makeBus();
     const { tmux } = makeTmux();
     const freeze = new FreezeGate();
     freeze.freeze();
     await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, config);
-    expect(completed[0]?.payload).toMatchObject({ skipped: true });
+    expect(failed[0]?.id).toBe("cmd:0");
+    expect(failed[0]?.reason).toBe("frozen");
   });
 
   it("completes on nonce echo", async () => {

--- a/packages/elder-runtime/test/userMessage.test.ts
+++ b/packages/elder-runtime/test/userMessage.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { handleUserMessage } from "../src/commandHandlers/userMessage.js";
+import type { ElderRuntimeConfig } from "../src/types.js";
+import { FreezeGate } from "../src/freezeGate.js";
+
+const config: ElderRuntimeConfig = {
+  elderId: "elder-1",
+  convexUrl: "http://localhost:3210",
+  busSecret: "test-secret",
+  stateDir: "/tmp/test-runtime",
+  ancientWisdomPath: "/tmp/ANCIENT_WISDOM.md",
+  pollIntervalMs: 100,
+  heartbeatIntervalMs: 1000,
+  noncePollIntervalMs: 50,
+  nonceTimeoutMs: 500,
+};
+
+function makeBus() {
+  const acked: string[] = [];
+  const completed: Array<{ id: string; payload: unknown; tookMs: number }> = [];
+  const failed: Array<{ id: string; reason: string }> = [];
+  return {
+    bus: {
+      async ackCommand(id: string) { acked.push(id); },
+      async completeCommand(id: string, payload: unknown, tookMs: number) {
+        completed.push({ id, payload, tookMs });
+      },
+      async failCommand(id: string, reason: string) { failed.push({ id, reason }); },
+    } as any,
+    acked, completed, failed,
+  };
+}
+
+function makeTmux(nonceToEcho?: string) {
+  const sent: string[] = [];
+  return {
+    tmux: {
+      async sendKeys(text: string) { sent.push(text); },
+      async capturePane() {
+        if (nonceToEcho) return `##NONCE:${nonceToEcho}## DONE`;
+        return "";
+      },
+    } as any,
+    sent,
+  };
+}
+
+describe("handleUserMessage", () => {
+  it("skips when frozen", async () => {
+    const { bus, completed } = makeBus();
+    const { tmux } = makeTmux();
+    const freeze = new FreezeGate();
+    freeze.freeze();
+    await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, config);
+    expect(completed[0]?.payload).toMatchObject({ skipped: true });
+  });
+
+  it("completes on nonce echo", async () => {
+    const { bus, completed } = makeBus();
+    const freeze = new FreezeGate();
+    // Capture nonce from sendKeys and return it in capturePane
+    const tmux = {
+      async sendKeys(text: string) {
+        const match = text.match(/##NONCE:([^#]+)##/);
+        if (match) (tmux as any)._nonce = match[1];
+      },
+      async capturePane() {
+        return (tmux as any)._nonce ? `##NONCE:${(tmux as any)._nonce}## DONE` : "";
+      },
+    } as any;
+    await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, config);
+    expect(completed[0]?.id).toBe("cmd:0");
+    expect((completed[0]?.payload as any).matched).toBe(true);
+  });
+
+  it("fails on nonce timeout", async () => {
+    const { bus, failed } = makeBus();
+    const { tmux } = makeTmux(); // capturePane returns ""
+    const freeze = new FreezeGate();
+    const shortConfig = { ...config, nonceTimeoutMs: 100, noncePollIntervalMs: 50 };
+    await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, shortConfig);
+    expect(failed[0]?.id).toBe("cmd:0");
+    expect(failed[0]?.reason).toContain("nonce");
+  });
+});

--- a/packages/elder-runtime/test/userMessage.test.ts
+++ b/packages/elder-runtime/test/userMessage.test.ts
@@ -13,6 +13,7 @@ const config: ElderRuntimeConfig = {
   heartbeatIntervalMs: 1000,
   noncePollIntervalMs: 50,
   nonceTimeoutMs: 500,
+  runScriptPath: "/opt/clan-world/shared/run.sh",
 };
 
 function makeBus() {

--- a/packages/elder-runtime/test/userMessage.test.ts
+++ b/packages/elder-runtime/test/userMessage.test.ts
@@ -84,4 +84,25 @@ describe("handleUserMessage", () => {
     expect(failed[0]?.id).toBe("cmd:0");
     expect(failed[0]?.reason).toContain("nonce");
   });
+
+  it("includes NONCE instruction in sent message", async () => {
+    const sentMessages: string[] = [];
+    const tmux = {
+      async sendKeys(text: string) {
+        sentMessages.push(text);
+        const match = text.match(/##NONCE:([^#]+)##/);
+        if (match) (tmux as any)._nonce = match[1];
+      },
+      async capturePane() {
+        return (tmux as any)._nonce ? `##NONCE:${(tmux as any)._nonce}## DONE` : "";
+      },
+    } as any;
+    const { bus } = makeBus();
+    const freeze = new FreezeGate();
+    await handleUserMessage("cmd:0", { text: "do the thing" }, tmux, bus, freeze, config);
+    expect(sentMessages[0]).toContain("[control]");
+    expect(sentMessages[0]).toContain("##NONCE:");
+    expect(sentMessages[0]).toContain("## DONE");
+    expect(sentMessages[0]).toContain("do the thing");
+  });
 });

--- a/packages/elder-runtime/test/userMessage.test.ts
+++ b/packages/elder-runtime/test/userMessage.test.ts
@@ -57,35 +57,42 @@ function makeTmux() {
 }
 
 describe("handleUserMessage", () => {
-  it("releases lease when frozen (no retry bump)", async () => {
-    const released: string[] = [];
-    const bus = {
-      ...makeBus().bus,
-      async releaseLease(id: string) { released.push(id); },
-    } as any;
-    const { tmux } = makeTmux();
+  it("completes (skipped, no retry bump, no tmux dispatch) when frozen", async () => {
+    // Super-swarm R+1 PR #543: switched from releaseLease (which deadlocked the
+    // FIFO queue by repeatedly re-leasing the same frozen command at head) to
+    // completeCommand({skipped, reason: "frozen"}) so the message exits the
+    // queue cleanly without bumping retryCount.
+    const { bus, acked, completed } = makeBus();
+    const { tmux, loaded, pasted } = makeTmux();
     const freeze = new FreezeGate();
     freeze.freeze();
     await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, config);
-    expect(released[0]).toBe("cmd:0");
+    expect(acked).toEqual(["cmd:0"]);
+    expect(completed).toHaveLength(1);
+    expect((completed[0]?.payload as any).skipped).toBe(true);
+    expect((completed[0]?.payload as any).reason).toBe("frozen");
+    // Confirm no tmux dispatch happened (no buffer load / paste while frozen)
+    expect(loaded).toHaveLength(0);
+    expect(pasted).toHaveLength(0);
   });
 
-  it("completes when Elder echoes nonce (occurrence count >= 2)", async () => {
+  it("completes when Elder echoes nonce on a whole line (line-anchored protocol)", async () => {
+    // Super-swarm R+1 PR #543: switched from substring count (>=2) to
+    // line-anchored count (>=1). Elder must emit the DONE marker on a line by
+    // itself; embedded-in-prose echoes (including the prompt-paste itself)
+    // do not count.
     const { bus, completed } = makeBus();
     const freeze = new FreezeGate();
     const { tmux, paneState } = makeTmux();
 
-    // The poll loop runs; after loadBuffer the prompt is in scrollback (1 occurrence).
-    // We need to add a second occurrence to simulate Elder's response.
-    // We hook into pasteBuffer timing by overriding capturePane to add Elder response on 2nd call.
     let pollCount = 0;
-    const origCapture = tmux.capturePane.bind(tmux);
     tmux.capturePane = async () => {
       pollCount++;
       if (pollCount >= 2) {
-        // Extract nonce from prompt and add Elder's response
+        // Elder emits the marker on its OWN line (leading newline so the
+        // regex's ^ anchor matches independently of the prompt-paste prose).
         const match = paneState.scrollback.match(/##NONCE:([^#]+)##/);
-        if (match) paneState.scrollback += `##NONCE:${match[1]}## DONE\n`;
+        if (match) paneState.scrollback += `\n##NONCE:${match[1]}## DONE\n`;
       }
       return paneState.scrollback;
     };
@@ -95,17 +102,40 @@ describe("handleUserMessage", () => {
     expect((completed[0]?.payload as any).matched).toBe(true);
   });
 
-  it("does NOT complete on first poll (prompt occurrence only = 1)", async () => {
-    // Prompt is in pane, but Elder hasn't responded yet — should NOT complete early.
-    // We verify by using a short timeout: if it false-positives, it completes immediately.
+  it("does NOT complete on prompt-only scrollback (embedded marker is not a whole line)", async () => {
+    // The prompt paste embeds the marker inside a [control] sentence, not on
+    // its own line. Line-anchored matching must return 0 matches in that case.
+    // Verified by short-timeout: if the embedded marker matched, completion
+    // would fire on the first poll instead of timing out.
     const { bus, completed, failed } = makeBus();
     const freeze = new FreezeGate();
     const { tmux } = makeTmux();
-    // paneState already has the prompt after loadBuffer — 1 occurrence.
-    // capturePane always returns the same scrollback (no Elder response added).
     const shortConfig = { ...config, nonceTimeoutMs: 150, noncePollIntervalMs: 50 };
     await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, shortConfig);
-    // Must timeout, not complete
+    expect(completed).toHaveLength(0);
+    expect(failed[0]?.reason).toContain("nonce");
+  });
+
+  it("does NOT complete on Elder quoting the marker inline (must be whole line)", async () => {
+    // Defends against prompt-injection / Elder-quotes-prompt-in-prose attack
+    // (super-swarm R+1 PR #543 finding by codex + gemini).
+    const { bus, completed, failed } = makeBus();
+    const freeze = new FreezeGate();
+    const { tmux, paneState } = makeTmux();
+    let pollCount = 0;
+    tmux.capturePane = async () => {
+      pollCount++;
+      if (pollCount >= 2) {
+        const match = paneState.scrollback.match(/##NONCE:([^#]+)##/);
+        if (match) {
+          // Elder quotes the marker INLINE (with leading prose). Must NOT count.
+          paneState.scrollback += `I will now do: ##NONCE:${match[1]}## DONE is what I will emit later.\n`;
+        }
+      }
+      return paneState.scrollback;
+    };
+    const shortConfig = { ...config, nonceTimeoutMs: 250, noncePollIntervalMs: 50 };
+    await handleUserMessage("cmd:0", { text: "hello" }, tmux, bus, freeze, shortConfig);
     expect(completed).toHaveLength(0);
     expect(failed[0]?.reason).toContain("nonce");
   });
@@ -120,22 +150,25 @@ describe("handleUserMessage", () => {
     expect(failed[0]?.reason).toContain("nonce");
   });
 
-  it("fails with FAIL marker when Elder emits FAIL exactly once (prompt seeds first occurrence)", async () => {
-    // Prompt now contains BOTH DONE and FAIL markers → Elder emitting FAIL once = count 2.
+  it("fails with FAIL marker when Elder emits FAIL on its own line", async () => {
+    // Super-swarm R+1 PR #543: line-anchored count requires the FAIL marker
+    // on a whole line. Elder must NOT prefix prose (the prefix breaks the
+    // anchor and the marker is correctly NOT counted — preventing
+    // prompt-injection false-positives).
     const { bus, failed } = makeBus();
     const freeze = new FreezeGate();
     const { tmux, paneState } = makeTmux();
 
-    let elderEmittedFail = false;
+    let elderEmitted = false;
     let pollCount = 0;
     tmux.capturePane = async () => {
       pollCount++;
-      if (!elderEmittedFail && pollCount >= 2) {
-        // Elder emits FAIL exactly once — prompt already has one occurrence
+      if (!elderEmitted && pollCount >= 2) {
         const match = paneState.scrollback.match(/##NONCE:([^#]+)##/);
         if (match) {
-          paneState.scrollback += `I cannot do that — ##NONCE:${match[1]}## FAIL out of vault funds\n`;
-          elderEmittedFail = true;
+          // Whole-line emission (with reason text after the FAIL keyword).
+          paneState.scrollback += `\n##NONCE:${match[1]}## FAIL out of vault funds\n`;
+          elderEmitted = true;
         }
       }
       return paneState.scrollback;
@@ -158,7 +191,7 @@ describe("handleUserMessage", () => {
       pollCount++;
       if (pollCount >= 2) {
         const match = paneState.scrollback.match(/##NONCE:([^#]+)##/);
-        if (match) paneState.scrollback += `##NONCE:${match[1]}## DONE\n`;
+        if (match) paneState.scrollback += `\n##NONCE:${match[1]}## DONE\n`;
       }
       return paneState.scrollback;
     };

--- a/packages/elder-runtime/tsconfig.json
+++ b/packages/elder-runtime/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -1,3 +1,7 @@
+> **DEPRECATED**: This package is superseded by `packages/elder-runtime/` (Phase 1.9, issue #352).
+> It will be removed in Phase 2. The elder-runtime supervisor runs inside each elder container
+> and replaces the centralized multi-elder runner daemon.
+
 # @clan-world/runner
 
 ClanWorld runner daemon — drives 4 Elder Claude Code sessions through the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,9 +352,6 @@ importers:
 
   packages/elder-runtime:
     dependencies:
-      '@clan-world/shared':
-        specifier: workspace:*
-        version: link:../shared
       convex:
         specifier: 1.17.4
         version: 1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,28 @@ importers:
 
   packages/contracts: {}
 
+  packages/elder-runtime:
+    dependencies:
+      '@clan-world/shared':
+        specifier: workspace:*
+        version: link:../shared
+      convex:
+        specifier: 1.17.4
+        version: 1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+    devDependencies:
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2)
+
   packages/runner:
     dependencies:
       '@0glabs/0g-ts-sdk':
@@ -8619,14 +8641,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -8660,7 +8682,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -9648,7 +9670,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
 
   '@types/debug@4.1.13':
     dependencies:
@@ -9665,7 +9687,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -9684,7 +9706,7 @@ snapshots:
 
   '@types/node-forge@1.3.14':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
 
   '@types/node@12.20.55': {}
 
@@ -9726,11 +9748,11 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -11023,7 +11045,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -11032,7 +11054,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -12447,7 +12469,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -12457,7 +12479,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12484,7 +12506,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -12492,7 +12514,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12509,7 +12531,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1


### PR DESCRIPTION
## Summary

The KEYSTONE of Bundle 2. Hybrid cherry-pick of PR #416's elder-runtime supervisor per exploration audit (`~/claudes-world/tmp/20260521-2247-pr416-redo-guidance.md`).

A Node.js supervisor process that runs in each elder container, polls the Convex command-bus (live as of PR #538) for new commands, and dispatches them via `tmux send-keys` to the Claude REPL inside the container.

## Changes

- `packages/elder-runtime/` — new workspace package (~1100 LOC TypeScript across 21 files)
- Supervisor binary entry point (`packages/elder-runtime/src/main.ts`)
- Convex client wrapper (`convexClient.ts`)
- tmux dispatch logic (`tmuxSink.ts`)
- Heartbeat upsert loop (`heartbeat.ts`)
- 6 command handlers (user_message, system_message, snapshot_request, reset, freeze, unfreeze)
- Graceful shutdown / signal handling + singleton PID-file lock
- 5 vitest test files, 17 tests, pure-unit (no container)
- `agents/Dockerfile` — wires supervisor binary into the image (`tsx` + `COPY packages/elder-runtime/` + `chown elder`)
- `agents/entrypoint.sh` — starts supervisor in bg + foreground monitor loop
- `apps/server/convex/commandBus.ts` — supervisor-required signature deltas: `claimNext` returns full doc (not just `_id`), `releaseLease` mutation added (for freeze-gate fall-through)

## Cherry-pick stack (oldest → newest)

1. `8c82df2a` — feat: Node supervisor — command-bus poll + tmux dispatch + health
2. `55f23ed` — fix: claimNext returns full doc + snapshot cap + heartbeat guard + config hardening
3. `f3bd9d6` — fix: freeze blocks user_message+system_message with failCommand reason=frozen
4. `22b8d20` — fix: tmux+ttyd boot + nonce protocol + workspace dep (super-swarm R1)
5. `4d11620` — fix: bracketed-paste nonce + releaseLease freeze + readiness file + timeout (super-swarm R2)
6. `e448037` — fix: healthcheck literals + writable readiness + nonce occurrence-count (super-swarm R2)
7. `23bce12` — fix: FAIL marker seeded in prompt + narrow singleton-lock catch (super-swarm R3)
8. `4e91698` — chore: regenerate pnpm-lock.yaml

Note: exploration report's plan was to skip f0a55977 (now committed as `e448037`), but it carried supervisor hardening that d8c34cde (now `23bce12`) depended on — both kept.

## Dependencies (all merged)

- PR #533 (agents/Dockerfile + agents/shared/) merged
- PR #536 (R2+R3 fixes) merged
- PR #538 (command-bus schema + mutations) merged at commit `1a47b2e`

This PR is the LAST keystone for Bundle 2.

## Signature verification (HIGHEST risk per exploration audit)

`convexClient.ts` uses `anyApi as unknown as {...}` cast — failure mode is RUNTIME, not typecheck. Verified manually against final commandBus.ts state on this branch (which extends #538's contract):

| Mutation | Supervisor expects | Convex provides | Match |
|---|---|---|---|
| `claimNext` | args `{secret, agentId}` → `AgentCommand \| null` | args `{secret, agentId}` → full doc with `{...cmd, status:"leased", leaseOwner, leaseExpiresAt}` or `null` | OK |
| `ackCommand` | args `{secret, agentId, commandId}` → void | args `{secret, agentId, commandId}`, leaseExpiresAt guard read from DB | OK (R1 fix doesn't require new caller arg) |
| `completeCommand` | args `{secret, agentId, commandId, resultPayload, tookMs}` → void | args match | OK |
| `failCommand` | args `{secret, agentId, commandId, reason}` → void | args match | OK |
| `releaseLease` | args `{secret, agentId, commandId}` → void | args match (added in `4d11620`) | OK |
| `getQueuedFor` | args `{secret, agentId}` → `AgentCommand[]` | args match | OK |
| `heartbeat` | args `{secret, agentId, lastTickProcessed, currentStrategy?, health}` → void | args match | OK |

Note: `claimNext` return shape was upgraded from `_id`-only (in #538's HEAD) to full doc (in `55f23ed`). This is a necessary contract change owned by this PR — without it the supervisor's `command.kind`, `command.payload`, `command._id` access would fail.

## Closes

- #352

## Test plan

- [x] `pnpm --filter @clan-world/elder-runtime test` — 5 files, 17 tests PASS
- [x] `pnpm --filter @clan-world/server test` — 13 files, 142 tests PASS (commandBus 23 tests, up from #538's 21)
- [x] `pnpm --filter @clan-world/elder-runtime typecheck` clean
- [x] `pnpm --filter @clan-world/server typecheck` clean
- [x] Convex signature verification (above)
- [x] `agents/entrypoint.sh` bash syntax clean
- [x] `docker-compose.yml` YAML valid
- [ ] Local 3-tier swarm
- [ ] Merge to dev-containerize-agents

Pre-existing `@clan-world/seeker` typecheck failure (apps/mobile/LinearGradient + WebView typing) exists on `dev-containerize-agents` HEAD; this PR introduces zero diff in `apps/mobile`.

## Refs

- Exploration audit: `~/claudes-world/tmp/20260521-2247-pr416-redo-guidance.md`
- PR #538 (command-bus) head: `1a47b2e`
- Bundle 2 synthesis: `~/claudes-world/tmp/20260521-2300-bundle2-exploration-synthesis.md`
- Original PR: #416