### PR TITLE
docs(design): Bundle 4 — simplified communications architecture (draft)

### DIFF
--- a/docs/design/bundle-4-simplified-communications.md
+++ b/docs/design/bundle-4-simplified-communications.md
@@ -1,248 +1,335 @@
 # Bundle 4 — Simplified Communications Architecture
 
-Design doc capturing the runner/elder/supervisor refactor that follows Bundle 2 + 3 dockerize migration. Replaces the over-engineered command bus with a thin message-injection layer plus hook-based liveness plus tick-driven resets.
+Design doc for the elder agent infrastructure refactor that follows Bundle 1 + 2 + 3 dockerize migration. Strips the over-engineered command bus and replaces it with a thin message-injection layer, hook-based liveness, kill-tmux resets, and per-elder runners co-located with each elder container.
 
-**Status:** Draft for review (2026-05-22 ~15:10 ET). Source of design points: Liam voice messages 16646 through 16720.
+**Status:** Locked design (2026-05-23 PM ET — superseded the 2026-05-22 draft after design conversation with Liam). Awaiting DA round 2 + sub-PR planning.
 
-## Motivation
+## Why this rewrite
 
-The current command bus (Bundle 2 PR #542 + Bundle 3 PR #549) ships a distributed-durable-queue design with lease management, ack/complete/fail state machines, sweep crons, and retry semantics. It was built assuming elders are unreliable and might die mid-command.
+The previous draft (2026-05-22) shipped to a DA review that surfaced 7 CRITICAL ambiguities. Most were about who owns which control surface — the runner, the supervisor, the indexer, or Convex. The 2026-05-23 design conversation collapsed those ambiguities by reframing the process layout:
 
-Liam's design intent is the opposite: elders are responsible for their own resilience, resets are intentionally jarring, and the runner uses fire-and-forget messaging into elder tmux sessions. The Claude Code harness already queues stdin properly so we don't need a separate queue layer.
+- The **heartbeat container** becomes a dumb singleton — it submits the on-chain heartbeat transaction and nothing else.
+- The **per-elder runner** moves inside each elder container and owns the entire elder lifecycle: tmux session management, send-keys injection, reset, recovery, healthcheck.
+- The **command bus** as a distributed-queue abstraction goes away. Messages are written to a thin `pendingMessages` table, read by the per-elder runner, fire-and-forget.
+- **Resets are kill-tmux + spawn-fresh-claude**, NOT `/clear`. Recovery is the same flow but with `claude --continue`.
 
-Bundle 4 strips the queue/lease/retry/sweep machinery and replaces it with the simpler shape below.
+This means three of the original DA CRITICAL findings (`/clear` detection too hand-wavy, reset path contradicts itself, pending-message loss not implementable) are simply resolved by the new shape rather than patched.
 
-## Communications taxonomy — eight categories
+## Process model
 
-Every cross-process interaction in the system falls into one of these:
+Five processes total in production:
 
-1. **Game state read** — elder calls Convex queries or chain reads to learn world state (vault, clansmen, missions, world tick).
-2. **Game state write** — elder submits orders to the contract via their own private key. On-chain transaction.
-3. **Communications read** — elder reads private whispers from other elders + public bulletin board entries. Convex queries.
-4. **Communications write** — elder writes whispers to specific elders + posts to bulletin board. Convex mutations.
-5. **Owner whispers** — Liam (or whoever owns the agent) injects arbitrary text into a specific elder's context. Goes through the admin-inject path.
-6. **Runner world messages** — per-tick world snapshot, memory-wipe-incoming warnings (no longer requires ack), post-reset re-orientation. Injected by runner.
-7. **Control plane** — process-level control: reset, restart-supervisor, kill-and-recreate. Not user-visible to elder. Tick-driven for reset; supervisor-managed for restarts.
-8. **Liveness/observability** — `PostToolUse` hook posts to Convex on every Claude tool call. Elder is unaware. Operator/dashboard queries the resulting log for "last activity" + "tool-use rate per tick" signals.
+| Process | Cardinality | Container | Responsibility |
+|---|---|---|---|
+| `heartbeat` | 1 | `heartbeat` container | Submit on-chain heartbeat tx on schedule. Nothing else. |
+| `elder-N runner` | 4 (one per elder) | `elder-N` container, alongside tmux | Subscribe to ticks, derive templates, send-keys into local tmux pane, manage tmux lifecycle, watch the local Claude process. |
+| `tmux` | 4 (one per elder) | `elder-N` container | Hosts the elder's claude process so ttyd can attach. |
+| `claude` | 4 (one per elder) | `elder-N` container, inside tmux | The actual LLM doing the agent work. |
+| `ttyd` | 4 (one per elder) | `elder-N` container | Read-only web terminal exposing the tmux pane to the operator cockpit. |
 
-Categories 1-4 go through the elder CLI (already exists). Categories 5-6 go through a new thin message-injection layer described below. Category 7 is process control (no user-visible API). Category 8 is hooks-only.
+Naming: what we previously called "supervisor" is now "runner". The thing previously called "runner" (the heartbeat package) is renamed "heartbeat" to match.
 
-## The message-injection layer
+## Package renames
 
-**Single operation:** "inject text into elder N's tmux session."
+Two `packages/` package renames as part of Bundle 4:
 
-Two writers: the runner (during tick injection) and the admin dev-UI (for R&D experimentation).
+| Before | After | Why |
+|---|---|---|
+| `packages/runner/` | `packages/heartbeat/` | Reflects the dumb-singleton role. Only owns heartbeat tx submission. |
+| `packages/elder-runtime/` | `packages/runner/` | Reflects the new role — runner is now the per-elder process. |
 
-### Convex table
+Codex handles the rename across the monorepo as part of the Bundle 4 PR (tsconfig paths, pnpm workspaces, Docker `COPY` targets, import paths in `apps/server/convex/`, etc.).
+
+## Runner lifecycle
+
+### Startup (per elder container boot)
+
+1. **Read game settings** from Convex once. Cache in memory. Settings include: heartbeat interval, ticks-between-memory-resets, winter timing, season length, current diamond address, etc.
+2. **Check one-claude-per-container invariant**. `pgrep claude` should return exactly zero (cold boot) or exactly one (warm restart, runner restarted but elder process survived). If we find multiple claudes, fail loud + exit non-zero. Do not pgrep+pkill — discovery beats silent recovery for R&D.
+3. **Check tmux session state**. Three possibilities:
+   - No session exists → fresh launch path.
+   - Session exists, claude alive → warm restart, continue normal flow.
+   - Session exists, no claude → recovery path: respawn claude inside the existing tmux session.
+4. **Look up last-received tick** from Convex (see "Two-phase commit" below). Compare to current tick.
+5. **Subscribe to tick updates**. Begin normal tick-handling loop.
+
+### Normal tick handling (per tick)
+
+1. Wake on new tick number from Convex subscription.
+2. Query Convex for current world state (tickClock + game settings drift check + auxiliary tables as needed for event-driven templates).
+3. **Drift check**: re-fetch game settings as part of the per-tick read. If any cached value diverges, panic + exit non-zero. Operator must restart all elder containers to pick up new settings.
+4. **Template selection** — compute which templates apply to this tick:
+   - **Pure-tick-math templates** (computed locally): `00_game_start.md`, `05_pre_memory_wipe_5ticks.md`, `06_pre_memory_wipe_1tick.md`, `07_post_memory_wipe.md`, `10_pre_winter_10ticks.md`, `11_winter_started.md`, `12_winter_ended.md`.
+   - **Event-driven templates** (require auxiliary query): `20_bandits_appeared.md`, `21_bandits_attacking.md`, `22_post_bandit_attack.md`. Runner queries `banditView` + `chainEvents` to detect events on this tick.
+5. **Compose message**: base line `tick: <N>` + each applicable template body wrapped in `<world_update name="<template-name>">...</world_update>` XML, concatenated in alphabetical order by template filename (numbered prefix = priority knob).
+6. **Two-phase commit**:
+   - Write `sent` row to Convex: `{elderId, tickNumber, sentAt, messageHash}`.
+   - Run `tmux load-buffer` + `tmux paste-buffer` + `tmux send-keys Enter`.
+7. The `UserPromptSubmit` hook fires when Claude actually receives the message; it writes `received` row to Convex: `{elderId, tickNumber, receivedAt}`.
+8. Loop.
+
+### Restart behavior (runner crash → docker compose restart)
+
+After `Startup` steps 1-3:
+
+1. Look up the highest `tickNumber` with a `received` record for this elder.
+2. Look up `current_tick` from Convex `tickClock`.
+3. Branch:
+   - **a) `current_tick == last_received`** → no-op. Don't re-send. Wait for next tick.
+   - **b) `current_tick > last_received` AND no memory-wipe boundary in the gap** → inject fast-forward prefix `"Fast-forwarding from tick <last_received> to tick <current_tick>"` (one line) + the normal tick-N message (template selection per current state). The fast-forward prefix is grep-able in logs for R&D anomaly hunting.
+   - **c) `current_tick > last_received` AND memory-wipe boundary falls in `(last_received, current_tick]`** → SPECIAL CASE. Do kill-tmux + spawn-fresh-claude (no `--continue`) + inject `07_post_memory_wipe.md` template for current tick. The elder's memory was wiped during the runner outage; they need a clean fresh start.
+   - **d) `current_tick == last_received + 1` AND received-but-not-sent state (hook landed without sent record)** → impossible state, log + treat as case (a).
+   - **e) `sent` recorded but no `received` for tick N == current_tick** → trust the `received` record. Re-send the message. Double-paste accepted as harmless: claude sees a duplicate prompt, responds twice or shrugs. The hook will then record the receipt.
+
+### Tick backlog handling
+
+A runner can fall behind only via: operator pause (`docker compose pause`), network partition, OS scheduling stall, OOM kill, container restart. All of these effectively look identical to the restart behavior above — the runner wakes up, reads `last_received` from Convex, computes `current_tick`, and runs the same branch logic. Same code path, no separate "backlog" handler.
+
+### Reset (tick-driven hard wipe)
+
+When `current_tick % ticks_between_memory_resets == 0` (computed locally from cached settings):
+
+1. **Log reset start** to Convex: `{elderId, resetTick, startedAt, reason: "scheduled"}`.
+2. **Kill the existing tmux session**: `tmux kill-session -t elder-N`. This disconnects ttyd; cockpit detects the disconnect and overlays a "Elder memory is being reset…" animation in place of the default ttyd reconnect screen.
+3. **Spawn a fresh tmux session**: `tmux new-session -d -s elder-N -c /workspace`.
+4. **Launch claude WITHOUT `--continue`**: `tmux send-keys -t elder-N "claude" Enter`. Fresh session id, fresh JSONL. Memory is gone.
+5. **Brand the session**: send-keys `"/rename Ælder Crimson"` + Enter + Enter + `"/color red"` + Enter + Enter. Branding values keyed off `ELDER_ID` env var. (Elders: Crimson/red, Azure/blue, Verdant/green, Amber/yellow — exact mapping in `agents/shared/runner/elder-config.json`.)
+6. **Inject first tick**: `tick: <current_tick>` + `<world_update name="07_post_memory_wipe">...</world_update>`.
+7. **Log reset complete** to Convex: `{elderId, resetTick, completedAt}`.
+8. Resume normal tick handling.
+
+The reset-event log is **observability-only**. It does NOT gate the next tick. The runner moves on as soon as step 7 commits.
+
+### Recovery / resume (cold boot with prior state)
+
+When the elder container boots and finds tmux + claude alive, OR boots fresh but `agents/elder-N/.claude/projects/` already has JSONL files from a prior life:
+
+1. If tmux + claude alive: do nothing, just begin tick handling. Claude is already running and has its history.
+2. If tmux exists but claude died: `tmux send-keys -t elder-N "claude --continue" Enter`. `--continue` picks up the latest session JSONL, restoring color + rename + chat history.
+3. If tmux doesn't exist but `.claude/projects/` does: `tmux new-session -d -s elder-N` + `tmux send-keys "claude --continue" Enter` (preserves prior state).
+4. If neither tmux nor `.claude/projects/` exists: fresh launch (same as reset step 3+ but inject `00_game_start.md` instead of `07_post_memory_wipe.md`).
+
+### Late-join (operator brings up a new elder mid-game)
+
+This is the "container 5+ created after game has been running for 500 ticks" scenario. Reuse the reset flow with the `07_post_memory_wipe.md` template. The elder wakes up with no memory in a running game; same semantic as post-wipe.
+
+## Game settings — immutable for game duration
+
+Read-once at runner startup. Cached in memory. Drift-checked on every per-tick query (piggyback, zero extra reads). If the cached value ever diverges from Convex on the per-tick re-fetch, panic. Fail loud — the operator forgot to restart after changing a setting.
+
+**Operational rule (capture in runbook):** To change ANY setting in `gameSettings` (heartbeat interval, memory-reset cadence, winter timing, season length), restart every elder container. There is no live-update path. The fail-loud drift check is a defensive trip-wire; it does not coordinate the change.
+
+## Prompt templates
+
+### Storage location
+
+On disk at `agents/shared/runner/prompts/`. Files copied into each elder container's image at build time. Template content is static markdown. Edits require a runner-image rebuild + container restart.
+
+(Future: skills could provide dynamic behavior — a prompt can include `/run <skill-name>` slash commands that claude executes. That makes the static templates extensible without inflating the runner code. Out of scope for Bundle 4.)
+
+### Naming + ordering
+
+Numbered prefix `NN_<purpose>.md`. Alphabetical sort = priority order. To reshuffle priority, renumber.
+
+### Template list (Bundle 4 v1)
+
+| File | Trigger | Class |
+|---|---|---|
+| `00_game_start.md` | First tick of a new game | tick-math |
+| `05_pre_memory_wipe_5ticks.md` | `current_tick % wipe_interval == wipe_interval - 5` | tick-math |
+| `06_pre_memory_wipe_1tick.md` | `current_tick % wipe_interval == wipe_interval - 1` | tick-math |
+| `07_post_memory_wipe.md` | First tick immediately after a wipe; also late-join + recovery from gap | tick-math |
+| `10_pre_winter_10ticks.md` | 10 ticks before winter starts | tick-math |
+| `11_winter_started.md` | Tick winter starts | tick-math |
+| `12_winter_ended.md` | Tick winter ends | tick-math |
+| `20_bandits_appeared.md` | Bandit just spawned this tick | event-driven |
+| `21_bandits_attacking.md` | Bandit in attack state this tick | event-driven |
+| `22_post_bandit_attack.md` | Tick after a bandit resolved an attack | event-driven |
+| `99_clansmen_revived_and_resources_injected.md` | Operator manually revived clansmen + injected resources (no fresh season) | event-driven |
+
+Multiple templates can fire on the same tick. They concat in alphabetical order. Tick number always prefixes.
+
+### Message wire format
+
+```
+tick: 537
+<world_update name="05_pre_memory_wipe_5ticks">
+Your memory will be reset in 5 ticks. Make sure your ancient wisdom journal is up-to-date.
+</world_update>
+<world_update name="10_pre_winter_10ticks">
+Winter approaches. 10 ticks remain in the harvest. Stockpile food.
+</world_update>
+```
+
+For most ticks, only the first line fires (no templates active).
+
+## Admin / user message injection
+
+Same writer table, separate trigger source.
+
+### Convex `pendingMessages` table
 
 ```typescript
-// pendingMessages
 {
   _id: Id<"pendingMessages">,
   targetElderId: "elder-1" | "elder-2" | "elder-3" | "elder-4",
   text: string,
   insertedAt: number,
-  source: "runner" | "admin-injection",
+  source: "admin-injection" | "user-message",
+  consumedBy: Optional<string>, // runner instance ID that processed this row
+  consumedAt: Optional<number>,
 }
 ```
 
