### PR TITLE
feat(bundle4): admin /api/admin/inject-message + Clerk auth + dev-UI panel (#568)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -31,6 +31,14 @@ CONVEX_DEPLOY_URL=
 INDEXER_SECRET=
 JUPITER_API_KEY=
 
+# --- Cockpit admin API ---
+# Local/dev only. The /api/admin/* middleware accepts anonymous requests only
+# when this is true and NODE_ENV is not production.
+ADMIN_AUTH_BYPASS=false
+# Clerk integration is scaffolded but unconfigured until Liam provisions the
+# Clerk app and sets this secret.
+CLERK_SECRET_KEY=
+
 # --- Solana Devnet GOLD token / Android wallet txs ---
 CLAN_WORLD_GOLD_RPC_URL=https://api.devnet.solana.com
 CLAN_WORLD_GOLD_MINT=FPBZJfEgxdkKEeT8pZhLRPg1NzwhyWJRqPKpzRWZLSAF
@@ -77,6 +85,10 @@ VITE_CLANWORLD_DEMO_MODE=false
 # Vercel: set this per-environment (preview/prod) so each deployment scopes
 # its localStorage to its own realm.
 VITE_CLAN_WORLD_CONTRACT_ADDRESS=
+
+# Clerk publishable key for cockpit admin auth. Leave unset for local
+# ADMIN_AUTH_BYPASS runs; Liam provisions the real Clerk app/keys separately.
+VITE_CLERK_PUBLISHABLE_KEY=
 
 # --- dev-ui (apps/dev-ui) ---
 # WalletConnect Cloud project ID — required to enable the WalletConnect
@@ -257,6 +269,7 @@ CONVEX_CLI_PINNED_VERSION=1.39.1
 #   convex env set CLANWORLD_USE_REAL_INDEXER true
 #   convex env set INDEXER_START_BLOCK <block-at-deploy>
 #   convex env set INDEXER_SECRET <secret>
+#   convex env set BUS_OPERATOR_SECRET <same bytes as BUS_OPERATOR_SECRET_FILE>
 #   convex env set RPC_URL_PRIMARY <base-sepolia-rpc>
 #   convex env set CLAN_WORLD_CONTRACT_ADDRESS <diamond>
 #   convex env set CLAN_WORLD_LENS_ADDRESS <lens>

--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type {
   FilterApi,
   FunctionReference,
 } from "convex/server";
+import type * as adminMessages from "../adminMessages.js";
 import type * as agentLogs from "../agentLogs.js";
 import type * as authShared from "../authShared.js";
 import type * as bulletins from "../bulletins.js";
@@ -46,6 +47,7 @@ import type * as vault from "../vault.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  adminMessages: typeof adminMessages;
   agentLogs: typeof agentLogs;
   authShared: typeof authShared;
   bulletins: typeof bulletins;

--- a/apps/server/convex/adminMessages.ts
+++ b/apps/server/convex/adminMessages.ts
@@ -1,0 +1,42 @@
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+import { requireBusOperatorSecret } from "./authShared";
+
+const elderId = v.union(
+  v.literal("elder-1"),
+  v.literal("elder-2"),
+  v.literal("elder-3"),
+  v.literal("elder-4"),
+);
+
+const messageSource = v.union(
+  v.literal("admin-injection"),
+  v.literal("user-message"),
+);
+
+export const injectMessage = mutation({
+  args: {
+    secret: v.string(),
+    targetElderId: elderId,
+    text: v.string(),
+    source: messageSource,
+  },
+  handler: async (ctx, args) => {
+    requireBusOperatorSecret(args.secret);
+
+    const text = args.text.trim();
+    if (!text) {
+      throw new Error("text is required");
+    }
+    if (text.length > 2000) {
+      throw new Error("text must be 2000 characters or fewer");
+    }
+
+    return await ctx.db.insert("pendingMessages", {
+      targetElderId: args.targetElderId,
+      text,
+      source: args.source,
+      insertedAt: Date.now(),
+    });
+  },
+});

--- a/apps/server/convex/authShared.ts
+++ b/apps/server/convex/authShared.ts
@@ -22,3 +22,21 @@ export function requireIndexerSecret(supplied: string): void {
     throw new Error("invalid indexer secret");
   }
 }
+
+/**
+ * Shared auth helper for admin/operator mutations.
+ *
+ * The web cockpit API reads BUS_OPERATOR_SECRET_FILE from its own server
+ * environment and passes the file contents as `secret`. Convex validates that
+ * value against its own BUS_OPERATOR_SECRET env var because Convex cannot read
+ * the Docker secret file directly.
+ */
+export function requireBusOperatorSecret(supplied: string): void {
+  const expected = process.env.BUS_OPERATOR_SECRET;
+  if (!expected) {
+    throw new Error("BUS_OPERATOR_SECRET is not configured on this Convex deployment");
+  }
+  if (supplied !== expected) {
+    throw new Error("invalid bus operator secret");
+  }
+}

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -32,12 +32,22 @@ VITE_CLANWORLD_DEMO_MODE=false
 # ============================================================
 
 # Local/dev only. The /api/admin/* middleware accepts anonymous requests only
-# when this is true and NODE_ENV is not production.
-ADMIN_AUTH_BYPASS=true
+# when this is true AND NODE_ENV === "development" (positive check — preview
+# or staging deploys with unset NODE_ENV will NOT bypass). Default off here
+# so a copied .env doesn't accidentally enable bypass on a hosted env.
+ADMIN_AUTH_BYPASS=false
 
 # Clerk secret key for production admin auth. Leave unset until Liam provisions
 # the Clerk app.
 CLERK_SECRET_KEY=
 
+# Admin allowlist — comma-separated list of Clerk userIds permitted to call
+# /api/admin/*. A valid Clerk session is necessary but NOT sufficient; only
+# users in this list pass. Empty = no admins (fails closed). Required before
+# Clerk paths fire in production.
+ADMIN_ALLOWED_USER_IDS=
+
 # Path to the BUS operator secret file read by the Vite admin middleware.
