### PR TITLE
fix(bundle2): Copilot cloud-review — singleton race + UTF-8 MAX_BYTES + doc mismatches

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -92,11 +92,9 @@ ENV HOME=/home/elder
 ENV CLAUDE_CONFIG_DIR=/home/elder/.claude
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# Healthcheck — v1 elder claude process alive. Tmux + ttyd are installed in the
-# image but NOT started by entrypoint.sh / run.sh in v1 (those are #353 Phase
-# 1.9 supervisor scope). The compose-level healthcheck on each elder-N service
-# block matches this image-level default; when #353 lands, both will tighten
-# to also verify the supervisor process + ttyd port 7681 .
+# Healthcheck — v1 elder claude process alive. entrypoint.sh / run.sh also
+# start ttyd, tmux, and the elder-runtime supervisor; compose-level healthchecks
+# on each elder-N service verify those process/port details.
 #
 # `pgrep claude` (without -f) matches by comm name only, so the healthcheck's
 # own shell command line doesn't self-match — `pgrep -f 'claude --'` would

--- a/agents/README.md
+++ b/agents/README.md
@@ -38,7 +38,7 @@ agents/
 
 ## Dev workflow
 
-1. Copy each `elder-N/.env.template` → `elder-N/.env`, fill in `ANTHROPIC_OAUTH_TOKEN` and `BUS_ELDER_SECRET`.
+1. Copy each `elder-N/.env.template` → `elder-N/.env`, fill in `CLAUDE_CODE_OAUTH_TOKEN` and `BUS_ELDER_SECRET`.
 2. `make up` — bring up all 4 elder containers + supporting services.
 3. `make status` — see container + tmux + plugin states.
 4. `make logs ELDER=elder-2` — tail one elder's run.sh + claude output.

--- a/agents/elder
+++ b/agents/elder
@@ -3,17 +3,17 @@
 #
 # Phase 1.2 of docs/plans/dockerize-elder-infra-v1.md.
 #
-# This is a placeholder. The real elder CLI (chain reads via `cast`,
-# Convex command-bus interaction, snapshot ingestion, etc.) is scoped to a
-# later issue. For v1 we ship a stub so the entrypoint test
+# This is a placeholder. The real elder CLI (chain reads, Convex command-bus
+# interaction, snapshot ingestion, etc.) is scoped to a later issue. For v1
+# we ship a stub so the entrypoint test
 # `which elder` resolves and downstream phases can wire calls without
 # blocking on the CLI implementation.
 
 cat >&2 <<'EOF'
 elder CLI not yet implemented — this is a v1 stub.
 
-Use the MCP tools or `cast` directly for chain interactions until the
-elder CLI is filled in. Tracking issue: TBD (Phase 2+ scope).
+Use only elder CLI subcommands for game interactions once they are available.
+Tracking issue: TBD (Phase 2+ scope).
 EOF
 
 exit 0

--- a/agents/shared/APPENDED_SYSTEM_PROMPT.md
+++ b/agents/shared/APPENDED_SYSTEM_PROMPT.md
@@ -35,7 +35,7 @@ You interact with ClanWorld exclusively through the `elder` CLI. See your shared
 
 ## Convex command bus (Phase 1.8+)
 
-In addition to ticks, you may receive `user_message` or `system_message` injections from the orchestrator (Liam or another supervisor) via the Convex command bus. These appear in your transcript like any other user message. Respond as you would to Liam directly. The bus delivery is at-most-once with leasing; if you see the same message twice, ack the second and continue.
+In addition to ticks, you may receive `user_message` or `system_message` injections from the orchestrator (Liam or another supervisor) via the Convex command bus. These appear in your transcript like any other user message. Respond as you would to Liam directly. The bus delivery is at-least-once with leasing and deduplication by `commandId`; if you see the same message twice, ack the second and continue.
 
 ## Tick discipline
 

--- a/agents/shared/run.sh
+++ b/agents/shared/run.sh
@@ -7,7 +7,7 @@
 #
 # Responsibilities:
 #   1. Validate required per-elder env vars (CLAUDE_CODE_OAUTH_TOKEN, ELDER_ID,
-#      CLAN_ID, BUS_ELDER_SECRET). Fail loud on missing — fail closed.
+#      CLAN_ID). Fail loud on missing identity/auth — fail closed.
 #   2. Bootstrap shared symlinks into /home/elder/.claude/ on first start so
 #      settings.json + CLAUDE.md + skills/ resolve to the host-authored versions.
 #   3. Detect whether a previous CC conversation exists for this CWD.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -266,7 +266,7 @@ services:
     # so the elder's Bash tool cannot `cat /agent/.env`. `required: false` keeps
     # `docker compose config` parseable in CI before operators run
     # `make bootstrap-elder-envs`; the elder container will fail loudly at startup
-    # if ANTHROPIC_OAUTH_TOKEN is empty (run.sh / claude CLI auth refusal).
+    # if CLAUDE_CODE_OAUTH_TOKEN is empty (run.sh / claude CLI auth refusal).
     env_file:
       - path: ./agents/elder-1/.env
         required: false