-That's the whole schema. No status, no lease, no retry count.
+### Runner subscription
 
-### Runner-side write
+The runner watches `pendingMessages` filtered by `targetElderId == own_id AND consumedBy == null`. When a row appears, the runner pastes immediately (does NOT wait for next tick). Marks `consumedBy` + `consumedAt` after the UserPromptSubmit hook confirms receipt.
 
-Per tick, runner calls a Convex mutation `enqueueElderMessage` with the tick's world snapshot text targeted at each living elder. One row per (elder, tick).
+### Admin injection flow
 
-For the mod-N reset tick, the runner instead writes a structured reset payload (see "Reset workflow" below).
+Dev-UI panel writes a row with `source: "admin-injection"`. Runner picks it up within poll interval (1-2 seconds), pastes into the elder's tmux pane. Same UserPromptSubmit hook records receipt to the same `tickReceiveLog` table (with `tickNumber == null` since it's not a tick message).
 
-### Admin dev-UI write
+### Authorization
 
-Dev-UI calls the same `enqueueElderMessage` mutation with `source: "admin-injection"` and an operator-supplied text. Selects target elders via checkbox or per-elder field.
+Admin injection requires `BUS_OPERATOR_SECRET`. Writes from other sources rejected at the Convex mutation level. (Survives from Bundle 2; carries forward.)
 
-### Supervisor-side read
+## Two-phase commit (tick delivery)
 
-Inside each elder container, the supervisor polls `pendingMessages` filtered by its own elder ID. For each pending row, in `insertedAt` ASC order:
-
-1. Read the row.
-2. Paste the text into the local tmux session targeting the Claude pane.
-3. Delete the row.
-
-No lease. No ack. No retry. If the supervisor crashes between read and paste, the row sits in the table until the supervisor restarts and picks it up. If the supervisor pastes successfully but crashes before delete, the next poll will paste the same row again — operator should design messages to be safely idempotent at the elder layer (typically a no-op since the elder reads world state fresh each turn anyway).
-
-### What this discards from Bundle 2 + 3
-
-- `agentCommands` table (replaced by `pendingMessages`)
-- `claimNext` / `ackCommand` / `completeCommand` / `failCommand` mutations
-- `sweepStaleDelivered` cron
-- `LEASE_MS`, `COMPLETION_GRACE_MS` constants
-- Bracketed-paste nonce protocol + supervisor scrollback grep
-- Control-verb priority pass in claimNext (reset is now process-level, not message-level)
-- `elderHeartbeat` table writes from the supervisor (replaced by hook-based liveness)
-- `elder ack-clear` CLI subcommand and the runner's await-ack flow (issue #555)
-
-### What this keeps from Bundle 2 + 3
-
-- Supervisor process inside each elder container (slimmed to a thin watchdog)
-- Tmux + ttyd lifecycle management
-- Bus secret per elder for authenticating the supervisor's Convex calls
-- Healthcheck infrastructure (Caddy + per-elder process supervision)
-- All the elder CLI surface (game read/write, comm read/write)
-
-## Liveness — PostToolUse hook
-
-Configure a `PostToolUse` hook in `agents/shared/home-claude/settings.json`. The hook fires after every Claude tool call. The hook script:
-
-1. Read tool-call metadata (tool name, timestamp) from hook stdin.
-2. Curl POST to a Convex action `recordToolUse` with `{ elderId, toolName, ts }`.
-3. Exit cleanly. Hook errors are silenced — elder must not be aware of liveness machinery.
-
-### Convex table
+### `tickSendLog` table
 
 ```typescript
-// elderActivity
 {
-  _id: Id<"elderActivity">,
+  _id: Id<"tickSendLog">,
   elderId: string,
-  toolName: string,
-  ts: number,
+  tickNumber: number,
+  sentAt: number,
+  messageHash: string,  // sha256 of the composed message body
 }
 ```
 
