### PR TITLE
feat(caddy): host-imported snippet for app.clan-world.com/elder-N/ routing (#348)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -281,6 +281,13 @@ BUS_ELDER_SECRET_FILE_4=agents/secrets/bus-elder-4.key
 # configuration change (#357 tracks the parameterized scale-out smoke test).
 ELDER_COUNT=4
 
+# Per-elder ttyd host ports exposed on 127.0.0.1 and proxied by host Caddy
+# through app.clan-world.com/elder-N/.
+ELDER_1_TTYD_PORT=7681
+ELDER_2_TTYD_PORT=7682
+ELDER_3_TTYD_PORT=7683
+ELDER_4_TTYD_PORT=7684
+
 # Per-elder Anthropic/Codex tokens (optional in dev — Elders typically use
 # OAuth via `claude setup-token`). When set, these are passed to the elder-N
 # containers and override the OAuth flow.

--- a/agents/shared/README-caddy.md
+++ b/agents/shared/README-caddy.md
@@ -1,0 +1,114 @@
+# `agents/shared/caddy.conf` — host caddy subroute snippet
+
+This file is the canonical Caddy config snippet for routing
+`app.clan-world.com` to the per-elder ttyd ports and the web frontend.
+It is **owned by this repo** and imported into the **host caddy** at
+`/etc/caddy/Caddyfile`. The host caddy remains the single TLS terminator
+and the single cloudflared peer — there is no docker caddy container in
+Phase 1.5.
+
+## How it integrates
+
+The host `/etc/caddy/Caddyfile` gets ONE additional line at the
+top level:
+
+```caddy
+import /home/claude/code/clan-world/clan-world-game/agents/shared/caddy.conf
+```
+
+(Adjust the path if the repo lives elsewhere on the host.) The
+`bin/install-caddy-snippet.sh` script in this repo idempotently adds
+that line, validates the resulting config, and reloads caddy.
+
+## Subroute layout (Phase 1.5)
+
+| Path           | Upstream                                  | Notes                                   |
+|----------------|-------------------------------------------|-----------------------------------------|
+| `/`            | `$CLAN_WORLD_WEB_UPSTREAM` (Vercel today) | Cockpit. Phase 2 cutover swaps to local docker web container. |
+| `/map*`        | `$CLAN_WORLD_WEB_UPSTREAM`                | Same as `/` until #354 URL rename ships separately. |
+| `/elder-1/*`   | `127.0.0.1:$ELDER_1_TTYD_PORT` (7681)     | ttyd via HTTP/1.1; `/elder-1` prefix is stripped. |
+| `/elder-2/*`   | `127.0.0.1:$ELDER_2_TTYD_PORT` (7682)     | "                                       |
+| `/elder-3/*`   | `127.0.0.1:$ELDER_3_TTYD_PORT` (7683)     | "                                       |
+| `/elder-4/*`   | `127.0.0.1:$ELDER_4_TTYD_PORT` (7684)     | "                                       |
+| `/elder-N`     | 301 → `/elder-N/`                         | Browser-relative-URL safety.            |
+
+## Environment variables
+
+The snippet reads these env vars (with safe defaults). Provide them via
+`/etc/default/caddy` or a systemd drop-in:
+
+```
+# /etc/systemd/system/caddy.service.d/clan-world.conf
+[Service]
+Environment="CLAN_WORLD_DOMAIN=clan-world.com"
+Environment="TLD_APP_SUBDOMAIN=app"
+Environment="ELDER_1_TTYD_PORT=7681"
+Environment="ELDER_2_TTYD_PORT=7682"
+Environment="ELDER_3_TTYD_PORT=7683"
+Environment="ELDER_4_TTYD_PORT=7684"
+Environment="CLAN_WORLD_WEB_UPSTREAM=https://clan-world-game.vercel.app"
+```
+
+After dropping in the unit, `sudo systemctl daemon-reload && sudo
+systemctl restart caddy`. Or just `sudo systemctl reload caddy` if env
+already loaded.
+
+## Host-global timeouts for ttyd
+
+ttyd terminal sessions are long-lived; the host caddy's GLOBAL options
+block needs the timeout overrides below to prevent mid-session WS
+disconnects. This is host-global, not site-level — it cannot live in
+this snippet.
+
+In `/etc/caddy/Caddyfile`, ensure the global block contains:
+
+```caddy
+{
+    servers {
+        timeouts {
+            read_body 30s
+            read_header 10s
+            write 0
+            idle 1h
+        }
+    }
+}
+```
+
+`write 0` disables the write timeout (ttyd streams continuously).
+`idle 1h` keeps connections alive across short user pauses.
+
+## Change workflow
+
+1. Edit `agents/shared/caddy.conf` in this repo.
+2. Validate: `caddy validate --config agents/shared/caddy.conf --adapter caddyfile`.
+3. PR + merge.
+4. On the host, after pulling: `caddy validate --config /etc/caddy/Caddyfile && sudo systemctl reload caddy`.
+
+No host file edits required after the initial install — the host caddy
+re-reads the imported snippet at every reload.
+
+## Coexistence with existing host caddy routes
+
+This snippet introduces `app.clan-world.com` as a NEW top-level site
+block. It does NOT touch the existing `*.clan-world.com` wildcard block
+or any of the other tunneled services (pm-dobot, narrator, cockpit,
+gstack, etc.). The pre-existing `cockpit.clan-world.com` block with its
+`/elder-N-tty/` routes proxying to ports 38790-38793 is the legacy
+phase-5 mirror — it remains untouched and continues to serve that
+hostname during the coexist window.
+
+## Limitations / known v1 caveats
+
+- Ports `7681-7684` are hardcoded. A later issue will dynamically
+  allocate these via the `port-for` system.
+- `CLAN_WORLD_WEB_UPSTREAM` defaults to a Vercel hostname; verify the
+  real production URL before relying on the default in prod.
+- The snippet does NOT include the convex dashboard basic-auth proxy
+  (`/convex-admin`) — that arrives in a later issue once the dashboard
+  is exposed on the host.
+- TLS is handled by the host caddy's existing cert/cloudflared
+  arrangement, NOT by this snippet. The site block as written assumes
+  Caddy will auto-provision TLS via the global cert path; if the host
+  uses a different TLS strategy for `*.clan-world.com`, the snippet may
+  need a `tls` directive added.

--- a/agents/shared/caddy.conf
+++ b/agents/shared/caddy.conf
@@ -1,0 +1,118 @@
+# clan-world subroute snippet — imported by host /etc/caddy/Caddyfile
+# Routes app.clan-world.com → docker-internal services and host-local ttyd ports
+# This file is OWNED BY THE AGENTS REPO; host Caddyfile gets ONE `import` line.
+#
+# Env vars (with safe defaults — override via /etc/default/caddy or systemd
+# Environment= directives):
+#   CLAN_WORLD_DOMAIN          base domain (default: clan-world.com)
+#   TLD_APP_SUBDOMAIN          app subdomain label (default: app)
+#   ELDER_1_TTYD_PORT          ttyd port for elder-1 (default: 7681)
+#   ELDER_2_TTYD_PORT          ttyd port for elder-2 (default: 7682)
+#   ELDER_3_TTYD_PORT          ttyd port for elder-3 (default: 7683)
+#   ELDER_4_TTYD_PORT          ttyd port for elder-4 (default: 7684)
+#   CLAN_WORLD_WEB_UPSTREAM    upstream for root + /map (default: Vercel
+#                              deployment hostname; intentionally NOT the
+#                              same host as this server block, otherwise the
+#                              reverse_proxy would loop). Phase 2 cutover
+#                              flips this to the docker web container.
+#
+# v1 hardcodes ttyd ports 7681-7684 (one per elder container). A later issue
+# will switch this to dynamic port-for allocation.
+
+{$TLD_APP_SUBDOMAIN:app}.{$CLAN_WORLD_DOMAIN:clan-world.com} {
+	# ----------------------------------------------------------------
+	# WebSocket-aware matcher (descriptive). Caddy 2's reverse_proxy
+	# already auto-detects Upgrade requests and passes them through with
+	# `versions 1.1` pinned below — so the elder routes work for both
+	# regular HTTP asset fetches AND ttyd's WS upgrade on /ws. This
+	# matcher is kept as documentation of the protocol expectation.
+	# ----------------------------------------------------------------
+	@ws_elder {
+		path /elder-1/* /elder-2/* /elder-3/* /elder-4/*
+		header Connection *Upgrade*
+		header Upgrade websocket
+	}
+
+	# ----------------------------------------------------------------
+	# /elder-N/* — strip the /elder-N prefix and proxy to local ttyd.
+	# ttyd serves its UI at "/" so the prefix MUST be stripped, and the
+	# transport MUST be HTTP/1.1 (ttyd does not speak h2).
+	# ----------------------------------------------------------------
+	handle_path /elder-1/* {
+		reverse_proxy http://127.0.0.1:{$ELDER_1_TTYD_PORT:7681} {
+			transport http {
+				versions 1.1
+			}
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+		}
+	}
+	handle_path /elder-2/* {
+		reverse_proxy http://127.0.0.1:{$ELDER_2_TTYD_PORT:7682} {
+			transport http {
+				versions 1.1
+			}
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+		}
+	}
+	handle_path /elder-3/* {
+		reverse_proxy http://127.0.0.1:{$ELDER_3_TTYD_PORT:7683} {
+			transport http {
+				versions 1.1
+			}
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+		}
+	}
+	handle_path /elder-4/* {
+		reverse_proxy http://127.0.0.1:{$ELDER_4_TTYD_PORT:7684} {
+			transport http {
+				versions 1.1
+			}
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+		}
+	}
+
+	# Bare /elder-N (no trailing slash) — redirect to /elder-N/ so the
+	# browser ends up with relative-path-correct ttyd asset URLs.
+	@bare_elder path /elder-1 /elder-2 /elder-3 /elder-4
+	redir @bare_elder {path}/ 301
+
+	# ----------------------------------------------------------------
+	# /map and root → web frontend.
+	#
+	# In Phase 1.5 the frontend still lives on Vercel; this block proxies
+	# to that deployment. Phase 2 cutover swaps CLAN_WORLD_WEB_UPSTREAM to
+	# the local docker web container (no Caddyfile edit needed — just env).
+	#
+	# DO NOT default this to `https://app.clan-world.com` — that's THIS
+	# host, and a reverse_proxy back to ourselves would loop.
+	# ----------------------------------------------------------------
+	handle /map* {
+		reverse_proxy {$CLAN_WORLD_WEB_UPSTREAM:https://clan-world-game.vercel.app} {
+			header_up Host {upstream_hostport}
+		}
+	}
+
+	handle {
+		# Cockpit (root). Same Vercel upstream until Phase 2 cutover.
+		reverse_proxy {$CLAN_WORLD_WEB_UPSTREAM:https://clan-world-game.vercel.app} {
+			header_up Host {upstream_hostport}
+		}
+	}
+
+	encode gzip
+
+	# NOTE: per-server timeouts (read/write/idle) live in the host
+	# /etc/caddy/Caddyfile's global `servers { timeouts { ... } }` block,
+	# not in this site-level snippet. ttyd needs `write 0` + `idle 1h`
+	# for long-lived terminal sessions — the host caddy global must be
+	# configured accordingly. See README-caddy.md for the host-global
+	# snippet to merge.
+
+	log {
+		output stdout
+	}
+}

--- a/apps/web/src/components/cockpit/tabs/TerminalTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/TerminalTab.tsx
@@ -13,8 +13,8 @@ interface Props {
 /**
  * Terminal tab — live ttyd iframe pointing at this Elder's tmux mirror.
  *
- * The iframe loads `https://cockpit.clan-world.com/elder-{N}-tty/`, which is
- * served by Caddy in front of `ttyd-elder-{N}.service`. ttyd renders the
+ * The iframe loads `https://app.clan-world.com/elder-{N}/`, which is
+ * served by Caddy in front of the elder-N container's ttyd port. ttyd renders the
  * Elder's tmux session as a read-only WebSocket-fed terminal in the browser.
  *
  * If the upstream service is down, the iframe will show the browser's
@@ -26,7 +26,7 @@ interface Props {
  * breaks the WS handshake.
  */
 export function TerminalTab({ elder, testIdPrefix }: Props) {
-  const url = `https://cockpit.clan-world.com/elder-${elder.clanId}-tty/`;
+  const url = `https://app.clan-world.com/elder-${elder.clanId}/`;
   const { src, status, reconnectNow, onFrameLoad } = useTerminalFrameReconnect({
     baseUrl: url,
     clanId: elder.clanId,

--- a/apps/web/src/hooks/useConnectionStatus.ts
+++ b/apps/web/src/hooks/useConnectionStatus.ts
@@ -21,7 +21,7 @@ const BACKOFF_MS = [2_000, 4_000, 8_000];
  * Phase B may revisit by adding a Convex query that the server polls.
  */
 export const HEARTBEAT_URL =
-  'https://cockpit.clan-world.com/elder-1-tty/';
+  'https://app.clan-world.com/elder-1/';
 
 interface Options {
   /** Override the heartbeat URL (for tests). */
@@ -38,7 +38,7 @@ interface Options {
  *       └─────────success─────┴────manual/auto retry─────────────┘
  *
  * The fetch uses `mode: 'no-cors'` because the cockpit page lives on a
- * different subdomain than ttyd — the response is opaque, but `fetch`
+ * same app-domain Caddy route as ttyd — the response is opaque, but `fetch`
  * resolving (vs rejecting) is enough signal that the host is reachable.
  *
  * On `visibilitychange` → visible, we fire an immediate heartbeat. The

--- a/apps/web/tests/e2e/04-cockpit-shell.spec.ts
+++ b/apps/web/tests/e2e/04-cockpit-shell.spec.ts
@@ -20,12 +20,12 @@ test.describe('cockpit shell (Phase A)', () => {
   // depends on external network. Individual tests override the route to
   // simulate connection failures.
   test.beforeEach(async ({ page }) => {
-    await page.route('**/cockpit.clan-world.com/elder-*-tty/**', (route) =>
+    await page.route('**/app.clan-world.com/elder-*/**', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'text/html',
         body: `<!DOCTYPE html><html><body data-stub="ttyd"><script>
-          const match = location.pathname.match(/elder-(\\d+)-tty/);
+          const match = location.pathname.match(/elder-(\\d+)/);
           parent.postMessage({
             type: 'clanworld-ttyd-status',
             clanId: Number(match?.[1] ?? 0),
@@ -106,7 +106,7 @@ test.describe('cockpit shell (Phase A)', () => {
     page,
   }) => {
     let shouldFail = true;
-    await page.route('**/cockpit.clan-world.com/elder-*-tty/**', (route) => {
+    await page.route('**/app.clan-world.com/elder-*/**', (route) => {
       if (shouldFail) {
         return route.abort('failed');
       }
@@ -143,7 +143,7 @@ test.describe('cockpit shell (Phase A)', () => {
     page,
   }) => {
     let documentLoads = 0;
-    await page.route('**/cockpit.clan-world.com/elder-1-tty/**', (route) => {
+    await page.route('**/app.clan-world.com/elder-1/**', (route) => {
       if (route.request().resourceType() !== 'document') {
         return route.fulfill({ status: 200, body: '' });
       }
@@ -185,7 +185,7 @@ test.describe('cockpit shell (Phase A)', () => {
     page,
   }) => {
     let documentLoads = 0;
-    await page.route('**/cockpit.clan-world.com/elder-1-tty/**', (route) => {
+    await page.route('**/app.clan-world.com/elder-1/**', (route) => {
       if (route.request().resourceType() !== 'document') {
         return route.fulfill({ status: 200, body: '' });
       }

--- a/apps/web/tests/e2e/07-cockpit-worldmap-unified.spec.ts
+++ b/apps/web/tests/e2e/07-cockpit-worldmap-unified.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 
 async function stubTerminalIframes(page: Page): Promise<void> {
-  await page.route('**/cockpit.clan-world.com/elder-*-tty/**', (route) =>
+  await page.route('**/app.clan-world.com/elder-*/**', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'text/html',

--- a/bin/install-caddy-snippet.sh
+++ b/bin/install-caddy-snippet.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# install-caddy-snippet.sh — idempotently install the clan-world caddy
+# subroute snippet into the host caddy config.
+#
+# Adds ONE `import <repo>/agents/shared/caddy.conf` line to
+# /etc/caddy/Caddyfile (with a timestamped backup), validates the
+# resulting config, and reloads caddy via systemctl.
+#
+# Usage:
+#   bin/install-caddy-snippet.sh             # install (idempotent)
+#   bin/install-caddy-snippet.sh --check     # dry-run; report-only
+#   bin/install-caddy-snippet.sh --uninstall # remove the import line
+#
+# Exit codes:
+#   0  success / already installed
+#   1  caddy validate failed
+#   2  caddyfile missing or unwritable
+#   3  uninstall requested but import not present
+#   4  caddy reload failed
+
+set -euo pipefail
+
+readonly CADDYFILE="${CADDYFILE:-/etc/caddy/Caddyfile}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+readonly REPO_ROOT
+readonly SNIPPET_PATH="${REPO_ROOT}/agents/shared/caddy.conf"
+readonly IMPORT_LINE="import ${SNIPPET_PATH}"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+readonly TIMESTAMP
+
+MODE="install"
+if [[ "${1:-}" == "--check" ]]; then MODE="check"; fi
+if [[ "${1:-}" == "--uninstall" ]]; then MODE="uninstall"; fi
+
+log() { printf '[install-caddy-snippet] %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit "${2:-1}"; }
+
+# --- Preflight ---------------------------------------------------------
+
+[[ -f "${SNIPPET_PATH}" ]] || die "snippet not found: ${SNIPPET_PATH}"
+[[ -f "${CADDYFILE}" ]]    || die "host Caddyfile missing: ${CADDYFILE}" 2
+
+if ! command -v caddy >/dev/null 2>&1; then
+    die "caddy binary not in PATH"
+fi
+
+# --- Detect existing import -------------------------------------------
+
+if grep -Fxq "${IMPORT_LINE}" "${CADDYFILE}"; then
+    ALREADY_INSTALLED=1
+else
+    ALREADY_INSTALLED=0
+fi
+
+# --- --check ----------------------------------------------------------
+
+if [[ "${MODE}" == "check" ]]; then
+    if [[ "${ALREADY_INSTALLED}" -eq 1 ]]; then
+        log "INSTALLED: '${IMPORT_LINE}' is present in ${CADDYFILE}"
+    else
+        log "NOT INSTALLED: '${IMPORT_LINE}' is missing from ${CADDYFILE}"
+    fi
+    log "Validating snippet on its own..."
+    if caddy validate --config "${SNIPPET_PATH}" --adapter caddyfile >/dev/null 2>&1; then
+        log "  snippet validates OK"
+    else
+        log "  snippet FAILS validation"
+    fi
+    log "Validating current host Caddyfile (via sudo)..."
+    if sudo caddy validate --config "${CADDYFILE}" >/dev/null 2>&1; then
+        log "  host Caddyfile validates OK"
+    else
+        log "  host Caddyfile FAILS validation (run \`sudo caddy validate --config ${CADDYFILE}\` for details)"
+    fi
+    exit 0
+fi
+
+# --- --uninstall ------------------------------------------------------
+
+if [[ "${MODE}" == "uninstall" ]]; then
+    if [[ "${ALREADY_INSTALLED}" -eq 0 ]]; then
+        log "import line not present — nothing to uninstall"
+        exit 3
+    fi
+    backup="${CADDYFILE}.bak.${TIMESTAMP}.pre-uninstall"
+    log "backing up ${CADDYFILE} → ${backup}"
+    sudo cp -p "${CADDYFILE}" "${backup}"
+    log "removing import line from ${CADDYFILE}"
+    sudo sed -i "\|^${IMPORT_LINE}$|d" "${CADDYFILE}"
+    log "validating result..."
+    if ! sudo caddy validate --config "${CADDYFILE}" >/dev/null 2>&1; then
+        log "validation FAILED after uninstall — restoring backup"
+        sudo cp -p "${backup}" "${CADDYFILE}"
+        die "validation failed; original restored" 1
+    fi
+    log "reloading caddy..."
+    sudo systemctl reload caddy || die "systemctl reload caddy failed" 4
+    log "DONE: uninstall complete"
+    exit 0
+fi
+
+# --- install (idempotent) ---------------------------------------------
+
+if [[ "${ALREADY_INSTALLED}" -eq 1 ]]; then
+    log "already installed — no changes to ${CADDYFILE}"
+    log "validating current config anyway..."
+    sudo caddy validate --config "${CADDYFILE}" >/dev/null \
+        || die "current Caddyfile fails validation" 1
+    log "OK"
+    exit 0
+fi
+
+# Pre-flight: snippet must validate before we touch the host file.
+log "pre-flight: validating snippet ${SNIPPET_PATH}"
+if ! caddy validate --config "${SNIPPET_PATH}" --adapter caddyfile >/dev/null 2>&1; then
+    caddy validate --config "${SNIPPET_PATH}" --adapter caddyfile 2>&1 | tail -20 >&2
+    die "snippet failed validation; refusing to install" 1
+fi
+
+backup="${CADDYFILE}.bak.${TIMESTAMP}.pre-clan-world-import"
+log "backing up ${CADDYFILE} → ${backup}"
+sudo cp -p "${CADDYFILE}" "${backup}"
+
+log "appending import line to ${CADDYFILE}"
+# Append AFTER the global options block (line 1-N) — caddy allows imports
+# at the file top level. Appending at the end is simplest + safest.
+echo "" | sudo tee -a "${CADDYFILE}" >/dev/null
+echo "${IMPORT_LINE}" | sudo tee -a "${CADDYFILE}" >/dev/null
+
+log "validating combined config..."
+if ! sudo caddy validate --config "${CADDYFILE}" >/dev/null 2>&1; then
+    log "combined config FAILED validation — restoring backup"
+    sudo cp -p "${backup}" "${CADDYFILE}"
+    sudo caddy validate --config "${CADDYFILE}" 2>&1 | tail -20 >&2 || true
+    die "validation failed; original restored" 1
+fi
+
+log "reloading caddy..."
+if ! sudo systemctl reload caddy; then
+    log "reload FAILED — restoring backup"
+    sudo cp -p "${backup}" "${CADDYFILE}"
+    sudo systemctl reload caddy || true
+    die "systemctl reload caddy failed; original restored" 4
+fi
+
+log "DONE: install complete"
+log "  backup: ${backup}"
+log "  import: ${IMPORT_LINE}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -270,6 +270,8 @@ services:
     env_file:
       - path: ./agents/elder-1/.env
         required: false
+    ports:
+      - "127.0.0.1:${ELDER_1_TTYD_PORT:-7681}:7681"
     environment:
       ELDER_N: "1"
       CONVEX_DEPLOY_URL: http://convex-backend:3210
@@ -304,6 +306,8 @@ services:
     env_file:
       - path: ./agents/elder-2/.env
         required: false
+    ports:
+      - "127.0.0.1:${ELDER_2_TTYD_PORT:-7682}:7681"
     environment:
       ELDER_N: "2"
       CONVEX_DEPLOY_URL: http://convex-backend:3210
@@ -328,6 +332,8 @@ services:
     env_file:
       - path: ./agents/elder-3/.env
         required: false
+    ports:
+      - "127.0.0.1:${ELDER_3_TTYD_PORT:-7683}:7681"
     environment:
       ELDER_N: "3"
       CONVEX_DEPLOY_URL: http://convex-backend:3210
@@ -352,6 +358,8 @@ services:
     env_file:
       - path: ./agents/elder-4/.env
         required: false
+    ports:
+      - "127.0.0.1:${ELDER_4_TTYD_PORT:-7684}:7681"
     environment:
       ELDER_N: "4"
       CONVEX_DEPLOY_URL: http://convex-backend:3210


### PR DESCRIPTION
## Summary

Closes #348. Bundle 3 Phase 3 final-polish PR. Adds the host-imported Caddy snippet that exposes the Docker-hosted ttyd terminals at `app.clan-world.com/elder-N/`, and closes the deferred-from-PR-#534 frontend URL cutover.

## Files

**New:**
- `agents/shared/caddy.conf` — host-imported snippet, validated via `caddy fmt` + `caddy validate --adapter caddyfile`. WebSocket-aware path-stripped reverse_proxy to `127.0.0.1:7681..7684`.
- `agents/shared/README-caddy.md` — operator notes, import-line, ports, coexist policy, v1 caveats.
- `bin/install-caddy-snippet.sh` — installer with `--check` + `--uninstall` modes, timestamped backup, pre-validate snippet, validate combined Caddyfile, restore-on-failure around `systemctl reload caddy`.

**Modified:**
- `.env.template` — adds `ELDER_1_TTYD_PORT`..`ELDER_4_TTYD_PORT` (defaults 7681-7684, loopback only).
- `docker-compose.yml` — adds `127.0.0.1:\${ELDER_N_TTYD_PORT:-...}:7681` port mapping to each elder-1..4 service.
- `apps/web/src/components/cockpit/tabs/TerminalTab.tsx` + `apps/web/src/hooks/useConnectionStatus.ts` — terminal iframe + probe URLs switch from `cockpit.clan-world.com/elder-N-tty/` to `app.clan-world.com/elder-N/`. Closes the deferred-from-#534 cutover.
- Playwright e2e specs — iframe stubs updated to new pattern.

## Coexist + DNS policy

**This PR is purely ADDITIVE.** Legacy `cockpit.clan-world.com/elder-*-tty/` stays live during the migration window. DNS deprecation of \`cockpit.clan-world.com\` is a prod-deploy/runbook concern handled outside this PR. Operators should leave the legacy subdomain live until 24h soak completes on the new routing.

## Test plan

- [x] \`caddy fmt --overwrite agents/shared/caddy.conf\` — passed
- [x] \`caddy validate --config agents/shared/caddy.conf --adapter caddyfile\` — passed
- [x] \`git diff --check\` — passed
- [x] \`docker compose --profile dev -f docker-compose.yml config --quiet\` — passed (with dummy required env)
- [ ] Frontend typecheck — CI will gate (worktree lacks hydrated node_modules)
- [ ] Local 3-tier swarm review
- [ ] Merge to dev-phase-3-final-polish

## Codex 5-stage trail

- Stage 1 plan: \`~/claudes-world/tmp/codex-issue-348/stage1.log\`
- Stage 2 implement: \`~/claudes-world/tmp/codex-issue-348/stage2.log\`
- Stage 3 critique: \`~/claudes-world/tmp/codex-issue-348/stage3.log\` — verdict: ready for commit, recommendations were PR-body only

## Refs

- Issue #348
- Bundle 3 exploration report: \`~/claudes-world/tmp/20260522-bundle3-exploration.md\`
- Closes deferred-from-#534 scope (cockpit→app URL cutover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)