### PR TITLE
fix(bundle3): Copilot cloud-review on agents/Makefile + migration runbook

### DIFF
--- a/agents/Makefile
+++ b/agents/Makefile
@@ -85,7 +85,7 @@ help:
 	@echo "BOOTSTRAP (one-time per stack - re-run with FORCE=1 to overwrite)"
 	@echo "  bootstrap-convex-admin-key     generate + persist Convex admin key (chmod 0600)"
 	@echo "  bootstrap-bus-secrets          generate bus/webhook secrets and set Convex BUS_* envs"
-	@echo "  bootstrap-convex-dashboard-auth generate basic-auth credentials for dashboard"
+	@echo "  bootstrap-convex-dashboard-auth generate reserved dashboard auth credentials"
 	@echo "  oauth-bootstrap                walk every elder through OAuth flow"
 	@echo "  oauth-bootstrap-elder-1        single-elder OAuth flow"
 	@echo ""
@@ -136,14 +136,19 @@ up: confirm-banner
 down:
 	$(DC) down
 
-status:
-	@$(DC) ps
+status: check-profile
+	@$(DC) --profile $(PROFILE) ps
 	@echo "---"
 	@for e in $(ELDERS); do \
+		$(DC) --profile $(PROFILE) ps $$e; \
 		echo -n "$$e tmux:       "; \
-		$(DC) exec -T $$e tmux ls 2>/dev/null | head -1 || echo DEAD; \
+		if $(DC) --profile $(PROFILE) exec -T $$e tmux has-session -t $$e 2>/dev/null; then \
+			echo OK; \
+		else \
+			echo "WARN session missing"; \
+		fi; \
 		echo -n "$$e supervisor: "; \
-		$(DC) exec -T $$e pgrep -f 'tsx.*elder-runtime/src/main.ts' > /dev/null 2>&1 \
+		$(DC) --profile $(PROFILE) exec -T $$e pgrep -f 'tsx.*elder-runtime/src/main.ts' > /dev/null 2>&1 \
 			&& echo OK || echo DEAD; \
 	done
 
@@ -284,6 +289,9 @@ bootstrap-bus-secrets:
 	echo "[bootstrap] File generation is idempotent, and Convex env sets are independent."; \
 	echo "[bootstrap] Verify all BUS_* and WEBHOOK_SHARED_SECRET values with: npx convex@$(CONVEX_CLI_PINNED_VERSION) env list"
 
+# No current compose/Caddy consumer reads this JSON; it is reserved for future
+# dashboard-local auth wiring. Do not pass password_sha512crypt to Caddy
+# basicauth; Caddy would require a bcrypt hash from `caddy hash-password`.
 bootstrap-convex-dashboard-auth:
 	@mkdir -p $(REPO_ROOT)/agents/secrets
 	@chmod 0700 $(REPO_ROOT)/agents/secrets

--- a/docs/runbooks/dockerize-migration-v1.md
+++ b/docs/runbooks/dockerize-migration-v1.md
@@ -64,7 +64,8 @@ Keep this export active before running `make deploy-convex` or
 
 ## Existing Make Targets
 
-These are the root targets that exist in this branch:
+These root targets exist in this branch for Convex deployment, schema import,
+backups, and broad stack checks:
 
 ```bash
 make bootstrap-convex-admin-key PROFILE=dev
@@ -75,9 +76,34 @@ make check-stack-health
 make reset-anvil
 ```
 
-Do not use older `agents/Makefile` examples for this migration. Targets such as
-`up`, `down`, `smoke-test`, bus-secret bootstrap, OAuth bootstrap, and Caddy
-snippet install/check are not present in this branch.
+The elder infrastructure operator entrypoint is also present at
+`agents/Makefile`. Use it for profile-scoped lifecycle and bootstrap work:
+
+```bash
+make -C agents setup PROFILE=dev|prod
+make -C agents up PROFILE=dev|prod
+make -C agents down
+make -C agents status PROFILE=dev|prod
+make -C agents logs ELDER=elder-2
+make -C agents smoke-test
+make -C agents build PROFILE=dev|prod
+make -C agents bootstrap-convex-admin-key PROFILE=dev|prod
+make -C agents bootstrap-bus-secrets PROFILE=dev|prod
+make -C agents bootstrap-convex-dashboard-auth
+make -C agents oauth-bootstrap
+make -C agents oauth-bootstrap-elder-1
+make -C agents pause
+make -C agents unpause
+make -C agents pause-heartbeat
+make -C agents unpause-heartbeat
+make -C agents reset-elder-3
+make -C agents restart-elder-3
+make -C agents wipe-elder-3 LEVEL=session
+make -C agents reset-anvil PROFILE=dev
+make -C agents link-mounts
+```
+
+Caddy snippet install/check remains outside `agents/Makefile` in this branch.
 
 ## Required Environment
 


### PR DESCRIPTION
## Summary

Addresses 3 Copilot cloud-review findings on PR #553 (Bundle 3 release PR).

## Findings + fixes

**M-1 (agents/Makefile `status` target):** Used `tmux ls` which produced false positives when ANY tmux session existed, even if the expected elder session was missing. Fixed: status now requires PROFILE + uses `docker compose --profile X exec elder-N tmux has-session -t elder-N` per-elder. Reports presence/absence per elder explicitly.

**M-2 (agents/Makefile `bootstrap-convex-dashboard-auth`):** Copilot flagged SHA-512-crypt as wrong (Caddy basicauth expects bcrypt). Investigation found no current consumer of `convex-dashboard-auth.json` — this is custom Convex dashboard auth (not Caddy basicauth). Added doc comment explaining intent + that the format choice is intentional pending future dashboard-image wiring. No code change to the hash itself.

**L-1 (docs/runbooks/dockerize-migration-v1.md):** Stale runbook section claimed `agents/Makefile targets are not present in this branch` — but Bundle 3 PR #548 added it. Updated to list the actual available targets.

## Test plan

- [x] `make -C agents help` — passes
- [x] `make -C agents -n status PROFILE=dev` — dry-run shows per-elder check
- [x] `git diff --check` — passes
- [x] Stale-doc grep clean
- [ ] Merge to dev-phase-3-final-polish before Bundle 3 release PR #553 merges

## Refs

- Cloud-review survey at 2026-05-22 ~16:25 ET (Liam voice 16780)
- Bundle 3 release PR #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)