### PR TITLE
feat(caddy): dockerized Caddy router for app.clan-world.com (#348 v3)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -185,7 +185,7 @@ TLD_APP_SUBDOMAIN=app
 # routes app.${CLAN_WORLD_DOMAIN} directly to http://127.0.0.1:${CADDY_HOST_PORT}.
 # Local dev can set CADDY_HOST_PORT=8080 and open http://127.0.0.1:8080 with no
 # host Caddy or cloudflared.
-CADDY_HOST_PORT=18081
+CADDY_HOST_PORT=58731
 
 # --- Chain selection (REQUIRED — heartbeat preflight asserts this) ---
 # CHAIN_NETWORK selects between the dev (anvil-fork) and prod (real RPC) RPC

--- a/.env.template
+++ b/.env.template
@@ -176,17 +176,16 @@ RUNNER_SETTLE_WINDOW_SEC=10
 # (Phase 1.12, issue #355). DO NOT put raw secret bytes in .env — the
 # compose file references file paths via the `secrets:` block.
 
-# --- Domain + Caddy host port ---
-# Hostname suffix used by the host caddy snippet in host/caddy/clan-world-docker.caddy
-# (added in Phase 1.5, issue #348). Default values bind the stack to
-# app.clan-world.com via cloudflared.
+# --- Domain + Docker Caddy host port ---
+# Domain metadata for operator runbooks. Docker Caddy itself listens on :80
+# inside the compose network and does not need hostname-specific site blocks.
 CLAN_WORLD_DOMAIN=clan-world.com
 TLD_APP_SUBDOMAIN=app
-# Host port the docker caddy listens on; the host (system-level) caddy
-# reverse-proxies app.${CLAN_WORLD_DOMAIN} -> 127.0.0.1:${CADDY_HOST_PORT}.
-# Canonical allocation via .world/ports.yml (purpose: clan-world-docker-caddy,
-# frontend prod sub-band). 58731 falls in 587xx slot's prod sub-band (10-39).
-CADDY_HOST_PORT=58731
+# Loopback port published by the Docker Caddy service. Prod VPS cloudflared
+# routes app.${CLAN_WORLD_DOMAIN} directly to http://127.0.0.1:${CADDY_HOST_PORT}.
+# Local dev can set CADDY_HOST_PORT=8080 and open http://127.0.0.1:8080 with no
+# host Caddy or cloudflared.
+CADDY_HOST_PORT=18081
 
 # --- Chain selection (REQUIRED — heartbeat preflight asserts this) ---
 # CHAIN_NETWORK selects between the dev (anvil-fork) and prod (real RPC) RPC

--- a/.world/ports.yml
+++ b/.world/ports.yml
@@ -67,4 +67,4 @@ purposes:
   - name: clan-world-docker-caddy
     type: frontend
     env: prod
-    canonical: 18081   # cloudflared routes app.clan-world.com -> 127.0.0.1:18081 -> docker caddy (Phase 1.5 #348)
+    canonical: 58731   # cloudflared routes app.clan-world.com -> 127.0.0.1:58731 -> docker caddy (Phase 1.5 #348)

--- a/.world/ports.yml
+++ b/.world/ports.yml
@@ -67,4 +67,4 @@ purposes:
   - name: clan-world-docker-caddy
     type: frontend
     env: prod
-    canonical: 58731   # host caddy reverse-proxies app.clan-world.com -> 127.0.0.1:58731 -> docker caddy (Phase 1.5 #348)
+    canonical: 18081   # cloudflared routes app.clan-world.com -> 127.0.0.1:18081 -> docker caddy (Phase 1.5 #348)

--- a/README.md
+++ b/README.md
@@ -251,9 +251,11 @@ docker compose --profile prod config   # validates prod topology
 > (`tsx --env-file=.env.local`, runbooks, etc.). `.env` is gitignored too
 > but `.env.local` matches existing conventions.
 
-Caddy is intentionally NOT a compose service — the host caddy stays
-authoritative and reverse-proxies `app.${CLAN_WORLD_DOMAIN}` to
-`127.0.0.1:${CADDY_HOST_PORT}` (see the host caddy snippet added in #348).
+ClanWorld's public app router is the compose `caddy` service. It publishes
+`127.0.0.1:${CADDY_HOST_PORT:-18081}:80`, routes `/elder-N/` to Docker-internal
+Elder ttyd services, and proxies `/` plus `/map` to `CLAN_WORLD_WEB_UPSTREAM`.
+On the VPS, cloudflared routes `app.${CLAN_WORLD_DOMAIN}` directly to that
+loopback port; host Caddy continues serving unrelated hostnames.
 
 **Bring-up + per-Elder lifecycle** is fronted by `agents/Makefile`, which
 ships in [#355](https://github.com/clan-world/clan-world-game/issues/355).

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ docker compose --profile prod config   # validates prod topology
 > but `.env.local` matches existing conventions.
 
 ClanWorld's public app router is the compose `caddy` service. It publishes
-`127.0.0.1:${CADDY_HOST_PORT:-18081}:80`, routes `/elder-N/` to Docker-internal
+`127.0.0.1:${CADDY_HOST_PORT:-58731}:80`, routes `/elder-N/` to Docker-internal
 Elder ttyd services, and proxies `/` plus `/map` to `CLAN_WORLD_WEB_UPSTREAM`.
 On the VPS, cloudflared routes `app.${CLAN_WORLD_DOMAIN}` directly to that
 loopback port; host Caddy continues serving unrelated hostnames.

--- a/agents/entrypoint.sh
+++ b/agents/entrypoint.sh
@@ -39,8 +39,10 @@ fi
 tmux new-session -d -s "${SESSION_NAME}" -c /workspace "/opt/clan-world/shared/run.sh"
 echo "[entrypoint] tmux session ${SESSION_NAME} created"
 
-# 2. Start ttyd attached to that session (background)
-ttyd --port "${TTYD_PORT}" --writable tmux attach-session -t "${SESSION_NAME}" &
+# 2. Start ttyd attached to that session (background). ttyd 1.7.7 is
+# read-only unless --writable is passed; operators send commands through the
+# Convex command bus, not through the browser terminal.
+ttyd --port "${TTYD_PORT}" tmux attach-session -t "${SESSION_NAME}" &
 TTYD_PID=$!
 echo "[entrypoint] ttyd started on port ${TTYD_PORT} (PID ${TTYD_PID})"
 

--- a/agents/shared/README-caddy.md
+++ b/agents/shared/README-caddy.md
@@ -19,6 +19,15 @@ bus, not through the browser terminal.
 Warning: restarting cloudflared briefly drops ALL tunnels, usually for about 5
 seconds. Choose an operator-approved time.
 
+Pre-check for duplicate ingress entries:
+
+```bash
+if sudo grep -q "hostname: *app.clan-world.com" /etc/cloudflared/config.yml; then
+  echo "ERROR: app.clan-world.com already exists in cloudflared config -- abort + update existing entry instead of adding"
+  exit 1
+fi
+```
+
 Back up the current config:
 
 ```bash
@@ -26,7 +35,9 @@ sudo cp /etc/cloudflared/config.yml /etc/cloudflared/config.yml.bak-$(date +%Y%m
 ```
 
 Edit `/etc/cloudflared/config.yml` and insert the `app.clan-world.com` ingress
-entry BEFORE the final `http_status:404` catch-all rule:
+entry BEFORE the final `http_status:404` catch-all rule. The port in
+`config.yml` is literal: if you change `CADDY_HOST_PORT` from the `18081`
+default, update this literal port to match.
 
 ```yaml
 - hostname: app.clan-world.com
@@ -38,6 +49,12 @@ entry BEFORE the final `http_status:404` catch-all rule:
 Validate and restart:
 
 ```bash
+EXPECTED_PORT=${CADDY_HOST_PORT:-18081}
+CURRENT_CLOUDFLARED_PORT=$(sudo grep -A1 'app.clan-world.com' /etc/cloudflared/config.yml | grep -oE 'localhost:[0-9]+|127.0.0.1:[0-9]+' | grep -oE '[0-9]+' | head -1)
+if [ "$EXPECTED_PORT" != "$CURRENT_CLOUDFLARED_PORT" ]; then
+  echo "ERROR: CADDY_HOST_PORT=$EXPECTED_PORT but cloudflared routes to port $CURRENT_CLOUDFLARED_PORT"
+  exit 1
+fi
 sudo cloudflared tunnel --config /etc/cloudflared/config.yml ingress validate
 sudo systemctl restart cloudflared
 ```
@@ -45,8 +62,8 @@ sudo systemctl restart cloudflared
 Verify the new route and one existing tunnel:
 
 ```bash
-curl -I https://app.clan-world.com/healthz
-curl -I https://cockpit.clan-world.com
+curl -fsS https://app.clan-world.com/healthz | grep -q "^ok$" || { echo "ERROR: healthz did not return ok"; exit 1; }
+curl -fsS -o /dev/null https://cockpit.clan-world.com
 ```
 
 Rollback uses the timestamped backup from the first command:
@@ -84,10 +101,17 @@ Docker network instead of `host.docker.internal`.
 
 ```bash
 docker compose --profile dev up -d caddy
-curl -sf "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/healthz"
-curl -I "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/elder-1/"
+curl -fsS "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/healthz" | grep -q "^ok$" || { echo "ERROR: healthz did not return ok"; exit 1; }
+curl -fsS -o /dev/null "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/elder-1/"
 ```
 
 These checks prove Caddy is reachable and can attempt an elder route. Full ttyd
 validation requires the full stack up and a follow-up Playwright or `websocat`
 smoke that verifies the WebSocket upgrade and terminal output.
+
+### Healthcheck Scope
+
+The compose `caddy` healthcheck only proves that Caddy itself responds on
+`/healthz`. It does not prove that `CLAN_WORLD_WEB_UPSTREAM` is reachable, that
+the elder services are running, or that ttyd WebSocket upgrades work. Operators
+must run the smoke commands after compose up for route-level validation.

--- a/agents/shared/README-caddy.md
+++ b/agents/shared/README-caddy.md
@@ -6,7 +6,7 @@ host, and routes to Docker-internal services such as `elder-1:7681`.
 
 ## Prod VPS
 
-Set `CADDY_HOST_PORT=18081` unless the operator intentionally chooses another
+Set `CADDY_HOST_PORT=58731` unless the operator intentionally chooses another
 free loopback port. The default `CLAN_WORLD_WEB_UPSTREAM` in the Caddyfile is
 `https://clan-world-game.vercel.app`.
 
@@ -36,12 +36,12 @@ sudo cp /etc/cloudflared/config.yml /etc/cloudflared/config.yml.bak-$(date +%Y%m
 
 Edit `/etc/cloudflared/config.yml` and insert the `app.clan-world.com` ingress
 entry BEFORE the final `http_status:404` catch-all rule. The port in
-`config.yml` is literal: if you change `CADDY_HOST_PORT` from the `18081`
+`config.yml` is literal: if you change `CADDY_HOST_PORT` from the `58731`
 default, update this literal port to match.
 
 ```yaml
 - hostname: app.clan-world.com
-  service: http://127.0.0.1:18081
+  service: http://127.0.0.1:58731
   originRequest:
     httpHostHeader: app.clan-world.com
 ```
@@ -49,7 +49,7 @@ default, update this literal port to match.
 Validate and restart:
 
 ```bash
-EXPECTED_PORT=${CADDY_HOST_PORT:-18081}
+EXPECTED_PORT=${CADDY_HOST_PORT:-58731}
 CURRENT_CLOUDFLARED_PORT=$(sudo grep -A1 'app.clan-world.com' /etc/cloudflared/config.yml | grep -oE 'localhost:[0-9]+|127.0.0.1:[0-9]+' | grep -oE '[0-9]+' | head -1)
 if [ "$EXPECTED_PORT" != "$CURRENT_CLOUDFLARED_PORT" ]; then
   echo "ERROR: CADDY_HOST_PORT=$EXPECTED_PORT but cloudflared routes to port $CURRENT_CLOUDFLARED_PORT"
@@ -101,8 +101,8 @@ Docker network instead of `host.docker.internal`.
 
 ```bash
 docker compose --profile dev up -d caddy
-curl -fsS "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/healthz" | grep -q "^ok$" || { echo "ERROR: healthz did not return ok"; exit 1; }
-curl -fsS -o /dev/null "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/elder-1/"
+curl -fsS "http://127.0.0.1:${CADDY_HOST_PORT:-58731}/healthz" | grep -q "^ok$" || { echo "ERROR: healthz did not return ok"; exit 1; }
+curl -fsS -o /dev/null "http://127.0.0.1:${CADDY_HOST_PORT:-58731}/elder-1/"
 ```
 
 These checks prove Caddy is reachable and can attempt an elder route. Full ttyd

--- a/agents/shared/README-caddy.md
+++ b/agents/shared/README-caddy.md
@@ -1,0 +1,93 @@
+# Docker Caddy Routing
+
+ClanWorld's public app router lives inside the compose stack as the `caddy`
+service. It reads `agents/shared/caddy.conf`, publishes one loopback port on the
+host, and routes to Docker-internal services such as `elder-1:7681`.
+
+## Prod VPS
+
+Set `CADDY_HOST_PORT=18081` unless the operator intentionally chooses another
+free loopback port. The default `CLAN_WORLD_WEB_UPSTREAM` in the Caddyfile is
+`https://clan-world-game.vercel.app`.
+
+Cloudflare Access is the production auth gate for `app.clan-world.com`. The
+ttyd terminals are read-only; operators send commands through the Convex command
+bus, not through the browser terminal.
+
+### Cloudflared Ingress
+
+Warning: restarting cloudflared briefly drops ALL tunnels, usually for about 5
+seconds. Choose an operator-approved time.
+
+Back up the current config:
+
+```bash
+sudo cp /etc/cloudflared/config.yml /etc/cloudflared/config.yml.bak-$(date +%Y%m%d%H%M%S)
+```
+
+Edit `/etc/cloudflared/config.yml` and insert the `app.clan-world.com` ingress
+entry BEFORE the final `http_status:404` catch-all rule:
+
+```yaml
+- hostname: app.clan-world.com
+  service: http://127.0.0.1:18081
+  originRequest:
+    httpHostHeader: app.clan-world.com
+```
+
+Validate and restart:
+
+```bash
+sudo cloudflared tunnel --config /etc/cloudflared/config.yml ingress validate
+sudo systemctl restart cloudflared
+```
+
+Verify the new route and one existing tunnel:
+
+```bash
+curl -I https://app.clan-world.com/healthz
+curl -I https://cockpit.clan-world.com
+```
+
+Rollback uses the timestamped backup from the first command:
+
+```bash
+sudo cp /etc/cloudflared/config.yml.bak-YYYYMMDDHHMMSS /etc/cloudflared/config.yml
+sudo systemctl restart cloudflared
+```
+
+## Local Dev
+
+Set `CADDY_HOST_PORT=8080` or any other free loopback port, then open:
+
+```text
+http://127.0.0.1:8080
+```
+
+No host Caddy or cloudflared setup is required for local development. Local dev
+has no Caddy auth layer; bind the port to `127.0.0.1` only.
+
+By default, Caddy proxies `/` and `/map` to
+`https://clan-world-game.vercel.app`. To use a host-run local frontend instead,
+set `CLAN_WORLD_WEB_UPSTREAM`, for example:
+
+```dotenv
+CLAN_WORLD_WEB_UPSTREAM=http://host.docker.internal:58740
+```
+
+The compose `caddy` service includes
+`host.docker.internal:host-gateway`, so this works on Linux Docker too. If a
+developer points at a frontend container instead, use that service name on the
+Docker network instead of `host.docker.internal`.
+
+## Smoke Checks
+
+```bash
+docker compose --profile dev up -d caddy
+curl -sf "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/healthz"
+curl -I "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/elder-1/"
+```
+
+These checks prove Caddy is reachable and can attempt an elder route. Full ttyd
+validation requires the full stack up and a follow-up Playwright or `websocat`
+smoke that verifies the WebSocket upgrade and terminal output.

--- a/agents/shared/caddy.conf
+++ b/agents/shared/caddy.conf
@@ -56,14 +56,14 @@
 	handle /map* {
 		reverse_proxy {$CLAN_WORLD_WEB_UPSTREAM:https://clan-world-game.vercel.app} {
 			header_up X-Forwarded-Proto https
-			header_up Host {upstream_hostport}
+			header_up Host {upstream_host}
 		}
 	}
 
 	handle {
 		reverse_proxy {$CLAN_WORLD_WEB_UPSTREAM:https://clan-world-game.vercel.app} {
 			header_up X-Forwarded-Proto https
-			header_up Host {upstream_hostport}
+			header_up Host {upstream_host}
 		}
 	}
 }

--- a/agents/shared/caddy.conf
+++ b/agents/shared/caddy.conf
@@ -1,0 +1,69 @@
+{
+	auto_https off
+	servers {
+		protocols h1 h2
+		timeouts {
+			read_body 30s
+			read_header 10s
+			write 0
+			idle 1h
+		}
+	}
+}
+
+:80 {
+	encode gzip zstd
+
+	handle /healthz {
+		respond "ok" 200
+	}
+
+	@bare_elder path /elder-1 /elder-2 /elder-3 /elder-4
+	redir @bare_elder {path}/ 308
+
+	handle_path /elder-1/* {
+		reverse_proxy elder-1:7681 {
+			transport http {
+				versions 1.1
+			}
+		}
+	}
+
+	handle_path /elder-2/* {
+		reverse_proxy elder-2:7681 {
+			transport http {
+				versions 1.1
+			}
+		}
+	}
+
+	handle_path /elder-3/* {
+		reverse_proxy elder-3:7681 {
+			transport http {
+				versions 1.1
+			}
+		}
+	}
+
+	handle_path /elder-4/* {
+		reverse_proxy elder-4:7681 {
+			transport http {
+				versions 1.1
+			}
+		}
+	}
+
+	handle /map* {
+		reverse_proxy {$CLAN_WORLD_WEB_UPSTREAM:https://clan-world-game.vercel.app} {
+			header_up X-Forwarded-Proto https
+			header_up Host {upstream_hostport}
+		}
+	}
+
+	handle {
+		reverse_proxy {$CLAN_WORLD_WEB_UPSTREAM:https://clan-world-game.vercel.app} {
+			header_up X-Forwarded-Proto https
+			header_up Host {upstream_hostport}
+		}
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -262,6 +262,8 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - ./agents/shared/caddy.conf:/etc/caddy/Caddyfile:ro
+    environment:
+      CLAN_WORLD_WEB_UPSTREAM: ${CLAN_WORLD_WEB_UPSTREAM:-https://clan-world-game.vercel.app}
     depends_on:
       elder-1:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,7 +247,7 @@ services:
 
   # ---------------------------------------------------------------------------
   # Dockerized Caddy — ClanWorld-only router. The host cloudflared ingress maps
-  # app.clan-world.com -> 127.0.0.1:${CADDY_HOST_PORT:-18081}; Caddy then routes
+  # app.clan-world.com -> 127.0.0.1:${CADDY_HOST_PORT:-58731}; Caddy then routes
   # to Docker-internal services by name.
   # ---------------------------------------------------------------------------
   caddy:
@@ -255,7 +255,7 @@ services:
     restart: unless-stopped
     networks: [clan-world-internal]
     ports:
-      - "127.0.0.1:${CADDY_HOST_PORT:-18081}:80"
+      - "127.0.0.1:${CADDY_HOST_PORT:-58731}:80"
     extra_hosts:
       # Lets local dev point CLAN_WORLD_WEB_UPSTREAM at a host-run Vite server,
       # e.g. http://host.docker.internal:58740, on Linux Docker.
@@ -264,15 +264,6 @@ services:
       - ./agents/shared/caddy.conf:/etc/caddy/Caddyfile:ro
     environment:
       CLAN_WORLD_WEB_UPSTREAM: ${CLAN_WORLD_WEB_UPSTREAM:-https://clan-world-game.vercel.app}
-    depends_on:
-      elder-1:
-        condition: service_started
-      elder-2:
-        condition: service_started
-      elder-3:
-        condition: service_started
-      elder-4:
-        condition: service_started
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/healthz || exit 1"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 #
 #   - #345 agents/Dockerfile (Phase 1.2)
 #   - #347 self-hosted Convex deploy (Phase 1.4)
-#   - #348 host caddy snippet + Caddyfile (Phase 1.5)
+#   - #348 dockerized Caddy routing for app.clan-world.com (Phase 1.5)
 #   - #349 elder-N service template (Phase 1.6) — these stubs will be
 #     overwritten by the generated docker-compose.elders.yml
 #   - #355 agents/Makefile (Phase 1.12)
@@ -16,9 +16,9 @@
 #   --profile dev   anvil-fork + bind-mount agents/  (local iteration)
 #   --profile prod  real Base Sepolia RPC, image-baked agents/  (VPS deploy)
 #
-# Caddy is NOT a compose service — host caddy stays authoritative (decision D
-# in the plan). The clan-world stack reverse-proxies through the host caddy via
-# CADDY_HOST_PORT.
+# Caddy is a compose service for ClanWorld-only routing. Host cloudflared sends
+# app.clan-world.com directly to the docker-published loopback CADDY_HOST_PORT;
+# host Caddy continues serving unrelated hostnames on its own port.
 #
 # Validation:
 #   docker compose --profile dev config
@@ -243,6 +243,40 @@ services:
       start_period: 60s
     # Retry transient preflight/runtime failures, then leave repeated failures visible.
     restart: on-failure:5
+    profiles: [dev, prod]
+
+  # ---------------------------------------------------------------------------
+  # Dockerized Caddy — ClanWorld-only router. The host cloudflared ingress maps
+  # app.clan-world.com -> 127.0.0.1:${CADDY_HOST_PORT:-18081}; Caddy then routes
+  # to Docker-internal services by name.
+  # ---------------------------------------------------------------------------
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    networks: [clan-world-internal]
+    ports:
+      - "127.0.0.1:${CADDY_HOST_PORT:-18081}:80"
+    extra_hosts:
+      # Lets local dev point CLAN_WORLD_WEB_UPSTREAM at a host-run Vite server,
+      # e.g. http://host.docker.internal:58740, on Linux Docker.
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./agents/shared/caddy.conf:/etc/caddy/Caddyfile:ro
+    depends_on:
+      elder-1:
+        condition: service_started
+      elder-2:
+        condition: service_started
+      elder-3:
+        condition: service_started
+      elder-4:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/healthz || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
     profiles: [dev, prod]
 
   # ---------------------------------------------------------------------------

--- a/docs/plans/dockerize-elder-infra-v1.md
+++ b/docs/plans/dockerize-elder-infra-v1.md
@@ -147,7 +147,7 @@ Trade-off: shared-base updates propagate on next container init (`make restart-e
 
 #### D. Caddy in container vs host caddy
 
-**Decision: keep host caddy authoritative for unrelated shared-host routes, but route `${TLD_APP_SUBDOMAIN}.${CLAN_WORLD_DOMAIN}` directly from cloudflared to Docker Caddy.** The host caddy currently fronts pm-dobot, gstack, narrator, and other unrelated tunnels through cloudflared — we do not break those. We add ONE new cloudflared ingress entry for `${TLD_APP_SUBDOMAIN}.${CLAN_WORLD_DOMAIN}` → `http://127.0.0.1:${CADDY_HOST_PORT:-18081}`. Inside the container, Docker Caddy handles the subroute fan-out (`/`, `/map`, `/elder-N`). This avoids editing host Caddy for ClanWorld app routing while keeping the blast radius narrow if the docker stack misbehaves.
+**Decision: keep host caddy authoritative for unrelated shared-host routes, but route `${TLD_APP_SUBDOMAIN}.${CLAN_WORLD_DOMAIN}` directly from cloudflared to Docker Caddy.** The host caddy currently fronts pm-dobot, gstack, narrator, and other unrelated tunnels through cloudflared — we do not break those. We add ONE new cloudflared ingress entry for `${TLD_APP_SUBDOMAIN}.${CLAN_WORLD_DOMAIN}` → `http://127.0.0.1:${CADDY_HOST_PORT:-58731}`. Inside the container, Docker Caddy handles the subroute fan-out (`/`, `/map`, `/elder-N`). This avoids editing host Caddy for ClanWorld app routing while keeping the blast radius narrow if the docker stack misbehaves.
 
 #### E. `settings.local.json` writable by Elders?
 
@@ -288,7 +288,7 @@ Each sub-issue below is sized for one PR. Filed sequentially as GH issues #339 t
 
 ### Phase 1.5 — Caddy container with subroute config
 
-**Scope.** Define the `caddy` compose service running `caddy:2-alpine`. Caddyfile provides the path-routing fan-out: `/elder-N` → `elder-N:7681` (ttyd, with WS upgrade), `/map` → `CLAN_WORLD_WEB_UPSTREAM`, and `/` → `CLAN_WORLD_WEB_UPSTREAM`. Docker Caddy listens on container `:80` and publishes `127.0.0.1:${CADDY_HOST_PORT:-18081}:80`. On the VPS, cloudflared routes `app.clan-world.com` directly to that loopback port; host Caddy is not in the ClanWorld app path.
+**Scope.** Define the `caddy` compose service running `caddy:2-alpine`. Caddyfile provides the path-routing fan-out: `/elder-N` → `elder-N:7681` (ttyd, with WS upgrade), `/map` → `CLAN_WORLD_WEB_UPSTREAM`, and `/` → `CLAN_WORLD_WEB_UPSTREAM`. Docker Caddy listens on container `:80` and publishes `127.0.0.1:${CADDY_HOST_PORT:-58731}:80`. On the VPS, cloudflared routes `app.clan-world.com` directly to that loopback port; host Caddy is not in the ClanWorld app path.
 
 **WebSocket upgrade for ttyd (Finding 12 fix).** ttyd uses plain HTTP/1.1 WebSocket upgrades — Caddy pins transport to HTTP/1.1 for the elder routes. ttyd by default serves from path `/`, so we use Caddy's `handle_path` directive to strip the `/elder-N` prefix before proxying (Finding 13 fix). Required Caddyfile snippet (canonical file: `agents/shared/caddy.conf`):
 
@@ -329,7 +329,7 @@ Each sub-issue below is sized for one PR. Filed sequentially as GH issues #339 t
 Cloudflared ingress entry added before the final `http_status:404` catch-all:
 ```yaml
 - hostname: app.clan-world.com
-  service: http://127.0.0.1:18081
+  service: http://127.0.0.1:58731
   originRequest:
     httpHostHeader: app.clan-world.com
 ```
@@ -913,7 +913,7 @@ sudo cp /etc/cloudflared/config.yml /etc/cloudflared/config.yml.bak-$(date +%Y%m
 
 # Insert the app.clan-world.com ingress BEFORE the final http_status:404 catch-all:
 # - hostname: app.clan-world.com
-#   service: http://127.0.0.1:18081
+#   service: http://127.0.0.1:58731
 #   originRequest:
 #     httpHostHeader: app.clan-world.com
 sudo cloudflared tunnel --config /etc/cloudflared/config.yml ingress validate
@@ -1286,13 +1286,12 @@ services:
     volumes:
       - ./agents/shared/caddy.conf:/etc/caddy/Caddyfile:ro
     ports:
-      - "127.0.0.1:${CADDY_HOST_PORT:-18081}:80"
+      - "127.0.0.1:${CADDY_HOST_PORT:-58731}:80"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    environment:
+      CLAN_WORLD_WEB_UPSTREAM: ${CLAN_WORLD_WEB_UPSTREAM:-https://clan-world-game.vercel.app}
     networks: [clan-world-internal]
-    depends_on:
-      elder-1:
-        condition: service_started
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/healthz || exit 1"]
       interval: 10s

--- a/docs/plans/dockerize-elder-infra-v1.md
+++ b/docs/plans/dockerize-elder-infra-v1.md
@@ -918,8 +918,8 @@ sudo cp /etc/cloudflared/config.yml /etc/cloudflared/config.yml.bak-$(date +%Y%m
 #     httpHostHeader: app.clan-world.com
 sudo cloudflared tunnel --config /etc/cloudflared/config.yml ingress validate
 sudo systemctl restart cloudflared
-curl -I https://app.clan-world.com/healthz
-curl -I https://cockpit.clan-world.com
+curl -fsS https://app.clan-world.com/healthz | grep -q '^ok$' || { echo 'ERROR: healthz did not return ok'; exit 1; }
+curl -fsS -o /dev/null https://cockpit.clan-world.com
 
 # Verify unrelated tunnels still resolve
 for tunnel in pm-dobot narrator gstack; do

--- a/docs/plans/dockerize-elder-infra-v1.md
+++ b/docs/plans/dockerize-elder-infra-v1.md
@@ -90,7 +90,7 @@ graph TD
 
 ### Locked decisions (from round 4 + earlier rounds)
 
-1. **Parallel-coexist cutover (NOT big-bang).** Stand up the compose stack in parallel with the current VPS layout on different ports. Legacy systemd units stay ENABLED AND RUNNING through Phase 2 internal smoke + Caddy cutover + a 30-minute observation window. ONLY after the 30-min coexist window validates all 10 smoke-test acceptance criteria do we disable legacy. This is the locked cutover policy — Phase 2 implements it in this order: (1) compose up on alternate ports, (2) Convex import, (3) internal smoke, (4) Caddy snippet add (additive, host caddy still routes legacy too), (5) 30-min coexist observation, (6) full smoke acceptance gate, (7) disable legacy systemd, (8) archive legacy state. If any step fails, legacy stays live and rollback is "remove the additive Caddy snippet + `docker compose down`". See Phase 2 for exact commands and the validation gate before step 7.
+1. **Parallel-coexist cutover (NOT big-bang).** Stand up the compose stack in parallel with the current VPS layout on different ports. Legacy systemd units stay ENABLED AND RUNNING through Phase 2 internal smoke + Caddy cutover + a 30-minute observation window. ONLY after the 30-min coexist window validates all 10 smoke-test acceptance criteria do we disable legacy. This is the locked cutover policy — Phase 2 implements it in this order: (1) compose up on alternate ports, (2) Convex import, (3) internal smoke, (4) cloudflared routes `app.clan-world.com` directly to the Docker Caddy loopback port, (5) 30-min coexist observation, (6) full smoke acceptance gate, (7) disable legacy systemd, (8) archive legacy state. If any step fails, legacy stays live and rollback is "remove the additive cloudflared ingress entry + `docker compose down`". See Phase 2 for exact commands and the validation gate before step 7.
 2. **Self-hosted Convex** in a separate container (backend + dashboard + SQLite). Image pin: `ghcr.io/get-convex/convex-backend:<commit-sha>` (not `:latest`), dashboard `ghcr.io/get-convex/convex-dashboard:<commit-sha>`. Admin key persisted via env var, not auto-regen.
 3. **Anvil-fork container for dev RPC** — `dev` compose profile only. Prod profile points at real Base Sepolia.
 4. **One container per Elder.** v1 spins up 4 Elders. Service definition is parameterized so 12-Elder mode is a config change (the compose file uses templated YAML or a small `gen-compose.sh` that emits per-Elder service blocks from a list).
@@ -103,7 +103,7 @@ graph TD
 9. **ANCIENT_WISDOM.md** auto-injected via `SessionStart` hook from per-Elder workspace.
 10. **No network egress** except an explicit allowlist (resolves Finding 4):
     - **Outbound TCP/443 allowed to:** `api.anthropic.com`, `claude.ai`, `accounts.anthropic.com`. (Codex API hosts added later under separate issue.)
-    - **Internal Docker network allowed:** the `clan-world-internal` bridge subnet (resolved at container init via `ip route | awk '/eth0/{print $1}'`). This permits container-to-container traffic to `convex-backend:3210`, `anvil-fork:8545`, `caddy:8080`, `heartbeat`, etc. without enumerating service IPs.
+    - **Internal Docker network allowed:** the `clan-world-internal` bridge subnet (resolved at container init via `ip route | awk '/eth0/{print $1}'`). This permits container-to-container traffic to `convex-backend:3210`, `anvil-fork:8545`, `caddy:80`, `heartbeat`, etc. without enumerating service IPs.
     - **Docker DNS allowed:** UDP/TCP 53 to `127.0.0.11` (Docker embedded DNS).
     - **Public DNS allowed:** UDP 53 to whatever resolver `/etc/resolv.conf` lists (needed for the Anthropic hostnames). The init script reads `/etc/resolv.conf` at startup and adds explicit rules per nameserver.
     - **DENIED by default:** GitHub, npm registry, Google, generic IPv4 internet. Image build is the ONLY time `npm install`/`apt-get` runs; runtime egress is locked down. If an agent needs npm/GitHub at runtime, file a follow-up issue (Phase 1.6 acceptance must include a test confirming this is blocked).
@@ -147,7 +147,7 @@ Trade-off: shared-base updates propagate on next container init (`make restart-e
 
 #### D. Caddy in container vs host caddy
 
-**Decision: keep host caddy authoritative, route ONLY the `${CLAN_WORLD_DOMAIN}` (i.e., `clan-world.com`) hostname to the docker Caddy.** The host caddy currently fronts pm-dobot, gstack, narrator, and other unrelated tunnels through cloudflared — we do not break those. We add ONE new server block to the host caddy that reverse-proxies `${TLD_APP_SUBDOMAIN}.${CLAN_WORLD_DOMAIN}` → `127.0.0.1:${COMPOSE_CADDY_PORT}` (we'll allocate a unique port via `port-for clan-world-docker-caddy`). Inside the container, the docker caddy handles the subroute fan-out (`/`, `/map`, `/elder-N`). Host caddy stays as the single TLS terminator + cloudflared peer; docker caddy is path-routing-only on plain HTTP inside the compose network. This minimizes the blast radius if the docker stack misbehaves: nothing about pm-dobot or narrator goes through the docker Caddy.
+**Decision: keep host caddy authoritative for unrelated shared-host routes, but route `${TLD_APP_SUBDOMAIN}.${CLAN_WORLD_DOMAIN}` directly from cloudflared to Docker Caddy.** The host caddy currently fronts pm-dobot, gstack, narrator, and other unrelated tunnels through cloudflared — we do not break those. We add ONE new cloudflared ingress entry for `${TLD_APP_SUBDOMAIN}.${CLAN_WORLD_DOMAIN}` → `http://127.0.0.1:${CADDY_HOST_PORT:-18081}`. Inside the container, Docker Caddy handles the subroute fan-out (`/`, `/map`, `/elder-N`). This avoids editing host Caddy for ClanWorld app routing while keeping the blast radius narrow if the docker stack misbehaves.
 
 #### E. `settings.local.json` writable by Elders?
 
@@ -288,77 +288,50 @@ Each sub-issue below is sized for one PR. Filed sequentially as GH issues #339 t
 
 ### Phase 1.5 — Caddy container with subroute config
 
-**Scope.** Define the `caddy` compose service running `caddy:2-alpine`. Caddyfile provides the path-routing fan-out: `/elder-N` → `elder-N:7681` (ttyd, with WS upgrade), `/map` → frontend container (wired in Phase 1.11), `/` → frontend (cockpit), `/convex-admin/` → `convex-dashboard:6791` with basic-auth. Caddy listens on internal `:8080` (HTTP); host caddy terminates TLS upstream and reverse-proxies plain HTTP into the container. Allocate the host-side port via `port-for clan-world-docker-caddy` (NOT hardcoded).
+**Scope.** Define the `caddy` compose service running `caddy:2-alpine`. Caddyfile provides the path-routing fan-out: `/elder-N` → `elder-N:7681` (ttyd, with WS upgrade), `/map` → `CLAN_WORLD_WEB_UPSTREAM`, and `/` → `CLAN_WORLD_WEB_UPSTREAM`. Docker Caddy listens on container `:80` and publishes `127.0.0.1:${CADDY_HOST_PORT:-18081}:80`. On the VPS, cloudflared routes `app.clan-world.com` directly to that loopback port; host Caddy is not in the ClanWorld app path.
 
-**WebSocket upgrade for ttyd (Finding 12 fix).** ttyd uses plain HTTP/1.1 WebSocket upgrades — Caddy must explicitly enable WS upgrades and pin transport to HTTP/1.1 for the elder routes. ttyd by default serves from path `/`, so we use Caddy's `handle_path` directive to strip the `/elder-N` prefix before proxying (Finding 13 fix). Required Caddyfile snippet (canonical for `agents/caddy/Caddyfile`):
+**WebSocket upgrade for ttyd (Finding 12 fix).** ttyd uses plain HTTP/1.1 WebSocket upgrades — Caddy pins transport to HTTP/1.1 for the elder routes. ttyd by default serves from path `/`, so we use Caddy's `handle_path` directive to strip the `/elder-N` prefix before proxying (Finding 13 fix). Required Caddyfile snippet (canonical file: `agents/shared/caddy.conf`):
 
 ```caddyfile
-:8080 {
-  # WebSocket matcher (any path matching elder routes with Connection: Upgrade)
-  @ws_elder {
-    path /elder-1* /elder-2* /elder-3* /elder-4*
-    header Connection *Upgrade*
-    header Upgrade websocket
+:80 {
+  handle /healthz {
+    respond "ok" 200
   }
 
-  # ttyd routes: strip /elder-N prefix, pin transport to HTTP/1.1 (ttyd does NOT speak h2)
+  @bare_elder path /elder-1 /elder-2 /elder-3 /elder-4
+  redir @bare_elder {path}/ 308
+
   handle_path /elder-1/* {
     reverse_proxy elder-1:7681 {
-      transport http { versions h1 }
-      header_up Host {host}
-      header_up X-Real-IP {remote_host}
+      transport http { versions 1.1 }
     }
   }
+
   handle_path /elder-2/* {
-    reverse_proxy elder-2:7681 { transport http { versions h1 } }
+    reverse_proxy elder-2:7681 { transport http { versions 1.1 } }
   }
   handle_path /elder-3/* {
-    reverse_proxy elder-3:7681 { transport http { versions h1 } }
+    reverse_proxy elder-3:7681 { transport http { versions 1.1 } }
   }
   handle_path /elder-4/* {
-    reverse_proxy elder-4:7681 { transport http { versions h1 } }
-  }
-  # Also handle the bare /elder-N (no trailing slash) — redirect to /elder-N/
-  @bare_elder path /elder-1 /elder-2 /elder-3 /elder-4
-  redir @bare_elder {path}/ 301
-
-  # Convex dashboard with basic-auth (Finding 14 fix — see basic-auth lifecycle below)
-  handle_path /convex-admin/* {
-    basicauth {
-      admin {$CONVEX_DASHBOARD_BASIC_AUTH_HASH}
-    }
-    reverse_proxy convex-dashboard:6791 {
-      transport http { versions h1 }
-    }
+    reverse_proxy elder-4:7681 { transport http { versions 1.1 } }
   }
 
-  # Frontend fallthrough (wired in Phase 1.11)
-  handle /map {
-    reverse_proxy frontend:3000
+  handle /map* {
+    reverse_proxy {$CLAN_WORLD_WEB_UPSTREAM:https://clan-world-game.vercel.app}
   }
-  handle / {
-    reverse_proxy frontend:3000
-  }
-  # Long timeouts for ttyd (interactive sessions can idle for hours)
-  servers {
-    timeouts {
-      read_body 30s
-      read_header 10s
-      write 0          # 0 = no write timeout (ttyd streams)
-      idle 1h
-    }
+  handle {
+    reverse_proxy {$CLAN_WORLD_WEB_UPSTREAM:https://clan-world-game.vercel.app}
   }
 }
 ```
 
-Host caddy snippet at `host/caddy/clan-world-docker.caddy`:
-```caddyfile
-app.{$CLAN_WORLD_DOMAIN} {
-  reverse_proxy 127.0.0.1:{$CADDY_HOST_PORT} {
-    transport http { versions h1 }
-    flush_interval -1     # stream ttyd output without buffering
-  }
-}
+Cloudflared ingress entry added before the final `http_status:404` catch-all:
+```yaml
+- hostname: app.clan-world.com
+  service: http://127.0.0.1:18081
+  originRequest:
+    httpHostHeader: app.clan-world.com
 ```
 
 **Basic-auth lifecycle for `/convex-admin` (Finding 14 fix).** Hash NOT committed to repo. Generated via `make bootstrap-convex-dashboard-auth` (Phase 1.12 must include this target):
@@ -369,16 +342,15 @@ app.{$CLAN_WORLD_DOMAIN} {
 5. If the hash file is missing at Caddy startup, Caddy FAILS to start (no fail-open on auth). Acceptance: stop the file, `docker compose up caddy` fails with clear error.
 
 **Files affected.**
-- `docker-compose.yml` (UPDATE — add caddy service, mount secrets)
-- `agents/caddy/Caddyfile` (NEW — per snippet above)
-- `agents/caddy/.gitignore` (NEW — `data/`, `config/`)
-- `host/caddy/clan-world-docker.caddy` (NEW — snippet per above; **routes only `app.${CLAN_WORLD_DOMAIN}`** (Finding 15 fix — wording normalized) — NOT the bare root domain)
-- `scripts/bootstrap-convex-dashboard-auth.sh` (NEW)
-- `docs/runbooks/caddy-coexistence.md` (NEW — explains host vs docker caddy responsibilities + WS upgrade gotchas)
+- `docker-compose.yml` (UPDATE — add caddy service)
+- `agents/shared/caddy.conf` (NEW — per snippet above)
+- `agents/shared/README-caddy.md` (NEW — explains Docker Caddy, cloudflared ingress, local dev, and smoke checks)
+- `docs/runbooks/dockerize-migration-v1.md` (UPDATE — Step 8 cloudflared cutover)
+- `.env.template` (UPDATE — `CADDY_HOST_PORT`, `CLAN_WORLD_WEB_UPSTREAM` docs if needed)
 
 **Dependencies.** Phase 1.1.
 
-**Complexity.** Medium (the host caddy snippet must integrate cleanly without disturbing pm-dobot / narrator routes; WS path-strip + h1 pin is easy to get wrong).
+**Complexity.** Medium (cloudflared cutover must preserve other tunnel entries; WS path-strip + h1 pin is easy to get wrong).
 
 **Acceptance.**
 - `make up` brings caddy healthy (with elder/frontend upstreams down, expect 502 on those paths, NOT Caddy crash)
@@ -390,7 +362,7 @@ app.{$CLAN_WORLD_DOMAIN} {
 - **Path-strip test:** static asset request `GET /elder-1/static/index.css` returns the ttyd asset (proves `handle_path` strips `/elder-1` correctly).
 - `/convex-admin` returns 401 without basic-auth header; returns 200 with correct credentials.
 - `/convex-admin` fails-closed if hash file missing.
-- Host caddy snippet placed via the deploy-host-caddy-snippet runbook does NOT break any existing tunnel (verify by hitting pm-dobot, narrator, etc. — explicit hostname-by-hostname test).
+- Cloudflared ingress added for `app.clan-world.com` does NOT break any existing tunnel (verify by hitting cockpit and one unrelated tunnel after restart).
 
 ---
 
@@ -845,7 +817,7 @@ Define the `dev` vs `prod` compose profile semantics in `docker-compose.dev.yml`
 3. Stand up self-hosted (`make up PROFILE=prod`), confirm backend healthy, schema deploys cleanly.
 4. Hosted→self-hosted import via `npx convex import --replace-all`. Compare schema fingerprints (before vs after). If diverged, abort and run targeted migration script (none expected for v1; document the migration-script slot for future use).
 5. Swap deploy targets in `apps/web/.env`, redeploy Vercel for the `web` app.
-6. Deploy host Caddy snippet (additive, with pre-edit backup).
+6. Add cloudflared ingress for `app.clan-world.com` → Docker Caddy loopback port.
 7. 30-min coexist observation.
 8. Validation gate (`make smoke-test`).
 9. Disable legacy systemd + cron.
@@ -933,20 +905,23 @@ Schema migration: v2.8.4 hosted → self-hosted backend at pinned commit SHA —
 
 Run the 10-criterion smoke acceptance list below against the compose stack via its alternate-port URLs (e.g., `http://localhost:${CADDY_HOST_PORT}/`). Legacy is still live on its own routes; do NOT touch host caddy yet. If any criterion fails, fix in-place; legacy is unaffected.
 
-### Step 4 — Add additive host-caddy snippet (legacy STILL routed too)
+### Step 4 — Add additive cloudflared ingress (legacy STILL routed too)
 
 ```bash
-# Back up the existing /etc/caddy/Caddyfile before any edit (Finding 45 fix)
-sudo cp /etc/caddy/Caddyfile /etc/caddy/Caddyfile.pre-dockerize-$(date +%Y%m%d-%H%M%S)
-sudo caddy validate --config /etc/caddy/Caddyfile
+# Back up the existing cloudflared config before any edit.
+sudo cp /etc/cloudflared/config.yml /etc/cloudflared/config.yml.bak-$(date +%Y%m%d%H%M%S)
 
-# Add the docker-caddy reverse-proxy snippet (DOES NOT touch existing blocks)
-sudo cp host/caddy/clan-world-docker.caddy /etc/caddy/snippets/
-sudo cat host/caddy/clan-world-docker.caddy | sudo tee -a /etc/caddy/Caddyfile  # OR include via import directive
-sudo caddy validate --config /etc/caddy/Caddyfile
-sudo caddy reload --config /etc/caddy/Caddyfile
+# Insert the app.clan-world.com ingress BEFORE the final http_status:404 catch-all:
+# - hostname: app.clan-world.com
+#   service: http://127.0.0.1:18081
+#   originRequest:
+#     httpHostHeader: app.clan-world.com
+sudo cloudflared tunnel --config /etc/cloudflared/config.yml ingress validate
+sudo systemctl restart cloudflared
+curl -I https://app.clan-world.com/healthz
+curl -I https://cockpit.clan-world.com
 
-# Verify pm-dobot, narrator, gstack still resolve
+# Verify unrelated tunnels still resolve
 for tunnel in pm-dobot narrator gstack; do
   curl -sf "https://${tunnel}.${BASE_DOMAIN}/health" > /dev/null && echo "$tunnel OK" || echo "$tunnel FAIL"
 done
@@ -961,7 +936,7 @@ For 30 minutes, observe BOTH stacks. Operator may use `https://app.clan-world.co
 Coexist observation gate (all must hold for full 30 min):
 - New stack `make status` shows all containers healthy throughout
 - New stack `tickClock.tick` in self-hosted Convex advances each time legacy heartbeat fires (via the new webhook — proves Convex is mirroring)
-- No new tunnel/route errors in `/var/log/caddy/access.log` for non-clan-world hosts
+- No new tunnel/route errors in cloudflared logs for non-clan-world hosts
 - `curl https://app.clan-world.com/map` and `/elder-1` work (WS upgrade verified per Finding 12)
 
 ### Step 6 — Validation gate (explicit pass/fail before step 7)
@@ -1021,11 +996,11 @@ make down                                                     # only the new sta
 # No host state changed yet. Legacy frontend still points at hosted Convex via Vercel env. Investigate import error.
 # To wipe and retry: docker compose down -v && make up && retry import
 
-# If step 4 (Caddy snippet add) fails:
-sudo cp /etc/caddy/Caddyfile.pre-dockerize-<TIMESTAMP> /etc/caddy/Caddyfile
-sudo caddy validate --config /etc/caddy/Caddyfile
-sudo caddy reload --config /etc/caddy/Caddyfile
-# pm-dobot, narrator, gstack now back on pre-snippet config.
+# If step 4 (cloudflared ingress add) fails:
+sudo cp /etc/cloudflared/config.yml.bak-<TIMESTAMP> /etc/cloudflared/config.yml
+sudo cloudflared tunnel --config /etc/cloudflared/config.yml ingress validate
+sudo systemctl restart cloudflared
+# pm-dobot, narrator, gstack now back on pre-ingress config.
 
 # If step 5 (coexist) reveals interference:
 make pause                                                     # pause all new-stack runners + heartbeat
@@ -1056,9 +1031,9 @@ systemctl --user enable --now clanworld-runner.service
 for n in 1 2 3 4; do systemctl --user enable --now ttyd-elder-${n}.service; done
 # Restore legacy heartbeat cron
 crontab -e   # re-add: */1 * * * * /home/claude/bin/start-heartbeat-loop.sh
-# Restore host Caddy
-sudo cp /etc/caddy/Caddyfile.pre-dockerize-<TIMESTAMP> /etc/caddy/Caddyfile
-sudo caddy reload --config /etc/caddy/Caddyfile
+# Restore cloudflared config
+sudo cp /etc/cloudflared/config.yml.bak-<TIMESTAMP> /etc/cloudflared/config.yml
+sudo systemctl restart cloudflared
 # Stop new stack
 make down
 ```
@@ -1070,7 +1045,7 @@ These are executed programmatically by `make smoke-test` (Phase 1.12). The valid
 1. **All four Elder containers alive.** `docker compose ps` shows `elder-1` ... `elder-4` in `healthy` state. Each container hosts 3 processes (ttyd + tmux + supervisor) — verified by `docker compose exec elder-N pgrep -fa <name>`. Healthchecks (Finding 47 fix) are explicit in compose:
    - elders: `healthcheck.test: ["CMD-SHELL", "tmux has-session -t elder-${N} && pgrep -f /opt/elder-runtime/main.js"]`
    - convex-backend: `healthcheck.test: ["CMD", "curl", "-f", "http://localhost:3210/health"]`
-   - caddy: `healthcheck.test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/healthz"]`
+   - caddy: `healthcheck.test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/healthz || exit 1"]`
    - heartbeat: derived from last successful webhook timestamp via a small `healthcheck.sh`
 2. **Heartbeat ticking AND single-caller.** `tickClock.tick` in self-hosted Convex advances by 1 every ~60s; legacy heartbeat cron is absent (Finding 29 fix — preflight). Verified by `make logs SERVICE=heartbeat` showing single-caller preflight passing and chain-network assertion green.
 3. **Convex receiving events with correct payload.** Inserting a manual `enqueueCommand` from the dashboard or CLI (with `BUS_OPERATOR_SECRET`) lands in the correct elder's tmux scrollback within 5s. Webhook payload matches the AGENTS.md shape (`{chain, engineAddress, txHash, firedAtTs, source}`; no `tick`).
@@ -1168,20 +1143,14 @@ Phase 2 cutover requires Liam approval (it touches production-adjacent VPS state
 
 **R3. Caddy coexistence breaks pm-dobot / narrator tunnels.**
 *Likelihood:* low (the docker caddy is path-scoped to one hostname).
-*Impact:* high (other agents unreachable, including the orchestrator's own bot).
-*Mitigation:* Phase 1.5 requires explicit verification that the host caddy reload does NOT change behavior for any other Caddy server block. Test by hitting each non-clan-world endpoint before and after.
-*Rollback (Finding 45 fix — `/etc/caddy/Caddyfile` is NOT in this repo's git history; corrected procedure):*
+*Impact:* medium (cloudflared restart briefly drops all tunnels).
+*Mitigation:* Phase 1.5 requires explicit verification that the cloudflared restart does NOT strand existing tunnels. Test by hitting `cockpit.clan-world.com` and at least one unrelated endpoint after restart.
+*Rollback:*
 ```bash
-# Before any /etc/caddy/Caddyfile edit, create a timestamped backup:
-sudo cp /etc/caddy/Caddyfile /etc/caddy/Caddyfile.pre-dockerize-$(date +%Y%m%d-%H%M%S)
-sudo caddy validate --config /etc/caddy/Caddyfile
-
-# Rollback:
-sudo cp /etc/caddy/Caddyfile.pre-dockerize-<TIMESTAMP> /etc/caddy/Caddyfile
-sudo caddy validate --config /etc/caddy/Caddyfile
-sudo caddy reload --config /etc/caddy/Caddyfile
+sudo cp /etc/cloudflared/config.yml.bak-<TIMESTAMP> /etc/cloudflared/config.yml
+sudo cloudflared tunnel --config /etc/cloudflared/config.yml ingress validate
+sudo systemctl restart cloudflared
 ```
-The host-caddy snippet is in this repo at `host/caddy/clan-world-docker.caddy`, but `/etc/caddy/Caddyfile` itself is NOT — it has host-specific content (other tunnels) that must NOT be reverted via git. Always use the timestamped-backup approach.
 
 **R4. Iptables init bricks the container's outbound to Anthropic.**
 *Likelihood:* medium (firewall scripts often miss DNS or have ordering bugs).
@@ -1216,13 +1185,12 @@ cd ~/code/clan-world/clan-world-game
 make down PROFILE=dev 2>/dev/null || docker compose down -v
 docker volume ls --format '{{.Name}}' | grep '^clan-world_' | xargs -r docker volume rm
 
-# 2. Remove host caddy snippet if it was deployed
-sudo cp /etc/caddy/Caddyfile.pre-dockerize-<TIMESTAMP> /etc/caddy/Caddyfile 2>/dev/null || \
-  echo "no pre-dockerize backup found — manually inspect /etc/caddy/Caddyfile"
-sudo caddy reload --config /etc/caddy/Caddyfile
+# 2. Remove app.clan-world.com cloudflared ingress if it was deployed
+sudo cp /etc/cloudflared/config.yml.bak-<TIMESTAMP> /etc/cloudflared/config.yml 2>/dev/null || \
+  echo "no cloudflared backup found — manually inspect /etc/cloudflared/config.yml"
+sudo systemctl restart cloudflared
 
-# 3. Remove cloudflared tunnel routes that were added (keep legacy routes intact)
-# (Only run if app.clan-world.com route was added during testing AND legacy cockpit.clan-world.com is the actual prod route)
+# 3. Remove DNS tunnel routes only if DNS was created during testing
 # cloudflared tunnel route dns delete app.clan-world.com  # only if needed
 
 # 4. Remove generated secrets that were bootstrapped (these are NOT in git, so safe to remove)
@@ -1316,18 +1284,17 @@ services:
   caddy:
     image: caddy:2-alpine
     volumes:
-      - ./agents/shared/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
-      - /etc/clan-world/secrets/convex-dashboard-basicauth.hash:/run/secrets/dashboard-basicauth:ro
-    environment:
-      CONVEX_DASHBOARD_BASIC_AUTH_HASH_FILE: /run/secrets/dashboard-basicauth
+      - ./agents/shared/caddy.conf:/etc/caddy/Caddyfile:ro
     ports:
-      - "${CADDY_HOST_PORT}:8080"
+      - "127.0.0.1:${CADDY_HOST_PORT:-18081}:80"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks: [clan-world-internal]
     depends_on:
-      convex-dashboard:
-        condition: service_healthy
+      elder-1:
+        condition: service_started
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/healthz"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/healthz || exit 1"]
       interval: 10s
       timeout: 3s
       retries: 3

--- a/docs/runbooks/dockerize-migration-v1.md
+++ b/docs/runbooks/dockerize-migration-v1.md
@@ -462,13 +462,13 @@ sudo cp /etc/cloudflared/config.yml /etc/cloudflared/config.yml.bak-$(date +%Y%m
 
 Edit `/etc/cloudflared/config.yml` and add one ingress entry BEFORE the final
 `http_status:404` catch-all rule. Cloudflared does not expand shell variables
-in `config.yml`; this example assumes the default `CADDY_HOST_PORT=18081`.
+in `config.yml`; this example assumes the default `CADDY_HOST_PORT=58731`.
 The port is literal: if you change `CADDY_HOST_PORT`, update the literal port in
 `/etc/cloudflared/config.yml` to match.
 
 ```yaml
 - hostname: app.clan-world.com
-  service: http://127.0.0.1:18081
+  service: http://127.0.0.1:58731
   originRequest:
     httpHostHeader: app.clan-world.com
 ```
@@ -477,15 +477,15 @@ Validate Docker Caddy locally before restarting cloudflared:
 
 ```bash
 docker compose --profile prod up -d caddy
-curl -fsS "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/healthz" | grep -q "^ok$" || { echo "ERROR: healthz did not return ok"; exit 1; }
-curl -fsS -o /dev/null "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/elder-1/"
+curl -fsS "http://127.0.0.1:${CADDY_HOST_PORT:-58731}/healthz" | grep -q "^ok$" || { echo "ERROR: healthz did not return ok"; exit 1; }
+curl -fsS -o /dev/null "http://127.0.0.1:${CADDY_HOST_PORT:-58731}/elder-1/"
 ```
 
 Validate the cloudflared config, restart cloudflared, and verify the new route
 plus one existing tunnel:
 
 ```bash
-EXPECTED_PORT=${CADDY_HOST_PORT:-18081}
+EXPECTED_PORT=${CADDY_HOST_PORT:-58731}
 CURRENT_CLOUDFLARED_PORT=$(sudo grep -A1 'app.clan-world.com' /etc/cloudflared/config.yml | grep -oE 'localhost:[0-9]+|127.0.0.1:[0-9]+' | grep -oE '[0-9]+' | head -1)
 if [ "$EXPECTED_PORT" != "$CURRENT_CLOUDFLARED_PORT" ]; then
   echo "ERROR: CADDY_HOST_PORT=$EXPECTED_PORT but cloudflared routes to port $CURRENT_CLOUDFLARED_PORT"

--- a/docs/runbooks/dockerize-migration-v1.md
+++ b/docs/runbooks/dockerize-migration-v1.md
@@ -7,9 +7,8 @@ running tmux, ttyd, and the `elder-runtime` supervisor in one container per
 Elder.
 
 **Strategy:** parallel coexistence. Bring up and validate the Docker stack
-before disabling legacy services. The Caddy host-routing snippet is pending in
-the parallel `feat/issue-348-caddy-snippet-v2` branch, so this runbook treats
-public cutover as a pending/manual gate rather than an available Make target.
+before disabling legacy services. Public cutover is a cloudflared-only routing
+change to the compose `caddy` service, guarded by the Step 8 health checks.
 
 **When to use:** scheduled Phase 2 migration on the ClanWorld VPS after the
 rehearsal transcript has been signed off.
@@ -436,31 +435,64 @@ Then verify `commandResults` and `elderHeartbeat` update in the dashboard.
 3. Verify the legacy runner is healthy and consuming heartbeats again before
    investigating the failed Docker health gate.
 
-## Step 8 - Pending Public Routing Gate
+## Step 8 - Docker Caddy Public Routing Gate
 
-**Goal:** route public traffic only after the Caddy snippet PR lands and has
-been reviewed.
+**Goal:** route `app.clan-world.com` to the Docker Caddy service only after the
+compose stack is healthy internally.
 
-The host Caddy snippet and install/check targets are pending in
-`feat/issue-348-caddy-snippet-v2`. Until that branch lands, do not claim public
-cutover is automated by this runbook.
+The ClanWorld router is the compose `caddy` service. Host Caddy is not in the
+`app.clan-world.com` path; it continues serving unrelated shared-host routes.
+Warning: restarting cloudflared briefly drops ALL tunnels, usually for about 5
+seconds. Choose an operator-approved time.
 
-When the Caddy PR lands, update this step with the final target names and
-public route checks. Expected checks should include:
-
-- self-hosted Convex public API URL reaches `convex-backend`,
-- web socket traffic reaches Convex HTTP actions/site,
-- `app.clan-world.com` routes to the current web app,
-- Elder ttyd routes reach `elder-1` through `elder-4` without breaking the
-  legacy cockpit URLs during coexistence.
-
-**Rollback:** once the Caddy snippet PR lands its uninstall helper, remove the
-additive host import/snippet and reload host Caddy:
+Back up the current config:
 
 ```bash
-bin/install-caddy-snippet.sh --uninstall
-sudo caddy validate --config /etc/caddy/Caddyfile
-sudo systemctl reload caddy
+sudo cp /etc/cloudflared/config.yml /etc/cloudflared/config.yml.bak-$(date +%Y%m%d%H%M%S)
+```
+
+Edit `/etc/cloudflared/config.yml` and add one ingress entry BEFORE the final
+`http_status:404` catch-all rule. Cloudflared does not expand shell variables
+in `config.yml`; this example assumes the default `CADDY_HOST_PORT=18081`:
+
+```yaml
+- hostname: app.clan-world.com
+  service: http://127.0.0.1:18081
+  originRequest:
+    httpHostHeader: app.clan-world.com
+```
+
+Validate Docker Caddy locally before restarting cloudflared:
+
+```bash
+docker compose --profile prod up -d caddy
+curl -sf "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/healthz"
+curl -I "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/elder-1/"
+```
+
+Validate the cloudflared config, restart cloudflared, and verify the new route
+plus one existing tunnel:
+
+```bash
+sudo cloudflared tunnel --config /etc/cloudflared/config.yml ingress validate
+sudo systemctl restart cloudflared
+curl -I https://app.clan-world.com/healthz
+curl -I https://cockpit.clan-world.com
+```
+
+Then verify:
+
+- `app.clan-world.com` routes to the current web app,
+- `/map` reaches the public map route,
+- `/elder-1/` through `/elder-4/` reach the Docker-internal ttyd services,
+- legacy `cockpit.clan-world.com/elder-N-tty/` still works during coexistence.
+
+**Rollback:** restore the timestamped backup from the first command and restart
+cloudflared:
+
+```bash
+sudo cp /etc/cloudflared/config.yml.bak-YYYYMMDDHHMMSS /etc/cloudflared/config.yml
+sudo systemctl restart cloudflared
 ```
 
 Keep the Docker stack running internally for diagnosis if it is healthy.

--- a/docs/runbooks/dockerize-migration-v1.md
+++ b/docs/runbooks/dockerize-migration-v1.md
@@ -445,6 +445,15 @@ The ClanWorld router is the compose `caddy` service. Host Caddy is not in the
 Warning: restarting cloudflared briefly drops ALL tunnels, usually for about 5
 seconds. Choose an operator-approved time.
 
+Pre-check for duplicate ingress entries:
+
+```bash
+if sudo grep -q "hostname: *app.clan-world.com" /etc/cloudflared/config.yml; then
+  echo "ERROR: app.clan-world.com already exists in cloudflared config -- abort + update existing entry instead of adding"
+  exit 1
+fi
+```
+
 Back up the current config:
 
 ```bash
@@ -453,7 +462,9 @@ sudo cp /etc/cloudflared/config.yml /etc/cloudflared/config.yml.bak-$(date +%Y%m
 
 Edit `/etc/cloudflared/config.yml` and add one ingress entry BEFORE the final
 `http_status:404` catch-all rule. Cloudflared does not expand shell variables
-in `config.yml`; this example assumes the default `CADDY_HOST_PORT=18081`:
+in `config.yml`; this example assumes the default `CADDY_HOST_PORT=18081`.
+The port is literal: if you change `CADDY_HOST_PORT`, update the literal port in
+`/etc/cloudflared/config.yml` to match.
 
 ```yaml
 - hostname: app.clan-world.com
@@ -466,18 +477,24 @@ Validate Docker Caddy locally before restarting cloudflared:
 
 ```bash
 docker compose --profile prod up -d caddy
-curl -sf "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/healthz"
-curl -I "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/elder-1/"
+curl -fsS "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/healthz" | grep -q "^ok$" || { echo "ERROR: healthz did not return ok"; exit 1; }
+curl -fsS -o /dev/null "http://127.0.0.1:${CADDY_HOST_PORT:-18081}/elder-1/"
 ```
 
 Validate the cloudflared config, restart cloudflared, and verify the new route
 plus one existing tunnel:
 
 ```bash
+EXPECTED_PORT=${CADDY_HOST_PORT:-18081}
+CURRENT_CLOUDFLARED_PORT=$(sudo grep -A1 'app.clan-world.com' /etc/cloudflared/config.yml | grep -oE 'localhost:[0-9]+|127.0.0.1:[0-9]+' | grep -oE '[0-9]+' | head -1)
+if [ "$EXPECTED_PORT" != "$CURRENT_CLOUDFLARED_PORT" ]; then
+  echo "ERROR: CADDY_HOST_PORT=$EXPECTED_PORT but cloudflared routes to port $CURRENT_CLOUDFLARED_PORT"
+  exit 1
+fi
 sudo cloudflared tunnel --config /etc/cloudflared/config.yml ingress validate
 sudo systemctl restart cloudflared
-curl -I https://app.clan-world.com/healthz
-curl -I https://cockpit.clan-world.com
+curl -fsS https://app.clan-world.com/healthz | grep -q "^ok$" || { echo "ERROR: healthz did not return ok"; exit 1; }
+curl -fsS -o /dev/null https://cockpit.clan-world.com
 ```
 
 Then verify:


### PR DESCRIPTION
## Summary

Third attempt at #348 — Caddy host-imported snippet for `app.clan-world.com` ttyd routing. **Replaces PR #546's host-Caddy-snippet design**, which the 3-tier swarm blocked on two CRITICAL findings (RCE risk from \`--writable\` ttyd + top-level site block never receives traffic via host caddy's \`:18080\` block).

Per Liam's 16:02 ET voice 16521 direction — dedicated dockerized Caddy alongside the host Caddy, so routing config lives in docker-compose and is portable for team members on their own Cloudflare setups.

## Architecture

- **NEW** \`caddy\` compose service (caddy:2-alpine) bound to \`127.0.0.1:\${CADDY_HOST_PORT:-18081}:80\`
- **NEW** \`agents/shared/caddy.conf\` — single \`:80\` site, \`handle_path /elder-N/*\` → \`elder-N:7681\` via Docker DNS
- **NEW** \`agents/shared/README-caddy.md\` operator doc (prod cloudflared setup + local dev + CLAN_WORLD_WEB_UPSTREAM)
- Cloudflared edit needed: one ingress entry routing \`app.clan-world.com\` → \`http://127.0.0.1:18081\` (runbook Step 8 walks through it)
- ttyd \`--writable\` REMOVED — closes C-1 RCE; operators send commands via command bus
- Cloudflare Access policy at perimeter (matches existing cockpit pattern)

## What's discarded vs PR #546

- Host caddy snippet install script
- Top-level \`app.clan-world.com { ... }\` block (root cause of C-2)
- Per-elder \`ELDER_N_TTYD_PORT\` host-loopback mappings
- Unauthenticated writable ttyd

## What's kept vs PR #546

- /elder-N/ public URL pattern
- \`handle_path\` stripping
- WebSocket-conscious proxying
- Frontend URL updates (TerminalTab + useConnectionStatus + Playwright)

## Test plan

- [x] \`docker compose --profile dev config --quiet\` (dummy env) — passed
- [x] \`caddy validate --config agents/shared/caddy.conf --adapter caddyfile\` — passed
- [x] \`git diff --check\` — passed
- [ ] Local 3-tier swarm review
- [ ] **Reviewer note:** Full \`docker compose up\` + ttyd WebSocket smoke NOT runnable in codex sandbox (Docker socket access denied). Config-level checks all green. WebSocket smoke deferred to follow-up issue per Stage 3 critique.
- [ ] Merge to dev-phase-3-final-polish

## Codex 5-stage trail

All 5 stages used file-pointer dispatch pattern + high reasoning effort. Stage 1 verified host topology by reading /etc/caddy/Caddyfile + /etc/cloudflared/config.yml directly. Stage 3 critique caught 5 polish items; 4 applied in Stage 4 (5th deferred as WebSocket-smoke follow-up).

## Refs

- Closes #348 (supersedes PRs #412 + #546)
- Bundle 3 final polish
- ADR 0018 (4-level branching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)