### PR TITLE
fix(bundle1): Copilot cloud-review — heartbeat doc/code + Viem import isolation + anvil runbook

### DIFF
--- a/agents/heartbeat/README.md
+++ b/agents/heartbeat/README.md
@@ -52,8 +52,8 @@ compose `anvil-fork` service and viem's `baseSepolia` chain config.
 
 The compose healthcheck reads `/tmp/last-heartbeat-success` (path configurable
 via `HEARTBEAT_SUCCESS_FILE_OVERRIDE`). The runner writes the current Unix timestamp
-there after either (a) a confirmed heartbeat transaction with a successful
-webhook POST, OR (b) the receipt-timeout recovery path when on-chain
+there after either (a) a confirmed heartbeat transaction, OR (b) the
+receipt-timeout recovery path when on-chain
 `nextHeartbeatAtTs` is observed to have advanced (no confirmed receipt, no
 webhook POST). The marker indicates the scheduler is making forward progress,
 NOT that the most recent transaction was confirmed end-to-end. A timestamp

--- a/docs/runbooks/anvil-fork-dev-rpc.md
+++ b/docs/runbooks/anvil-fork-dev-rpc.md
@@ -92,7 +92,7 @@ docker compose --profile dev restart anvil-fork
 
 After a restart, dev txs you submitted before the restart are still in chain state. You only lose the last <60s of activity (whatever happened between the most recent state dump and the restart).
 
-To inspect the volume from the host (read-only snapshot pattern — see `agents/Makefile` `link-mounts` for the canonical helper-container approach):
+To inspect the volume from the host with a read-only helper container:
 
 ```bash
 docker run --rm -v clan-world_anvil_data:/data:ro busybox ls -lh /data
@@ -103,16 +103,18 @@ docker run --rm -v clan-world_anvil_data:/data:ro busybox ls -lh /data
 Use this when fork state has drifted too far from real Base Sepolia, or when you want a fresh fork pinned to a new `FORK_BLOCK_NUMBER`.
 
 ```bash
-make -C agents reset-anvil PROFILE=dev
+make reset-anvil PROFILE=dev
 ```
 
-What that does (`agents/Makefile`):
+What that does (root `Makefile`):
 
 1. `docker compose --profile dev stop anvil-fork`
 2. `docker volume rm clan-world_anvil_data`
 3. `docker compose --profile dev up -d anvil-fork` — re-forks from `RPC_URL_PRIMARY` at `FORK_BLOCK_NUMBER`
 
 The Makefile target fails loud if `PROFILE` is unset or `PROFILE=prod` — the named volume `clan-world_anvil_data` should not exist in prod, but the guard is there as a safety net.
+
+After Bundle 3 lands, the per-elder `agents/Makefile` workflow can invoke this as `make -C agents reset-anvil`.
 
 When to reset:
 
@@ -134,7 +136,7 @@ Most common cause: `RPC_URL_PRIMARY` is unset, malformed, or rate-limited. Check
 docker compose --profile dev logs anvil-fork | tail -50
 ```
 
-Look for "fork URL" or "401 Unauthorized" or "429 Too Many Requests". Fix `RPC_URL_PRIMARY` in `.env.local` (e.g. swap to an Alchemy key with quota left), then `make -C agents reset-anvil PROFILE=dev`.
+Look for "fork URL" or "401 Unauthorized" or "429 Too Many Requests". Fix `RPC_URL_PRIMARY` in `.env.local` (e.g. swap to an Alchemy key with quota left), then `make reset-anvil PROFILE=dev`.
 
 ### "fork block not available" / "header not found"
 