-### Liveness query
+Index: `by_elder_tick` on `(elderId, tickNumber DESC)`.
+
+Runner writes one row BEFORE running `tmux paste-buffer`. If the runner crashes between write and paste, the row is a "sent but no record of receipt" → restart logic re-sends per case (e) above.
+
+### `tickReceiveLog` table
 
 ```typescript
-// "is elder-N alive?"
-const lastActivity = await ctx.db
-  .query("elderActivity")
-  .withIndex("by_elder_ts", q => q.eq("elderId", "elder-1"))
-  .order("desc")
-  .first();
-
-const isAlive = lastActivity && (Date.now() - lastActivity.ts) < ALIVENESS_THRESHOLD_MS;
-```
-
-### Dashboard signals
-
-The same `elderActivity` table powers richer signals:
-
-- Tool-use frequency per elder (idle vs active)
-- Tool-type distribution (which tools are getting used)
-- Per-tick activity (how many tool calls between two `UserPromptSubmit` events from the runner's tick injection)
-
-## Reset workflow — tick-driven
-
-### Configuration
-
-A new Convex table `gameSettings` holds the reset-cadence knob.
-
-```typescript
-// gameSettings
 {
-  _id: Id<"gameSettings">,
-  resetEveryNTicks: 50, // default
-  // future: maxTick, tickIntervalMs, etc.
+  _id: Id<"tickReceiveLog">,
+  elderId: string,
+  tickNumber: number | null,  // null for admin injections
+  receivedAt: number,
+  messagePreview: string,     // first 100 chars for operator visibility
 }
 ```
 
-### Trigger condition
+Index: `by_elder_tick` on `(elderId, tickNumber DESC)`.
 
-On each tick `T`, the runner queries `gameSettings.resetEveryNTicks` (call it `N`). If `T % N === 0`, the next tick injection becomes a reset workflow instead of a normal tick injection.
+### `UserPromptSubmit` hook
 
-### Reset workflow (per-elder, parallel)
+Lives at `agents/shared/home-claude/hooks/user_prompt_submit.sh` (or `.py`). Triggers on every user prompt submitted to Claude. Inspects the prompt for the deterministic first-line pattern `tick: <N>`. If matched, extracts `<N>` and writes a `tickReceiveLog` row. If first line doesn't match `tick:` (admin injection), writes the row with `tickNumber: null`.
 
-For each elder:
+Hook authentication: passes `BUS_ELDER_SECRET_N` from env (already injected into the container via Docker secrets, available to the hook). Convex mutation rejects writes without a valid secret.
 
-1. **Issue Claude `/clear`** — write `/clear` into the elder's tmux pane via the supervisor. (Open question: paste as text vs send-keys. `/clear` is a Claude Code REPL command, not a tmux primitive — pasting it as text should work if the Claude pane is foreground.)
-2. **Wait for `/clear` to land** — supervisor watches session JSONL for the `system: cleared` marker or equivalent. Configurable timeout, default 10 seconds.
-3. **If `/clear` doesn't land in timeout** — supervisor escalates: kill the Claude process inside tmux, restart Claude via `claude` (no `--continue`), which gives a fresh context. Tmux session itself stays alive — ttyd terminal UX preserved, no flicker.
-4. **If kill-restart also fails** — supervisor escalates further: `exit 1` from the supervisor process, container exits, docker compose `restart: unless-stopped` brings up a fresh container.
-5. **After Claude is fresh** — runner injects the rename + color seed message, then injects the reorientation prompt: "You're in the middle of a game on tick N out of TOTAL_TICKS. Check world snapshot, recall memories, resume play."
+Hook failure (network blip, Convex down): logs the error to stderr + does NOT block the prompt. Next runner restart will see the missing `received` row and re-send — the double-paste is the accepted recovery cost.
 
-### What's NOT in the reset workflow
+## Healthcheck (three-part)
 
-- No graceful drain of pending messages. Any `pendingMessages` rows targeted at the elder at reset moment are LOST. Intentional — by design, the elder has to deal with the gap.
-- No elder-side ack. Runner doesn't wait for elder to confirm. Reset happens unconditionally.
-- No reset-warning message. The 60-second warning (if we keep it) is embedded as a field in the regular world-snapshot tick message: `ticksUntilWipe: 1` or similar. Elder reads it or doesn't.
+`docker-compose.yml` healthcheck for each elder container:
 
-### Open question — does the runner inject reset directly or via supervisor?
+```yaml
+healthcheck:
+  test: ["CMD-SHELL", "sh /opt/clan-world/shared/runner/bin/healthcheck.sh"]
+  interval: 30s
+  timeout: 10s
+  retries: 3
+```
 
-Option A: Runner has docker exec access to each elder container, writes the `/clear` itself.
-Option B: Runner writes a structured reset row to `pendingMessages` with `source: "reset"`, supervisor recognizes and executes the workflow locally.
+`healthcheck.sh` validates:
 
-Option B is consistent with the rest of the architecture (everything routes through `pendingMessages`) but introduces a marshalled "reset" type that breaks the "just text injection" simplicity. Option A keeps `pendingMessages` purely text but requires the runner to have docker control access.
+1. **Runner process alive**: `pgrep -x runner` returns one PID.
+2. **Tmux session alive**: `tmux has-session -t $ELDER_ID` returns 0.
+3. **Claude process alive**: `pgrep -x claude` returns exactly one PID (one-claude invariant).
 
-**Recommended:** Option A. Runner can do `docker exec elder-N tmux send-keys ...` directly. Keeps `pendingMessages` simple. Reset is process control, separate from message injection.
+Failure on any check → docker restarts the container. Compose `restart: unless-stopped` retries indefinitely until the operator intervenes.
 
-## Supervisor — thin watchdog
+## Liveness observability
 
-Two-layer recovery:
+Separate from healthcheck. The dev-UI subscribes to two tables:
 
-1. **Layer 1 — Claude restart inside tmux.** Supervisor monitors the Claude process. If Claude exits or hangs, supervisor kills it and restarts `claude` inside the same tmux session. Ttyd terminal UX preserved.
-2. **Layer 2 — Container restart fallback.** If Layer 1 fails N times within M minutes (e.g. 3 failures in 5 minutes), supervisor exits 1 → docker compose `restart: unless-stopped` recreates the entire container. Fresh tmux, fresh ttyd, fresh everything. Ttyd briefly disappears from the dev UI.
+- `tickReceiveLog`: last-received-per-elder is the freshest liveness signal. If an elder hasn't received a tick in N intervals while ticks are firing, alert.
+- `resetEventLog`: shows reset history per elder. Useful for forensics.
 
-Configurable thresholds via env vars.
+No `elderHeartbeat` table from the old design. The runner doesn't self-report; the hook does the reporting.
 
-Beyond watchdog, the supervisor also:
+## New + dropped Convex tables
 
-- Polls `pendingMessages` for its elder ID and pastes them into tmux.
-- Optionally captures snapshot scrollback on operator demand (for debugging).
+### NEW
 
-That's it. No bus polling, no state machine, no liveness reporting, no nonce verification.
+- `pendingMessages` — admin + user message injection queue.
+- `tickSendLog` — runner-side "sent" record.
+- `tickReceiveLog` — hook-side "received" record.
+- `resetEventLog` — observability log for reset events.
 
-## Admin dev-UI injection
+### DROPPED (compared to Bundle 1+2+3 state)
 
-A new dev-UI panel allows the operator to:
+- `agentCommands` — old command bus FSM (queued/leased/acked/completed/failed). Gone.
+- `elderHeartbeat` — old supervisor self-report. Gone (replaced by `tickReceiveLog` derived liveness).
+- `commandResults` — old result rows. Gone.
 
-- Select target elders (checkboxes for elder-1..N or "all")
-- Write arbitrary text in a textarea
-- Click "Inject" — fires a Convex mutation `enqueueElderMessage` with `source: "admin-injection"` per selected elder
+`crons.ts` cron `bus-sweep-stale-delivered` also dropped — no leases to sweep.
 
-Use cases: R&D experimentation, prompting an elder with a specific scenario while watching gameplay, sending "you are now in a debug session" cues during dev.
+## Schema migration
 
-## What goes to issue trackers
+Bundle 4 ships a clean break. The new tables are created, old tables are dropped. No data migration — production has no data in `agentCommands` / `elderHeartbeat` / `commandResults` worth preserving (the bus was never actually exercised; per the PR #560 super-swarm finding, the bootstrap secrets were never plumbed so the bus was non-functional on dev).
 
-Bundle 4 PR will include:
+## Sub-PR planning hints
 
-- `apps/server/convex/commandBus.ts` — strip queue/lease/sweep code, leave only `enqueueElderMessage` mutation + `recordToolUse` action + liveness query helpers
-- `apps/server/convex/schema.ts` — drop `agentCommands`, add `pendingMessages` + `elderActivity` + `gameSettings`
-- `packages/elder-runtime/` — strip bus polling logic, slim to watchdog + paste loop
-- `agents/shared/home-claude/settings.json` — add PostToolUse hook config
-- `agents/shared/home-claude/hooks/post-tool-use.sh` — new hook script
-- `packages/runner/` — add tick-driven reset trigger, replace user-message dispatch with `enqueueElderMessage`
-- Reset workflow — runner-side docker-exec dispatch (Option A)
-- `agents/shared/home-claude/CLAUDE.md` — remove ack-clear cheat-sheet entry, simplify memory-wipe cycle docs
-- `agents/shared/APPENDED_SYSTEM_PROMPT.md` — same
-- Tests — full review for tech debt; existing tests on the queue machinery get deleted, new tests on the simpler shape get added
+Bundle 4 likely decomposes into ~6 sub-PRs targeting `dev-phase-4-simplified-comms`:
 
-Separate (after Bundle 4):
+1. **Package renames + Convex schema migration**: `packages/runner/` → `packages/heartbeat/`, `packages/elder-runtime/` → `packages/runner/`. New tables in `packages/sdk/convex/schema.ts`. Drop the old tables + cron.
+2. **Runner core rewrite**: `packages/runner/src/main.ts` becomes the per-elder runner. Tick subscription + template selection + tmux send-keys + reset/recovery flow.
+3. **Prompt templates**: `agents/shared/runner/prompts/*.md` per the table above.
+4. **UserPromptSubmit hook**: `agents/shared/home-claude/hooks/user_prompt_submit.sh` + settings.json wiring.
+5. **Cockpit UI**: ttyd-disconnect-detection overlay with "Elder memory is being reset…" animation.
+6. **Admin injection UI panel**: dev-UI form for operator message injection. (Could split to follow-up if scope is tight.)
 
-- Issue #555 — remove `elder ack-clear` from elder CLI in `packages/agents/`
-- Dev UI panel for admin injection (separate PR in `apps/web/`)
+Stack them under `dev-phase-4-simplified-comms` per the ADR 0018 4-level branching pattern.
 
-## Open questions
+## Open items for DA round 2
 
-1. **Two pending messages for one elder — batch-paste or serialize?** Recommend serialize (one-at-a-time in insertedAt order) because Claude Code already handles stdin queuing properly. Batching would just inject extra `--- next message ---` separators that are noise.
-2. **Admin-inject rate limiting?** Probably not needed in v1. Operator is the only authorized writer to that source, and abuse from operator is operator's problem.
-3. **Liveness threshold default?** Recommend 5 minutes — elders take long Claude turns occasionally (especially during complex strategy planning), so a 30-second threshold would false-positive. 5 minutes catches dead elders without flapping.
-4. **Hook failure handling?** PostToolUse hook posts to Convex via curl. If Convex is down, the hook should fail silent so elder is unaware. Worst-case effect: liveness signal drops until Convex returns. Acceptable.
-5. **Bundle 4 vs separate ack-clear PR ordering?** Bundle 4 can land first; ack-clear is in a different package (`packages/agents/`) outside the dockerize migration scope. Sequence: Bundle 4 → ack-clear PR.
+The locked-in design above resolves the 2026-05-22 DA review's 7 CRITICAL findings. The remaining DA SHOULD-RESOLVE items get re-asked against the new shape:
 
-## Release plan
+- Poll cadence and batch semantics for the per-elder runner reading `pendingMessages`.
+- Retention/TTL for `tickSendLog`, `tickReceiveLog`, `resetEventLog` (write-heavy, grow forever otherwise).
+- Hook failure aggregate alerting (one elder's hook stops posting → operator knows).
+- Container-restart-mid-tick orientation (which template, which session JSONL).
+- Specific test plan: duplicate paste, fast-forward gap, memory-wipe-in-gap special case, hook failure, late-join.
+- Naming convention nits: `tickSendLog` vs `runnerSentTicks`, etc.
 
-**Option A (preferred):** Ship Bundle 2 + Bundle 3 release PRs to dev as they are. Open Bundle 4 immediately on top of dev. Pros: ships working code now, no rebase pain. Cons: dev briefly contains the over-engineered queue before Bundle 4 strips it.
+Dispatch DA round 2 against this rewrite for sharper findings.
 
-**Option B:** Hold Bundle 2 release PR, rewrite the queue parts of PR #542 on the new shape, ship Bundle 2 with the simpler design from the start. Pros: never ships the over-engineered version. Cons: significant rework of Bundle 2 PR #542's design, weeks of delay.
+---
 
-Liam's call (voice 16713): Option A. Watch closely for tech debt in the test files during Bundle 4 — the queue-machinery tests need to be deleted cleanly, not left as dead helpers.
+**Locked decisions recap** (Liam-locked 2026-05-23 PM ET, do not re-litigate):
 
-## Verification before Bundle 4 lands
-
-- Codex DA round on this design doc to catch architectural gaps before code lands
-- 3-tier swarm review on the Bundle 4 PR
-- Manual smoke test once stack is up: admin-inject a message, see it land in elder tmux, see the elder respond, see the PostToolUse hook fire and record activity in Convex
-- Reset workflow smoke: force a tick to be `T % N === 0`, observe `/clear` landing, observe reorientation message, observe elder picking up
-
-## Mental model summary
-
-The system becomes: "elders play the game by themselves; the only inbound channel from the operator is text injection; the only outbound signal the operator can read is the hook-driven tool-use log; the runner manages tick + reset cadence deterministically from world tick number."
-
-Elders are autonomous, harshly time-bound, and have to be strategic about their own state preservation. The infrastructure is dumb fire-and-forget plumbing.
+1. Heartbeat container = dumb chain submitter, package rename `packages/runner/` → `packages/heartbeat/`.
+2. Per-elder runner inside elder container, package rename `packages/elder-runtime/` → `packages/runner/`.
+3. Reset = kill-tmux + spawn-fresh + `claude` no `--continue` + inject first-tick. NOT `/clear`.
+4. Recovery = same flow + `claude --continue`.
+5. Cockpit UI animation overlays the ttyd disconnect window during reset.
+6. Per-elder branding via `/rename` + `/color` CC TUI slash commands keyed off `ELDER_ID`.
+7. Game settings = read-once at boot, cached, immutable. Restart-all to change.
+8. Drift detection = piggyback on per-tick read, panic on drift.
+9. Runner reacts to tick number only. Queries Convex auxiliary tables per tick for event-driven template inputs (Option B — business logic in runner, not indexer).
+10. Prompt templates on disk under `agents/shared/runner/prompts/`. Numbered prefix = alphabetical = priority. Concat multiple when applicable.
+11. Message format = `tick: <N>` + optional `<world_update name="...">...</world_update>` wraps.
+12. Two-phase commit = runner writes `tickSendLog` before paste, `UserPromptSubmit` hook writes `tickReceiveLog` after landing.
+13. Restart trust = `tickReceiveLog` is authoritative. Re-send when sent-but-not-received (Option B). Double-paste harmless.
+14. Memory-wipe-in-gap = SPECIAL CASE kill-tmux fresh launch with post-memory-wipe template (Option A).
+15. One-claude-per-container = defensive fail-loud check at runner boot. No pgrep+pkill (Option B).
+16. Tick backlog collapses into restart logic (same code path).
+17. Reset event logging = observability only, never gates tick processing.
+18. Admin + user message injection IS in Bundle 4 scope. Same `pendingMessages` table, separate trigger from ticks.
+19. Late-join (operator brings up new elder mid-game) reuses `07_post_memory_wipe.md` template.
+20. Container healthcheck = three-part: runner alive + tmux alive + exactly one claude alive.

--- a/docs/design/bundle-4-simplified-communications.md
+++ b/docs/design/bundle-4-simplified-communications.md
@@ -1,19 +1,16 @@
 # Bundle 4 — Simplified Communications Architecture
 
-Design doc for the elder agent infrastructure refactor that follows Bundle 1 + 2 + 3 dockerize migration. Strips the over-engineered command bus and replaces it with a thin message-injection layer, hook-based liveness, kill-tmux resets, and per-elder runners co-located with each elder container.
+Locked design for the elder agent infrastructure refactor following Bundle 1 + 2 + 3 dockerize migration. Strips the over-engineered command bus and replaces it with a thin message-injection layer, hook-based liveness, kill-tmux resets, per-elder runners co-located with each elder container, and a small set of operational hardening invariants.
 
-**Status:** Locked design (2026-05-23 PM ET — superseded the 2026-05-22 draft after design conversation with Liam). Awaiting DA round 2 + sub-PR planning.
+**Status:** Locked design (2026-05-23 PM/PM ET — final pass after 12 CRITICAL + 16 SHOULD-RESOLVE DA round-2 findings were triaged). Ready for sub-PR breakdown + implementation.
 
 ## Why this rewrite
 
-The previous draft (2026-05-22) shipped to a DA review that surfaced 7 CRITICAL ambiguities. Most were about who owns which control surface — the runner, the supervisor, the indexer, or Convex. The 2026-05-23 design conversation collapsed those ambiguities by reframing the process layout:
+The DA round-1 review (2026-05-22) found 7 CRITICAL ambiguities, most about who owns which control surface. The 2026-05-23 design conversation collapsed those ambiguities by reframing the process layout — per-elder runner inside each container, dumb heartbeat singleton, kill-tmux reset, two-phase commit on every tick delivery.
 
-- The **heartbeat container** becomes a dumb singleton — it submits the on-chain heartbeat transaction and nothing else.
-- The **per-elder runner** moves inside each elder container and owns the entire elder lifecycle: tmux session management, send-keys injection, reset, recovery, healthcheck.
-- The **command bus** as a distributed-queue abstraction goes away. Messages are written to a thin `pendingMessages` table, read by the per-elder runner, fire-and-forget.
-- **Resets are kill-tmux + spawn-fresh-claude**, NOT `/clear`. Recovery is the same flow but with `claude --continue`.
+DA round 2 (2026-05-23 PM, against this rewrite's first pass) found 12 CRITICAL + 16 SHOULD-RESOLVE concerns. The 2026-05-23 evening triage walked each finding under an "over-engineering filter" — accepting real correctness work, rejecting LLM-default-defensive complexity that re-introduced the queue/lease/sweep machinery Bundle 4 exists to strip.
 
-This means three of the original DA CRITICAL findings (`/clear` detection too hand-wavy, reset path contradicts itself, pending-message loss not implementable) are simply resolved by the new shape rather than patched.
+This document is the result.
 
 ## Process model
 
@@ -22,314 +19,487 @@ Five processes total in production:
 | Process | Cardinality | Container | Responsibility |
 |---|---|---|---|
 | `heartbeat` | 1 | `heartbeat` container | Submit on-chain heartbeat tx on schedule. Nothing else. |
-| `elder-N runner` | 4 (one per elder) | `elder-N` container, alongside tmux | Subscribe to ticks, derive templates, send-keys into local tmux pane, manage tmux lifecycle, watch the local Claude process. |
+| `runner` | 4 (one per elder) | `elder-N` container, alongside tmux | Subscribe to ticks, derive templates, send-keys into local tmux pane, manage tmux lifecycle, watch the local Claude process, two-phase commit on every paste. |
 | `tmux` | 4 (one per elder) | `elder-N` container | Hosts the elder's claude process so ttyd can attach. |
 | `claude` | 4 (one per elder) | `elder-N` container, inside tmux | The actual LLM doing the agent work. |
 | `ttyd` | 4 (one per elder) | `elder-N` container | Read-only web terminal exposing the tmux pane to the operator cockpit. |
 
-Naming: what we previously called "supervisor" is now "runner". The thing previously called "runner" (the heartbeat package) is renamed "heartbeat" to match.
+What we previously called "supervisor" is now "runner". What we previously called "runner" (the heartbeat-only package) is renamed "heartbeat".
 
 ## Package renames
 
-Two `packages/` package renames as part of Bundle 4:
-
 | Before | After | Why |
 |---|---|---|
-| `packages/runner/` | `packages/heartbeat/` | Reflects the dumb-singleton role. Only owns heartbeat tx submission. |
+| `packages/runner/` | `packages/heartbeat/` | Reflects the dumb-singleton role — only owns heartbeat tx submission. |
 | `packages/elder-runtime/` | `packages/runner/` | Reflects the new role — runner is now the per-elder process. |
 
-Codex handles the rename across the monorepo as part of the Bundle 4 PR (tsconfig paths, pnpm workspaces, Docker `COPY` targets, import paths in `apps/server/convex/`, etc.).
+Codex handles the rename across the monorepo (tsconfig paths, pnpm workspaces, Docker `COPY` targets, server convex import paths). Lands as a standalone PR1 — mechanical churn with no behavior change.
 
 ## Runner lifecycle
 
 ### Startup (per elder container boot)
 
-1. **Read game settings** from Convex once. Cache in memory. Settings include: heartbeat interval, ticks-between-memory-resets, winter timing, season length, current diamond address, etc.
-2. **Check one-claude-per-container invariant**. `pgrep claude` should return exactly zero (cold boot) or exactly one (warm restart, runner restarted but elder process survived). If we find multiple claudes, fail loud + exit non-zero. Do not pgrep+pkill — discovery beats silent recovery for R&D.
-3. **Check tmux session state**. Three possibilities:
-   - No session exists → fresh launch path.
-   - Session exists, claude alive → warm restart, continue normal flow.
-   - Session exists, no claude → recovery path: respawn claude inside the existing tmux session.
-4. **Look up last-received tick** from Convex (see "Two-phase commit" below). Compare to current tick.
-5. **Subscribe to tick updates**. Begin normal tick-handling loop.
+1. **Acquire local `flock`** on `/var/run/elder-runner.lock`. Kernel-managed exclusive lock — second runner in same container fails immediately, exits non-zero. Defense in depth alongside the one-claude check at step 3.
+2. **Read game settings** from Convex once. Cache in memory. Settings include heartbeat interval, ticks-between-memory-resets, winter timing, season length, current diamond address. If Convex unreachable: retry with exponential backoff (1s → 2s → 4s → cap at 60s). Don't exit. Log prominently. (Per item 7: separate "Convex outage" from "elder unhealthy".)
+3. **Check one-claude-per-container invariant.** `pgrep claude` should return zero (cold boot) or one (warm restart). Multiple → fail loud + exit non-zero. NO pgrep+pkill recovery — discovery beats silent fixup for R&D.
+4. **Check tmux session state**: no session → fresh launch; session + claude alive → warm restart; session + no claude → recovery.
+5. **Look up last-received tick** from Convex (see Two-phase commit below). Compare to current tick. Branch into the 5-case restart decision table.
+6. **Subscribe to tick updates**. Begin normal tick-handling loop.
 
 ### Normal tick handling (per tick)
 
 1. Wake on new tick number from Convex subscription.
-2. Query Convex for current world state (tickClock + game settings drift check + auxiliary tables as needed for event-driven templates).
-3. **Drift check**: re-fetch game settings as part of the per-tick read. If any cached value diverges, panic + exit non-zero. Operator must restart all elder containers to pick up new settings.
-4. **Template selection** — compute which templates apply to this tick:
-   - **Pure-tick-math templates** (computed locally): `00_game_start.md`, `05_pre_memory_wipe_5ticks.md`, `06_pre_memory_wipe_1tick.md`, `07_post_memory_wipe.md`, `10_pre_winter_10ticks.md`, `11_winter_started.md`, `12_winter_ended.md`.
-   - **Event-driven templates** (require auxiliary query): `20_bandits_appeared.md`, `21_bandits_attacking.md`, `22_post_bandit_attack.md`. Runner queries `banditView` + `chainEvents` to detect events on this tick.
-5. **Compose message**: base line `tick: <N>` + each applicable template body wrapped in `<world_update name="<template-name>">...</world_update>` XML, concatenated in alphabetical order by template filename (numbered prefix = priority knob).
-6. **Two-phase commit**:
-   - Write `sent` row to Convex: `{elderId, tickNumber, sentAt, messageHash}`.
-   - Run `tmux load-buffer` + `tmux paste-buffer` + `tmux send-keys Enter`.
-7. The `UserPromptSubmit` hook fires when Claude actually receives the message; it writes `received` row to Convex: `{elderId, tickNumber, receivedAt}`.
-8. Loop.
+2. Per-tick auxiliary query — pulls current tickClock + game settings + any auxiliary tables (banditView, chainEvents) needed for event-driven template selection. **This single query also re-reads game settings — drift check piggybacks here. If any cached setting differs from current, panic + exit non-zero.** Operator must restart all elder containers to pick up new settings.
+3. **Template selection** — compute which templates apply:
+   - **Pure tick-math** (computed locally from tick number + game settings): `00_game_start.md`, `05_pre_memory_wipe_5ticks.md`, `06_pre_memory_wipe_1tick.md`, `07_post_memory_wipe.md`, `10_pre_winter_10ticks.md`, `11_winter_started.md`, `12_winter_ended.md`.
+   - **Event-driven** (uses auxiliary query results): `20_bandits_appeared.md`, `21_bandits_attacking.md`, `22_post_bandit_attack.md`. Per Liam Q1: business logic in the runner, not the indexer — the runner inspects banditView + chainEvents from this tick to decide.
+4. **Compose message** using the section-based format (see Message format).
+5. **Two-phase commit pre-paste**: write `tickSendLog` row to Convex `{elderId, tickNumber, sentAt, messageHash, resetMetadata?}`.
+6. **Paste verification layer (pre-paste)**: capture tmux pane, confirm Claude is at empty input prompt — not mid-tool-call, not at shell, not at auth prompt. If not ready: wait + retry up to N times. If still not ready after retry budget: log failure, skip this tick, don't paste (next tick wakes runner again).
+7. `tmux load-buffer` + `tmux paste-buffer` + `tmux send-keys Enter`.
+8. **Paste verification layer (post-paste)**: capture tmux pane, confirm input box is empty (= message was submitted). If text still in input box: re-send Enter, retry up to 3 times. If still stuck: log + give up.
+9. The `UserPromptSubmit` hook fires when Claude actually receives the message; writes `tickReceiveLog` row.
+10. **Resend cap (item 4)**: if a tick has been pasted 3 times without ever getting a `tickReceiveLog` row → write `HOOK_FAILURE` alert to runner events table + stop resending that tick. Continue processing new ticks. Operator sees the alert + investigates hook.
 
-### Restart behavior (runner crash → docker compose restart)
+### Restart 5-case decision table
 
-After `Startup` steps 1-3:
+Given `current_tick` (from Convex), `last_received` (highest tickNumber in tickReceiveLog for this elder), `sent[current]` (sendLog row for current tick exists?), and `gap = current_tick - last_received`:
 
-1. Look up the highest `tickNumber` with a `received` record for this elder.
-2. Look up `current_tick` from Convex `tickClock`.
-3. Branch:
-   - **a) `current_tick == last_received`** → no-op. Don't re-send. Wait for next tick.
-   - **b) `current_tick > last_received` AND no memory-wipe boundary in the gap** → inject fast-forward prefix `"Fast-forwarding from tick <last_received> to tick <current_tick>"` (one line) + the normal tick-N message (template selection per current state). The fast-forward prefix is grep-able in logs for R&D anomaly hunting.
-   - **c) `current_tick > last_received` AND memory-wipe boundary falls in `(last_received, current_tick]`** → SPECIAL CASE. Do kill-tmux + spawn-fresh-claude (no `--continue`) + inject `07_post_memory_wipe.md` template for current tick. The elder's memory was wiped during the runner outage; they need a clean fresh start.
-   - **d) `current_tick == last_received + 1` AND received-but-not-sent state (hook landed without sent record)** → impossible state, log + treat as case (a).
-   - **e) `sent` recorded but no `received` for tick N == current_tick** → trust the `received` record. Re-send the message. Double-paste accepted as harmless: claude sees a duplicate prompt, responds twice or shrugs. The hook will then record the receipt.
-
-### Tick backlog handling
-
-A runner can fall behind only via: operator pause (`docker compose pause`), network partition, OS scheduling stall, OOM kill, container restart. All of these effectively look identical to the restart behavior above — the runner wakes up, reads `last_received` from Convex, computes `current_tick`, and runs the same branch logic. Same code path, no separate "backlog" handler.
+| Case | Condition | Action |
+|---|---|---|
+| A | `gap == 0` | No-op. Wait for next tick. |
+| B | `gap == 1 AND !sent[current]` | Fresh send for current tick. |
+| C | `gap == 1 AND sent[current]` | Re-send (trust receive log). Double-paste accepted as harmless. |
+| D | `gap > 1 AND memory_wipe_tick ∈ (last_received, current_tick]` | **Special case**: kill-tmux + spawn-fresh + `claude` no-`--continue` + inject `07_post_memory_wipe.md`. The elder's memory was wiped during the runner outage. |
+| E | `gap > 1 AND no memory-wipe in gap` | Inject fast-forward prefix `"Fast-forwarding from tick X to tick Y"` + normal current-tick message. Prefix is grep-able for R&D anomaly hunting. |
 
 ### Reset (tick-driven hard wipe)
 