-BUS_OPERATOR_SECRET_FILE=agents/secrets/bus-operator.key
+# MUST be absolute, or relative to the repo root the Vite dev server is
+# launched from. Default points at the canonical agents/ location.
+BUS_OPERATOR_SECRET_FILE=/etc/clan-world/secrets/bus-operator.key

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -9,6 +9,10 @@
 # Convex backend URL
 VITE_CONVEX_URL=
 
+# Clerk publishable key for configured admin auth. Leave unset for local
+# dev-bypass runs; Liam will provision the real Clerk app/keys separately.
+VITE_CLERK_PUBLISHABLE_KEY=
+
 # Diamond address realm-discriminator for client-side caches. Mirrors the
 # server-side `CLAN_WORLD_CONTRACT_ADDRESS` and SHOULD be set to the SAME
 # value. Used to scope `localStorage` snapshot caches per realm so that the
@@ -22,3 +26,18 @@ VITE_CLAN_WORLD_CONTRACT_ADDRESS=
 # true = show mock clans, bandits, walls, canned travel (dev UX preserved)
 # false/unset = render real Convex/chain state; empty world stays empty
 VITE_CLANWORLD_DEMO_MODE=false
+
+# ============================================================
+# Server-only admin API values — MUST NOT be VITE_-prefixed
+# ============================================================
+
+# Local/dev only. The /api/admin/* middleware accepts anonymous requests only
+# when this is true and NODE_ENV is not production.
+ADMIN_AUTH_BYPASS=true
+
+# Clerk secret key for production admin auth. Leave unset until Liam provisions
+# the Clerk app.
+CLERK_SECRET_KEY=
+
+# Path to the BUS operator secret file read by the Vite admin middleware.
+BUS_OPERATOR_SECRET_FILE=agents/secrets/bus-operator.key

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@clan-world/contract-types": "workspace:*",
     "@clan-world/shared": "workspace:*",
+    "@clerk/backend": "^2.16.0",
+    "@clerk/clerk-react": "^5.61.6",
     "convex": "1.17.4",
     "framer-motion": "^12.38.0",
     "pixi-viewport": "^6.0.3",

--- a/apps/web/server/admin/auth.ts
+++ b/apps/web/server/admin/auth.ts
@@ -4,8 +4,11 @@ type AuthResult =
   | { ok: true }
   | { ok: false; status: number; code: string; message: string };
 