@@ -144,7 +146,7 @@ Look for "fork URL" or "401 Unauthorized" or "429 Too Many Requests". Fix `RPC_U
 - Pick a more recent block from `cast block-number --rpc-url "$RPC_URL_PRIMARY"`, or
 - Swap to an archive RPC (Alchemy growth tier, QuickNode, etc).
 
-Then `make -C agents reset-anvil PROFILE=dev`.
+Then `make reset-anvil PROFILE=dev`.
 
 ### App side reports chain-ID mismatch
 
@@ -152,7 +154,7 @@ The heartbeat container's preflight asserts the observed chain ID matches `CHAIN
 
 - Confirm the compose `command:` block still passes `--chain-id=84532` (someone may have overridden it locally).
 - Confirm `CHAIN_NETWORK=dev` (not `prod`) in `.env.local`.
-- Reset the fork (`make -C agents reset-anvil PROFILE=dev`) to drop any state from a wrong-chain-id run.
+- Reset the fork (`make reset-anvil PROFILE=dev`) to drop any state from a wrong-chain-id run.
 
 ### Healthcheck flapping but RPC responds
 
@@ -162,6 +164,6 @@ The healthcheck uses `cast chain-id --rpc-url http://localhost:8545` with a 5s t
 
 - `docs/runbooks/fresh-vps-bootstrap.md` — full VPS bring-up; prod stack uses real Base Sepolia, not anvil-fork.
 - `docs/runbooks/soft-game-reset.md` — mid-season recovery flow; on dev profile, anvil-fork is the RPC the recovery txs hit.
-- `agents/Makefile` — `reset-anvil`, `up PROFILE=dev`, `down`, `status`, `link-mounts`.
+- `Makefile` — `reset-anvil`.
 - `docker-compose.yml` — `anvil-fork:` service definition.
 - `.env.template` — `RPC_URL_PRIMARY`, `FORK_BLOCK_NUMBER`, `DEV_RPC_URL`.

--- a/packages/runner/src/heartbeatScheduler.ts
+++ b/packages/runner/src/heartbeatScheduler.ts
@@ -1,6 +1,6 @@
 import { HeartbeatRateLimitedError, type IHeartbeatCaller } from '@clan-world/agents/seams';
 import type { IConvexClient, RunnerStatusUpdate } from '@clan-world/shared/adapters';
-import { writeHeartbeatSuccessFile } from './runnerCastHeartbeat';
+import { writeHeartbeatSuccessFile } from './heartbeatSuccessFile';
 import { sendTelegramAlert } from './telegramAlert';
 
 export type HeartbeatFireResult = RunnerStatusUpdate['lastFireResult'];

--- a/packages/runner/src/heartbeatSuccessFile.ts
+++ b/packages/runner/src/heartbeatSuccessFile.ts
@@ -1,0 +1,16 @@
+import { renameSync, writeFileSync } from 'node:fs';
+
+const DEFAULT_HEARTBEAT_SUCCESS_FILE = '/tmp/last-heartbeat-success';
+
+export function writeHeartbeatSuccessFile(
+  successFile =
+    process.env['HEARTBEAT_SUCCESS_FILE_OVERRIDE'] ?? DEFAULT_HEARTBEAT_SUCCESS_FILE,
+): void {
+  try {
+    const tmpFile = `${successFile}.${process.pid}.tmp`;
+    writeFileSync(tmpFile, String(Math.floor(Date.now() / 1000)));
+    renameSync(tmpFile, successFile);
+  } catch (err) {
+    console.warn('[heartbeatSuccessFile] heartbeat success file write failed:', err);
+  }
+}