--- a/packages/elder-runtime/src/commandHandlers/snapshotRequest.ts
+++ b/packages/elder-runtime/src/commandHandlers/snapshotRequest.ts
@@ -2,6 +2,20 @@ import fs from "node:fs";
 import type { BusClient } from "../convexClient.js";
 import type { ElderRuntimeConfig } from "../types.js";
 
+function sliceUtf8Bytes(value: string, maxBytes: number): string {
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(value.slice(0, mid), "utf8") <= maxBytes) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return value.slice(0, low);
+}
+
 export async function handleSnapshotRequest(
   commandId: string,
   _payload: unknown,
@@ -17,8 +31,10 @@ export async function handleSnapshotRequest(
     snapshot = "[ANCIENT_WISDOM.md not found]";
   }
   const MAX_BYTES = 50_000;
-  if (snapshot.length > MAX_BYTES) {
-    snapshot = snapshot.slice(0, MAX_BYTES) + "\n[TRUNCATED: snapshot exceeded 50 KB cap]";
+  const TRUNCATED_SUFFIX = "\n[TRUNCATED: snapshot exceeded 50 KB cap]";
+  if (Buffer.byteLength(snapshot, "utf8") > MAX_BYTES) {
+    const suffixBytes = Buffer.byteLength(TRUNCATED_SUFFIX, "utf8");
+    snapshot = sliceUtf8Bytes(snapshot, MAX_BYTES - suffixBytes) + TRUNCATED_SUFFIX;
   }
   await bus.completeCommand(commandId, { snapshot }, Date.now() - startMs);
 }

--- a/packages/elder-runtime/src/main.ts
+++ b/packages/elder-runtime/src/main.ts
@@ -71,7 +71,6 @@ async function main(): Promise<void> {
     try { closeSync(lockFd); } catch { /* ignore */ }
     try { unlinkSync(lockPath); } catch { /* ignore */ }
   };
-  process.on("exit", cleanupLock);
 
   // Write readiness file to writable stateDir — entrypoint polls for this
   const readyPath = path.join(config.stateDir, "elder-runtime.ready");
@@ -87,8 +86,8 @@ async function main(): Promise<void> {
   const freeze = new FreezeGate();
 
   const ac = new AbortController();
-  process.on("SIGTERM", () => { cleanupLock(); ac.abort(); });
-  process.on("SIGINT", () => { cleanupLock(); ac.abort(); });
+  process.on("SIGTERM", () => { ac.abort(); });
+  process.on("SIGINT", () => { ac.abort(); });
 
   const heartbeatState: HeartbeatState = {
     lastTickProcessed: 0,
@@ -146,6 +145,7 @@ async function main(): Promise<void> {
       await new Promise(r => setTimeout(r, config.pollIntervalMs));
     }
   }
+  cleanupLock();
   console.log(`[elder-runtime] shutdown complete`);
 }
 


### PR DESCRIPTION
## Summary

Addresses 7 Copilot cloud-review findings on PR #552 (Bundle 2 release PR). Two HIGH correctness bugs + 5 doc/comment mismatches.

## HIGH

**Singleton lock race (`packages/elder-runtime/src/main.ts`):** SIGTERM/SIGINT handlers called `cleanupLock()` immediately, leaving a window where lock was gone but supervisor was still polling. Concurrent supervisor could start. Fixed: handlers only abort; cleanupLock() runs after poll loop exits.

**UTF-8 MAX_BYTES (`packages/elder-runtime/src/commandHandlers/snapshotRequest.ts`):** size check used `snapshot.length` (UTF-16 code units) not bytes. Multibyte payloads exceeded cap. Fixed: `Buffer.byteLength(snapshot, "utf8")`, truncation sized to fit final payload.

## MEDIUM (doc/comment vs code mismatches)

- `agents/Dockerfile` HEALTHCHECK comment said tmux/ttyd/supervisor NOT started — they are now via entrypoint
- `docker-compose.yml` comment referenced `ANTHROPIC_OAUTH_TOKEN`; validation uses `CLAUDE_CODE_OAUTH_TOKEN`
- `agents/shared/run.sh` header listed wrong required env vars
- `agents/shared/APPENDED_SYSTEM_PROMPT.md` said "at-most-once with leasing"; effectively at-least-once with commandId dedup
- `agents/elder` stub recommended `cast` but settings.json deny list blocks it
- `agents/README.md` matched OAuth var name fix

## Test plan

- [x] `git diff --check` — passes
- [x] `bash -n agents/elder` + `bash -n agents/shared/run.sh` — passes
- [x] `snapshot.length` grep — clean (replaced with `Buffer.byteLength`)
- [x] Stale-strings scan — clean
- [ ] `pnpm typecheck` — not runnable locally (no node_modules); CI gates
- [ ] Merge to dev-containerize-agents before Bundle 2 release PR #552 merges

## Note: Bundle 4 scope overlap

Bundle 4 (design doc PR #556) will significantly simplify the elder-runtime supervisor — potentially removing the entire bus-polling code path including the singleton-lock semantics. These fixes are still worth landing because Bundle 2 ships first per Liam's Option A release plan, and the over-engineered baseline should at least be CORRECT until Bundle 4 strips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)