+// Positive check: only the literal string "development" enables bypass.
+// "test"/"staging"/unset will NOT bypass. This closes the "NODE_ENV unset
+// in preview deploy" hole that codex flagged on R1.
 function isDevBypassEnabled(): boolean {
-  return process.env.NODE_ENV !== "production" && process.env.ADMIN_AUTH_BYPASS === "true";
+  return process.env.NODE_ENV === "development" && process.env.ADMIN_AUTH_BYPASS === "true";
 }
 
 function bearerToken(req: IncomingMessage): string | null {
@@ -14,6 +17,20 @@ function bearerToken(req: IncomingMessage): string | null {
   const [scheme, token] = raw.split(" ");
   if (scheme?.toLowerCase() !== "bearer" || !token) return null;
   return token;
+}
+
+// Admin allowlist: a valid Clerk session is necessary but NOT sufficient.
+// Any user signed into the Clerk instance has a valid session; only the
+// userIds listed in ADMIN_ALLOWED_USER_IDS are operators. Empty list = no
+// admins (fails closed). Each entry trimmed; whitespace tolerated.
+function parseAdminAllowlist(): Set<string> {
+  const raw = process.env.ADMIN_ALLOWED_USER_IDS ?? "";
+  return new Set(
+    raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
 }
 
 export async function verifyAdminRequest(req: IncomingMessage): Promise<AuthResult> {
@@ -43,7 +60,29 @@ export async function verifyAdminRequest(req: IncomingMessage): Promise<AuthResu
 
   try {
     const clerk = await import("@clerk/backend");
-    await clerk.verifyToken(token, { secretKey });
+    const claims = await clerk.verifyToken(token, { secretKey });
+
+    const allowed = parseAdminAllowlist();
+    if (allowed.size === 0) {
+      return {
+        ok: false,
+        status: 503,
+        code: "admin_allowlist_unconfigured",
+        message:
+          "Admin allowlist is empty. Set ADMIN_ALLOWED_USER_IDS to a comma-separated list of Clerk userIds before enabling admin auth.",
+      };
+    }
+
+    const userId = (claims as { sub?: string }).sub;
+    if (!userId || !allowed.has(userId)) {
+      return {
+        ok: false,
+        status: 403,
+        code: "not_admin",
+        message: "User is signed in but not on the admin allowlist",
+      };
+    }
+
     return { ok: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/apps/web/server/admin/auth.ts
+++ b/apps/web/server/admin/auth.ts
@@ -1,0 +1,57 @@
+import type { IncomingMessage } from "node:http";
+
+type AuthResult =
+  | { ok: true }
+  | { ok: false; status: number; code: string; message: string };
+
+function isDevBypassEnabled(): boolean {
+  return process.env.NODE_ENV !== "production" && process.env.ADMIN_AUTH_BYPASS === "true";
+}
+
+function bearerToken(req: IncomingMessage): string | null {
+  const raw = req.headers.authorization;
+  if (!raw) return null;
+  const [scheme, token] = raw.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) return null;
+  return token;
+}
+
+export async function verifyAdminRequest(req: IncomingMessage): Promise<AuthResult> {
+  if (isDevBypassEnabled()) {
+    return { ok: true };
+  }
+
+  const secretKey = process.env.CLERK_SECRET_KEY;
+  if (!secretKey) {
+    return {
+      ok: false,
+      status: 401,
+      code: "clerk_not_configured",
+      message: "Clerk admin auth is not configured",
+    };
+  }
+
+  const token = bearerToken(req);
+  if (!token) {
+    return {
+      ok: false,
+      status: 401,
+      code: "missing_session",
+      message: "Missing Clerk session token",
+    };
+  }
+
+  try {
+    const clerk = await import("@clerk/backend");
+    await clerk.verifyToken(token, { secretKey });
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      status: 401,
+      code: "invalid_session",
+      message,
+    };
+  }
+}

--- a/apps/web/server/admin/convex.ts
+++ b/apps/web/server/admin/convex.ts
@@ -21,8 +21,23 @@ const injectMessageRef = (anyApi as unknown as {
 }).adminMessages.injectMessage;
 
 function readOperatorSecret(): string {
-  const secretFile = process.env.BUS_OPERATOR_SECRET_FILE ?? "agents/secrets/bus-operator.key";
-  const resolved = path.isAbsolute(secretFile) ? secretFile : path.resolve(process.cwd(), secretFile);
+  // Default points at the canonical bind-mount location used by all elder
+  // containers (matches BUS_ELDER_SECRET_FILE convention). Relative paths
+  // are resolved against process.cwd(), which is reliable inside a container
+  // entrypoint but brittle when running `node` from a subdirectory locally.
+  // Always pass an absolute path in production.
+  const secretFile = process.env.BUS_OPERATOR_SECRET_FILE
+    ?? "/etc/clan-world/secrets/bus-operator.key";
+  const resolved = path.isAbsolute(secretFile)
+    ? secretFile
+    : path.resolve(process.cwd(), secretFile);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(
+      `BUS operator secret file not found at ${resolved} ` +
+      `(BUS_OPERATOR_SECRET_FILE='${secretFile}'). ` +
+      `Set BUS_OPERATOR_SECRET_FILE to an absolute path.`,
+    );
+  }
   return fs.readFileSync(resolved, "utf8").trim();
 }
 

--- a/apps/web/server/admin/convex.ts
+++ b/apps/web/server/admin/convex.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ConvexHttpClient } from "convex/browser";
+import { anyApi } from "convex/server";
+import type { FunctionReference } from "convex/server";
+
+type ElderId = "elder-1" | "elder-2" | "elder-3" | "elder-4";
+type MessageSource = "admin-injection" | "user-message";
+
+type InjectMessageArgs = {
+  secret: string;
+  targetElderId: ElderId;
+  text: string;
+  source: MessageSource;
+};
+
+const injectMessageRef = (anyApi as unknown as {
+  adminMessages: {
+    injectMessage: FunctionReference<"mutation", "public", InjectMessageArgs, string>;
+  };
+}).adminMessages.injectMessage;
+
+function readOperatorSecret(): string {
+  const secretFile = process.env.BUS_OPERATOR_SECRET_FILE ?? "agents/secrets/bus-operator.key";
+  const resolved = path.isAbsolute(secretFile) ? secretFile : path.resolve(process.cwd(), secretFile);
+  return fs.readFileSync(resolved, "utf8").trim();
+}
+
+function convexUrl(): string {
+  const url = process.env.CONVEX_URL ?? process.env.CONVEX_DEPLOY_URL ?? process.env.VITE_CONVEX_URL;
+  if (!url) {
+    throw new Error("CONVEX_URL, CONVEX_DEPLOY_URL, or VITE_CONVEX_URL is required");
+  }
+  return url;
+}
+
+export async function injectPendingMessage(args: Omit<InjectMessageArgs, "secret">): Promise<string> {
+  const client = new ConvexHttpClient(convexUrl());
+  return await client.mutation(injectMessageRef, {
+    secret: readOperatorSecret(),
+    ...args,
+  });
+}
+
+export type { ElderId, MessageSource };

--- a/apps/web/server/admin/injectMessage.ts
+++ b/apps/web/server/admin/injectMessage.ts
@@ -1,0 +1,137 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { generateThematicSlug } from "./thematicSlug";
+import { injectPendingMessage, type ElderId, type MessageSource } from "./convex";
+import { verifyAdminRequest } from "./auth";
+
+const ELDERS: ElderId[] = ["elder-1", "elder-2", "elder-3", "elder-4"];
+const SOURCES: MessageSource[] = ["admin-injection", "user-message"];
+const MAX_TEXT_LENGTH = 2000;
+
+type Target = ElderId | "all";
+
+type JsonRecord = Record<string, unknown>;
+
+function sendJson(res: ServerResponse, status: number, body: JsonRecord): void {
+  res.statusCode = status;
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(body));
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      body += chunk;
+      if (body.length > 32_000) {
+        reject(new Error("request body too large"));
+        req.destroy();
+      }
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+function parseBody(raw: string): { targetElderId: Target; text: string; source: MessageSource } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("invalid JSON body");
+  }
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("body must be an object");
+  }
+
+  const body = parsed as Record<string, unknown>;
+  const targetElderId = body.targetElderId;
+  const text = body.text;
+  const source = body.source;
+
+  if (targetElderId !== "all" && !ELDERS.includes(targetElderId as ElderId)) {
+    throw new Error("targetElderId must be elder-1, elder-2, elder-3, elder-4, or all");
+  }
+  if (typeof text !== "string" || !text.trim()) {
+    throw new Error("text is required");
+  }
+  if (text.trim().length > MAX_TEXT_LENGTH) {
+    throw new Error("text must be 2000 characters or fewer");
+  }
+  if (!SOURCES.includes(source as MessageSource)) {
+    throw new Error("source must be admin-injection or user-message");
+  }
+
+  return {
+    targetElderId: targetElderId as Target,
+    text: text.trim(),
+    source: source as MessageSource,
+  };
+}
+
+export async function handleInjectMessage(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (req.method === "OPTIONS") {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+  if (req.method !== "POST") {
+    sendJson(res, 405, { error: { code: "method_not_allowed", message: "Use POST" } });
+    return;
+  }
+
+  const auth = await verifyAdminRequest(req);
+  if (!auth.ok) {
+    sendJson(res, auth.status, { error: { code: auth.code, message: auth.message } });
+    return;
+  }
+
+  let body: ReturnType<typeof parseBody>;
+  try {
+    body = parseBody(await readBody(req));
+  } catch (err) {
+    sendJson(res, 400, {
+      error: {
+        code: "validation_error",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    });
+    return;
+  }
+
+  const targets = body.targetElderId === "all" ? ELDERS : [body.targetElderId];
+  const slugs: Array<{ targetElderId: ElderId; pendingMessageId: string; slug: string }> = [];
+  const errors: Array<{ targetElderId: ElderId; message: string }> = [];
+
+  for (const targetElderId of targets) {
+    const slug = generateThematicSlug();
+    try {
+      const pendingMessageId = await injectPendingMessage({
+        targetElderId,
+        text: body.text,
+        source: body.source,
+      });
+      slugs.push({ targetElderId, pendingMessageId, slug });
+    } catch (err) {
+      errors.push({
+        targetElderId,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (body.targetElderId !== "all" && slugs[0] && errors.length === 0) {
+    sendJson(res, 200, {
+      pendingMessageId: slugs[0].pendingMessageId,
+      slug: slugs[0].slug,
+    });
+    return;
+  }
+
+  if (slugs.length === 0 && errors.length > 0) {
+    sendJson(res, 500, { slugs, errors });
+    return;
+  }
+
+  sendJson(res, errors.length > 0 ? 207 : 200, { slugs, errors });
+}

--- a/apps/web/server/admin/middleware.ts
+++ b/apps/web/server/admin/middleware.ts
@@ -1,0 +1,41 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Plugin } from "vite";
+import { handleInjectMessage } from "./injectMessage";
+
+type Next = (err?: unknown) => void;
+
+function pathOf(req: IncomingMessage): string {
+  const host = req.headers.host ?? "127.0.0.1";
+  return new URL(req.url ?? "/", `http://${host}`).pathname;
+}
+
+async function handleAdminApi(req: IncomingMessage, res: ServerResponse, next: Next): Promise<void> {
+  if (pathOf(req) !== "/api/admin/inject-message") {
+    next();
+    return;
+  }
+
+  try {
+    await handleInjectMessage(req, res);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export function adminApiPlugin(): Plugin {
+  return {
+    name: "clan-world-admin-api",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        void handleAdminApi(req, res, next);
+      });
+    },
+    configurePreviewServer(server) {
+      // TODO(production): hosted cockpit deployment needs a Node adapter or
+      // Vercel function equivalent for /api/admin/*.
+      server.middlewares.use((req, res, next) => {
+        void handleAdminApi(req, res, next);
+      });
+    },
+  };
+}

--- a/apps/web/server/admin/thematicSlug.ts
+++ b/apps/web/server/admin/thematicSlug.ts
@@ -1,0 +1,50 @@
+const WEATHER = [
+  "mist", "thunder", "frost", "rain", "cloud", "gale", "ember", "snow",
+  "storm", "dawn", "dusk", "hail",
+];
+const MYTHOLOGY = [
+  "oracle", "rune", "wyrd", "aegis", "nymph", "titan", "saga", "relic",
+  "altar", "omen", "spire", "crown",
+];
+const GEMSTONES = [
+  "amber", "opal", "onyx", "jade", "ruby", "beryl", "topaz", "quartz",
+  "agate", "pearl", "garnet", "coral",
+];
+const SEASONS = [
+  "spring", "summer", "autumn", "winter", "solstice", "harvest", "bloom",
+  "thaw", "embertide", "fallow", "midsun", "firstsnow",
+];
+const TERRAIN = [
+  "oak", "river", "stone", "grove", "valley", "peak", "marsh", "field",
+  "ridge", "meadow", "cairn", "cliff",
+];
+const COLORS_FEELINGS = [
+  "crimson", "gold", "silver", "violet", "brave", "quiet", "bright",
+  "ashen", "verdant", "kind", "wild", "keen",
+];
+
+const THEMES = [WEATHER, MYTHOLOGY, GEMSTONES, SEASONS, TERRAIN, COLORS_FEELINGS];
+
+function pickRandom(words: readonly string[], count: number): string[] {
+  const picked: string[] = [];
+  for (let i = 0; i < count; i += 1) {
+    picked.push(words[Math.floor(Math.random() * words.length)]!);
+  }
+  return picked;
+}
+
+function randomHex(length: number): string {
+  let out = "";
+  for (let i = 0; i < length; i += 1) {
+    out += Math.floor(Math.random() * 16).toString(16);
+  }
+  return out;
+}
+
+export function generateThematicSlug(): string {
+  const theme = THEMES[Math.floor(Math.random() * THEMES.length)]!;
+  const words = pickRandom(theme, 3);
+  const hex = randomHex(4);
+  // TODO(post-PR2): migrate to shared utility from packages/shared/src/thematicUid.ts.
+  return `${words.join("-")}-${hex}`;
+}

--- a/apps/web/src/components/cockpit/MiniCockpit.tsx
+++ b/apps/web/src/components/cockpit/MiniCockpit.tsx
@@ -6,6 +6,7 @@ import { VaultTab } from './tabs/VaultTab';
 import { ClansmanTab } from './tabs/ClansmanTab';
 import { ZeroGTab } from './tabs/ZeroGTab';
 import { CommsTab } from './tabs/CommsTab';
+import { AdminMessageTab } from './tabs/AdminMessageTab';
 
 interface Props {
   elder: ElderDef;
@@ -65,6 +66,7 @@ export function MiniCockpit({ elder, initialTab = 'terminal' }: Props) {
         {active === 'clansman' && <ClansmanTab elder={elder} testIdPrefix={testIdPrefix} />}
         {active === '0g'       && <ZeroGTab    elder={elder} testIdPrefix={testIdPrefix} />}
         {active === 'comms'    && <CommsTab    elder={elder} testIdPrefix={testIdPrefix} />}
+        {active === 'admin'    && <AdminMessageTab elder={elder} testIdPrefix={testIdPrefix} />}
       </div>
     </section>
   );

--- a/apps/web/src/components/cockpit/shared/CockpitTabBar.tsx
+++ b/apps/web/src/components/cockpit/shared/CockpitTabBar.tsx
@@ -1,6 +1,6 @@
 import { tokens } from '../../../styles/cockpit-tokens';
 
-export type TabId = 'terminal' | 'vault' | 'clansman' | '0g' | 'comms';
+export type TabId = 'terminal' | 'vault' | 'clansman' | '0g' | 'comms' | 'admin';
 
 export interface TabDef {
   id: TabId;
@@ -16,6 +16,7 @@ export const TABS: ReadonlyArray<TabDef> = [
   { id: 'clansman', icon: '☗', label: 'CLAN' },
   { id: '0g',       icon: '◉', label: '0G' },
   { id: 'comms',    icon: '✉', label: 'COMMS' },
+  { id: 'admin',    icon: '⚙', label: 'ADMIN' },
 ];
 
 interface Props {

--- a/apps/web/src/components/cockpit/tabs/AdminMessageTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/AdminMessageTab.tsx
@@ -184,7 +184,7 @@ export function AdminMessageTab({ elder, testIdPrefix }: Props) {
         <textarea
           data-testid={`${testIdPrefix}-admin-text`}
           value={text}
-          maxLength={MAX_CHARS + 1}
+          maxLength={MAX_CHARS}
           onChange={(event) => setText(event.currentTarget.value)}
           style={{
             ...controlStyle,

--- a/apps/web/src/components/cockpit/tabs/AdminMessageTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/AdminMessageTab.tsx
@@ -1,0 +1,283 @@
+import { useMemo, useState } from 'react';
+import { tokens } from '../../../styles/cockpit-tokens';
+import type { ElderDef } from '../../../styles/cockpit-tokens';
+
+interface Props {
+  elder: ElderDef;
+  testIdPrefix: string;
+}
+
+type TargetElderId = 'elder-1' | 'elder-2' | 'elder-3' | 'elder-4' | 'all';
+type Source = 'admin-injection' | 'user-message';
+
+type ApiSlug = {
+  targetElderId: string;
+  pendingMessageId: string;
+  slug: string;
+};
+
+type ApiError = {
+  targetElderId?: string;
+  message: string;
+};
+
+type ApiResponse =
+  | { pendingMessageId: string; slug: string; error?: never }
+  | { slugs: ApiSlug[]; errors?: ApiError[]; error?: never }
+  | { error: { code?: string; message: string } };
+
+const MAX_CHARS = 2000;
+
+declare global {
+  interface Window {
+    Clerk?: {
+      session?: {
+        getToken: () => Promise<string | null>;
+      } | null;
+    };
+  }
+}
+
+async function getClerkToken(): Promise<string | null> {
+  return await (window.Clerk?.session?.getToken() ?? Promise.resolve(null));
+}
+
+function defaultTarget(elder: ElderDef): TargetElderId {
+  return `elder-${elder.clanId}` as TargetElderId;
+}
+
+export function AdminMessageTab({ elder, testIdPrefix }: Props) {
+  const [targetElderId, setTargetElderId] = useState<TargetElderId>(() => defaultTarget(elder));
+  const [source, setSource] = useState<Source>('admin-injection');
+  const [text, setText] = useState('');
+  const [isSubmitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState<ApiSlug[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const remaining = MAX_CHARS - text.length;
+  const canSubmit = text.trim().length > 0 && remaining >= 0 && !isSubmitting;
+
+  const targetOptions = useMemo(
+    () => [
+      { value: 'elder-1', label: 'Elder 1' },
+      { value: 'elder-2', label: 'Elder 2' },
+      { value: 'elder-3', label: 'Elder 3' },
+      { value: 'elder-4', label: 'Elder 4' },
+      { value: 'all', label: 'All elders' },
+    ],
+    [elder],
+  );
+
+  async function submit() {
+    setSubmitting(true);
+    setError(null);
+    setSuccess([]);
+    try {
+      const token = await getClerkToken();
+      const headers: Record<string, string> = { 'content-type': 'application/json' };
+      if (token) headers.authorization = `Bearer ${token}`;
+
+      const res = await fetch('/api/admin/inject-message', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ targetElderId, text, source }),
+      });
+      const json = (await res.json()) as ApiResponse;
+
+      if ('error' in json && json.error) {
+        throw new Error(json.error.message);
+      }
+      if ('pendingMessageId' in json) {
+        setSuccess([{ targetElderId, pendingMessageId: json.pendingMessageId, slug: json.slug }]);
+      } else {
+        setSuccess(json.slugs);
+        if (json.errors?.length) {
+          setError(json.errors.map((e) => `${e.targetElderId ?? 'unknown'}: ${e.message}`).join('; '));
+        }
+      }
+      if (!res.ok && !('slugs' in json)) {
+        throw new Error(`Request failed with ${res.status}`);
+      }
+      if (!('errors' in json) || !json.errors?.length) {
+        setText('');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      data-testid={`${testIdPrefix}-content-admin`}
+      style={{
+        flex: 1,
+        background: tokens.bg.parchment,
+        color: tokens.text.onParchment,
+        padding: tokens.space.md,
+        overflowY: 'auto',
+        fontFamily: tokens.font.body,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: tokens.space.md,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-end',
+          justifyContent: 'space-between',
+          gap: tokens.space.md,
+          borderBottom: `1px solid ${tokens.border.parchmentEdge}`,
+          paddingBottom: '4px',
+        }}
+      >
+        <h3
+          style={{
+            margin: 0,
+            fontFamily: tokens.font.display,
+            fontSize: '11px',
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: tokens.text.onParchmentDim,
+          }}
+        >
+          Admin — Elder {elder.clanId}
+        </h3>
+        <span style={{ fontFamily: tokens.font.mono, fontSize: '10px', color: remaining < 0 ? '#9c2f2f' : tokens.text.onParchmentDim }}>
+          {text.length}/{MAX_CHARS}
+        </span>
+      </div>
+
+      <label style={labelStyle}>
+        Target
+        <select
+          data-testid={`${testIdPrefix}-admin-target`}
+          value={targetElderId}
+          onChange={(event) => setTargetElderId(event.currentTarget.value as TargetElderId)}
+          style={controlStyle}
+        >
+          {targetOptions.map((option, index) => (
+            <option key={`${option.value}-${index}`} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label style={labelStyle}>
+        Source
+        <select
+          data-testid={`${testIdPrefix}-admin-source`}
+          value={source}
+          onChange={(event) => setSource(event.currentTarget.value as Source)}
+          style={controlStyle}
+        >
+          <option value="admin-injection">admin-injection</option>
+          <option value="user-message">user-message</option>
+        </select>
+      </label>
+
+      <label style={{ ...labelStyle, flex: 1, minHeight: '140px' }}>
+        Message
+        <textarea
+          data-testid={`${testIdPrefix}-admin-text`}
+          value={text}
+          maxLength={MAX_CHARS + 1}
+          onChange={(event) => setText(event.currentTarget.value)}
+          style={{
+            ...controlStyle,
+            flex: 1,
+            minHeight: '110px',
+            resize: 'vertical',
+            lineHeight: 1.35,
+          }}
+        />
+      </label>
+
+      {success.length > 0 && (
+        <div data-testid={`${testIdPrefix}-admin-success`} style={successStyle}>
+          {success.map((item) => (
+            <div key={`${item.targetElderId}-${item.pendingMessageId}`}>
+              Injected {item.targetElderId} as <code>{item.slug}</code>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div data-testid={`${testIdPrefix}-admin-error`} style={errorStyle}>
+          {error}
+        </div>
+      )}
+
+      <button
+        type="button"
+        data-testid={`${testIdPrefix}-admin-submit`}
+        disabled={!canSubmit}
+        onClick={() => void submit()}
+        style={{
+          alignSelf: 'flex-start',
+          border: `1px solid ${tokens.border.iron}`,
+          borderRadius: tokens.radius.sm,
+          background: canSubmit ? tokens.text.accent : 'rgba(60,45,28,0.18)',
+          color: canSubmit ? tokens.bg.ink : tokens.text.onParchmentDim,
+          cursor: canSubmit ? 'pointer' : 'not-allowed',
+          fontFamily: tokens.font.mono,
+          fontSize: '11px',
+          fontWeight: 700,
+          letterSpacing: '0.08em',
+          padding: '8px 12px',
+          textTransform: 'uppercase',
+        }}
+      >
+        {isSubmitting ? 'Injecting' : 'Inject'}
+      </button>
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '5px',
+  color: tokens.text.onParchmentDim,
+  fontFamily: tokens.font.display,
+  fontSize: '10px',
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
+};
+
+const controlStyle: React.CSSProperties = {
+  border: `1px solid ${tokens.border.parchmentEdge}`,
+  borderRadius: tokens.radius.sm,
+  background: 'rgba(255,255,255,0.45)',
+  color: tokens.text.onParchment,
+  fontFamily: tokens.font.body,
+  fontSize: '13px',
+  padding: '8px 9px',
+  width: '100%',
+};
+
+const successStyle: React.CSSProperties = {
+  border: '1px solid rgba(88,126,72,0.45)',
+  borderRadius: tokens.radius.sm,
+  background: 'rgba(88,126,72,0.12)',
+  color: '#355528',
+  fontFamily: tokens.font.mono,
+  fontSize: '11px',
+  lineHeight: 1.5,
+  padding: '8px',
+};
+
+const errorStyle: React.CSSProperties = {
+  border: '1px solid rgba(156,47,47,0.45)',
+  borderRadius: tokens.radius.sm,
+  background: 'rgba(156,47,47,0.12)',
+  color: '#7a2525',
+  fontFamily: tokens.font.mono,
+  fontSize: '11px',
+  lineHeight: 1.5,
+  padding: '8px',
+};

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+// Clerk's published types ship ComponentClass<Props> with React-18 refs
+// that don't satisfy this app's stricter @types/react JSX element constraint.
+// The component works at runtime; the type-only cast avoids the JSX mismatch
+// without disabling strict mode elsewhere.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import { ClerkProvider as ClerkProviderRaw } from '@clerk/clerk-react';
+const ClerkProvider: any = ClerkProviderRaw;
 import { ConvexProvider, ConvexReactClient } from 'convex/react';
 import { App } from './App';
 import './styles/viewport.css';
@@ -31,6 +38,7 @@ if (tg) {
 }
 
 const convexUrl = import.meta.env.VITE_CONVEX_URL as string | undefined;
+const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
 
 // Cast required: convex's React.FC type conflicts with @types/react@18.3 ReactNode (bigint addition)
 const Provider = ConvexProvider as React.ComponentType<{
@@ -118,11 +126,16 @@ if (!convexUrl && !isStandalonePath) {
   // VITE_CONVEX_URL also falls back. `??` only handles null/undefined and
   // would let `''` through, breaking ConvexReactClient construction.
   const convex = new ConvexReactClient(convexUrl || 'https://203.0.113.1');
+  const app = (
+    <Provider client={convex}>
+      <App />
+    </Provider>
+  );
   root.render(
     <React.StrictMode>
-      <Provider client={convex}>
-        <App />
-      </Provider>
+      {clerkPublishableKey ? (
+        <ClerkProvider publishableKey={clerkPublishableKey}>{app}</ClerkProvider>
+      ) : app}
     </React.StrictMode>,
   );
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -8,5 +8,5 @@
     "declarationMap": false,
     "types": ["vite/client", "node"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "server/**/*", "vite.config.ts"]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
+import { adminApiPlugin } from './server/admin/middleware';
 
 // Canonical port resolved from port-for registry (clan-world slot 587, env=dev).
 // Falls back to FALLBACK_PORT (canonical value from .world/ports.yml) when port-for is
@@ -104,7 +105,7 @@ const APP_VERSION = process.env.VITE_APP_VERSION ?? 'dev';
 // Without this, VITE_* values are undefined at build time and the prod bundle
 // has no Convex URL or demo-mode configuration baked in.
 export default defineConfig({
-  plugins: [react(), mapBgPreloadPlugin()],
+  plugins: [react(), mapBgPreloadPlugin(), adminApiPlugin()],
   envDir: path.resolve(__dirname, '../..'),
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(APP_VERSION),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
         version: 6.0.3
       convex:
         specifier: ^1.17.4
-        version: 1.17.4(react-dom@19.2.5(react@18.3.1))(react@18.3.1)
+        version: 1.17.4(@clerk/clerk-react@5.61.7(react-dom@19.2.5(react@18.3.1))(react@18.3.1))(react-dom@19.2.5(react@18.3.1))(react@18.3.1)
       expo:
         specifier: ~52.0.0
         version: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(bufferutil@4.1.0)(graphql@16.13.2)(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.12)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.12)(bufferutil@4.1.0)(react@18.3.1)(utf-8-validate@6.0.6))(react@18.3.1)(utf-8-validate@6.0.6)
@@ -256,7 +256,7 @@ importers:
         version: link:../../packages/shared
       convex:
         specifier: 1.17.4
-        version: 1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.17.4(@clerk/clerk-react@5.61.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       viem:
         specifier: 2.48.4
         version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.2)
@@ -276,9 +276,15 @@ importers:
       '@clan-world/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@clerk/backend':
+        specifier: ^2.16.0
+        version: 2.33.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/clerk-react':
+        specifier: ^5.61.6
+        version: 5.61.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       convex:
         specifier: 1.17.4
-        version: 1.17.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.17.4(@clerk/clerk-react@5.61.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -350,25 +356,6 @@ importers:
 
   packages/contracts: {}
 
-  packages/runner:
-    dependencies:
-      convex:
-        specifier: 1.17.4
-        version: 1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      tsx:
-        specifier: 4.19.2
-        version: 4.19.2
-    devDependencies:
-      '@types/node':
-        specifier: 25.6.0
-        version: 25.6.0
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
-      vitest:
-        specifier: ^3.2.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2)
-
   packages/heartbeat:
     dependencies:
       '@0glabs/0g-ts-sdk':
@@ -400,6 +387,25 @@ importers:
         specifier: ^3.2.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2)
 
+  packages/runner:
+    dependencies:
+      convex:
+        specifier: 1.17.4
+        version: 1.17.4(@clerk/clerk-react@5.61.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+    devDependencies:
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2)
+
   packages/sdk:
     dependencies:
       '@clan-world/contract-types':
@@ -407,7 +413,7 @@ importers:
         version: link:../contract-types
       convex:
         specifier: 1.17.4
-        version: 1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.17.4(@clerk/clerk-react@5.61.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -426,7 +432,7 @@ importers:
         version: link:../sdk
       convex:
         specifier: 1.17.4
-        version: 1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.17.4(@clerk/clerk-react@5.61.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       viem:
         specifier: ^2.48.4
         version: 2.48.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.2)
@@ -1189,6 +1195,33 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@clerk/backend@2.33.4':
+    resolution: {integrity: sha512-aF5IZGxicN6I5tq1g8GFTS3wbSVGzCRQ4zyZmZvRrux1xre2pVyWRoZ1qvMOjQ7doWJtEndxTZPjUaxXa4Zr2Q==}
+    engines: {node: '>=18.17.0'}
+
+  '@clerk/clerk-react@5.61.7':
+    resolution: {integrity: sha512-w2V01rQiQdZHmnvSD8TjHoPq2lXQ9Ft2sT+Zu9ZQXzhyKF02ZFKENUFG40rkxmFViZXfcLhzLauiEbh42jBd6g==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/shared@3.47.6':
+    resolution: {integrity: sha512-hg2UFiwmSb3FnAciMxZZZculRN08NrlajXbBhT+nylMG6ljZoic0OlIGs+Rtp49scVMkX3Ytz5EUUj9pgVvcWQ==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/types@4.101.24':
+    resolution: {integrity: sha512-QMxfO7kGng2sJyUTwejRFSxTbVqJXVbr9rkI5Ow8sLEa+HHc+33D9KVJDjMQeJ6XIxwOk7d86X9gLnGFHxnncg==}
+    engines: {node: '>=18.17.0'}
 
   '@coinbase/wallet-sdk@4.3.6':
     resolution: {integrity: sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==}
@@ -2625,6 +2658,9 @@ packages:
   '@solana/web3.js@1.98.4':
     resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
 
@@ -3676,6 +3712,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -3771,6 +3810,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   derive-valtio@0.1.0:
     resolution: {integrity: sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==}
@@ -4238,6 +4281,9 @@ packages:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
@@ -4458,6 +4504,9 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -4779,6 +4828,10 @@ packages:
 
   js-binary-schema-parser@2.0.3:
     resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
+
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
@@ -6100,6 +6153,9 @@ packages:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -6197,6 +6253,11 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swr@2.3.4:
+    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
@@ -7923,6 +7984,84 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@clerk/backend@2.33.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@clerk/shared': 3.47.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/types': 4.101.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/clerk-react@5.61.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@clerk/shared': 3.47.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+
+  '@clerk/clerk-react@5.61.7(react-dom@19.2.5(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@clerk/shared': 3.47.6(react-dom@19.2.5(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 19.2.5(react@18.3.1)
+      tslib: 2.8.1
+    optional: true
+
+  '@clerk/clerk-react@5.61.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@clerk/shared': 3.47.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+    optional: true
+
+  '@clerk/shared@3.47.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.7
+      std-env: 3.10.0
+      swr: 2.3.4(react@18.3.1)
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@clerk/shared@3.47.6(react-dom@19.2.5(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.7
+      std-env: 3.10.0
+      swr: 2.3.4(react@18.3.1)
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 19.2.5(react@18.3.1)
+    optional: true
+
+  '@clerk/shared@3.47.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.7
+      std-env: 3.10.0
+      swr: 2.3.4(react@19.2.5)
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optional: true
+
+  '@clerk/types@4.101.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@clerk/shared': 3.47.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(immer@10.2.0)(react@19.2.5)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@6.0.6)(zod@4.4.2)':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -9605,6 +9744,8 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@stablelib/base64@1.0.1': {}
+
   '@swc/helpers@0.5.21':
     dependencies:
       tslib: 2.8.1
@@ -11157,30 +11298,33 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convex@1.17.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  convex@1.17.4(@clerk/clerk-react@5.61.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       esbuild: 0.23.0
       jwt-decode: 3.1.2
       prettier: 3.2.5
     optionalDependencies:
+      '@clerk/clerk-react': 5.61.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  convex@1.17.4(react-dom@19.2.5(react@18.3.1))(react@18.3.1):
+  convex@1.17.4(@clerk/clerk-react@5.61.7(react-dom@19.2.5(react@18.3.1))(react@18.3.1))(react-dom@19.2.5(react@18.3.1))(react@18.3.1):
     dependencies:
       esbuild: 0.23.0
       jwt-decode: 3.1.2
       prettier: 3.2.5
     optionalDependencies:
+      '@clerk/clerk-react': 5.61.7(react-dom@19.2.5(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 19.2.5(react@18.3.1)
 
-  convex@1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  convex@1.17.4(@clerk/clerk-react@5.61.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       esbuild: 0.23.0
       jwt-decode: 3.1.2
       prettier: 3.2.5
     optionalDependencies:
+      '@clerk/clerk-react': 5.61.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
@@ -11243,6 +11387,8 @@ snapshots:
       source-map: 0.6.1
 
   css-what@6.2.2: {}
+
+  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 
@@ -11322,6 +11468,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5)):
     dependencies:
@@ -11958,6 +12106,8 @@ snapshots:
   fast-redact@3.5.0:
     optional: true
 
+  fast-sha256@1.3.0: {}
+
   fast-stable-stringify@1.0.0: {}
 
   fast-uri@3.1.2: {}
@@ -12184,6 +12334,8 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob-to-regexp@0.4.1: {}
 
   glob@10.5.0:
     dependencies:
@@ -12540,6 +12692,8 @@ snapshots:
   js-base64@3.7.8: {}
 
   js-binary-schema-parser@2.0.3: {}
+
+  js-cookie@3.0.7: {}
 
   js-sha3@0.8.0: {}
 
@@ -14043,6 +14197,11 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
@@ -14134,6 +14293,19 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swr@2.3.4(react@18.3.1):
+    dependencies:
+      dequal: 2.0.3
+      react: 18.3.1
+      use-sync-external-store: 1.4.0(react@18.3.1)
+
+  swr@2.3.4(react@19.2.5):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.5
+      use-sync-external-store: 1.4.0(react@19.2.5)
+    optional: true
 
   tar@6.2.1:
     dependencies:
@@ -14367,6 +14539,10 @@ snapshots:
     dependencies:
       react: 19.2.5
     optional: true
+
+  use-sync-external-store@1.4.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   use-sync-external-store@1.4.0(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## Bundle 4 PR6 of 6 — Admin endpoint + dev-UI panel

Adds the operator path for injecting pendingMessages rows via dev-UI. Sets the auth pattern for ALL future admin features — never hand-roll auth, always go through `/api/admin/*` + Clerk.

Closes #568.

## Changes

### Server-side admin
- `apps/web/server/admin/` — server-only code (outside `src/` to prevent Vite bundling) for Clerk auth wrapper + Convex client + slug generator + Vite middleware handler
- `apps/web/vite.config.ts` — mounts `/api/admin/*` middleware in dev/preview
- `apps/server/convex/adminMessages.ts` — `injectMessage` mutation (BUS_OPERATOR_SECRET validated via existing `authShared` helper)

### Dev-UI panel
- `apps/web/src/components/cockpit/tabs/AdminMessageTab.tsx` — per-elder admin panel:
  - Target dropdown: `elder-1..elder-4` + `all` (fan-out)
  - Source dropdown: `admin-injection` / `user-message`
  - Textarea: max 2000 chars + counter
  - Submit → POST `/api/admin/inject-message` → returns thematic slug
- Wired `ADMIN` into existing `CockpitTabBar` + `MiniCockpit` tab patterns

### Auth scaffold
- `@clerk/clerk-react` + `@clerk/backend` pinned
- `ClerkProvider` in `main.tsx` (only when `VITE_CLERK_PUBLISHABLE_KEY` is set)
- `ADMIN_AUTH_BYPASS=true` env var in non-prod for dev work
- `BUS_OPERATOR_SECRET_FILE` server-side only — never reaches client

### Thematic slug
Server-side ad-hoc (6 themed pools × 3 words + 4-hex suffix). TODO(post-PR2): migrate to shared utility once PR2 lands.

## Validation

- ✅ `pnpm --filter @clan-world/web typecheck`
- ✅ `pnpm --filter @clan-world/server typecheck`
- ✅ `pnpm --filter @clan-world/web test`: 8 pass
- ✅ `pnpm --filter @clan-world/server test`: 119 pass
- ✅ Convex codegen clean

## Notes

- **Clerk app NOT provisioned yet.** Production requires Liam to set `CLERK_SECRET_KEY` + `VITE_CLERK_PUBLISHABLE_KEY` before Clerk paths fire. Until then, `ADMIN_AUTH_BYPASS=true` enables the dev path.
- **Vite middleware covers dev/preview only.** Production deploy needs a Node/Vercel function adapter — TODO documented in handler.
- **Type-cast workarounds** (intentional, documented in code):
  - `ClerkProvider: any` — Clerk ComponentClass typings don't satisfy strict React 18 JSX element constraint
  - `anyApi → unknown → typed` — codegen lag for admin mutation

## Process

Codex 5-stage (high reasoning):
- Stage 1: framework identification + scope planning
- Stage 2: implement (sandbox couldn't pull Clerk deps — orchestrator finished install + 2 type fixes)
- Type-error fixes applied orchestrator-side: `pickRandom` non-null assertion + `ClerkProvider: any` cast + `anyApi unknown` cast

Targets integration branch `dev-phase-4-simplified-comms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)