--- a/packages/runner/src/runnerCastHeartbeat.ts
+++ b/packages/runner/src/runnerCastHeartbeat.ts
@@ -1,4 +1,3 @@
-import { renameSync, writeFileSync } from 'node:fs';
 import {
   ContractFunctionRevertedError,
   createPublicClient,
@@ -15,8 +14,7 @@ import {
   HeartbeatRateLimitedError,
   type IHeartbeatCaller,
 } from '@clan-world/agents/seams';
-
-const DEFAULT_HEARTBEAT_SUCCESS_FILE = '/tmp/last-heartbeat-success';
+import { writeHeartbeatSuccessFile } from './heartbeatSuccessFile';
 
 export interface RunnerHeartbeatConfig {
   /** Hex-encoded 64-char private key, optionally 0x-prefixed. */
@@ -256,17 +254,4 @@ function deriveConvexWebhookUrl(convexDeployUrl?: string): string | undefined {
   url.hostname = url.hostname.replace(/\.convex\.cloud$/, '.convex.site');
   // Preserve protocol/port; strip trailing slash if URL had no explicit path.
   return url.toString().replace(/\/$/, '');
-}
-
-export function writeHeartbeatSuccessFile(
-  successFile =
-    process.env['HEARTBEAT_SUCCESS_FILE_OVERRIDE'] ?? DEFAULT_HEARTBEAT_SUCCESS_FILE,
-): void {
-  try {
-    const tmpFile = `${successFile}.${process.pid}.tmp`;
-    writeFileSync(tmpFile, String(Math.floor(Date.now() / 1000)));
-    renameSync(tmpFile, successFile);
-  } catch (err) {
-    console.warn('[RunnerCastHeartbeat] heartbeat success file write failed:', err);
-  }
 }

--- a/packages/runner/test/runnerCastHeartbeat.test.ts
+++ b/packages/runner/test/runnerCastHeartbeat.test.ts
@@ -33,8 +33,8 @@ vi.mock('viem/accounts', () => ({
 import {
   configFromEnv,
   RunnerCastHeartbeat,
-  writeHeartbeatSuccessFile,
 } from '../src/runnerCastHeartbeat';
+import { writeHeartbeatSuccessFile } from '../src/heartbeatSuccessFile';
 
 let heartbeatSuccessDir = '';
 let heartbeatSuccessFile = '';
@@ -202,7 +202,7 @@ describe('RunnerCastHeartbeat', () => {
     try {
       expect(() => writeHeartbeatSuccessFile(join(unwritableDir, 'success'))).not.toThrow();
       expect(warn).toHaveBeenCalledWith(
-        '[RunnerCastHeartbeat] heartbeat success file write failed:',
+        '[heartbeatSuccessFile] heartbeat success file write failed:',
         expect.objectContaining({ code: 'EACCES' }),
       );
     } finally {


### PR DESCRIPTION
## Summary

Addresses Copilot cloud-review findings on PR #532 (Bundle 1 release PR). 3 of 6 applied; 3 skipped as duplicate of already-documented work.

## Applied

**M-1 (`agents/heartbeat/README.md`):** Healthcheck doc said success marker is written only after a "successful webhook POST"; actual code writes the marker after confirmed heartbeat transaction with webhook as best-effort. Fixed the doc to match.

**M-2 (`packages/runner/src/heartbeatScheduler.ts`):** Scheduler imported `writeHeartbeatSuccessFile` from `runnerCastHeartbeat.ts` which pulled in the Viem client stack as a transitive dep. Extracted writer into pure-IO `heartbeatSuccessFile.ts`. Scheduler imports from there. Tests updated.

**L-1 (`docs/runbooks/anvil-fork-dev-rpc.md`):** Referenced `make -C agents reset-anvil` but `agents/Makefile` is Bundle 3 (PR #548). Fixed to use root `make reset-anvil PROFILE=dev` with a Bundle 3 forward-reference note.

## Skipped (duplicate)

- 3 Convex 1.17.4 vs 1.39.1 doc findings — already documented in PR #547 Bundle 3 runbook + issue #531.

## Test plan

- [x] `git diff --check` — passes
- [x] Scheduler grep for `runnerCastHeartbeat` import — clean
- [x] `agents/Makefile` reference grep in anvil runbook — only the forward-reference note
- [ ] `pnpm typecheck` — not runnable locally (no node_modules); CI gates
- [ ] Merge to dev-containerize-services before Bundle 1 release PR #532 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)