### PR TITLE
feat(agents): Makefile + .docker-mounts scaffolding — operator entrypoint (#355)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,7 +199,8 @@ docs/planning/V1/
 # Makefile targets generate them at runtime.
 agents/runtime/
 agents/.env
-agents/.docker-mounts/
+agents/.docker-mounts/*
+!agents/.docker-mounts/.gitkeep
 agents/backups/
 agents/secrets/
 agents/elder-*/.env

--- a/agents/.docker-mounts/.gitkeep
+++ b/agents/.docker-mounts/.gitkeep
@@ -1,0 +1,11 @@
+# agents/.docker-mounts/
+#
+# Populated by `make link-mounts`. The Makefile runs a helper busybox
+# container that snapshots each elder's named volumes (`elder-N-workspace`,
+# `elder-N-home`) into this directory with the operator's UID, so the
+# contents are readable WITHOUT sudo and inspectable from anywhere in the
+# repo via `ls agents/.docker-mounts/elder-1-workspace/`.
+#
+# Trade-off: snapshots get stale — re-run `make link-mounts` to refresh.
+# All contents under this directory are gitignored (only this .gitkeep is
+# tracked).

--- a/agents/.gitignore
+++ b/agents/.gitignore
@@ -5,5 +5,8 @@ runtime/
 .env
 elder-*/.env
 
-# Docker-compose symlink helper dir (created by `make link-mounts`)
-.docker-mounts/
+# Docker-compose helper-container snapshot dir (populated by `make link-mounts`).
+# The directory is checked in (via .gitkeep) so operators see it without
+# needing to run link-mounts first, but all snapshot contents are gitignored.
+.docker-mounts/*
+!.docker-mounts/.gitkeep

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -1,0 +1,334 @@
+# agents/Makefile - ClanWorld Elder Infrastructure operator entrypoint
+#
+# Issue #355 (Phase 1.12). Codifies operator-facing lifecycle, bootstrap,
+# wipe, and smoke-test targets for the dockerized elder stack. The compose
+# project name is `clan-world` (declared in docker-compose.yml), so volumes
+# created by compose are prefixed `clan-world_*`.
+#
+# PROFILE is REQUIRED on every state-mutating target. No default - fail loud.
+# On the VPS, almost certainly PROFILE=prod.
+#
+# Run from the repo root: `make -C agents <target> PROFILE=dev|prod`
+# Or `cd agents && make <target> PROFILE=...`
+#
+# All paths in compose-volume names + secrets files are relative to the
+# REPO ROOT (the parent of this Makefile), because docker-compose.yml lives
+# at the repo root and `docker compose` is invoked from there.
+
+SHELL := /usr/bin/env bash
+
+REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+COMPOSE   := docker compose
+DC        := cd $(REPO_ROOT) && $(COMPOSE)
+
+ELDERS := elder-1 elder-2 elder-3 elder-4
+ELDER_NUMS := 1 2 3 4
+
+PROFILE ?=
+LEVEL ?= session
+
+CONVEX_CLI_PINNED_VERSION ?= 1.39.1
+CONVEX_SELF_HOSTED_ADMIN_KEY_FILE ?= agents/secrets/convex-admin.key
+WEBHOOK_SHARED_SECRET_FILE ?= agents/secrets/webhook-shared.key
+BUS_OPERATOR_SECRET_FILE ?= agents/secrets/bus-operator.key
+BUS_ELDER_SECRET_FILE_1 ?= agents/secrets/bus-elder-1.key
+BUS_ELDER_SECRET_FILE_2 ?= agents/secrets/bus-elder-2.key
+BUS_ELDER_SECRET_FILE_3 ?= agents/secrets/bus-elder-3.key
+BUS_ELDER_SECRET_FILE_4 ?= agents/secrets/bus-elder-4.key
+
+.PHONY: help \
+        check-profile confirm-banner setup \
+        up down status logs \
+        pause unpause \
+        pause-heartbeat unpause-heartbeat \
+        reset-anvil \
+        link-mounts \
+        bootstrap-convex-admin-key bootstrap-bus-secrets bootstrap-convex-dashboard-auth \
+        oauth-bootstrap \
+        smoke-test build FORCE
+
+FORCE:
+
+help:
+	@echo "ClanWorld Elder Infrastructure - agents/Makefile"
+	@echo ""
+	@echo "USAGE"
+	@echo "  make <target> PROFILE=dev|prod"
+	@echo ""
+	@echo "  PROFILE is required for compose lifecycle targets: setup, up, build,"
+	@echo "  reset-anvil, and any target that starts/restarts profile-scoped services."
+	@echo "  On the VPS, use PROFILE=prod unless intentionally operating dev."
+	@echo ""
+	@echo "LIFECYCLE"
+	@echo "  setup PROFILE=...              One-time bring-up: bootstrap secrets + secret dirs"
+	@echo "  up PROFILE=...                 docker compose --profile <P> up -d (with confirmation banner)"
+	@echo "  down                           docker compose down (idempotent; no profile required)"
+	@echo "  status                         compose ps + per-elder tmux/supervisor health"
+	@echo "  logs ELDER=elder-2             tail one service"
+	@echo ""
+	@echo "PAUSE / RESUME"
+	@echo "  pause-elder-2                  SIGSTOP elder-runtime supervisor inside elder-2"
+	@echo "  unpause-elder-2                SIGCONT elder-runtime supervisor"
+	@echo "  pause                          fan-out SIGSTOP across all elders"
+	@echo "  unpause                        fan-out SIGCONT across all elders"
+	@echo "  pause-heartbeat                stop heartbeat service (coexist window)"
+	@echo "  unpause-heartbeat              start heartbeat service"
+	@echo ""
+	@echo "RESET / WIPE"
+	@echo "  reset-elder-3                  soft reset: kill tmux session, restart container"
+	@echo "  restart-elder-3                full container restart (no wipe)"
+	@echo "  wipe-elder-3 LEVEL=workspace   clear /workspace/* only, keep ~/.claude"
+	@echo "  wipe-elder-3 LEVEL=session     clear /workspace/* + ~/.claude/projects"
+	@echo "  wipe-elder-3 LEVEL=full        destroy named volumes; oauth-bootstrap required after"
+	@echo "  reset-anvil PROFILE=dev        wipe anvil fork state + restart (dev only)"
+	@echo ""
+	@echo "BOOTSTRAP (one-time per stack - re-run with FORCE=1 to overwrite)"
+	@echo "  bootstrap-convex-admin-key     generate + persist Convex admin key (chmod 0600)"
+	@echo "  bootstrap-bus-secrets          generate bus/webhook secrets and set Convex BUS_* envs"
+	@echo "  bootstrap-convex-dashboard-auth generate basic-auth credentials for dashboard"
+	@echo "  oauth-bootstrap                walk every elder through OAuth flow"
+	@echo "  oauth-bootstrap-elder-1        single-elder OAuth flow"
+	@echo ""
+	@echo "DEV HELPERS"
+	@echo "  link-mounts                    snapshot named-volume contents into agents/.docker-mounts/"
+	@echo "  smoke-test                     run end-to-end stack health check (bin/check-stack-health.sh)"
+	@echo "  build                          docker compose build for the selected profile"
+
+check-profile:
+	@if [ -z "$(PROFILE)" ]; then \
+		echo "ERROR: PROFILE=dev|prod required. On VPS, almost certainly PROFILE=prod." >&2; \
+		exit 1; \
+	fi
+	@if [ "$(PROFILE)" != "dev" ] && [ "$(PROFILE)" != "prod" ]; then \
+		echo "ERROR: PROFILE must be dev or prod (got: $(PROFILE))" >&2; \
+		exit 1; \
+	fi
+
+confirm-banner: check-profile
+	@echo "===================================="
+	@echo " ClanWorld stack bring-up"
+	@echo " PROFILE:        $(PROFILE)"
+	@echo " CHAIN_NETWORK:  $${CHAIN_NETWORK:-<unset>}"
+	@if [ "$(PROFILE)" = "dev" ]; then \
+		echo " RPC URL:        $${DEV_RPC_URL:-<unset - anvil-fork will be used>}"; \
+	else \
+		echo " RPC URL:        $${RPC_URL_PRIMARY:-<unset - bring-up WILL fail>}"; \
+	fi
+	@echo " Contract:       $${CLAN_WORLD_CONTRACT_ADDRESS:-<unset>}"
+	@echo " Convex:         $${CONVEX_SELF_HOSTED_URL:-http://127.0.0.1:$${CONVEX_BACKEND_HOST_PORT:-3210}}"
+	@echo "===================================="
+
+setup: check-profile
+	@echo "[setup] bootstrapping ClanWorld stack for PROFILE=$(PROFILE)"
+	@mkdir -p $(REPO_ROOT)/agents/secrets
+	@chmod 0700 $(REPO_ROOT)/agents/secrets
+	$(MAKE) bootstrap-convex-admin-key PROFILE=$(PROFILE) FORCE=$(FORCE)
+	$(MAKE) bootstrap-bus-secrets PROFILE=$(PROFILE) FORCE=$(FORCE)
+	@echo "[setup] done."
+	@echo "[setup] Next:"
+	@echo "  1. make oauth-bootstrap                  # per-elder OAuth credentials"
+	@echo "  2. make up PROFILE=$(PROFILE)            # spin up the stack"
+	@echo "  3. make smoke-test                       # verify all green"
+
+up: confirm-banner
+	$(DC) --profile $(PROFILE) up -d
+
+down:
+	$(DC) down
+
+status:
+	@$(DC) ps
+	@echo "---"
+	@for e in $(ELDERS); do \
+		echo -n "$$e tmux:       "; \
+		$(DC) exec -T $$e tmux ls 2>/dev/null | head -1 || echo DEAD; \
+		echo -n "$$e supervisor: "; \
+		$(DC) exec -T $$e pgrep -f 'tsx.*elder-runtime/src/main.ts' > /dev/null 2>&1 \
+			&& echo OK || echo DEAD; \
+	done
+
+logs:
+	@if [ -z "$(ELDER)" ]; then \
+		echo "ERROR: ELDER=<service-name> required (e.g. ELDER=elder-2 or ELDER=heartbeat)" >&2; \
+		exit 1; \
+	fi
+	$(DC) logs -f $(ELDER)
+
+pause-elder-%: FORCE
+	$(DC) exec -T elder-$* sh -c 'kill -STOP $$(pgrep -f "tsx.*elder-runtime/src/main.ts")'
+
+unpause-elder-%: FORCE
+	$(DC) exec -T elder-$* sh -c 'kill -CONT $$(pgrep -f "tsx.*elder-runtime/src/main.ts")'
+
+pause:
+	@for n in $(ELDER_NUMS); do $(MAKE) pause-elder-$$n || true; done
+
+unpause:
+	@for n in $(ELDER_NUMS); do $(MAKE) unpause-elder-$$n || true; done
+
+pause-heartbeat:
+	$(DC) stop heartbeat
+
+unpause-heartbeat:
+	$(DC) start heartbeat
+
+reset-%: FORCE
+	-$(DC) exec -T $* tmux kill-session -t $* 2>/dev/null || true
+	$(DC) restart $*
+
+restart-%: FORCE
+	$(DC) restart $*
+
+wipe-%: FORCE
+	@if [ "$(LEVEL)" = "workspace" ]; then \
+		echo "[wipe] $* LEVEL=workspace - clearing /workspace/*"; \
+		$(DC) exec -T $* sh -c 'rm -rf /workspace/*' || exit 1; \
+		$(MAKE) reset-$*; \
+	elif [ "$(LEVEL)" = "session" ]; then \
+		echo "[wipe] $* LEVEL=session - clearing /workspace/* + ~/.claude/projects"; \
+		$(DC) exec -T $* sh -c 'rm -rf /home/elder/.claude/projects /workspace/*' || exit 1; \
+		$(DC) exec -T $* sh -c 'if [ -f /opt/clan-world/shared/elder-bootstrap/workspace-CLAUDE.md ]; then cp /opt/clan-world/shared/elder-bootstrap/workspace-CLAUDE.md /workspace/CLAUDE.md; fi' || true; \
+		$(DC) exec -T $* sh -c 'if [ -f /opt/clan-world/shared/elder-bootstrap/workspace-ANCIENT_WISDOM.md ]; then cp /opt/clan-world/shared/elder-bootstrap/workspace-ANCIENT_WISDOM.md /workspace/ANCIENT_WISDOM.md; fi' || true; \
+		$(MAKE) reset-$*; \
+	elif [ "$(LEVEL)" = "full" ]; then \
+		echo "[wipe] $* LEVEL=full - destroying named volumes (compose project: clan-world)"; \
+		$(DC) stop $* || true; \
+		$(DC) rm -f $* || true; \
+		docker volume rm clan-world_$*-home clan-world_$*-workspace 2>/dev/null || true; \
+		echo "[wipe] $* FULL WIPE done."; \
+		echo "[wipe] NEXT: run \`make oauth-bootstrap-$*\` BEFORE \`make up\`; volumes will be recreated empty."; \
+	else \
+		echo "ERROR: LEVEL must be workspace, session, or full (got: $(LEVEL))" >&2; \
+		exit 1; \
+	fi
+
+reset-anvil: check-profile
+	@if [ "$(PROFILE)" != "dev" ]; then \
+		echo "ERROR: reset-anvil is dev-only (PROFILE=dev)" >&2; \
+		exit 1; \
+	fi
+	$(DC) --profile dev stop anvil-fork
+	-docker volume rm clan-world_anvil_data 2>/dev/null || true
+	$(DC) --profile dev up -d anvil-fork
+
+link-mounts:
+	@mkdir -p $(REPO_ROOT)/agents/.docker-mounts
+	@for e in $(ELDERS); do \
+		echo "[link-mounts] snapshotting $$e-workspace + $$e-home"; \
+		docker run --rm \
+			-v clan-world_$$e-workspace:/src-workspace:ro \
+			-v clan-world_$$e-home:/src-home:ro \
+			-v $(REPO_ROOT)/agents/.docker-mounts:/dst \
+			busybox sh -c "\
+				rm -rf /dst/$$e-workspace /dst/$$e-home && \
+				cp -a /src-workspace /dst/$$e-workspace && \
+				cp -a /src-home /dst/$$e-home && \
+				chown -R $$(id -u):$$(id -g) /dst/$$e-workspace /dst/$$e-home \
+			" || echo "[link-mounts] WARN: $$e snapshot skipped (volume may not exist yet)"; \
+	done
+	@echo "[link-mounts] snapshots at $(REPO_ROOT)/agents/.docker-mounts/"
+
+bootstrap-convex-admin-key: check-profile
+	$(MAKE) -C $(REPO_ROOT) bootstrap-convex-admin-key PROFILE=$(PROFILE) FORCE=$(FORCE) CONVEX_SELF_HOSTED_ADMIN_KEY_FILE="$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)"
+
+bootstrap-bus-secrets:
+	@set -euo pipefail; \
+	resolve_path() { case "$$1" in /*) printf '%s\n' "$$1";; *) printf '%s/%s\n' "$(REPO_ROOT)" "$$1";; esac; }; \
+	write_secret() { \
+		name="$$1"; path="$$(resolve_path "$$2")"; \
+		mkdir -p "$$(dirname "$$path")"; chmod 0700 "$$(dirname "$$path")"; \
+		if [ -s "$$path" ] && [ "$(FORCE)" != "1" ]; then \
+			echo "[bootstrap] $$path exists; skipping. Re-run with FORCE=1 to regenerate."; \
+		else \
+			openssl rand -hex 32 > "$$path"; chmod 0600 "$$path"; \
+			echo "[bootstrap] $$name generated at $$path"; \
+		fi; \
+	}; \
+	write_secret bus-operator "$(BUS_OPERATOR_SECRET_FILE)"; \
+	write_secret webhook-shared "$(WEBHOOK_SHARED_SECRET_FILE)"; \
+	write_secret bus-elder-1 "$(BUS_ELDER_SECRET_FILE_1)"; \
+	write_secret bus-elder-2 "$(BUS_ELDER_SECRET_FILE_2)"; \
+	write_secret bus-elder-3 "$(BUS_ELDER_SECRET_FILE_3)"; \
+	write_secret bus-elder-4 "$(BUS_ELDER_SECRET_FILE_4)"; \
+	admin_key_file="$$(resolve_path "$(CONVEX_SELF_HOSTED_ADMIN_KEY_FILE)")"; \
+	if [ ! -s "$$admin_key_file" ]; then \
+		echo "ERROR: $$admin_key_file not found - run bootstrap-convex-admin-key first" >&2; \
+		exit 1; \
+	fi; \
+	export CONVEX_SELF_HOSTED_ADMIN_KEY="$$(cat "$$admin_key_file")"; \
+	export CONVEX_SELF_HOSTED_URL="$${CONVEX_SELF_HOSTED_URL:-http://127.0.0.1:$${CONVEX_BACKEND_HOST_PORT:-3210}}"; \
+	unset CONVEX_DEPLOYMENT CONVEX_DEPLOY_KEY; \
+	npx -y convex@$(CONVEX_CLI_PINNED_VERSION) env set BUS_OPERATOR_SECRET "$$(cat "$$(resolve_path "$(BUS_OPERATOR_SECRET_FILE)")")"; \
+	for n in 1 2 3 4; do \
+		case "$$n" in \
+			1) file="$(BUS_ELDER_SECRET_FILE_1)" ;; \
+			2) file="$(BUS_ELDER_SECRET_FILE_2)" ;; \
+			3) file="$(BUS_ELDER_SECRET_FILE_3)" ;; \
+			4) file="$(BUS_ELDER_SECRET_FILE_4)" ;; \
+		esac; \
+		npx -y convex@$(CONVEX_CLI_PINNED_VERSION) env set BUS_ELDER_SECRET_$$n "$$(cat "$$(resolve_path "$$file")")"; \
+	done; \
+	npx -y convex@$(CONVEX_CLI_PINNED_VERSION) env set WEBHOOK_SHARED_SECRET "$$(cat "$$(resolve_path "$(WEBHOOK_SHARED_SECRET_FILE)")")"; \
+	echo "[bootstrap] bus secrets injected into Convex env (BUS_OPERATOR_SECRET, BUS_ELDER_SECRET_1..4, WEBHOOK_SHARED_SECRET)."; \
+	echo "[bootstrap] If a Convex env set failed partway through, rerun this target without FORCE=1."; \
+	echo "[bootstrap] File generation is idempotent, and Convex env sets are independent."; \
+	echo "[bootstrap] Verify all BUS_* and WEBHOOK_SHARED_SECRET values with: npx convex@$(CONVEX_CLI_PINNED_VERSION) env list"
+
+bootstrap-convex-dashboard-auth:
+	@mkdir -p $(REPO_ROOT)/agents/secrets
+	@chmod 0700 $(REPO_ROOT)/agents/secrets
+	@DEST=$(REPO_ROOT)/agents/secrets/convex-dashboard-auth.json; \
+	if [ -s "$$DEST" ] && [ "$(FORCE)" != "1" ]; then \
+		echo "[bootstrap] $$DEST exists; skipping. Re-run with FORCE=1 to regenerate."; \
+		exit 0; \
+	fi; \
+	printf "Username: " >&2; \
+	read u; \
+	printf "Password: " >&2; \
+	stty -echo 2>/dev/null || true; \
+	read p; \
+	stty echo 2>/dev/null || true; \
+	echo >&2; \
+	if [ -z "$$u" ] || [ -z "$$p" ]; then \
+		echo "ERROR: username + password required" >&2; \
+		exit 1; \
+	fi; \
+	HASH=$$(printf '%s' "$$p" | sha256sum | cut -d' ' -f1); \
+	printf '{"username":"%s","password_sha256":"%s"}\n' "$$u" "$$HASH" > "$$DEST"; \
+	chmod 0600 "$$DEST"; \
+	echo "[bootstrap] convex-dashboard-auth.json saved to $$DEST"
+
+oauth-bootstrap:
+	@for n in 1 2 3 4; do $(MAKE) oauth-bootstrap-elder-$$n; done
+
+oauth-bootstrap-%: FORCE
+	@mkdir -p $(REPO_ROOT)/agents/$*
+	@DEST=$(REPO_ROOT)/agents/$*/.env; \
+	if [ -s "$$DEST" ] && [ "$(FORCE)" != "1" ]; then \
+		echo "[oauth] $$DEST already populated; skipping. Re-run with FORCE=1 to overwrite."; \
+		exit 0; \
+	fi; \
+	echo "[oauth] $* - paste CLAUDE_CODE_OAUTH_TOKEN (input hidden):" >&2; \
+	stty -echo 2>/dev/null || true; \
+	read token; \
+	stty echo 2>/dev/null || true; \
+	echo >&2; \
+	if [ -z "$$token" ]; then \
+		echo "ERROR: empty token" >&2; \
+		exit 1; \
+	fi; \
+	CLAN_ID=$$(echo "$*" | sed 's/elder-//'); \
+	{ \
+		echo "# Generated by \`make oauth-bootstrap-$*\` - do not commit."; \
+		echo "CLAUDE_CODE_OAUTH_TOKEN=$$token"; \
+		echo "ELDER_ID=$*"; \
+		echo "CLAN_ID=$$CLAN_ID"; \
+	} > "$$DEST"; \
+	chmod 0600 "$$DEST"; \
+	echo "[oauth] $* credentials saved to $$DEST"
+
+build: check-profile
+	$(DC) --profile $(PROFILE) build
+
+smoke-test:
+	bash $(REPO_ROOT)/bin/check-stack-health.sh

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -303,7 +303,9 @@ bootstrap-convex-dashboard-auth:
 		echo "ERROR: username + password required" >&2; \
 		exit 1; \
 	fi; \
-	HASH=$$(openssl passwd -6 -salt "$$(openssl rand -base64 16)" "$$p"); \
+	SALT="$$(openssl rand -base64 16)"; \
+	HASH=$$(printf '%s\n' "$$p" | openssl passwd -6 -stdin -salt "$$SALT" 2>/dev/null) || { echo "ERROR: openssl passwd -6 failed (LibreSSL not supported; install GNU openssl)" >&2; exit 1; }; \
+	if [ -z "$$HASH" ]; then echo "ERROR: openssl passwd -6 returned empty hash" >&2; exit 1; fi; \
 	printf '{"username":"%s","password_sha512crypt":"%s"}\n' "$$u" "$$HASH" > "$$DEST"; \
 	chmod 0600 "$$DEST"; \
 	echo "[bootstrap] convex-dashboard-auth.json saved to $$DEST"

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -155,10 +155,20 @@ logs:
 	$(DC) logs -f $(ELDER)
 
 pause-elder-%: FORCE
-	$(DC) exec -T elder-$* sh -c 'kill -STOP $$(pgrep -f "tsx.*elder-runtime/src/main.ts")'
+	@PID=$$($(DC) exec -T elder-$* pgrep -f 'tsx.*elder-runtime/src/main.ts' 2>/dev/null | head -1); \
+	if [ -z "$$PID" ]; then \
+		echo "[pause-elder-$*] no supervisor process running - already paused or stopped"; \
+	else \
+		$(DC) exec -T elder-$* kill -STOP "$$PID" && echo "[pause-elder-$*] SIGSTOP sent to PID $$PID"; \
+	fi
 
 unpause-elder-%: FORCE
-	$(DC) exec -T elder-$* sh -c 'kill -CONT $$(pgrep -f "tsx.*elder-runtime/src/main.ts")'
+	@PID=$$($(DC) exec -T elder-$* pgrep -f 'tsx.*elder-runtime/src/main.ts' 2>/dev/null | head -1); \
+	if [ -z "$$PID" ]; then \
+		echo "[unpause-elder-$*] no supervisor process running - already unpaused or stopped"; \
+	else \
+		$(DC) exec -T elder-$* kill -CONT "$$PID" && echo "[unpause-elder-$*] SIGCONT sent to PID $$PID"; \
+	fi
 
 pause:
 	@for n in $(ELDER_NUMS); do $(MAKE) pause-elder-$$n || true; done
@@ -174,7 +184,7 @@ unpause-heartbeat:
 
 reset-%: FORCE
 	-$(DC) exec -T $* tmux kill-session -t $* 2>/dev/null || true
-	$(DC) restart $*
+	$(DC) up -d --force-recreate $*
 
 restart-%: FORCE
 	$(DC) restart $*
@@ -293,8 +303,8 @@ bootstrap-convex-dashboard-auth:
 		echo "ERROR: username + password required" >&2; \
 		exit 1; \
 	fi; \
-	HASH=$$(printf '%s' "$$p" | sha256sum | cut -d' ' -f1); \
-	printf '{"username":"%s","password_sha256":"%s"}\n' "$$u" "$$HASH" > "$$DEST"; \
+	HASH=$$(openssl passwd -6 -salt "$$(openssl rand -base64 16)" "$$p"); \
+	printf '{"username":"%s","password_sha512crypt":"%s"}\n' "$$u" "$$HASH" > "$$DEST"; \
 	chmod 0600 "$$DEST"; \
 	echo "[bootstrap] convex-dashboard-auth.json saved to $$DEST"
 


### PR DESCRIPTION
## Summary

Closes #355. Bundle 3 Phase 3 final-polish PR. Adds the operator-facing \`agents/Makefile\` (~330 lines) + the \`.docker-mounts/\` scaffolding. Operators run \`make -C agents <target> PROFILE=dev|prod\` for compose lifecycle and \`make -C agents <bootstrap-*>\` for secret materialization.

## Targets shipped

**Compose lifecycle (PROFILE-gated):** \`up\`, \`down\`, \`status\`, \`logs\`, \`build\`, \`pause\`, \`unpause\`, \`pause-elder-N\`, \`unpause-elder-N\`, \`pause-heartbeat\`, \`unpause-heartbeat\`, \`restart-X\`, \`reset-X\`, \`wipe-X\`, \`reset-anvil\`

**Bootstrap (no PROFILE needed):**
- \`bootstrap-convex-admin-key\` — delegates to root Makefile (waits for backend health, rejects empty key, writes .sha256)
- \`bootstrap-bus-secrets\` — generates local Docker secret files AND sets corresponding Convex env vars via \`npx convex env set\`. Idempotent without \`FORCE=1\`; rerun on partial failure.
- \`bootstrap-convex-dashboard-auth\` — prompts for user + password, stores SHA-256 in \`agents/secrets/convex-dashboard-auth.json\`
- \`oauth-bootstrap-elder-N\` — prompts per-elder \`CLAUDE_CODE_OAUTH_TOKEN\`, writes to \`agents/elder-N/.env\`

**Misc:** \`link-mounts\` (helper-container snapshots into \`agents/.docker-mounts/\`), \`smoke-test\` (calls \`bin/check-stack-health.sh\`)

## What's NOT here (intentionally)

- **Caddy Makefile targets** — OMITTED. PR #546 (Caddy snippet) is currently BLOCKED on architectural review (top-level site block won't route via cloudflared; ttyd needs auth gate). Follow-up PR can wire them in after #546's architectural shape resolves.
- **\`docker-compose.yml\` edits** — OMITTED. PR #546 already added the ttyd port mappings; no double-work.
- **Top-level Makefile wiring** — OMITTED. Root Makefile already owns the Convex helper targets.

## Drift fixes from original recover branch

Six drift fixes vs the 2026-05-16 recover/issue-355-makefile branch:
1. Process probe corrected: \`pgrep -f 'tsx.*elder-runtime/src/main.ts'\` (was stale \`/opt/elder-runtime/main.js\`)
2. Prod RPC banner: prints \`RPC_URL_PRIMARY\` (was nonexistent \`PROD_RPC_URL\`)
3. Secret paths honor \`*_FILE\` env vars for operator override
4. \`bootstrap-bus-secrets\` now also sets Convex env vars (was file-only)
5. Pattern targets use \`FORCE:\` instead of \`.PHONY: pattern-%\` (the latter doesn't reliably make pattern instances phony)
6. Fixed \`pause-elder-N\` stem-expansion bug (was targeting service \`2\`, now correctly \`elder-2\`)

## Test plan

- [x] \`make -C agents help\` — passes
- [x] \`docker compose --profile dev -f docker-compose.yml config --quiet\` — passed with dummy env
- [x] \`grep -rE 'caddy-install|caddy-uninstall' agents/Makefile\` — no matches
- [x] Pattern target dry-runs all correct (pause-elder-2, reset-elder-2, oauth-bootstrap-elder-2)
- [x] \`git diff --check\` — passed
- [x] Stale-ref scan: no \`main.js\`, \`PROD_RPC_URL\`, or caddy targets
- [ ] Local 3-tier swarm review
- [ ] Merge to dev-phase-3-final-polish

## Codex 5-stage trail

- Stage 1 plan: \`~/claudes-world/tmp/codex-issue-355/stage1.log\`
- Stage 2 implement: \`~/claudes-world/tmp/codex-issue-355/stage2.log\`
- Stage 3 critique: \`~/claudes-world/tmp/codex-issue-355/stage3.log\` — 3 polish items
- Stage 4 polish: \`~/claudes-world/tmp/codex-issue-355/stage4.log\` — all applied + pause-elder bug fix
- Stage 5 final: \`~/claudes-world/tmp/codex-issue-355/stage5.log\` — done

## Refs

- Issue #355
- Bundle 3 exploration: \`~/claudes-world/tmp/20260522-bundle3-exploration.md\`
- Caddy snippet (BLOCKED): #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)