-When `current_tick % ticks_between_memory_resets == 0` (computed locally from cached settings):
+When `current_tick % ticks_between_memory_resets == 0` (and `current_tick > 0` — tick 0 is excluded; that's the game_start path not memory wipe):
 
-1. **Log reset start** to Convex: `{elderId, resetTick, startedAt, reason: "scheduled"}`.
-2. **Kill the existing tmux session**: `tmux kill-session -t elder-N`. This disconnects ttyd; cockpit detects the disconnect and overlays a "Elder memory is being reset…" animation in place of the default ttyd reconnect screen.
-3. **Spawn a fresh tmux session**: `tmux new-session -d -s elder-N -c /workspace`.
-4. **Launch claude WITHOUT `--continue`**: `tmux send-keys -t elder-N "claude" Enter`. Fresh session id, fresh JSONL. Memory is gone.
-5. **Brand the session**: send-keys `"/rename Ælder Crimson"` + Enter + Enter + `"/color red"` + Enter + Enter. Branding values keyed off `ELDER_ID` env var. (Elders: Crimson/red, Azure/blue, Verdant/green, Amber/yellow — exact mapping in `agents/shared/runner/elder-config.json`.)
-6. **Inject first tick**: `tick: <current_tick>` + `<world_update name="07_post_memory_wipe">...</world_update>`.
-7. **Log reset complete** to Convex: `{elderId, resetTick, completedAt}`.
-8. Resume normal tick handling.
+1. **Write `last_wipe_tick` marker** to local disk at `/var/run/elder-runner-last-wipe`. Atomic write — `/var/run/elder-runner-last-wipe.tmp` then `os.rename`. Prevents `claude --continue` from resurrecting pre-wipe memory if the runner crashes mid-reset.
+2. **Log reset start** to `resetEventLog`: `{elderId, resetTick, startedAt, reason: "scheduled"}`.
+3. **Kill the existing tmux session**: `tmux kill-session -t elder-N`. This disconnects ttyd; cockpit detects the disconnect, cross-references `resetEventLog` to confirm intent, and overlays the "Elder memory is being reset…" animation in place of ttyd's default reconnect screen.
+4. **Spawn a fresh tmux session**: `tmux new-session -d -s elder-N -c /workspace`.
+5. **Paste verification: pre-paste readiness probe** waits for Claude to launch + be ready at empty input prompt.
+6. **Launch claude WITHOUT `--continue`**: `tmux send-keys -t elder-N "claude" Enter`. Fresh session id, fresh JSONL. Memory is gone.
+7. **Brand the session**: send-keys `/rename Ælder Crimson` + Enter + Enter + `/color red` + Enter + Enter. Branding values keyed off `ELDER_ID` env var. (Mapping in `agents/shared/runner/elder-config.json`: Crimson/red, Azure/blue, Verdant/green, Amber/yellow.)
+8. **Two-phase commit for first-tick**: write `tickSendLog` with `resetMetadata: {resetTick, resetReason, resetEventId}`. Paste `tick: <current_tick>` + `07_post_memory_wipe.md` template body. Verify post-paste.
+9. **Log reset complete** to `resetEventLog`.
+10. Resume normal tick handling.
 
-The reset-event log is **observability-only**. It does NOT gate the next tick. The runner moves on as soon as step 7 commits.
+The reset-event log is **observability only**. Does NOT gate tick processing.
 
-### Recovery / resume (cold boot with prior state)
+### Recovery / resume
 
-When the elder container boots and finds tmux + claude alive, OR boots fresh but `agents/elder-N/.claude/projects/` already has JSONL files from a prior life:
+Per the 5-case table — case A (`gap==0`) means warm restart with no work. Cases B and C handle within-one-tick restarts via fresh send or re-send. The `last_wipe_tick` marker on disk is checked at every runner boot:
 
-1. If tmux + claude alive: do nothing, just begin tick handling. Claude is already running and has its history.
-2. If tmux exists but claude died: `tmux send-keys -t elder-N "claude --continue" Enter`. `--continue` picks up the latest session JSONL, restoring color + rename + chat history.
-3. If tmux doesn't exist but `.claude/projects/` does: `tmux new-session -d -s elder-N` + `tmux send-keys "claude --continue" Enter` (preserves prior state).
-4. If neither tmux nor `.claude/projects/` exists: fresh launch (same as reset step 3+ but inject `00_game_start.md` instead of `07_post_memory_wipe.md`).
+- If `last_wipe_tick == current_tick` → memory wipe in progress, refuse `claude --continue`, treat as case D.
+- If `last_wipe_tick < current_tick` and case D applies (memory-wipe in gap) → same.
+- Otherwise → `claude --continue` is safe, picks up prior session JSONL.
 
-### Late-join (operator brings up a new elder mid-game)
+### Late-join (operator brings up new elder mid-game)
 
-This is the "container 5+ created after game has been running for 500 ticks" scenario. Reuse the reset flow with the `07_post_memory_wipe.md` template. The elder wakes up with no memory in a running game; same semantic as post-wipe.
+Reuse the reset flow with `07_post_memory_wipe.md`. The elder wakes with no memory in a running game; same semantic as post-wipe.
 
 ## Game settings — immutable for game duration
 
-Read-once at runner startup. Cached in memory. Drift-checked on every per-tick query (piggyback, zero extra reads). If the cached value ever diverges from Convex on the per-tick re-fetch, panic. Fail loud — the operator forgot to restart after changing a setting.
+Read-once at runner startup. Cached in memory. Drift-checked on every per-tick query (zero extra Convex reads — piggybacks on the auxiliary query). If a cached value diverges from Convex on the per-tick re-fetch, panic and exit non-zero.
 
-**Operational rule (capture in runbook):** To change ANY setting in `gameSettings` (heartbeat interval, memory-reset cadence, winter timing, season length), restart every elder container. There is no live-update path. The fail-loud drift check is a defensive trip-wire; it does not coordinate the change.
+**Operational rule (capture in runbook):** To change ANY value in `gameSettings`, restart every elder container. There is no live-update path. The drift-check is a defensive trip-wire for the operator-forgot-to-restart case.
 
-## Prompt templates
+## Message format
 
-### Storage location
-
-On disk at `agents/shared/runner/prompts/`. Files copied into each elder container's image at build time. Template content is static markdown. Edits require a runner-image rebuild + container restart.
-
-(Future: skills could provide dynamic behavior — a prompt can include `/run <skill-name>` slash commands that claude executes. That makes the static templates extensible without inflating the runner code. Out of scope for Bundle 4.)
-
-### Naming + ordering
-
-Numbered prefix `NN_<purpose>.md`. Alphabetical sort = priority order. To reshuffle priority, renumber.
-
-### Template list (Bundle 4 v1)
-
-| File | Trigger | Class |
-|---|---|---|
-| `00_game_start.md` | First tick of a new game | tick-math |
-| `05_pre_memory_wipe_5ticks.md` | `current_tick % wipe_interval == wipe_interval - 5` | tick-math |
-| `06_pre_memory_wipe_1tick.md` | `current_tick % wipe_interval == wipe_interval - 1` | tick-math |
-| `07_post_memory_wipe.md` | First tick immediately after a wipe; also late-join + recovery from gap | tick-math |
-| `10_pre_winter_10ticks.md` | 10 ticks before winter starts | tick-math |
-| `11_winter_started.md` | Tick winter starts | tick-math |
-| `12_winter_ended.md` | Tick winter ends | tick-math |
-| `20_bandits_appeared.md` | Bandit just spawned this tick | event-driven |
-| `21_bandits_attacking.md` | Bandit in attack state this tick | event-driven |
-| `22_post_bandit_attack.md` | Tick after a bandit resolved an attack | event-driven |
-| `99_clansmen_revived_and_resources_injected.md` | Operator manually revived clansmen + injected resources (no fresh season) | event-driven |
-
-Multiple templates can fire on the same tick. They concat in alphabetical order. Tick number always prefixes.
-
-### Message wire format
+Section-based, `---` separator between sections, prefix header per section, UID is the first line after the prefix.
 
 ```
-tick: 537
-<world_update name="05_pre_memory_wipe_5ticks">
-Your memory will be reset in 5 ticks. Make sure your ancient wisdom journal is up-to-date.
-</world_update>
-<world_update name="10_pre_winter_10ticks">
-Winter approaches. 10 ticks remain in the harvest. Stockpile food.
-</world_update>
+---
+tick: 12345
+[zero or more concatenated prompt template bodies]
+---
+whisper: silent-screams-beneath-bedrock-7f3a
+<1000 char message from clan owner>
+---
+special-msg: winter-mealworms-fluttering-calls-9a4c
+<any length admin debug message>
 ```
 
-For most ticks, only the first line fires (no templates active).
+Replaces the earlier `<world_update>` XML wrapping. Cleaner — no risk of stray closing tags in template bodies breaking the envelope, easier for Claude to parse visually, multiple distinct sections chain naturally in one paste.
 
-## Admin / user message injection
+The `tick:` section is always first. `whisper:` and `special-msg:` sections only appear when there's a corresponding `pendingMessages` row to deliver.
 
-Same writer table, separate trigger source.
+## Thematic UUIDs
 
-### Convex `pendingMessages` table
+For every message ID (tickSendLog `messageHash`-companion, whisper UUID, special-msg UUID, pendingMessages `_id`), generate a 4-segment slug.
+
+**Six themed generators in a shared pool. Random selection per ID — generator chosen uniformly at random regardless of message type.** Variety of themes makes IDs visually interesting for log-grepping without baking semantic info into the UID (message type is distinguished via DB column + envelope prefix).
+
+Generator templates:
+1. `<volume>-<speech>-<direction>-<location>` — e.g. `booming-whisper-northward-thicket`
+2. `<time>-<animal>-<action>-<utterance>` — e.g. `morning-lark-swooping-sigh`
+3. `<weather>-<creature>-<motion>-<sound>` — e.g. `stormbound-fox-creeping-whisper`
+4. `<season>-<terrain>-<creature>-<action>` — e.g. `autumn-marsh-otter-summoning`
+5. `<mood>-<celestial>-<creature>-<call>` — e.g. `wistful-moonlit-stoat-summons`
+6. `<color>-<material>-<creature>-<vocalization>` — e.g. `crimson-quartz-magpie-warning`
+
+Each word slot has 50-100 candidates. Total combinatorial space per generator: ~25M-100M. Plus a 4-hex suffix appended (`-7f3a`) for true collision-free uniqueness: total space ~10 billion per generator × 6 generators.
+
+Mutation does an exact `(slug, hex)` collision check pre-commit. If collision found, regenerate.
+
+## UserPromptSubmit hook
+
+### Implementation
+
+Python 3.11+ script at `agents/shared/home-claude/hooks/user_prompt_submit.py`. Wired in via `agents/shared/home-claude/settings.json`.
+
+### Dependencies
+
+Pinned in `agents/shared/home-claude/hooks/requirements.txt`:
+
+```
+convex==0.7.0
+```
+
+That's the only dep. Convex Python SDK provides the mutation client with built-in retry, backoff, and timeout. We use it instead of hand-rolling around `urllib.request` so that:
+
+- The pattern of "pinned PyPI deps in requirements.txt + Dependabot scanning" is established explicitly in the repo from day one.
+- Future agents working in `agents/shared/home-claude/hooks/` follow the example instead of inventing a new dep solution.
+- We don't reinvent retry/backoff/timeout that the SDK already handles.
+
+`.github/dependabot.yml` adds an entry watching this requirements.txt with weekly cadence.
+
+The Dockerfile copies + `pip install --no-cache-dir -r requirements.txt --require-hashes` (hashes generated via `pip-compile --generate-hashes requirements.in`).
+
+### Behavior — positive filter
+
+Hook acts as an **allowlist**, not a denylist. Only writes a `tickReceiveLog` row if the first line of the prompt starts with one of:
+
+- `tick:` → tick message receipt, parses tick number for the receive log
+- `whisper:` → admin/user whisper receipt, parses UUID
+- `special-msg:` → admin debug message receipt, parses UUID
+
+Everything else (including `/rename`, `/color`, free-form text typed by an operator via ttyd if it were writable) is ignored. Hook returns immediately, no Convex write.
+
+Future allowlist additions are explicit code edits — keeps the surface scrutinized.
+
+### Failure mode
+
+Hook errors are logged to stderr but do NOT block the prompt — Claude still processes the message normally. The runner's resend-cap-3 with HOOK_FAILURE alert catches the case where the hook stops writing entirely.
+
+## Convex schema
+
+### NEW tables
 
 ```typescript
-{
-  _id: Id<"pendingMessages">,
-  targetElderId: "elder-1" | "elder-2" | "elder-3" | "elder-4",
-  text: string,
-  insertedAt: number,
-  source: "admin-injection" | "user-message",
-  consumedBy: Optional<string>, // runner instance ID that processed this row
-  consumedAt: Optional<number>,
-}
+// agentCommands etc. dropped — see "Dropped" below
+
+pendingMessages: defineTable({
+  targetElderId: v.string(),
+  text: v.string(),
+  source: v.union(v.literal("admin-injection"), v.literal("user-message")),
+  insertedAt: v.number(),
+  consumedAt: v.optional(v.number()),
+}).index("by_target_unconsumed", ["targetElderId", "consumedAt"]),
+
+tickSendLog: defineTable({
+  elderId: v.string(),
+  tickNumber: v.number(),
+  sentAt: v.number(),
+  messageHash: v.string(),
+  resetMetadata: v.optional(v.object({
+    resetTick: v.number(),
+    resetReason: v.union(
+      v.literal("scheduled"),
+      v.literal("manual"),
+      v.literal("memory_wipe_gap"),
+      v.literal("late_join"),
+    ),
+    resetEventId: v.id("resetEventLog"),
+  })),
+}).index("by_elder_tick", ["elderId", "tickNumber"]),
+
+tickReceiveLog: defineTable({
+  elderId: v.string(),
+  receivedAt: v.number(),
+  prefix: v.union(v.literal("tick"), v.literal("whisper"), v.literal("special-msg")),
+  // Exactly one of these is set based on `prefix`:
+  tickNumber: v.optional(v.number()),
+  whisperUid: v.optional(v.string()),
+  specialMsgUid: v.optional(v.string()),
+  messagePreview: v.string(),  // first 100 chars (redacted for secrets in messagePreview redaction pass — follow-up)
+}).index("by_elder_tick", ["elderId", "tickNumber"])
+  .index("by_elder_received", ["elderId", "receivedAt"]),
+
+resetEventLog: defineTable({
+  elderId: v.string(),
+  resetTick: v.number(),
+  reason: v.union(
+    v.literal("scheduled"),
+    v.literal("manual"),
+    v.literal("memory_wipe_gap"),
+    v.literal("late_join"),
+  ),
+  startedAt: v.number(),
+  completedAt: v.optional(v.number()),
+}).index("by_elder_started", ["elderId", "startedAt"]),
+
+runnerEvents: defineTable({
+  elderId: v.string(),
+  kind: v.union(
+    v.literal("hook_failure"),
+    v.literal("convex_outage_recovery"),
+    v.literal("settings_drift_panic"),
+    v.literal("invariant_violation"),
+    v.literal("ready_probe_timeout"),
+  ),
+  message: v.string(),
+  at: v.number(),
+}).index("by_elder_at", ["elderId", "at"]),
 ```
+
+### DROPPED tables
+
+- `agentCommands` — old command bus FSM.
+- `elderHeartbeat` — old supervisor self-report (replaced by `tickReceiveLog`-derived liveness).
+- `commandResults` — old result rows.
+
+### DROPPED cron
+
+- `bus-sweep-stale-delivered` — no leases to sweep.
+
+### Migration
+
+Clean break. Production never exercised the old bus (per the PR #560 super-swarm finding — bootstrap-bus-secrets was never plumbed correctly, so bus auth always rejected). Drop the old tables in the schema migration; no data preservation needed.
+
+## Admin & user message injection
+
+### Server endpoint
+
+Per Liam Q4 lock: new `/api/admin/` route namespace in the dev-UI server-side. Clerk authentication. Never ship `BUS_OPERATOR_SECRET` to client code.
+
+`POST /api/admin/inject-message` accepts `{targetElderId, text, source: "admin-injection"}`. Server-side Clerk middleware verifies session. Server then writes `pendingMessages` row via Convex with `BUS_OPERATOR_SECRET` (server-side env var, never client-visible).
+
+This becomes the auth pattern for ALL future admin features. Avoid hand-rolled auth anywhere in the system.
 
 ### Runner subscription
 
-The runner watches `pendingMessages` filtered by `targetElderId == own_id AND consumedBy == null`. When a row appears, the runner pastes immediately (does NOT wait for next tick). Marks `consumedBy` + `consumedAt` after the UserPromptSubmit hook confirms receipt.
+Each runner subscribes to `pendingMessages` filtered by `targetElderId == own_id AND consumedAt == null`. New row → paste immediately (don't wait for next tick). Same paste verification + UserPromptSubmit hook receipt as ticks. After hook records receipt, runner marks `consumedAt`.
 
-### Admin injection flow
+Note: no atomic claim mutation. Admin messages are rare debug pings — double-paste under a runner restart race is acceptable (Liam directive: "no locking bullshit, we are clearly over-engineering").
 
-Dev-UI panel writes a row with `source: "admin-injection"`. Runner picks it up within poll interval (1-2 seconds), pastes into the elder's tmux pane. Same UserPromptSubmit hook records receipt to the same `tickReceiveLog` table (with `tickNumber == null` since it's not a tick message).
+## Hooks language + dep management
 
-### Authorization
+All Claude Code hooks inside elder containers are Python 3.11+. Pinned dependencies in `agents/shared/home-claude/hooks/requirements.txt`. Dependabot watches the file. Initial dep: `convex==0.7.0`.
 
-Admin injection requires `BUS_OPERATOR_SECRET`. Writes from other sources rejected at the Convex mutation level. (Survives from Bundle 2; carries forward.)
+Pattern for future hooks: edit `requirements.in` → run `pip-compile --generate-hashes` to regenerate `requirements.txt` with pinned hashes. Don't hand-edit requirements.txt. Don't use pyproject.toml (we're shipping scripts, not packages).
 
-## Two-phase commit (tick delivery)
+## Invariants + operational guards
 
-### `tickSendLog` table
+1. **Local flock** at runner startup (`/var/run/elder-runner.lock`).
+2. **One-claude-per-container** check at runner startup (defense in depth alongside flock).
+3. **Drift check** of game settings on every per-tick query (zero-cost piggyback).
+4. **Container healthcheck** = LOCAL ONLY: runner alive + tmux alive + claude alive. Does NOT check Convex.
+5. **Convex outage handling** = retry with backoff + log loudly. NEVER exit non-zero on Convex error.
+6. **Resend cap** = 3 attempts per tick → HOOK_FAILURE alert + stop resending that tick (continue with new ticks).
+7. **Paste verification** = pre-paste readiness + post-paste stuck-input detection.
+8. **`last_wipe_tick` marker** = local disk file prevents `claude --continue` from resurrecting pre-wipe memory if runner crashes mid-reset.
 
-```typescript
-{
-  _id: Id<"tickSendLog">,
-  elderId: string,
-  tickNumber: number,
-  sentAt: number,
-  messageHash: string,  // sha256 of the composed message body
-}
+## Prompt templates
+
+On disk at `agents/shared/runner/prompts/`. Numbered prefix = alphabetical = priority. Concat multiple in alphabetical order when several apply.
+
+| File | Trigger | Class |
+|---|---|---|
+| `00_game_start.md` | Tick 0 of new game season | tick-math |
+| `05_pre_memory_wipe_5ticks.md` | 5 ticks before wipe | tick-math |
+| `06_pre_memory_wipe_1tick.md` | 1 tick before wipe | tick-math |
+| `07_post_memory_wipe.md` | Memory wipe tick (fires FIRST template that tick) + late-join + memory-wipe-in-gap recovery | tick-math |
+| `10_pre_winter_10ticks.md` | 10 ticks before winter | tick-math |
+| `11_winter_started.md` | First winter tick | tick-math |
+| `12_winter_ended.md` | First post-winter tick | tick-math |
+| `20_bandits_appeared.md` | Bandit spawned this tick | event-driven |
+| `21_bandits_attacking.md` | Bandit in attack state this tick | event-driven |
+| `22_post_bandit_attack.md` | Tick after bandit resolved an attack | event-driven |
+| `99_clansmen_revived_and_resources_injected.md` | Manual operator recovery | event-driven |
+
+Skills (future extensibility): templates can include `/run <skill>` slash commands that Claude executes. Out of scope for Bundle 4 v1, but the design allows for it.
+
+## Cockpit UI overlay
+
+`apps/web` cockpit detects ttyd WebSocket disconnect AND cross-references `resetEventLog` to confirm it's a deliberate reset event (vs a transient network blip). When confirmed:
+
+- Overlay "Elder memory is being reset…" with a branded animation in place of ttyd's default reconnect screen.
+- Fade out on ttyd reconnect.
+
+This turns the worst UX moment (ttyd disconnect during reset) into a visible deliberate event.
+
+## Sub-PR plan
+
+Bundle 4 decomposes into 6 sub-PRs targeting `dev-phase-4-simplified-comms`. Each PR is small enough to be locally reviewable + tied to a single GitHub issue. Issues filed in order so dependencies are clear.
+
+### PR1: Foundation — package renames + Convex schema migration
+
+**One GitHub issue.** Mechanical churn, no behavior change. Lands first.
+
+- Rename `packages/runner/` → `packages/heartbeat/` (codex handles import paths across monorepo).
+- Rename `packages/elder-runtime/` → `packages/runner/`.
+- Update tsconfig paths, pnpm-workspace.yaml, Docker `COPY` targets, server convex imports, mobile imports.
+- New Convex tables: `pendingMessages`, `tickSendLog`, `tickReceiveLog`, `resetEventLog`, `runnerEvents`.
+- Drop `agentCommands`, `elderHeartbeat`, `commandResults`. Drop `bus-sweep-stale-delivered` cron.
+
+CI must stay green after this PR — typecheck, contract types, all sub-package builds.
+
+### PR2: Runner core rewrite
+
+**One GitHub issue.** Replaces the old elder-runtime supervisor with the new per-elder runner.
+
+- Rewrite `packages/runner/src/main.ts` with the locked lifecycle.
+- Tick subscription via Convex.
+- Per-tick auxiliary query (settings drift check + event-driven template inputs).
+- Two-phase commit (tickSendLog → paste → hook fires → tickReceiveLog).
+- Resend cap 3 + HOOK_FAILURE alert.
+- One-claude invariant + local flock at boot.
+- Game settings cache + drift-panic.
+- Reset flow: kill-tmux + spawn-fresh + `claude` no-continue + branding + first-tick paste.
+- Recovery flow: `claude --continue` with `last_wipe_tick` marker check.
+- 5-case restart decision table.
+- Convex retry+backoff for outages.
+- Thematic UUID generator utility (6 generators + collision check).
+
+### PR3: Hook + templates
+
+**One GitHub issue.** Lands the Python UserPromptSubmit hook + prompt template library.
+
+- `agents/shared/home-claude/hooks/user_prompt_submit.py` (positive-filter allowlist).
+- `agents/shared/home-claude/hooks/requirements.txt` with `convex==0.7.0` pinned + hashes.
+- `agents/shared/home-claude/hooks/requirements.in` source file.
+- `agents/shared/home-claude/settings.json` wires the hook to UserPromptSubmit.
+- Dockerfile installs `pip install --no-cache-dir -r requirements.txt --require-hashes`.
+- `.github/dependabot.yml` entry watching the requirements file (weekly).
+- 11 prompt templates at `agents/shared/runner/prompts/00_game_start.md` through `99_clansmen_revived.md` (Bundle 4 v1 set per the table above).
+
+### PR4: Paste verification layer
+
+**One GitHub issue.** Adds the pre-paste readiness probe + post-paste stuck-input detection to the runner. Could fold into PR2 if scope is comfortable, but separated for independent review.
+
+- Pre-paste readiness probe: `tmux capture-pane` + regex match against input-box region.
+- Post-paste submit verification: re-capture + retry Enter if input box still has text.
+- Configurable retry budget + timeouts.
+
+### PR5: Cockpit UI reset overlay
+
+**One GitHub issue.** Frontend-only — uses existing Convex subscription pattern.
+
+- Detect ttyd WebSocket disconnect in cockpit elder-pane component.
+- Subscribe to `resetEventLog` filtered by `elderId == focused_elder`.
+- If recent reset event spans the disconnect window, render the "memory is being reset" overlay; otherwise show standard reconnect message.
+- Fade out animation on reconnect.
+
+### PR6: Admin endpoint + UI panel
+
+**One GitHub issue.** Server-side `/api/admin/` namespace + Clerk auth wrapper + dev-UI form.
+
+- Add Clerk dependency to dev-UI app (server-side auth middleware).
+- New route group `apps/web/src/api/admin/` with Clerk-protected middleware.
+- `POST /api/admin/inject-message` writes `pendingMessages` row via server-side Convex client.
+- Dev-UI panel component: dropdown for target elder + textarea for message + submit button.
+- Sets the pattern for ALL future admin features — never hand-roll auth, always go through `/api/admin/*` + Clerk.
+
+### Stack + merge order
+
+Branch hierarchy per ADR 0018:
+
+```
+dev
+  └── dev-phase-4-simplified-comms        (integration branch)
+        ├── feat/issue-XXX-pr1-renames        (lands first)
+        ├── feat/issue-XXX-pr2-runner-core    (depends on PR1)
+        ├── feat/issue-XXX-pr3-hook-templates (depends on PR1)
+        ├── feat/issue-XXX-pr4-paste-verify   (depends on PR2)
+        ├── feat/issue-XXX-pr5-cockpit-overlay(depends on PR1)
+        └── feat/issue-XXX-pr6-admin-api      (depends on PR1)
 ```
 
-Index: `by_elder_tick` on `(elderId, tickNumber DESC)`.
+PR1 lands first. Then PR3 + PR5 + PR6 can land in parallel (they depend on PR1 only). PR2 lands next (uses PR1's schema). PR4 lands last (uses PR2's paste path).
 
-Runner writes one row BEFORE running `tmux paste-buffer`. If the runner crashes between write and paste, the row is a "sent but no record of receipt" → restart logic re-sends per case (e) above.
+Each PR goes through the local 3-tier swarm review per `swarm-pr-review.md`. The phase release PR (`dev-phase-4-simplified-comms → dev`) runs the 6-model super-swarm before merging to dev. Then the next dev→main release picks up Bundle 4 alongside any other Bundle 1/2/3 polish.
 
-### `tickReceiveLog` table
+## Test coverage
 
-```typescript
-{
-  _id: Id<"tickReceiveLog">,
-  elderId: string,
-  tickNumber: number | null,  // null for admin injections
-  receivedAt: number,
-  messagePreview: string,     // first 100 chars for operator visibility
-}
-```
+Per DA r2 SHOULD-RESOLVE list — test plan for the highest-risk behaviors:
 
-Index: `by_elder_tick` on `(elderId, tickNumber DESC)`.
+- Duplicate runner lock (flock catches second runner).
+- Hook missing / misinstalled (resend cap fires HOOK_FAILURE after 3 attempts).
+- Reset first tick lands via two-phase commit (tickSendLog with reset metadata).
+- Convex outage at boot (retry with backoff, eventual success).
+- Memory-wipe-in-gap (kill-tmux fresh launch with post-wipe template, `last_wipe_tick` marker prevents `--continue`).
+- Tick 0 → game-start template (NOT post-memory-wipe).
+- Fast-forward across gap with skipped event templates (current-tick state only — event-driven templates between gap and current are NOT replayed).
+- Stuck-input detection (Enter not submitted → re-Enter retry).
+- Game settings drift panic.
 
-### `UserPromptSubmit` hook
+## Operational rules captured in runbook
 
-Lives at `agents/shared/home-claude/hooks/user_prompt_submit.sh` (or `.py`). Triggers on every user prompt submitted to Claude. Inspects the prompt for the deterministic first-line pattern `tick: <N>`. If matched, extracts `<N>` and writes a `tickReceiveLog` row. If first line doesn't match `tick:` (admin injection), writes the row with `tickNumber: null`.
-
-Hook authentication: passes `BUS_ELDER_SECRET_N` from env (already injected into the container via Docker secrets, available to the hook). Convex mutation rejects writes without a valid secret.
-
-Hook failure (network blip, Convex down): logs the error to stderr + does NOT block the prompt. Next runner restart will see the missing `received` row and re-send — the double-paste is the accepted recovery cost.
-
-## Healthcheck (three-part)
-
-`docker-compose.yml` healthcheck for each elder container:
-
-```yaml
-healthcheck:
-  test: ["CMD-SHELL", "sh /opt/clan-world/shared/runner/bin/healthcheck.sh"]
-  interval: 30s
-  timeout: 10s
-  retries: 3
-```
-
-`healthcheck.sh` validates:
-
-1. **Runner process alive**: `pgrep -x runner` returns one PID.
-2. **Tmux session alive**: `tmux has-session -t $ELDER_ID` returns 0.
-3. **Claude process alive**: `pgrep -x claude` returns exactly one PID (one-claude invariant).
-
-Failure on any check → docker restarts the container. Compose `restart: unless-stopped` retries indefinitely until the operator intervenes.
-
-## Liveness observability
-
-Separate from healthcheck. The dev-UI subscribes to two tables:
-
-- `tickReceiveLog`: last-received-per-elder is the freshest liveness signal. If an elder hasn't received a tick in N intervals while ticks are firing, alert.
-- `resetEventLog`: shows reset history per elder. Useful for forensics.
-
-No `elderHeartbeat` table from the old design. The runner doesn't self-report; the hook does the reporting.
-
-## New + dropped Convex tables
-
-### NEW
-
-- `pendingMessages` — admin + user message injection queue.
-- `tickSendLog` — runner-side "sent" record.
-- `tickReceiveLog` — hook-side "received" record.
-- `resetEventLog` — observability log for reset events.
-
-### DROPPED (compared to Bundle 1+2+3 state)
-
-- `agentCommands` — old command bus FSM (queued/leased/acked/completed/failed). Gone.
-- `elderHeartbeat` — old supervisor self-report. Gone (replaced by `tickReceiveLog` derived liveness).
-- `commandResults` — old result rows. Gone.
-
-`crons.ts` cron `bus-sweep-stale-delivered` also dropped — no leases to sweep.
-
-## Schema migration
-
-Bundle 4 ships a clean break. The new tables are created, old tables are dropped. No data migration — production has no data in `agentCommands` / `elderHeartbeat` / `commandResults` worth preserving (the bus was never actually exercised; per the PR #560 super-swarm finding, the bootstrap secrets were never plumbed so the bus was non-functional on dev).
-
-## Sub-PR planning hints
-
-Bundle 4 likely decomposes into ~6 sub-PRs targeting `dev-phase-4-simplified-comms`:
-
-1. **Package renames + Convex schema migration**: `packages/runner/` → `packages/heartbeat/`, `packages/elder-runtime/` → `packages/runner/`. New tables in `packages/sdk/convex/schema.ts`. Drop the old tables + cron.
-2. **Runner core rewrite**: `packages/runner/src/main.ts` becomes the per-elder runner. Tick subscription + template selection + tmux send-keys + reset/recovery flow.
-3. **Prompt templates**: `agents/shared/runner/prompts/*.md` per the table above.
-4. **UserPromptSubmit hook**: `agents/shared/home-claude/hooks/user_prompt_submit.sh` + settings.json wiring.
-5. **Cockpit UI**: ttyd-disconnect-detection overlay with "Elder memory is being reset…" animation.
-6. **Admin injection UI panel**: dev-UI form for operator message injection. (Could split to follow-up if scope is tight.)
-
-Stack them under `dev-phase-4-simplified-comms` per the ADR 0018 4-level branching pattern.
-
-## Open items for DA round 2
-
-The locked-in design above resolves the 2026-05-22 DA review's 7 CRITICAL findings. The remaining DA SHOULD-RESOLVE items get re-asked against the new shape:
-
-- Poll cadence and batch semantics for the per-elder runner reading `pendingMessages`.
-- Retention/TTL for `tickSendLog`, `tickReceiveLog`, `resetEventLog` (write-heavy, grow forever otherwise).
-- Hook failure aggregate alerting (one elder's hook stops posting → operator knows).
-- Container-restart-mid-tick orientation (which template, which session JSONL).
-- Specific test plan: duplicate paste, fast-forward gap, memory-wipe-in-gap special case, hook failure, late-join.
-- Naming convention nits: `tickSendLog` vs `runnerSentTicks`, etc.
-
-Dispatch DA round 2 against this rewrite for sharper findings.
+- **Change ANY game setting → restart every elder container.** No live update path. Drift-panic catches operator forgetfulness.
+- **Convex outage → wait it out.** Runners retry with backoff. Don't restart containers.
+- **Hook failure (HOOK_FAILURE alerts in runnerEvents) → SSH into elder container, check hook script + auth.** Restart container after fixing.
+- **Manual reset of a specific elder** → write admin message `RESET` (or kill+restart docker compose elder-N).
+- **Late-join (new elder mid-game)** → just bring up the container; runner detects no prior state + uses post-memory-wipe template automatically.
 
 ---
 
-**Locked decisions recap** (Liam-locked 2026-05-23 PM ET, do not re-litigate):
+## Locked decisions recap
 
-1. Heartbeat container = dumb chain submitter, package rename `packages/runner/` → `packages/heartbeat/`.
-2. Per-elder runner inside elder container, package rename `packages/elder-runtime/` → `packages/runner/`.
-3. Reset = kill-tmux + spawn-fresh + `claude` no `--continue` + inject first-tick. NOT `/clear`.
-4. Recovery = same flow + `claude --continue`.
-5. Cockpit UI animation overlays the ttyd disconnect window during reset.
+Liam-locked from 2026-05-23 design conversation + DA r2 fix-round triage. Do not re-litigate.
+
+**Architecture (20 from session 1):**
+
+1. Heartbeat container = dumb chain submitter, `packages/runner/` → `packages/heartbeat/`.
+2. Per-elder runner inside elder container, `packages/elder-runtime/` → `packages/runner/`.
+3. Reset = kill-tmux + spawn-fresh + `claude` no-`--continue` + inject first-tick template.
+4. Recovery = same + `claude --continue`.
+5. Cockpit UI animation during ttyd disconnect window.
 6. Per-elder branding via `/rename` + `/color` CC TUI slash commands keyed off `ELDER_ID`.
-7. Game settings = read-once at boot, cached, immutable. Restart-all to change.
+7. Game settings = read-once at boot, cached, immutable, restart-all to change.
 8. Drift detection = piggyback on per-tick read, panic on drift.
-9. Runner reacts to tick number only. Queries Convex auxiliary tables per tick for event-driven template inputs (Option B — business logic in runner, not indexer).
-10. Prompt templates on disk under `agents/shared/runner/prompts/`. Numbered prefix = alphabetical = priority. Concat multiple when applicable.
-11. Message format = `tick: <N>` + optional `<world_update name="...">...</world_update>` wraps.
-12. Two-phase commit = runner writes `tickSendLog` before paste, `UserPromptSubmit` hook writes `tickReceiveLog` after landing.
-13. Restart trust = `tickReceiveLog` is authoritative. Re-send when sent-but-not-received (Option B). Double-paste harmless.
-14. Memory-wipe-in-gap = SPECIAL CASE kill-tmux fresh launch with post-memory-wipe template (Option A).
-15. One-claude-per-container = defensive fail-loud check at runner boot. No pgrep+pkill (Option B).
-16. Tick backlog collapses into restart logic (same code path).
+9. Runner reacts to tick number only, queries Convex auxiliary tables per tick (Option B — business logic in runner).
+10. Prompt templates on disk at `agents/shared/runner/prompts/`, numbered prefix alphabetical, concat multiple.
+11. Message format = `tick: N` + section-based with `---` separators (replaces XML wrap).
+12. Two-phase commit = runner writes `tickSendLog` before paste, hook writes `tickReceiveLog` after landing.
+13. Restart trust = `tickReceiveLog` is authoritative. Re-send when sent-but-not-received.
+14. Memory-wipe-in-gap = special-case kill-tmux fresh launch + post-memory-wipe template.
+15. One-claude-per-container = defensive fail-loud check at runner boot.
+16. Tick backlog collapses into restart logic.
 17. Reset event logging = observability only, never gates tick processing.
-18. Admin + user message injection IS in Bundle 4 scope. Same `pendingMessages` table, separate trigger from ticks.
-19. Late-join (operator brings up new elder mid-game) reuses `07_post_memory_wipe.md` template.
-20. Container healthcheck = three-part: runner alive + tmux alive + exactly one claude alive.
+18. Admin + user message injection in Bundle 4 scope via `pendingMessages` table.
+19. Late-join reuses `07_post_memory_wipe.md` template.
+20. Container healthcheck = three-part: runner + tmux + claude alive.
+
+**DA r2 fix-round decisions (session 2):**
+
+21. Thematic UUIDs: 6 generators in shared pool, random selection per ID, 3 themed words + 4-hex suffix, collision-check before commit. Message type via DB column + envelope prefix, not via UID pattern.
+22. Reset two-phase commit: reset injection uses same `tickSendLog`/`tickReceiveLog` pipeline + reset metadata fields.
+23. Restart 5-case state table: A no-op, B fresh send, C re-send, D kill-tmux post-wipe special case, E fast-forward.
+24. `00_game_start.md` separate from `07_post_memory_wipe.md`. Tick 0 = game start. Memory-wipe tick = post-wipe template fires first.
+25. `/api/admin/` route namespace + Clerk auth for dev-UI. Never ship BUS_OPERATOR_SECRET to client.
+26. `last_wipe_tick` marker on disk prevents `claude --continue` from resurrecting pre-wipe memory.
+27. Local `flock` at runner startup (`/var/run/elder-runner.lock`), defense in depth alongside one-claude check.
+28. NO pendingMessages atomic claim (rejected — over-engineering). Double-paste on admin messages accepted.
+29. NO unique key on tickSendLog/tickReceiveLog (rejected — forensic concern, not correctness).
+30. Resend cap 3 with HOOK_FAILURE alert (replaces active hook self-test).
+31. Paste verification layer: pre-paste readiness probe + post-paste stuck-input detection with Enter retry.
+32. UserPromptSubmit hook = POSITIVE filter (allowlist). Only writes for `tick:`/`whisper:`/`special-msg:` prefixes.
+33. Convex outage handling: separate from elder health. Retry with backoff in runner. Healthcheck local-only. Don't exit on Convex error.
+34. Hooks language = Python 3.11+. Pinned deps in `requirements.txt`. Dependabot scanning. Include `convex==0.7.0` as the first dep to set the example for future agents.
+
+## Open items for DA round 3 (light pass)
+
+Most concerns from DA r2 are now addressed. The DA r3 dispatch should focus on:
+
+- Verify the 6 sub-PR boundaries are clean (no cross-PR dependencies missed).
+- Check the runnerEvents kind enum is comprehensive.
+- Validate the `last_wipe_tick` marker placement (`/var/run/` is tmpfs; need persistent volume? Or accept that mid-reset crash = fresh wipe anyway is OK?).
+- Audit Clerk integration assumption (does the dev-UI already have a Clerk account/setup, or is this Bundle-4 net-new?).
+- Test plan completeness against the 9 listed scenarios.
+
+DA r3 is expected to be a SHOULD-RESOLVE-level pass — no CRITICAL findings expected.

--- a/docs/design/bundle-4-simplified-communications.md
+++ b/docs/design/bundle-4-simplified-communications.md
@@ -1,0 +1,248 @@
+# Bundle 4 — Simplified Communications Architecture
+
+Design doc capturing the runner/elder/supervisor refactor that follows Bundle 2 + 3 dockerize migration. Replaces the over-engineered command bus with a thin message-injection layer plus hook-based liveness plus tick-driven resets.
+
+**Status:** Draft for review (2026-05-22 ~15:10 ET). Source of design points: Liam voice messages 16646 through 16720.
+
+## Motivation
+
+The current command bus (Bundle 2 PR #542 + Bundle 3 PR #549) ships a distributed-durable-queue design with lease management, ack/complete/fail state machines, sweep crons, and retry semantics. It was built assuming elders are unreliable and might die mid-command.
+
+Liam's design intent is the opposite: elders are responsible for their own resilience, resets are intentionally jarring, and the runner uses fire-and-forget messaging into elder tmux sessions. The Claude Code harness already queues stdin properly so we don't need a separate queue layer.
+
+Bundle 4 strips the queue/lease/retry/sweep machinery and replaces it with the simpler shape below.
+
+## Communications taxonomy — eight categories
+
+Every cross-process interaction in the system falls into one of these:
+
+1. **Game state read** — elder calls Convex queries or chain reads to learn world state (vault, clansmen, missions, world tick).
+2. **Game state write** — elder submits orders to the contract via their own private key. On-chain transaction.
+3. **Communications read** — elder reads private whispers from other elders + public bulletin board entries. Convex queries.
+4. **Communications write** — elder writes whispers to specific elders + posts to bulletin board. Convex mutations.
+5. **Owner whispers** — Liam (or whoever owns the agent) injects arbitrary text into a specific elder's context. Goes through the admin-inject path.
+6. **Runner world messages** — per-tick world snapshot, memory-wipe-incoming warnings (no longer requires ack), post-reset re-orientation. Injected by runner.
+7. **Control plane** — process-level control: reset, restart-supervisor, kill-and-recreate. Not user-visible to elder. Tick-driven for reset; supervisor-managed for restarts.
+8. **Liveness/observability** — `PostToolUse` hook posts to Convex on every Claude tool call. Elder is unaware. Operator/dashboard queries the resulting log for "last activity" + "tool-use rate per tick" signals.
+
+Categories 1-4 go through the elder CLI (already exists). Categories 5-6 go through a new thin message-injection layer described below. Category 7 is process control (no user-visible API). Category 8 is hooks-only.
+
+## The message-injection layer
+
+**Single operation:** "inject text into elder N's tmux session."
+
+Two writers: the runner (during tick injection) and the admin dev-UI (for R&D experimentation).
+
+### Convex table
+
+```typescript
+// pendingMessages
+{
+  _id: Id<"pendingMessages">,
+  targetElderId: "elder-1" | "elder-2" | "elder-3" | "elder-4",
+  text: string,
+  insertedAt: number,
+  source: "runner" | "admin-injection",
+}
+```
+
+That's the whole schema. No status, no lease, no retry count.
+
+### Runner-side write
+
+Per tick, runner calls a Convex mutation `enqueueElderMessage` with the tick's world snapshot text targeted at each living elder. One row per (elder, tick).
+
+For the mod-N reset tick, the runner instead writes a structured reset payload (see "Reset workflow" below).
+
+### Admin dev-UI write
+
+Dev-UI calls the same `enqueueElderMessage` mutation with `source: "admin-injection"` and an operator-supplied text. Selects target elders via checkbox or per-elder field.
+
+### Supervisor-side read
+
+Inside each elder container, the supervisor polls `pendingMessages` filtered by its own elder ID. For each pending row, in `insertedAt` ASC order:
+
+1. Read the row.
+2. Paste the text into the local tmux session targeting the Claude pane.
+3. Delete the row.
+
+No lease. No ack. No retry. If the supervisor crashes between read and paste, the row sits in the table until the supervisor restarts and picks it up. If the supervisor pastes successfully but crashes before delete, the next poll will paste the same row again — operator should design messages to be safely idempotent at the elder layer (typically a no-op since the elder reads world state fresh each turn anyway).
+
+### What this discards from Bundle 2 + 3
+
+- `agentCommands` table (replaced by `pendingMessages`)
+- `claimNext` / `ackCommand` / `completeCommand` / `failCommand` mutations
+- `sweepStaleDelivered` cron
+- `LEASE_MS`, `COMPLETION_GRACE_MS` constants
+- Bracketed-paste nonce protocol + supervisor scrollback grep
+- Control-verb priority pass in claimNext (reset is now process-level, not message-level)
+- `elderHeartbeat` table writes from the supervisor (replaced by hook-based liveness)
+- `elder ack-clear` CLI subcommand and the runner's await-ack flow (issue #555)
+
+### What this keeps from Bundle 2 + 3
+
+- Supervisor process inside each elder container (slimmed to a thin watchdog)
+- Tmux + ttyd lifecycle management
+- Bus secret per elder for authenticating the supervisor's Convex calls
+- Healthcheck infrastructure (Caddy + per-elder process supervision)
+- All the elder CLI surface (game read/write, comm read/write)
+
+## Liveness — PostToolUse hook
+
+Configure a `PostToolUse` hook in `agents/shared/home-claude/settings.json`. The hook fires after every Claude tool call. The hook script:
+
+1. Read tool-call metadata (tool name, timestamp) from hook stdin.
+2. Curl POST to a Convex action `recordToolUse` with `{ elderId, toolName, ts }`.
+3. Exit cleanly. Hook errors are silenced — elder must not be aware of liveness machinery.
+
+### Convex table
+
+```typescript
+// elderActivity
+{
+  _id: Id<"elderActivity">,
+  elderId: string,
+  toolName: string,
+  ts: number,
+}
+```
+
+### Liveness query
+
+```typescript
+// "is elder-N alive?"
+const lastActivity = await ctx.db
+  .query("elderActivity")
+  .withIndex("by_elder_ts", q => q.eq("elderId", "elder-1"))
+  .order("desc")
+  .first();
+
+const isAlive = lastActivity && (Date.now() - lastActivity.ts) < ALIVENESS_THRESHOLD_MS;
+```
+
+### Dashboard signals
+
+The same `elderActivity` table powers richer signals:
+
+- Tool-use frequency per elder (idle vs active)
+- Tool-type distribution (which tools are getting used)
+- Per-tick activity (how many tool calls between two `UserPromptSubmit` events from the runner's tick injection)
+
+## Reset workflow — tick-driven
+
+### Configuration
+
+A new Convex table `gameSettings` holds the reset-cadence knob.
+
+```typescript
+// gameSettings
+{
+  _id: Id<"gameSettings">,
+  resetEveryNTicks: 50, // default
+  // future: maxTick, tickIntervalMs, etc.
+}
+```
+
+### Trigger condition
+
+On each tick `T`, the runner queries `gameSettings.resetEveryNTicks` (call it `N`). If `T % N === 0`, the next tick injection becomes a reset workflow instead of a normal tick injection.
+
+### Reset workflow (per-elder, parallel)
+
+For each elder:
+
+1. **Issue Claude `/clear`** — write `/clear` into the elder's tmux pane via the supervisor. (Open question: paste as text vs send-keys. `/clear` is a Claude Code REPL command, not a tmux primitive — pasting it as text should work if the Claude pane is foreground.)
+2. **Wait for `/clear` to land** — supervisor watches session JSONL for the `system: cleared` marker or equivalent. Configurable timeout, default 10 seconds.
+3. **If `/clear` doesn't land in timeout** — supervisor escalates: kill the Claude process inside tmux, restart Claude via `claude` (no `--continue`), which gives a fresh context. Tmux session itself stays alive — ttyd terminal UX preserved, no flicker.
+4. **If kill-restart also fails** — supervisor escalates further: `exit 1` from the supervisor process, container exits, docker compose `restart: unless-stopped` brings up a fresh container.
+5. **After Claude is fresh** — runner injects the rename + color seed message, then injects the reorientation prompt: "You're in the middle of a game on tick N out of TOTAL_TICKS. Check world snapshot, recall memories, resume play."
+
+### What's NOT in the reset workflow
+
+- No graceful drain of pending messages. Any `pendingMessages` rows targeted at the elder at reset moment are LOST. Intentional — by design, the elder has to deal with the gap.
+- No elder-side ack. Runner doesn't wait for elder to confirm. Reset happens unconditionally.
+- No reset-warning message. The 60-second warning (if we keep it) is embedded as a field in the regular world-snapshot tick message: `ticksUntilWipe: 1` or similar. Elder reads it or doesn't.
+
+### Open question — does the runner inject reset directly or via supervisor?
+
+Option A: Runner has docker exec access to each elder container, writes the `/clear` itself.
+Option B: Runner writes a structured reset row to `pendingMessages` with `source: "reset"`, supervisor recognizes and executes the workflow locally.
+
+Option B is consistent with the rest of the architecture (everything routes through `pendingMessages`) but introduces a marshalled "reset" type that breaks the "just text injection" simplicity. Option A keeps `pendingMessages` purely text but requires the runner to have docker control access.
+
+**Recommended:** Option A. Runner can do `docker exec elder-N tmux send-keys ...` directly. Keeps `pendingMessages` simple. Reset is process control, separate from message injection.
+
+## Supervisor — thin watchdog
+
+Two-layer recovery:
+
+1. **Layer 1 — Claude restart inside tmux.** Supervisor monitors the Claude process. If Claude exits or hangs, supervisor kills it and restarts `claude` inside the same tmux session. Ttyd terminal UX preserved.
+2. **Layer 2 — Container restart fallback.** If Layer 1 fails N times within M minutes (e.g. 3 failures in 5 minutes), supervisor exits 1 → docker compose `restart: unless-stopped` recreates the entire container. Fresh tmux, fresh ttyd, fresh everything. Ttyd briefly disappears from the dev UI.
+
+Configurable thresholds via env vars.
+
+Beyond watchdog, the supervisor also:
+
+- Polls `pendingMessages` for its elder ID and pastes them into tmux.
+- Optionally captures snapshot scrollback on operator demand (for debugging).
+
+That's it. No bus polling, no state machine, no liveness reporting, no nonce verification.
+
+## Admin dev-UI injection
+
+A new dev-UI panel allows the operator to:
+
+- Select target elders (checkboxes for elder-1..N or "all")
+- Write arbitrary text in a textarea
+- Click "Inject" — fires a Convex mutation `enqueueElderMessage` with `source: "admin-injection"` per selected elder
+
+Use cases: R&D experimentation, prompting an elder with a specific scenario while watching gameplay, sending "you are now in a debug session" cues during dev.
+
+## What goes to issue trackers
+
+Bundle 4 PR will include:
+
+- `apps/server/convex/commandBus.ts` — strip queue/lease/sweep code, leave only `enqueueElderMessage` mutation + `recordToolUse` action + liveness query helpers
+- `apps/server/convex/schema.ts` — drop `agentCommands`, add `pendingMessages` + `elderActivity` + `gameSettings`
+- `packages/elder-runtime/` — strip bus polling logic, slim to watchdog + paste loop
+- `agents/shared/home-claude/settings.json` — add PostToolUse hook config
+- `agents/shared/home-claude/hooks/post-tool-use.sh` — new hook script
+- `packages/runner/` — add tick-driven reset trigger, replace user-message dispatch with `enqueueElderMessage`
+- Reset workflow — runner-side docker-exec dispatch (Option A)
+- `agents/shared/home-claude/CLAUDE.md` — remove ack-clear cheat-sheet entry, simplify memory-wipe cycle docs
+- `agents/shared/APPENDED_SYSTEM_PROMPT.md` — same
+- Tests — full review for tech debt; existing tests on the queue machinery get deleted, new tests on the simpler shape get added
+
+Separate (after Bundle 4):
+
+- Issue #555 — remove `elder ack-clear` from elder CLI in `packages/agents/`
+- Dev UI panel for admin injection (separate PR in `apps/web/`)
+
+## Open questions
+
+1. **Two pending messages for one elder — batch-paste or serialize?** Recommend serialize (one-at-a-time in insertedAt order) because Claude Code already handles stdin queuing properly. Batching would just inject extra `--- next message ---` separators that are noise.
+2. **Admin-inject rate limiting?** Probably not needed in v1. Operator is the only authorized writer to that source, and abuse from operator is operator's problem.
+3. **Liveness threshold default?** Recommend 5 minutes — elders take long Claude turns occasionally (especially during complex strategy planning), so a 30-second threshold would false-positive. 5 minutes catches dead elders without flapping.
+4. **Hook failure handling?** PostToolUse hook posts to Convex via curl. If Convex is down, the hook should fail silent so elder is unaware. Worst-case effect: liveness signal drops until Convex returns. Acceptable.
+5. **Bundle 4 vs separate ack-clear PR ordering?** Bundle 4 can land first; ack-clear is in a different package (`packages/agents/`) outside the dockerize migration scope. Sequence: Bundle 4 → ack-clear PR.
+
+## Release plan
+
+**Option A (preferred):** Ship Bundle 2 + Bundle 3 release PRs to dev as they are. Open Bundle 4 immediately on top of dev. Pros: ships working code now, no rebase pain. Cons: dev briefly contains the over-engineered queue before Bundle 4 strips it.
+
+**Option B:** Hold Bundle 2 release PR, rewrite the queue parts of PR #542 on the new shape, ship Bundle 2 with the simpler design from the start. Pros: never ships the over-engineered version. Cons: significant rework of Bundle 2 PR #542's design, weeks of delay.
+
+Liam's call (voice 16713): Option A. Watch closely for tech debt in the test files during Bundle 4 — the queue-machinery tests need to be deleted cleanly, not left as dead helpers.
+
+## Verification before Bundle 4 lands
+
+- Codex DA round on this design doc to catch architectural gaps before code lands
+- 3-tier swarm review on the Bundle 4 PR
+- Manual smoke test once stack is up: admin-inject a message, see it land in elder tmux, see the elder respond, see the PostToolUse hook fire and record activity in Convex
+- Reset workflow smoke: force a tick to be `T % N === 0`, observe `/clear` landing, observe reorientation message, observe elder picking up
+
+## Mental model summary
+
+The system becomes: "elders play the game by themselves; the only inbound channel from the operator is text injection; the only outbound signal the operator can read is the hook-driven tool-use log; the runner manages tick + reset cadence deterministically from world tick number."
+
+Elders are autonomous, harshly time-bound, and have to be strategic about their own state preservation. The infrastructure is dumb fire-and-forget plumbing.


### PR DESCRIPTION
## Summary

Captures the design refinements from Liam's 2026-05-22 voice messages 16646 through 16720. Bundle 4 will strip the over-engineered command bus queue/lease/sweep machinery and replace it with a thin message-injection layer plus hook-based liveness plus tick-driven resets.

This PR adds the **draft design doc only** — no code changes. Bundle 4 implementation lands in subsequent PRs after the design is reviewed and the open questions are resolved.

## What's in the doc

- **Motivation** — why the current bus is over-engineered for Liam's actual use case
- **8-category communications taxonomy** — game read/write, comm read/write, owner whispers, runner world messages, control plane, liveness
- **pendingMessages table** + admin-inject path for dev UI
- **PostToolUse hook**-based liveness (replaces elder self-reporting via heartbeat writes)
- **Tick-driven reset workflow** — runner sees `tick % N === 0` from gameSettings, fires reset locally
- **2-layer supervisor recovery** — kill Claude inside tmux first, docker restart as fallback
- **What goes** (queue/lease/sweep/retry/nonce) vs **what stays** (supervisor watchdog, tmux+ttyd, bus secret) from Bundle 2/3
- **5 open questions** for review before Bundle 4 coding begins
- **Bundle 4 scope sketch** + release plan (Option A — ship Bundle 2/3 first, then strip via Bundle 4)

## Status

**Draft for review.** Pairs with codex DA round dispatched in parallel — DA findings will get woven back in before Bundle 4 implementation begins.

## Related

- Issue #555 (remove elder ack-clear) — Bundle 4 picks up after this lands as a separate PR
- PRs being closed in walkthrough today: #409, #412, #414, #415, #416, #418, #419 (and #420 + #421 in progress)
- Bundle 2 release PR: #552 (will ship the over-engineered baseline that Bundle 4 strips)
- Bundle 3 release PR: #553 (final polish layered on top)

🤖 Generated with [Claude Code](https://claude.com/claude-code)