### PR TITLE
feat(bundle4): cockpit UI reset overlay (#567)

### DIFF
--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -32,6 +32,7 @@ import type * as kickstart from "../kickstart.js";
 import type * as memory from "../memory.js";
 import type * as mock from "../mock.js";
 import type * as ops from "../ops.js";
+import type * as resetEvents from "../resetEvents.js";
 import type * as resetLock from "../resetLock.js";
 import type * as retention from "../retention.js";
 import type * as runnerStatus from "../runnerStatus.js";
@@ -65,6 +66,7 @@ declare const fullApi: ApiFromModules<{
   memory: typeof memory;
   mock: typeof mock;
   ops: typeof ops;
+  resetEvents: typeof resetEvents;
   resetLock: typeof resetLock;
   retention: typeof retention;
   runnerStatus: typeof runnerStatus;

--- a/apps/server/convex/resetEvents.ts
+++ b/apps/server/convex/resetEvents.ts
@@ -1,0 +1,25 @@
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const getResetDuringDisconnect = query({
+  args: {
+    elderId: v.string(),
+    sinceTs: v.number(),
+    disconnectedAt: v.number(),
+  },
+  handler: async (ctx, { elderId, sinceTs, disconnectedAt }) => {
+    const recent = await ctx.db
+      .query("resetEventLog")
+      .withIndex("by_elder_started", (q) =>
+        q.eq("elderId", elderId).gte("startedAt", sinceTs),
+      )
+      .order("desc")
+      .take(5);
+
+    return (
+      recent.find((event) =>
+        event.completedAt === undefined || event.completedAt >= disconnectedAt
+      ) ?? null
+    );
+  },
+});

--- a/apps/web/src/components/cockpit/ElderResetOverlay.tsx
+++ b/apps/web/src/components/cockpit/ElderResetOverlay.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from 'react';
+import { tokens } from '../../styles/cockpit-tokens';
+import type { ElderDef } from '../../styles/cockpit-tokens';
+import { RESET_OVERLAY_MAX_DISPLAY_MS } from './resetOverlayState';
+
+interface Props {
+  elder: ElderDef;
+  testIdPrefix: string;
+  isExiting: boolean;
+  onReconnect: () => void;
+}
+
+const SHARDS = [
+  { left: '14%', top: '24%', delay: '0ms', size: '7px' },
+  { left: '24%', top: '68%', delay: '160ms', size: '5px' },
+  { left: '40%', top: '18%', delay: '320ms', size: '6px' },
+  { left: '58%', top: '74%', delay: '480ms', size: '5px' },
+  { left: '70%', top: '28%', delay: '640ms', size: '8px' },
+  { left: '84%', top: '58%', delay: '800ms', size: '6px' },
+];
+
+export function ElderResetOverlay({ elder, testIdPrefix, isExiting, onReconnect }: Props) {
+  const [takingLong, setTakingLong] = useState(false);
+
+  useEffect(() => {
+    setTakingLong(false);
+    const timer = window.setTimeout(() => {
+      setTakingLong(true);
+    }, RESET_OVERLAY_MAX_DISPLAY_MS);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  return (
+    <div
+      data-testid={`${testIdPrefix}-elder-reset-overlay`}
+      data-exiting={isExiting}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 4,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden',
+        background: `radial-gradient(circle at 50% 42%, ${elder.accent}30 0%, rgba(0,0,0,0.9) 44%, rgba(0,0,0,0.97) 100%)`,
+        borderTop: `1px solid ${elder.accent}`,
+        color: tokens.text.onIron,
+        fontFamily: tokens.font.mono,
+        pointerEvents: 'auto',
+        animation: isExiting
+          ? 'cw-reset-overlay-out 320ms ease forwards'
+          : 'cw-reset-overlay-in 180ms ease forwards',
+      }}
+      aria-live="polite"
+    >
+      <style>{`
+        @keyframes cw-reset-overlay-in {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        @keyframes cw-reset-overlay-out {
+          from { opacity: 1; }
+          to { opacity: 0; }
+        }
+        @keyframes cw-reset-core-pulse {
+          0%, 100% { opacity: 0.62; transform: scale(0.96); }
+          50% { opacity: 1; transform: scale(1.04); }
+        }
+        @keyframes cw-reset-shard-drift {
+          0% { opacity: 0; transform: translate3d(0, 10px, 0) rotate(0deg); }
+          35% { opacity: 0.72; }
+          100% { opacity: 0; transform: translate3d(0, -18px, 0) rotate(42deg); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          [data-testid="${testIdPrefix}-elder-reset-overlay"] {
+            animation: none !important;
+          }
+          [data-testid="${testIdPrefix}-elder-reset-overlay"] [data-reset-animated="true"] {
+            animation: none !important;
+          }
+        }
+      `}</style>
+
+      {SHARDS.map((shard, idx) => (
+        <span
+          key={idx}
+          data-reset-animated="true"
+          aria-hidden
+          style={{
+            position: 'absolute',
+            left: shard.left,
+            top: shard.top,
+            width: shard.size,
+            height: shard.size,
+            border: `1px solid ${elder.accent}`,
+            background: `${elder.accent}28`,
+            boxShadow: `0 0 12px ${elder.accent}66`,
+            transform: 'rotate(45deg)',
+            animation: `cw-reset-shard-drift 2.4s ease-in-out ${shard.delay} infinite`,
+          }}
+        />
+      ))}
+
+      <div
+        style={{
+          width: 'min(88%, 360px)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: tokens.space.md,
+          padding: tokens.space.lg,
+          textAlign: 'center',
+        }}
+      >
+        <div
+          data-reset-animated="true"
+          aria-hidden
+          style={{
+            width: '58px',
+            height: '58px',
+            display: 'grid',
+            placeItems: 'center',
+            border: `1px solid ${elder.accent}`,
+            borderRadius: tokens.radius.md,
+            background: `linear-gradient(135deg, ${elder.accent}24, rgba(0,0,0,0.72))`,
+            boxShadow: `0 0 26px ${elder.accent}55, inset 0 0 18px rgba(0,0,0,0.7)`,
+            color: elder.accent,
+            fontFamily: tokens.font.display,
+            fontSize: '30px',
+            lineHeight: 1,
+            animation: 'cw-reset-core-pulse 1.45s ease-in-out infinite',
+          }}
+        >
+          {elder.glyph}
+        </div>
+        <div
+          style={{
+            color: tokens.text.onIron,
+            fontSize: '12px',
+            letterSpacing: '0.08em',
+            lineHeight: 1.55,
+            textTransform: 'uppercase',
+          }}
+        >
+          Elder {elder.name} is being reset.
+          <br />
+          Memory wipe in progress.
+        </div>
+        {takingLong && (
+          <div
+            data-testid={`${testIdPrefix}-elder-reset-long`}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: tokens.space.sm,
+              color: tokens.text.onIronDim,
+              fontSize: '10px',
+              letterSpacing: '0.06em',
+              lineHeight: 1.45,
+              textTransform: 'uppercase',
+            }}
+          >
+            <span>Reset taking longer than expected.</span>
+            <button
+              type="button"
+              onClick={onReconnect}
+              style={{
+                border: `1px solid ${tokens.border.ironLight}`,
+                borderRadius: tokens.radius.sm,
+                background: 'rgba(0,0,0,0.45)',
+                color: tokens.text.accent,
+                cursor: 'pointer',
+                fontFamily: tokens.font.mono,
+                fontSize: '10px',
+                letterSpacing: '0.08em',
+                padding: '4px 8px',
+                textTransform: 'uppercase',
+              }}
+            >
+              Retry
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/cockpit/resetOverlayState.ts
+++ b/apps/web/src/components/cockpit/resetOverlayState.ts
@@ -1,0 +1,13 @@
+import type { TerminalFrameStatus } from '../../hooks/useTerminalFrameReconnect';
+
+export const RESET_DETECTION_WINDOW_MS = 10_000;
+export const RESET_OVERLAY_MAX_DISPLAY_MS = 30_000;
+export const RESET_OVERLAY_FADE_MS = 320;
+
+export function getElderResetId(clanId: number): string {
+  return `elder-${clanId}`;
+}
+
+export function shouldCheckForReset(status: TerminalFrameStatus): boolean {
+  return status === 'reconnecting' || status === 'disconnected';
+}

--- a/apps/web/src/components/cockpit/tabs/TerminalTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/TerminalTab.tsx
@@ -1,9 +1,19 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSafeQuery as useQuery } from '../../../hooks/useSafeQuery';
+import { api } from '../../../../../server/convex/_generated/api';
 import { tokens } from '../../../styles/cockpit-tokens';
 import type { ElderDef } from '../../../styles/cockpit-tokens';
 import {
   useTerminalFrameReconnect,
   type TerminalFrameStatus,
 } from '../../../hooks/useTerminalFrameReconnect';
+import { ElderResetOverlay } from '../ElderResetOverlay';
+import {
+  getElderResetId,
+  RESET_DETECTION_WINDOW_MS,
+  RESET_OVERLAY_FADE_MS,
+  shouldCheckForReset,
+} from '../resetOverlayState';
 
 interface Props {
   elder: ElderDef;
@@ -31,7 +41,62 @@ export function TerminalTab({ elder, testIdPrefix }: Props) {
     baseUrl: url,
     clanId: elder.clanId,
   });
-  const showOverlay = status !== 'connected';
+  const [disconnectedAt, setDisconnectedAt] = useState<number | null>(null);
+  const [resetConfirmed, setResetConfirmed] = useState(false);
+  const [resetExiting, setResetExiting] = useState(false);
+  const clearResetTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const resetCheckActive = shouldCheckForReset(status);
+  const elderResetId = useMemo(() => getElderResetId(elder.clanId), [elder.clanId]);
+  const resetQueryArgs = resetCheckActive && disconnectedAt != null
+    ? {
+        elderId: elderResetId,
+        sinceTs: disconnectedAt - RESET_DETECTION_WINDOW_MS,
+        disconnectedAt,
+      }
+    : 'skip';
+  const resetEvent = useQuery(api.resetEvents.getResetDuringDisconnect, resetQueryArgs);
+  const showResetOverlay = resetConfirmed || resetExiting;
+  const showReconnectOverlay = status !== 'connected' && !showResetOverlay;
+
+  useEffect(() => {
+    if (resetCheckActive && disconnectedAt == null) {
+      setDisconnectedAt(Date.now());
+    }
+  }, [disconnectedAt, resetCheckActive]);
+
+  useEffect(() => {
+    if (resetEvent) {
+      setResetConfirmed(true);
+    }
+  }, [resetEvent]);
+
+  useEffect(() => {
+    if (status !== 'connected') return;
+
+    setDisconnectedAt(null);
+    if (!resetConfirmed) {
+      setResetExiting(false);
+      return;
+    }
+
+    if (clearResetTimerRef.current) {
+      clearTimeout(clearResetTimerRef.current);
+    }
+    setResetExiting(true);
+    setResetConfirmed(false);
+    clearResetTimerRef.current = setTimeout(() => {
+      setResetExiting(false);
+      clearResetTimerRef.current = undefined;
+    }, RESET_OVERLAY_FADE_MS);
+  }, [resetConfirmed, status]);
+
+  useEffect(() => {
+    return () => {
+      if (clearResetTimerRef.current) {
+        clearTimeout(clearResetTimerRef.current);
+      }
+    };
+  }, []);
 
   return (
     <div
@@ -76,10 +141,18 @@ export function TerminalTab({ elder, testIdPrefix }: Props) {
           background: '#000',
         }}
       />
-      {showOverlay && (
+      {showReconnectOverlay && (
         <TerminalReconnectOverlay
           status={status}
           testIdPrefix={testIdPrefix}
+          onReconnect={reconnectNow}
+        />
+      )}
+      {showResetOverlay && (
+        <ElderResetOverlay
+          elder={elder}
+          testIdPrefix={testIdPrefix}
+          isExiting={resetExiting}
           onReconnect={reconnectNow}
         />
       )}

--- a/apps/web/src/components/cockpit/tabs/TerminalTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/TerminalTab.tsx
@@ -75,7 +75,11 @@ export function TerminalTab({ elder, testIdPrefix }: Props) {
 
     setDisconnectedAt(null);
     if (!resetConfirmed) {
-      setResetExiting(false);
+      // Either we never confirmed a reset (no exit state to clear) OR the
+      // exit-transition is already in flight (started by the previous run
+      // that flipped resetConfirmed true→false). Don't touch resetExiting
+      // here — the fade-out timer owns it. Without this guard, the effect
+      // re-runs after we set resetConfirmed=false and cancels its own fade.
       return;
     }
 


### PR DESCRIPTION
## Bundle 4 PR5 of 6 — Cockpit reset overlay

Frontend-only. Cockpit detects ttyd WebSocket disconnect during a reset event and overlays a branded animation instead of ttyd's default reconnect message.

Closes #567.

## Changes

**New files:**
- `apps/server/convex/resetEvents.ts` — `getResetDuringDisconnect` query
- `apps/web/src/components/cockpit/resetOverlayState.ts` — `RESET_DETECTION_WINDOW_MS = 10_000` + max display + fade constants
- `apps/web/src/components/cockpit/ElderResetOverlay.tsx` — branded per-elder overlay (pulse + 6 drifting shards + reduced-motion fallback + 30s "taking longer" fallback + retry button)

**Modified:**
- `apps/web/src/components/cockpit/tabs/TerminalTab.tsx` — subscribes to reset query only while ttyd is reconnecting/disconnected; latches confirmed reset event; preserves default reconnect UI for non-reset disconnects; fades out on reconnect

## Design alignment

- Uses existing `ELDERS` array (Storm Riders, Iron Guard, Crimson, Verdant Wardens) for branding consistency
- Per design "don't hide real disconnects": query loading/failure/no-event all preserve the default reconnect overlay
- Per design 10s reset detection window: named const + reused in query args + frontend

## Validation

- ✅ `pnpm --filter @clan-world/web typecheck`
- ✅ `pnpm --filter @clan-world/web test`: 2 files, 8 tests pass

## Process notes

Generated via codex-implement 5-stage pattern (high reasoning):
- Stage 1: plan with comprehensive risk register
- Stage 2: implement
- Stage 3: self-critique — 1 polish item (aria-live `role="status"` could be stronger), no blockers. Deferred polish per hackathon posture.

Targets integration branch `dev-phase-4-simplified-comms`. PR3 + PR6 + PR2 land in parallel; PR4 queued behind PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)