### PR TITLE
feat(bundle4): per-elder runner core rewrite — lifecycle + two-phase commit (#564)

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -64,7 +64,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash \
 RUN userdel -r node 2>/dev/null || true \
     && groupadd -g ${ELDER_GID} elder \
     && useradd -m -u ${ELDER_UID} -g ${ELDER_GID} -s /bin/bash elder \
-    && mkdir -p /home/elder/.claude /workspace /opt/clan-world \
+    && mkdir -p /home/elder/.claude /home/elder/.runner-state /workspace /opt/clan-world \
     && chown -R elder:elder /home/elder /workspace
 
 # Entrypoint scripts. init-firewall.sh requires CAP_NET_ADMIN; it runs via

--- a/agents/entrypoint.sh
+++ b/agents/entrypoint.sh
@@ -5,9 +5,10 @@
 #
 # Runs as the `elder` non-root user (UID 1000). Calls the iptables egress
 # lockdown via sudo (which is allowed only for /opt/clan-world/init-firewall.sh
-# via /etc/sudoers.d/elder-firewall), creates a named tmux session, starts
-# ttyd against it, starts the elder-runtime supervisor, then runs a foreground
-# monitor loop that exits the container if any process dies.
+# via /etc/sudoers.d/elder-firewall), starts the runner, then runs a foreground
+# monitor loop that exits the container if any process dies. The runner owns
+# tmux + claude launch so it can enforce memory-wipe recovery before any
+# `claude --continue` happens.
 
 set -euo pipefail
 
@@ -35,38 +36,37 @@ else
   exit 3
 fi
 
-# 1. Create named tmux session running run.sh (detached, working dir /workspace)
-tmux new-session -d -s "${SESSION_NAME}" -c /workspace "/opt/clan-world/shared/run.sh"
-echo "[entrypoint] tmux session ${SESSION_NAME} created"
+# Clear any session inherited from a previous entrypoint invocation in the same
+# container. The runner will recreate it after its local invariants are checked.
+tmux kill-session -t "${SESSION_NAME}" 2>/dev/null || true
 
-# 2. Start ttyd attached to that session (background)
-ttyd --port "${TTYD_PORT}" --writable tmux attach-session -t "${SESSION_NAME}" &
-TTYD_PID=$!
-echo "[entrypoint] ttyd started on port ${TTYD_PORT} (PID ${TTYD_PID})"
-
-# 3. Start elder-runtime supervisor (background)
-# Readiness file lives in the per-elder state dir (writable by UID 1000)
-READY_FILE="${CLAN_WORLD_RUNNER_STATE_DIR:-/workspace/.runtime}/elder-runtime.ready"
+# 1. Start elder-runner (background). It creates tmux and launches claude.
+READY_FILE="${CLAN_WORLD_RUNNER_STATE_DIR:-/home/elder/.runner-state}/elder-runtime.ready"
 RUNTIME_PID=""
 if command -v tsx &>/dev/null && [[ -f /opt/elder-runtime/src/main.ts ]]; then
-  rm -f "${READY_FILE}"   # clear any stale ready file from previous run
+  rm -f "${READY_FILE}"
   tsx /opt/elder-runtime/src/main.ts &
   RUNTIME_PID=$!
-  # Wait up to 30s for readiness file written by supervisor after startup
-  for i in $(seq 1 30); do
+  for i in $(seq 1 45); do
     sleep 1
     if [[ -f "${READY_FILE}" ]]; then
-      echo "[entrypoint] elder-runtime ready (file=${READY_FILE})"
+      echo "[entrypoint] elder-runner ready (file=${READY_FILE})"
       break
     fi
-    if [[ $i -eq 30 ]]; then
-      echo "[entrypoint] ERROR: elder-runtime did not become ready in 30s — aborting" >&2
+    if [[ $i -eq 45 ]]; then
+      echo "[entrypoint] ERROR: elder-runner did not become ready in 45s — aborting" >&2
       exit 1
     fi
   done
 else
-  echo "[entrypoint] WARNING: elder-runtime not found — running without supervisor" >&2
+  echo "[entrypoint] FATAL: elder-runner not found at /opt/elder-runtime/src/main.ts" >&2
+  exit 1
 fi
+
+# 2. Start ttyd attached to the runner-created tmux session (background)
+ttyd --port "${TTYD_PORT}" --writable tmux attach-session -t "${SESSION_NAME}" &
+TTYD_PID=$!
+echo "[entrypoint] ttyd started on port ${TTYD_PORT} (PID ${TTYD_PID})"
 
 # 4. Foreground monitor loop — exit container if any process dies.
 # compose restart: on-failure will restart the whole container.
@@ -80,7 +80,7 @@ while true; do
     exit 1
   fi
   if [[ -n "${RUNTIME_PID}" ]] && ! kill -0 "${RUNTIME_PID}" 2>/dev/null; then
-    echo "[entrypoint] elder-runtime (PID ${RUNTIME_PID}) died — exiting container" >&2
+    echo "[entrypoint] elder-runner (PID ${RUNTIME_PID}) died — exiting container" >&2
     exit 1
   fi
   sleep 5

--- a/agents/shared/run.sh
+++ b/agents/shared/run.sh
@@ -12,6 +12,8 @@
 #      settings.json + CLAUDE.md + skills/ resolve to the host-authored versions.
 #   3. Detect whether a previous CC conversation exists for this CWD.
 #   4. Exec `claude` with --continue when prior history exists, fresh otherwise.
+#      The runner may override auto-detection with CLAN_WORLD_CLAUDE_CONTINUE:
+#      `always`, `never`, or `auto` (default).
 #      Always append the shared system prompt via --append-system-prompt-file.
 #
 # Per-elder env vars are injected by docker compose's `env_file:` directive
@@ -119,7 +121,14 @@ APPEND_PROMPT="/opt/clan-world/shared/APPENDED_SYSTEM_PROMPT.md"
 
 # --- launch ----------------------------------------------------------------
 
-if compgen -G "$SESSIONS_DIR/*.jsonl" > /dev/null 2>&1; then
+CONTINUE_MODE="${CLAN_WORLD_CLAUDE_CONTINUE:-auto}"
+if [ "$CONTINUE_MODE" = "always" ]; then
+  echo "[run.sh] runner requested --continue"
+  exec claude --continue --append-system-prompt-file "$APPEND_PROMPT"
+elif [ "$CONTINUE_MODE" = "never" ]; then
+  echo "[run.sh] runner requested fresh session"
+  exec claude --append-system-prompt-file "$APPEND_PROMPT"
+elif compgen -G "$SESSIONS_DIR/*.jsonl" > /dev/null 2>&1; then
   echo "[run.sh] previous conversation found at $SESSIONS_DIR, resuming with --continue"
   exec claude --continue --append-system-prompt-file "$APPEND_PROMPT"
 else

--- a/agents/shared/runner/elder-config.json
+++ b/agents/shared/runner/elder-config.json
@@ -1,0 +1,6 @@
+{
+  "elder-1": { "displayName": "Storm Riders", "color": "blue", "glyph": "⚡" },
+  "elder-2": { "displayName": "Iron Guard", "color": "olive", "glyph": "⛨" },
+  "elder-3": { "displayName": "Crimson", "color": "red", "glyph": "✦" },
+  "elder-4": { "displayName": "Verdant Wardens", "color": "green", "glyph": "❦" }
+}

--- a/apps/server/convex/_generated/api.d.ts
+++ b/apps/server/convex/_generated/api.d.ts
@@ -34,6 +34,7 @@ import type * as mock from "../mock.js";
 import type * as ops from "../ops.js";
 import type * as resetLock from "../resetLock.js";
 import type * as retention from "../retention.js";
+import type * as runner from "../runner.js";
 import type * as runnerStatus from "../runnerStatus.js";
 import type * as vault from "../vault.js";
 
@@ -67,6 +68,7 @@ declare const fullApi: ApiFromModules<{
   ops: typeof ops;
   resetLock: typeof resetLock;
   retention: typeof retention;
+  runner: typeof runner;
   runnerStatus: typeof runnerStatus;
   vault: typeof vault;
 }>;

--- a/apps/server/convex/runner.test.ts
+++ b/apps/server/convex/runner.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  consumePendingMessages,
+  getRunnerStartupState,
+  hasTickReceive,
+  recordResetEvent,
+  recordTickSend,
+} from "./runner";
+
+function createDb(tables: Record<string, any[]> = {}) {
+  return {
+    query(table: string) {
+      let rows = [...(tables[table] ?? [])];
+      const builder = {
+        withIndex(_name: string, apply: (q: any) => unknown) {
+          const clauses: Array<{ field: string; value: unknown }> = [];
+          const q = {
+            eq(field: string, value: unknown) {
+              clauses.push({ field, value });
+              return q;
+            },
+          };
+          apply(q);
+          rows = rows.filter((row) => clauses.every((clause) => row[clause.field] === clause.value));
+          return builder;
+        },
+        order(direction: "asc" | "desc") {
+          rows = [...rows].sort((a, b) =>
+            direction === "desc"
+              ? (b._creationTime ?? 0) - (a._creationTime ?? 0)
+              : (a._creationTime ?? 0) - (b._creationTime ?? 0),
+          );
+          return builder;
+        },
+        async first() { return rows[0] ?? null; },
+        async take(n: number) { return rows.slice(0, n); },
+      };
+      return builder;
+    },
+    async insert(table: string, row: Record<string, unknown>) {
+      const id = `${table}:${(tables[table] ?? []).length + 1}`;
+      tables[table] ??= [];
+      tables[table].push({ _id: id, _creationTime: tables[table].length + 1, ...row });
+      return id;
+    },
+    async patch(id: string, patch: Record<string, unknown>) {
+      for (const rows of Object.values(tables)) {
+        const row = rows.find(candidate => candidate._id === id);
+        if (row) {
+          Object.assign(row, patch);
+          return;
+        }
+      }
+      throw new Error(`missing row ${id}`);
+    },
+  };
+}
+
+function call(fn: any, db: any, args: any) {
+  return fn._handler({ db }, args);
+}
+
+describe("convex runner functions", () => {
+  it("returns startup state with last received tick and sent flag", async () => {
+    const db = createDb({
+      tickClock: [{ _id: "tickClock:1", _creationTime: 1, tick: 8, tickEpochStartedAt: 0, tickEpochDurationMs: 60_000, seasonStartTick: 0, seasonEndTick: 360, winterActive: false }],
+      tickReceiveLog: [{ _id: "tickReceiveLog:1", _creationTime: 1, elderId: "elder-1", receivedAt: 1, prefix: "tick", tickNumber: 7, messagePreview: "" }],
+      tickSendLog: [{ _id: "tickSendLog:1", _creationTime: 1, elderId: "elder-1", tickNumber: 8, sentAt: 1, messageHash: "abc" }],
+    });
+
+    const result = await call(getRunnerStartupState, db, { elderId: "elder-1" });
+    expect(result.lastReceivedTick).toBe(7);
+    expect(result.sentForCurrentTick).toBe(true);
+    expect(result.gameSettings.memoryWipeTickInterval).toBe(50);
+  });
+
+  it("records tick sends and reset events", async () => {
+    const tables: Record<string, any[]> = {};
+    const db = createDb(tables);
+    const resetEventId = await call(recordResetEvent, db, {
+      elderId: "elder-1",
+      resetTick: 50,
+      reason: "scheduled",
+    });
+    const sendId = await call(recordTickSend, db, {
+      elderId: "elder-1",
+      tickNumber: 50,
+      messageHash: "hash",
+      resetMetadata: { resetTick: 50, resetReason: "scheduled", resetEventId },
+    });
+    expect(sendId).toBe("tickSendLog:1");
+    expect(tables.tickSendLog?.[0]?.resetMetadata.resetReason).toBe("scheduled");
+  });
+
+  it("checks tick receive and consumes pending messages", async () => {
+    const tables: Record<string, any[]> = {
+      tickReceiveLog: [{ _id: "tickReceiveLog:1", _creationTime: 1, elderId: "elder-1", receivedAt: 1, prefix: "tick", tickNumber: 9, messagePreview: "" }],
+      pendingMessages: [{ _id: "pendingMessages:1", _creationTime: 1, targetElderId: "elder-1", text: "x", source: "user-message", insertedAt: 1, consumedAt: undefined }],
+    };
+    const db = createDb(tables);
+    expect(await call(hasTickReceive, db, { elderId: "elder-1", tickNumber: 9 })).toBe(true);
+    await call(consumePendingMessages, db, { messageIds: ["pendingMessages:1"], consumedAt: 123 });
+    expect(tables.pendingMessages?.[0]?.consumedAt).toBe(123);
+  });
+});

--- a/apps/server/convex/runner.ts
+++ b/apps/server/convex/runner.ts
@@ -1,0 +1,264 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import {
+  HEARTBEAT_INTERVAL_SECONDS,
+  SEASON_DURATION_TICKS,
+  WINTER_DURATION_TICKS,
+  WINTER_PERIOD_TICKS,
+  WINTER_START_TICK,
+} from "@clan-world/shared/generated/constants";
+
+const VALID_ELDER_IDS = ["elder-1", "elder-2", "elder-3", "elder-4"] as const;
+const EVENT_FETCH_LIMIT = 50;
+const PENDING_FETCH_LIMIT = 25;
+const UID_SCAN_LIMIT = 5000;
+
+const elderIdValidator = v.union(
+  v.literal("elder-1"),
+  v.literal("elder-2"),
+  v.literal("elder-3"),
+  v.literal("elder-4"),
+);
+
+const resetReasonValidator = v.union(
+  v.literal("scheduled"),
+  v.literal("manual"),
+  v.literal("memory_wipe_gap"),
+  v.literal("late_join"),
+);
+
+const runnerEventKindValidator = v.union(
+  v.literal("hook_failure"),
+  v.literal("convex_outage_recovery"),
+  v.literal("settings_drift_panic"),
+  v.literal("invariant_violation"),
+  v.literal("ready_probe_timeout"),
+);
+
+function assertKnownElder(elderId: string): void {
+  if (!VALID_ELDER_IDS.includes(elderId as (typeof VALID_ELDER_IDS)[number])) {
+    throw new Error(`unknown elderId: ${elderId}`);
+  }
+}
+
+function memoryWipeTickInterval(): number {
+  const configured = process.env.CLAN_WORLD_MEMORY_WIPE_TICK_INTERVAL;
+  if (configured) {
+    const parsed = Number(configured);
+    if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+  }
+  // TODO(future): source from contract/settings table when runtime settings exist.
+  return 50;
+}
+
+function gameSettings(clock?: { heartbeatIntervalSeconds?: number } | null) {
+  return {
+    heartbeatIntervalSeconds:
+      clock?.heartbeatIntervalSeconds ?? Number(HEARTBEAT_INTERVAL_SECONDS),
+    memoryWipeTickInterval: memoryWipeTickInterval(),
+    winterStartTick: Number(WINTER_START_TICK),
+    winterDurationTicks: Number(WINTER_DURATION_TICKS),
+    winterPeriodTicks: Number(WINTER_PERIOD_TICKS),
+    seasonDurationTicks: Number(SEASON_DURATION_TICKS),
+    contractAddress: process.env.CLAN_WORLD_CONTRACT_ADDRESS ?? "",
+  };
+}
+
+async function latestClock(ctx: { db: any }) {
+  const clock = await ctx.db.query("tickClock").order("desc").first();
+  if (clock) return clock;
+  return {
+    tick: 0,
+    tickEpochStartedAt: 0,
+    tickEpochDurationMs: Number(HEARTBEAT_INTERVAL_SECONDS) * 1000,
+    heartbeatIntervalSeconds: Number(HEARTBEAT_INTERVAL_SECONDS),
+    seasonStartTick: 0,
+    seasonEndTick: Number(SEASON_DURATION_TICKS),
+    winterActive: false,
+    winterStartsAtTick: Number(WINTER_START_TICK),
+  };
+}
+
+async function latestReceivedTick(ctx: { db: any }, elderId: string): Promise<number | null> {
+  const rows = await ctx.db
+    .query("tickReceiveLog")
+    .withIndex("by_elder_received", (q: any) => q.eq("elderId", elderId))
+    .order("desc")
+    .take(200);
+  const tickRows = rows.filter((row: any) => typeof row.tickNumber === "number");
+  if (tickRows.length === 0) return null;
+  return Math.max(...tickRows.map((row: any) => row.tickNumber));
+}
+
+export const getRunnerStartupState = query({
+  args: { elderId: elderIdValidator },
+  handler: async (ctx, { elderId }) => {
+    assertKnownElder(elderId);
+    const clock = await latestClock(ctx);
+    const lastReceivedTick = await latestReceivedTick(ctx, elderId);
+    const sentForCurrentTick =
+      (await ctx.db
+        .query("tickSendLog")
+        .withIndex("by_elder_tick", (q) =>
+          q.eq("elderId", elderId).eq("tickNumber", clock.tick),
+        )
+        .first()) !== null;
+
+    return {
+      tickClock: clock,
+      gameSettings: gameSettings(clock),
+      lastReceivedTick,
+      sentForCurrentTick,
+    };
+  },
+});
+
+export const getRunnerAuxiliary = query({
+  args: { elderId: elderIdValidator },
+  handler: async (ctx, { elderId }) => {
+    assertKnownElder(elderId);
+    const clock = await latestClock(ctx);
+    const snapshot = await ctx.db.query("worldSnapshot").order("desc").first();
+    const activeBanditId =
+      typeof snapshot?.activeBanditId === "number" && snapshot.activeBanditId > 0
+        ? snapshot.activeBanditId
+        : undefined;
+    const banditView =
+      activeBanditId === undefined
+        ? null
+        : await ctx.db
+          .query("banditView")
+          .withIndex("by_bandit_id", (q) => q.eq("id", activeBanditId))
+          .order("desc")
+          .first();
+
+    const chainEvents = await ctx.db
+      .query("chainEvents")
+      .withIndex("by_tick", (q) => q.eq("tick", clock.tick))
+      .order("desc")
+      .take(EVENT_FETCH_LIMIT);
+
+    const pendingMessages = await ctx.db
+      .query("pendingMessages")
+      .withIndex("by_target_unconsumed", (q) =>
+        q.eq("targetElderId", elderId).eq("consumedAt", undefined),
+      )
+      .order("asc")
+      .take(PENDING_FETCH_LIMIT);
+
+    return {
+      tickClock: clock,
+      gameSettings: gameSettings(clock),
+      banditView,
+      chainEvents,
+      pendingMessages,
+    };
+  },
+});
+
+export const hasTickReceive = query({
+  args: { elderId: elderIdValidator, tickNumber: v.number() },
+  handler: async (ctx, { elderId, tickNumber }) => {
+    assertKnownElder(elderId);
+    return (
+      (await ctx.db
+        .query("tickReceiveLog")
+        .withIndex("by_elder_tick", (q) =>
+          q.eq("elderId", elderId).eq("tickNumber", tickNumber),
+        )
+        .first()) !== null
+    );
+  },
+});
+
+export const isThematicUidTaken = query({
+  args: { uid: v.string() },
+  handler: async (ctx, { uid }) => {
+    const rows = await ctx.db.query("tickReceiveLog").order("desc").take(UID_SCAN_LIMIT);
+    return rows.some((row) => row.whisperUid === uid || row.specialMsgUid === uid);
+  },
+});
+
+export const hasMessageUidReceive = query({
+  args: { uid: v.string() },
+  handler: async (ctx, { uid }) => {
+    const rows = await ctx.db.query("tickReceiveLog").order("desc").take(UID_SCAN_LIMIT);
+    return rows.some((row) => row.whisperUid === uid || row.specialMsgUid === uid);
+  },
+});
+
+export const recordTickSend = mutation({
+  args: {
+    elderId: elderIdValidator,
+    tickNumber: v.number(),
+    messageHash: v.string(),
+    resetMetadata: v.optional(v.object({
+      resetTick: v.number(),
+      resetReason: resetReasonValidator,
+      resetEventId: v.id("resetEventLog"),
+    })),
+  },
+  handler: async (ctx, args) => {
+    assertKnownElder(args.elderId);
+    return await ctx.db.insert("tickSendLog", {
+      elderId: args.elderId,
+      tickNumber: args.tickNumber,
+      sentAt: Date.now(),
+      messageHash: args.messageHash,
+      ...(args.resetMetadata ? { resetMetadata: args.resetMetadata } : {}),
+    });
+  },
+});
+
+export const consumePendingMessages = mutation({
+  args: {
+    messageIds: v.array(v.id("pendingMessages")),
+    consumedAt: v.number(),
+  },
+  handler: async (ctx, { messageIds, consumedAt }) => {
+    for (const id of messageIds) {
+      await ctx.db.patch(id, { consumedAt });
+    }
+  },
+});
+
+export const recordResetEvent = mutation({
+  args: {
+    elderId: elderIdValidator,
+    resetTick: v.number(),
+    reason: resetReasonValidator,
+  },
+  handler: async (ctx, { elderId, resetTick, reason }) => {
+    assertKnownElder(elderId);
+    return await ctx.db.insert("resetEventLog", {
+      elderId,
+      resetTick,
+      reason,
+      startedAt: Date.now(),
+    });
+  },
+});
+
+export const completeResetEvent = mutation({
+  args: { resetEventId: v.id("resetEventLog") },
+  handler: async (ctx, { resetEventId }) => {
+    await ctx.db.patch(resetEventId, { completedAt: Date.now() });
+  },
+});
+
+export const recordRunnerEvent = mutation({
+  args: {
+    elderId: elderIdValidator,
+    kind: runnerEventKindValidator,
+    message: v.string(),
+  },
+  handler: async (ctx, { elderId, kind, message }) => {
+    assertKnownElder(elderId);
+    await ctx.db.insert("runnerEvents", {
+      elderId,
+      kind,
+      message,
+      at: Date.now(),
+    });
+  },
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,7 +291,7 @@ services:
       # Verifies tmux session, ttyd process, and elder-runtime supervisor (tsx) — all three
       # required for Phase 1.9 (#352). Hardcoded elder-1 literal because compose-time
       # ${ELDER_N} was empty at compose-config time (super-swarm R2 finding f0a55977).
-      test: ["CMD-SHELL", "tmux has-session -t elder-1 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null"]
+      test: ["CMD-SHELL", "tmux has-session -t elder-1 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null && test \"$(pgrep claude | wc -l)\" -eq 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -315,7 +315,7 @@ services:
       - elder-2-home:/home/elder/.claude
       - elder-2-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "tmux has-session -t elder-2 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null"]
+      test: ["CMD-SHELL", "tmux has-session -t elder-2 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null && test \"$(pgrep claude | wc -l)\" -eq 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -339,7 +339,7 @@ services:
       - elder-3-home:/home/elder/.claude
       - elder-3-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "tmux has-session -t elder-3 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null"]
+      test: ["CMD-SHELL", "tmux has-session -t elder-3 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null && test \"$(pgrep claude | wc -l)\" -eq 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -363,7 +363,7 @@ services:
       - elder-4-home:/home/elder/.claude
       - elder-4-workspace:/workspace
     healthcheck:
-      test: ["CMD-SHELL", "tmux has-session -t elder-4 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null"]
+      test: ["CMD-SHELL", "tmux has-session -t elder-4 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null && test \"$(pgrep claude | wc -l)\" -eq 1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/packages/runner/src/config.ts
+++ b/packages/runner/src/config.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
-import type { ElderRuntimeConfig, ElderN } from "./types.js";
+import path from "node:path";
+import type { ElderRuntimeConfig, ElderN, RunnerConfig } from "./types.js";
 
-const VALID_ELDER_IDS: ElderN[] = ["elder-1", "elder-2", "elder-3", "elder-4"];
+export const VALID_ELDER_IDS: ElderN[] = ["elder-1", "elder-2", "elder-3", "elder-4"];
 
 function parsePositiveInt(val: string | undefined, fallback: number, name: string): number {
   if (!val) return fallback;
@@ -12,11 +13,27 @@ function parsePositiveInt(val: string | undefined, fallback: number, name: strin
   return n;
 }
 
-export function loadConfig(): ElderRuntimeConfig {
+function parseElderId(): { elderId: ElderN; elderN: string } {
+  const elderIdEnv = process.env["ELDER_ID"];
   const elderN = process.env["ELDER_N"];
-  if (!elderN) throw new Error("ELDER_N env var required (1..4)");
+  if (elderIdEnv) {
+    if (!VALID_ELDER_IDS.includes(elderIdEnv as ElderN)) {
+      throw new Error(`Invalid ELDER_ID: ${elderIdEnv}`);
+    }
+    const derivedN = elderIdEnv.replace("elder-", "");
+    if (elderN && elderN !== derivedN) {
+      throw new Error(`ELDER_ID (${elderIdEnv}) does not match ELDER_N (${elderN})`);
+    }
+    return { elderId: elderIdEnv as ElderN, elderN: derivedN };
+  }
+  if (!elderN) throw new Error("ELDER_ID or ELDER_N env var required");
   const elderId = `elder-${elderN}` as ElderN;
   if (!VALID_ELDER_IDS.includes(elderId)) throw new Error(`Invalid ELDER_N: ${elderN}`);
+  return { elderId, elderN };
+}
+
+export function loadConfig(): RunnerConfig {
+  const { elderId, elderN } = parseElderId();
 
   const convexUrl = process.env["CONVEX_DEPLOY_URL"];
   if (!convexUrl) throw new Error("CONVEX_DEPLOY_URL env var required");
@@ -29,12 +46,15 @@ export function loadConfig(): ElderRuntimeConfig {
   } catch {
     throw new Error(`Cannot read bus secret from ${secretFile}`);
   }
+  const stateDir = process.env["CLAN_WORLD_RUNNER_STATE_DIR"] ?? "/home/elder/.runner-state";
+  const readyPath = path.join(stateDir, "elder-runtime.ready");
 
   return {
     elderId,
     convexUrl,
     busSecret,
-    stateDir: process.env["CLAN_WORLD_RUNNER_STATE_DIR"] ?? "/workspace/.runtime",
+    runnerSecret: busSecret,
+    stateDir,
     ancientWisdomPath: process.env["ANCIENT_WISDOM_PATH"] ?? "/workspace/ANCIENT_WISDOM.md",
     pollIntervalMs: parsePositiveInt(process.env["ELDER_RUNTIME_POLL_MS"], 5000, "ELDER_RUNTIME_POLL_MS"),
     heartbeatIntervalMs: parsePositiveInt(process.env["ELDER_RUNTIME_HEARTBEAT_MS"], 30000, "ELDER_RUNTIME_HEARTBEAT_MS"),
@@ -43,5 +63,17 @@ export function loadConfig(): ElderRuntimeConfig {
     // delivery. PR1 preserves the knob so the renamed runtime boots unchanged.
     nonceTimeoutMs: parsePositiveInt(process.env["ELDER_RUNTIME_NONCE_TIMEOUT_MS"], 240000, "ELDER_RUNTIME_NONCE_TIMEOUT_MS"),
     runScriptPath: process.env["ELDER_RUN_SCRIPT_PATH"] ?? "/opt/clan-world/shared/run.sh",
+    lockPath: path.join(stateDir, "elder-runner.lock"),
+    wipeMarkerPath: path.join(stateDir, "last-wipe-tick"),
+    readyPath,
+    promptDir: process.env["RUNNER_PROMPTS_DIR"] ?? "/opt/clan-world/shared/runner/prompts",
+    elderConfigPath: process.env["RUNNER_ELDER_CONFIG_PATH"] ?? "/opt/clan-world/shared/runner/elder-config.json",
+    workspaceDir: process.env["RUNNER_WORKSPACE_DIR"] ?? "/workspace",
+    appendSystemPromptFile: process.env["RUNNER_APPEND_SYSTEM_PROMPT_FILE"] ?? "/opt/clan-world/shared/APPENDED_SYSTEM_PROMPT.md",
+    hookReceiveTimeoutMs: parsePositiveInt(process.env["RUNNER_HOOK_RECEIVE_TIMEOUT_MS"], 90_000, "RUNNER_HOOK_RECEIVE_TIMEOUT_MS"),
+    hookReceivePollMs: parsePositiveInt(process.env["RUNNER_HOOK_RECEIVE_POLL_MS"], 3_000, "RUNNER_HOOK_RECEIVE_POLL_MS"),
+    maxPasteAttempts: parsePositiveInt(process.env["RUNNER_MAX_PASTE_ATTEMPTS"], 3, "RUNNER_MAX_PASTE_ATTEMPTS"),
   };
 }
+
+export type { ElderRuntimeConfig };

--- a/packages/runner/src/convexClient.ts
+++ b/packages/runner/src/convexClient.ts
@@ -1,34 +1,183 @@
-import type { AgentCommand, ElderN, Health } from "./types.js";
+import { ConvexHttpClient, ConvexClient } from "convex/browser";
+import { anyApi } from "convex/server";
+import type {
+  AgentCommand,
+  ElderN,
+  GameSettings,
+  Health,
+  PendingMessage,
+  ResetMetadata,
+  ResetReason,
+  RunnerAuxiliary,
+  RunnerEventKind,
+  RunnerStartupState,
+  TickSendResult,
+} from "./types.js";
+import { withBackoff } from "./retry.js";
 
-export class BusClient {
-  constructor(_url: string, _secret: string, _agentId: ElderN) {
-    // TODO(PR2): replace command-bus calls with pendingMessages reads and
-    // tickSendLog/tickReceiveLog writes. PR1 keeps the old runtime bootable
-    // after deleting the old Convex bus module.
+const api = anyApi as any;
+
+export class RunnerConvexClient {
+  private readonly http: ConvexHttpClient;
+  private readonly live: ConvexClient;
+
+  constructor(
+    private readonly url: string,
+    private readonly elderId: ElderN,
+  ) {
+    this.http = new ConvexHttpClient(url);
+    this.live = new ConvexClient(url);
   }
 
-  async claimNext(): Promise<AgentCommand | null> {
-    // TODO(PR2): read the next pending message for this elder.
-    return null;
+  async getStartupState(signal?: AbortSignal): Promise<RunnerStartupState> {
+    return await this.call("getRunnerStartupState", () =>
+      this.http.query(api.runner.getRunnerStartupState, { elderId: this.elderId }) as Promise<RunnerStartupState>, signal);
   }
 
-  async ackCommand(_commandId: string): Promise<void> {
-    // TODO(PR2): mark a received tick/message in tickReceiveLog.
+  async getAuxiliary(signal?: AbortSignal): Promise<RunnerAuxiliary> {
+    return await this.call("getRunnerAuxiliary", () =>
+      this.http.query(api.runner.getRunnerAuxiliary, { elderId: this.elderId }) as Promise<RunnerAuxiliary>, signal);
   }
 
-  async completeCommand(_commandId: string, _resultPayload: unknown, _tookMs: number): Promise<void> {
-    // TODO(PR2): replace command completion with Bundle 4 runner logs.
+  watchAuxiliary(signal: AbortSignal): AsyncIterable<RunnerAuxiliary> {
+    const live = this.live as any;
+    const elderId = this.elderId;
+    const self = this;
+    return {
+      async *[Symbol.asyncIterator]() {
+        const queue: Array<RunnerAuxiliary | Error> = [];
+        let wake: (() => void) | undefined;
+        const push = (item: RunnerAuxiliary | Error) => {
+          queue.push(item);
+          wake?.();
+          wake = undefined;
+        };
+        const wakeOnAbort = () => {
+          wake?.();
+          wake = undefined;
+        };
+        signal.addEventListener("abort", wakeOnAbort, { once: true });
+        const unsubscribe = live.onUpdate(
+          api.runner.getRunnerAuxiliary,
+          { elderId },
+          (value: RunnerAuxiliary) => push(value),
+          (err: Error) => push(err),
+        );
+        try {
+          while (!signal.aborted) {
+            if (queue.length === 0) {
+              await new Promise<void>((resolve) => { wake = resolve; });
+            }
+            const item = queue.shift();
+            if (!item) continue;
+            if (item instanceof Error) {
+              console.warn("[convex] subscription error; falling back to query retry:", item);
+              yield await self.getAuxiliary(signal);
+            } else {
+              yield item;
+            }
+          }
+        } finally {
+          signal.removeEventListener("abort", wakeOnAbort);
+          unsubscribe?.();
+        }
+      },
+    };
   }
 
-  async failCommand(_commandId: string, _reason: string): Promise<void> {
-    // TODO(PR2): write runnerEvents rows for delivery/handler failures.
+  async hasTickReceive(tickNumber: number, signal?: AbortSignal): Promise<boolean> {
+    return await this.call("hasTickReceive", () =>
+      this.http.query(api.runner.hasTickReceive, { elderId: this.elderId, tickNumber }) as Promise<boolean>, signal);
   }
 
-  async releaseLease(_commandId: string): Promise<void> {
-    // TODO(PR2): remove lease semantics entirely.
+  async isThematicUidTaken(uid: string, signal?: AbortSignal): Promise<boolean> {
+    return await this.call("isThematicUidTaken", () =>
+      this.http.query(api.runner.isThematicUidTaken, { uid }) as Promise<boolean>, signal);
   }
 
-  async heartbeat(_lastTickProcessed: number, _health: Health, _currentStrategy?: string): Promise<void> {
-    // TODO(PR2): replace old heartbeat writes with runnerEvents/readiness logs.
+  async hasMessageUidReceive(uid: string, signal?: AbortSignal): Promise<boolean> {
+    return await this.call("hasMessageUidReceive", () =>
+      this.http.query(api.runner.hasMessageUidReceive, { uid }) as Promise<boolean>, signal);
+  }
+
+  async recordTickSend(
+    tickNumber: number,
+    messageHash: string,
+    resetMetadata?: ResetMetadata,
+    signal?: AbortSignal,
+  ): Promise<TickSendResult> {
+    const sendLogId = await this.call("recordTickSend", () =>
+      this.http.mutation(api.runner.recordTickSend, {
+        elderId: this.elderId,
+        tickNumber,
+        messageHash,
+        ...(resetMetadata ? { resetMetadata } : {}),
+      }) as Promise<string>, signal);
+    return { sendLogId };
+  }
+
+  async consumePendingMessages(messageIds: string[], consumedAt: number, signal?: AbortSignal): Promise<void> {
+    if (messageIds.length === 0) return;
+    await this.call("consumePendingMessages", () =>
+      this.http.mutation(api.runner.consumePendingMessages, { messageIds, consumedAt }) as Promise<void>, signal);
+  }
+
+  async recordResetEvent(resetTick: number, reason: ResetReason, signal?: AbortSignal): Promise<string> {
+    return await this.call("recordResetEvent", () =>
+      this.http.mutation(api.runner.recordResetEvent, {
+        elderId: this.elderId,
+        resetTick,
+        reason,
+      }) as Promise<string>, signal);
+  }
+
+  async completeResetEvent(resetEventId: string, signal?: AbortSignal): Promise<void> {
+    await this.call("completeResetEvent", () =>
+      this.http.mutation(api.runner.completeResetEvent, { resetEventId }) as Promise<void>, signal);
+  }
+
+  async recordRunnerEvent(kind: RunnerEventKind, message: string, signal?: AbortSignal): Promise<void> {
+    await this.call("recordRunnerEvent", () =>
+      this.http.mutation(api.runner.recordRunnerEvent, {
+        elderId: this.elderId,
+        kind,
+        message,
+      }) as Promise<void>, signal);
+  }
+
+  close(): void {
+    (this.live as any).close?.();
+  }
+
+  private async call<T>(label: string, run: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    return await withBackoff(run, {
+      label: `convex:${label}`,
+      signal,
+      onRecovered: () => this.recordRunnerEventDirect("convex_outage_recovery", `${label} recovered after outage`),
+    });
+  }
+
+  private async recordRunnerEventDirect(kind: RunnerEventKind, message: string): Promise<void> {
+    try {
+      await this.http.mutation(api.runner.recordRunnerEvent, {
+        elderId: this.elderId,
+        kind,
+        message,
+      });
+    } catch {
+      // Best effort only; the recovered foreground call already succeeded.
+    }
   }
 }
+
+export class BusClient {
+  constructor(_url: string, _secret: string, _agentId: ElderN) {}
+  async claimNext(): Promise<AgentCommand | null> { return null; }
+  async ackCommand(_commandId: string): Promise<void> {}
+  async completeCommand(_commandId: string, _resultPayload: unknown, _tookMs: number): Promise<void> {}
+  async failCommand(_commandId: string, _reason: string): Promise<void> {}
+  async releaseLease(_commandId: string): Promise<void> {}
+  async heartbeat(_lastTickProcessed: number, _health: Health, _currentStrategy?: string): Promise<void> {}
+}
+
+export type { GameSettings, PendingMessage, RunnerAuxiliary, RunnerStartupState };

--- a/packages/runner/src/elderConfig.ts
+++ b/packages/runner/src/elderConfig.ts
@@ -1,0 +1,10 @@
+import fs from "node:fs";
+import type { ElderDisplayConfig, ElderN } from "./types.js";
+
+export function loadElderDisplayConfig(filePath: string, elderId: ElderN): ElderDisplayConfig {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const parsed = JSON.parse(raw) as Record<string, ElderDisplayConfig | undefined>;
+  const config = parsed[elderId];
+  if (!config) throw new Error(`missing elder display config for ${elderId}`);
+  return config;
+}

--- a/packages/runner/src/flockGuard.ts
+++ b/packages/runner/src/flockGuard.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+export interface FlockHandle {
+  release(): void;
+}
+
+export function acquireFlock(lockPath: string): FlockHandle {
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const fd = fs.openSync(lockPath, "w");
+  const result = spawnSync("flock", ["-n", "3"], {
+    stdio: ["ignore", "pipe", "pipe", fd],
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    fs.closeSync(fd);
+    const stderr = result.stderr ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`could not acquire flock ${lockPath}${stderr}`);
+  }
+  let released = false;
+  return {
+    release() {
+      if (released) return;
+      released = true;
+      fs.closeSync(fd);
+    },
+  };
+}

--- a/packages/runner/src/main.ts
+++ b/packages/runner/src/main.ts
@@ -1,155 +1,56 @@
-import { openSync, writeSync, closeSync, unlinkSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
-import path from "node:path";
 import { loadConfig } from "./config.js";
-import { BusClient } from "./convexClient.js";
+import { RunnerConvexClient } from "./convexClient.js";
+import { startup } from "./startup.js";
+import { handleAuxiliaryUpdate, handlePendingMessages, handleStartupDecision } from "./tickHandler.js";
 import { TmuxSink } from "./tmuxSink.js";
-import { FreezeGate } from "./freezeGate.js";
-import { startHeartbeat, type HeartbeatState } from "./heartbeat.js";
-import { handleUserMessage } from "./commandHandlers/userMessage.js";
-import { handleSystemMessage } from "./commandHandlers/systemMessage.js";
-import { handleSnapshotRequest } from "./commandHandlers/snapshotRequest.js";
-import { handleReset } from "./commandHandlers/reset.js";
-import { handleFreeze } from "./commandHandlers/freeze.js";
-import { handleUnfreeze } from "./commandHandlers/unfreeze.js";
 
 async function main(): Promise<void> {
-  console.log(`[elder-runtime] starting at ${new Date().toISOString()}`);
-
+  console.log(`[elder-runner] starting at ${new Date().toISOString()}`);
   const config = loadConfig();
-  console.log(`[elder-runtime] elder=${config.elderId} convex=${config.convexUrl}`);
+  console.log(`[elder-runner] elder=${config.elderId} convex=${config.convexUrl}`);
 
-  // Ensure state dir exists
-  mkdirSync(config.stateDir, { recursive: true });
-
-  // Atomic singleton lock via wx (exclusive create) — eliminates TOCTOU
-  const lockPath = path.join(config.stateDir, "supervisor.lock");
-  let lockFd: number;
-  try {
-    lockFd = openSync(lockPath, "wx");
-    writeSync(lockFd, String(process.pid));
-  } catch (err: any) {
-    if (err.code === "EEXIST") {
-      // Stale-lock check: split kill-0 and cmdline-read to avoid safe-default confusion
-      try {
-        const stalePid = parseInt(readFileSync(lockPath, "utf8").trim(), 10);
-        if (Number.isFinite(stalePid)) {
-          let pidAlive = false;
-          try {
-            process.kill(stalePid, 0);
-            pidAlive = true;
-          } catch { /* pid dead — stale lock */ }
-
-          if (pidAlive) {
-            // PID alive. Try to confirm it's actually a tsx supervisor (not PID reuse).
-            let isOurProcess = true; // default safe: assume locked when cmdline unreadable
-            try {
-              const cmdline = readFileSync(`/proc/${stalePid}/cmdline`, "utf8");
-              isOurProcess = cmdline.includes("tsx") && cmdline.includes("elder-runtime");
-            } catch {
-              // cmdline unreadable (restricted procfs, transient) — DEFAULT SAFE: treat as locked
-              console.error(`[elder-runtime] cannot read /proc/${stalePid}/cmdline; treating as locked`);
-            }
-            if (isOurProcess) {
-              console.error(`[elder-runtime] FATAL: another supervisor running at PID ${stalePid}`);
-              process.exit(1);
-            }
-            // cmdline confirmed different process — PID reuse; fall through to unlink
-          }
-          // pid dead or PID-reuse confirmed — stale, safe to unlink
-        }
-      } catch { /* lock unreadable; treat as stale */ }
-      // Stale lock — remove and retry
-      unlinkSync(lockPath);
-      lockFd = openSync(lockPath, "wx");
-      writeSync(lockFd, String(process.pid));
-    } else {
-      console.error("[elder-runtime] could not acquire singleton lock:", err);
-      process.exit(1);
-    }
-  }
-  const cleanupLock = () => {
-    try { closeSync(lockFd); } catch { /* ignore */ }
-    try { unlinkSync(lockPath); } catch { /* ignore */ }
-  };
-
-  // Write readiness file to writable stateDir — entrypoint polls for this
-  const readyPath = path.join(config.stateDir, "elder-runtime.ready");
-  try {
-    writeFileSync(readyPath, String(process.pid));
-  } catch (err) {
-    console.error("[elder-runtime] FATAL: could not write readiness file", err);
-    process.exit(1);
-  }
-
-  const bus = new BusClient(config.convexUrl, config.busSecret, config.elderId);
-  const tmux = new TmuxSink(config.elderId); // session name = "elder-1" etc.
-  const freeze = new FreezeGate();
-
+  const convex = new RunnerConvexClient(config.convexUrl, config.elderId);
+  const tmux = new TmuxSink(config.elderId);
   const ac = new AbortController();
-  process.on("SIGTERM", () => { ac.abort(); });
-  process.on("SIGINT", () => { ac.abort(); });
+  process.on("SIGTERM", () => ac.abort());
+  process.on("SIGINT", () => ac.abort());
 
-  const heartbeatState: HeartbeatState = {
-    lastTickProcessed: 0,
-    lastSuccessAt: Date.now(),
-    consecutiveErrors: 0,
-  };
-  startHeartbeat(bus, heartbeatState, config.heartbeatIntervalMs, ac.signal);
+  const started = await startup(config, convex, tmux, ac.signal);
+  try {
+    await handleStartupDecision({
+      config,
+      convex,
+      tmux,
+      cachedSettings: started.startupState.gameSettings,
+      signal: ac.signal,
+    }, started.decision);
 
-  // Poll loop
-  console.log(`[elder-runtime] poll loop started (interval=${config.pollIntervalMs}ms)`);
-  while (!ac.signal.aborted) {
-    try {
-      const command = await bus.claimNext();
-      if (command) {
-        console.log(`[elder-runtime] dispatching ${command.kind} (${command._id})`);
-        try {
-          switch (command.kind) {
-            case "user_message":
-              await handleUserMessage(command._id, command.payload, tmux, bus, freeze, config);
-              break;
-            case "system_message":
-              await handleSystemMessage(command._id, command.payload, tmux, bus, freeze, config);
-              break;
-            case "snapshot_request":
-              await handleSnapshotRequest(command._id, command.payload, bus, config);
-              break;
-            case "reset":
-              await handleReset(command._id, command.payload, tmux, bus, freeze);
-              break;
-            case "freeze":
-              await handleFreeze(command._id, command.payload, bus, freeze);
-              break;
-            case "unfreeze":
-              await handleUnfreeze(command._id, command.payload, bus, freeze);
-              break;
-            default: {
-              const kind = (command as { kind: string }).kind;
-              console.warn(`[elder-runtime] unknown kind: ${kind}`);
-              await bus.failCommand(command._id, `unknown kind: ${kind}`);
-            }
-          }
-          heartbeatState.lastTickProcessed++;
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          console.error(`[elder-runtime] handler error for ${command._id}:`, err);
-          try { await bus.failCommand(command._id, reason); } catch { /* best-effort */ }
-          heartbeatState.consecutiveErrors++;
-        }
+    let lastTickDelivered = started.decision.kind === "wait"
+      ? (started.startupState.lastReceivedTick ?? -1)
+      : started.startupState.tickClock.tick;
+    for await (const aux of convex.watchAuxiliary(ac.signal)) {
+      if (ac.signal.aborted) break;
+      const deps = {
+        config,
+        convex,
+        tmux,
+        cachedSettings: started.startupState.gameSettings,
+        signal: ac.signal,
+      };
+      if (aux.tickClock.tick <= lastTickDelivered) {
+        if (aux.pendingMessages.length > 0) await handlePendingMessages(deps, aux);
+        continue;
       }
-    } catch (err) {
-      console.error("[elder-runtime] poll error:", err);
-      heartbeatState.consecutiveErrors++;
+      await handleAuxiliaryUpdate(deps, aux);
+      lastTickDelivered = aux.tickClock.tick;
     }
-    if (!ac.signal.aborted) {
-      await new Promise(r => setTimeout(r, config.pollIntervalMs));
-    }
+  } finally {
+    started.flock.release();
+    convex.close();
   }
-  cleanupLock();
-  console.log(`[elder-runtime] shutdown complete`);
 }
 
 main().catch(err => {
-  console.error("[elder-runtime] fatal:", err);
+  console.error("[elder-runner] fatal:", err);
   process.exit(1);
 });

--- a/packages/runner/src/main.ts
+++ b/packages/runner/src/main.ts
@@ -41,8 +41,16 @@ async function main(): Promise<void> {
         if (aux.pendingMessages.length > 0) await handlePendingMessages(deps, aux);
         continue;
       }
-      await handleAuxiliaryUpdate(deps, aux);
-      lastTickDelivered = aux.tickClock.tick;
+      const result = await handleAuxiliaryUpdate(deps, aux);
+      // Only advance the "delivered" cursor on confirmed receipt — if the
+      // hook didn't write tickReceiveLog within the resend cap, the next
+      // tick subscription wake-up will see this tick still un-delivered and
+      // retry via the regular path (including any bundled pendingMessages).
+      // Without this guard, lastTickDelivered ratchets past unconfirmed
+      // ticks and the within-tick retry path is bypassed (tier-1 MED).
+      if (result.confirmed) {
+        lastTickDelivered = aux.tickClock.tick;
+      }
     }
   } finally {
     started.flock.release();

--- a/packages/runner/src/messageComposer.ts
+++ b/packages/runner/src/messageComposer.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+import type { PendingMessage } from "./types.js";
+import type { SelectedTemplate } from "./templateLoader.js";
+
+export interface ComposeInput {
+  tickNumber?: number;
+  templates?: SelectedTemplate[];
+  fastForwardPrefix?: string;
+  userMessages?: Array<PendingMessage & { uid: string }>;
+  adminMessages?: Array<PendingMessage & { uid: string }>;
+}
+
+export interface ComposedMessage {
+  text: string;
+  messageHash: string;
+  pendingMessageIds: string[];
+}
+
+export function composeMessage(input: ComposeInput): ComposedMessage {
+  const sections: string[] = [];
+  if (input.tickNumber !== undefined) {
+    const bodyParts = [
+      input.fastForwardPrefix,
+      ...(input.templates ?? []).map((template) => template.content.trim()),
+    ].filter((part): part is string => Boolean(part && part.trim().length > 0));
+    sections.push([`tick: ${input.tickNumber}`, ...bodyParts].join("\n"));
+  }
+
+  for (const message of input.userMessages ?? []) {
+    sections.push([`whisper: ${message.uid}`, message.text].join("\n"));
+  }
+  for (const message of input.adminMessages ?? []) {
+    sections.push([`special-msg: ${message.uid}`, message.text].join("\n"));
+  }
+
+  if (sections.length === 0) {
+    throw new Error("cannot compose empty runner message");
+  }
+
+  const text = sections.join("\n---\n");
+  return {
+    text,
+    messageHash: sha256(text),
+    pendingMessageIds: [
+      ...(input.userMessages ?? []).map((message) => message._id),
+      ...(input.adminMessages ?? []).map((message) => message._id),
+    ],
+  };
+}
+
+export function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}

--- a/packages/runner/src/messageDelivery.ts
+++ b/packages/runner/src/messageDelivery.ts
@@ -1,0 +1,153 @@
+import { generateUniqueThematicUid } from "./thematicUid.js";
+import { composeMessage, type ComposedMessage } from "./messageComposer.js";
+import { postPasteSubmitted, prePasteReady } from "./pasteVerification.js";
+import { sleep } from "./retry.js";
+import type { RunnerConvexClient } from "./convexClient.js";
+import type { TmuxSink } from "./tmuxSink.js";
+import type { PendingMessage, ResetMetadata } from "./types.js";
+
+export interface DeliverInput {
+  tickNumber?: number;
+  templates?: Array<{ fileName: string; content: string }>;
+  fastForwardPrefix?: string;
+  pendingMessages?: PendingMessage[];
+  resetMetadata?: ResetMetadata;
+  receiveTickNumber?: number;
+  receiveTimeoutMs: number;
+  receivePollMs: number;
+  maxAttempts: number;
+  signal?: AbortSignal;
+}
+
+export interface DeliveryResult extends ComposedMessage {
+  confirmed: boolean;
+}
+
+export async function deliverMessage(
+  convex: RunnerConvexClient,
+  tmux: TmuxSink,
+  input: DeliverInput,
+): Promise<DeliveryResult> {
+  const composed = await composeWithPendingUids(convex, input);
+  if (input.tickNumber !== undefined) {
+    await convex.recordTickSend(input.tickNumber, composed.messageHash, input.resetMetadata, input.signal);
+  }
+
+  for (let attempt = 1; attempt <= input.maxAttempts; attempt++) {
+    input.signal?.throwIfAborted();
+    if (!(await prePasteReady(tmux))) {
+      await convex.recordRunnerEvent("ready_probe_timeout", `pre-paste readiness failed for tick ${input.tickNumber ?? "message"}`, input.signal);
+      return { ...composed, confirmed: false };
+    }
+    await tmux.pasteMessage(composed.text);
+    await postPasteSubmitted(tmux);
+
+    if (input.receiveTickNumber === undefined) {
+      await convex.consumePendingMessages(composed.pendingMessageIds, Date.now(), input.signal);
+      return { ...composed, confirmed: true };
+    }
+
+    const received = await waitForReceive(convex, input.receiveTickNumber, input.receiveTimeoutMs, input.receivePollMs, input.signal);
+    if (received) {
+      await convex.consumePendingMessages(composed.pendingMessageIds, Date.now(), input.signal);
+      return { ...composed, confirmed: true };
+    }
+  }
+
+  await convex.recordRunnerEvent(
+    "hook_failure",
+    `No tickReceiveLog for tick ${input.receiveTickNumber} after ${input.maxAttempts} paste attempts`,
+    input.signal,
+  );
+  return { ...composed, confirmed: false };
+}
+
+export async function deliverPendingOnly(
+  convex: RunnerConvexClient,
+  tmux: TmuxSink,
+  input: Omit<DeliverInput, "tickNumber" | "templates" | "receiveTickNumber">,
+): Promise<DeliveryResult | null> {
+  if ((input.pendingMessages ?? []).length === 0) return null;
+  const composed = await composeWithPendingUids(convex, input);
+  const receiveUid = firstEnvelopeUid(composed.text);
+  for (let attempt = 1; attempt <= input.maxAttempts; attempt++) {
+    input.signal?.throwIfAborted();
+    if (!(await prePasteReady(tmux))) {
+      await convex.recordRunnerEvent("ready_probe_timeout", "pre-paste readiness failed for pending message", input.signal);
+      return { ...composed, confirmed: false };
+    }
+    await tmux.pasteMessage(composed.text);
+    await postPasteSubmitted(tmux);
+    if (receiveUid && await waitForUidReceive(convex, receiveUid, input.receiveTimeoutMs, input.receivePollMs, input.signal)) {
+      await convex.consumePendingMessages(composed.pendingMessageIds, Date.now(), input.signal);
+      return { ...composed, confirmed: true };
+    }
+  }
+  await convex.recordRunnerEvent(
+    "hook_failure",
+    `No tickReceiveLog for pending message after ${input.maxAttempts} paste attempts`,
+    input.signal,
+  );
+  return { ...composed, confirmed: false };
+}
+
+async function composeWithPendingUids(
+  convex: RunnerConvexClient,
+  input: DeliverInput,
+): Promise<ComposedMessage> {
+  const userMessages: Array<PendingMessage & { uid: string }> = [];
+  const adminMessages: Array<PendingMessage & { uid: string }> = [];
+  for (const message of input.pendingMessages ?? []) {
+    const uid = await generateUniqueThematicUid((candidate) =>
+      convex.isThematicUidTaken(candidate, input.signal),
+    );
+    if (message.source === "user-message") {
+      userMessages.push({ ...message, uid });
+    } else {
+      adminMessages.push({ ...message, uid });
+    }
+  }
+  return composeMessage({
+    tickNumber: input.tickNumber,
+    templates: input.templates,
+    fastForwardPrefix: input.fastForwardPrefix,
+    userMessages,
+    adminMessages,
+  });
+}
+
+async function waitForReceive(
+  convex: RunnerConvexClient,
+  tickNumber: number,
+  timeoutMs: number,
+  pollMs: number,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await convex.hasTickReceive(tickNumber, signal)) return true;
+    await sleep(pollMs, signal);
+  }
+  return false;
+}
+
+async function waitForUidReceive(
+  convex: RunnerConvexClient,
+  uid: string,
+  timeoutMs: number,
+  pollMs: number,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await convex.hasMessageUidReceive(uid, signal)) return true;
+    await sleep(pollMs, signal);
+  }
+  return false;
+}
+
+function firstEnvelopeUid(text: string): string | null {
+  const firstLine = text.split("\n", 1)[0] ?? "";
+  const match = /^(?:whisper|special-msg):\s+(\S+)/.exec(firstLine);
+  return match?.[1] ?? null;
+}

--- a/packages/runner/src/oneClaudeCheck.ts
+++ b/packages/runner/src/oneClaudeCheck.ts
@@ -1,0 +1,24 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export async function countClaudeProcesses(): Promise<number> {
+  try {
+    const result = await execFileAsync("pgrep", ["claude"]) as unknown;
+    const stdout = typeof result === "string"
+      ? result
+      : (result as { stdout?: string }).stdout ?? "";
+    return stdout.split(/\s+/).filter(Boolean).length;
+  } catch (err: any) {
+    if (err?.code === 1) return 0;
+    throw err;
+  }
+}
+
+export async function assertOneClaudeProcess(): Promise<void> {
+  const count = await countClaudeProcesses();
+  if (count > 1) {
+    throw new Error(`one-claude invariant violated: found ${count} claude processes`);
+  }
+}

--- a/packages/runner/src/pasteVerification.ts
+++ b/packages/runner/src/pasteVerification.ts
@@ -1,0 +1,11 @@
+import type { TmuxSink } from "./tmuxSink.js";
+
+export async function prePasteReady(_tmux: TmuxSink): Promise<boolean> {
+  // TODO(PR4): pre-paste readiness probe via tmux capture-pane.
+  return true;
+}
+
+export async function postPasteSubmitted(_tmux: TmuxSink): Promise<boolean> {
+  // TODO(PR4): post-paste stuck-input detection and Enter retry.
+  return true;
+}

--- a/packages/runner/src/resetFlow.ts
+++ b/packages/runner/src/resetFlow.ts
@@ -1,0 +1,58 @@
+import { loadElderDisplayConfig } from "./elderConfig.js";
+import { deliverMessage } from "./messageDelivery.js";
+import { selectTemplates } from "./templateLoader.js";
+import { clearWipeMarker, writeWipeMarker } from "./wipeMarker.js";
+import type { RunnerConvexClient } from "./convexClient.js";
+import type { TmuxSink } from "./tmuxSink.js";
+import type { ResetReason, RunnerAuxiliary, RunnerConfig } from "./types.js";
+
+export interface ResetFlowInput {
+  config: RunnerConfig;
+  convex: RunnerConvexClient;
+  tmux: TmuxSink;
+  aux: RunnerAuxiliary;
+  reason: ResetReason;
+  signal?: AbortSignal;
+}
+
+export async function runResetFlow(input: ResetFlowInput): Promise<void> {
+  const resetTick = input.aux.tickClock.tick;
+  writeWipeMarker(input.config.wipeMarkerPath, resetTick);
+  const resetEventId = await input.convex.recordResetEvent(resetTick, input.reason, input.signal);
+
+  await input.tmux.killSession();
+  await input.tmux.newSession(input.config.workspaceDir);
+  await input.tmux.launchClaude({
+    continue: false,
+    runScriptPath: input.config.runScriptPath,
+  });
+  await brandElder(input);
+
+  const templates = await selectTemplates(input.config.promptDir, input.aux, {
+    forcePostMemoryWipe: true,
+  });
+  const delivery = await deliverMessage(input.convex, input.tmux, {
+    tickNumber: resetTick,
+    receiveTickNumber: resetTick,
+    templates,
+    resetMetadata: {
+      resetTick,
+      resetReason: input.reason,
+      resetEventId,
+    },
+    receiveTimeoutMs: input.config.hookReceiveTimeoutMs,
+    receivePollMs: input.config.hookReceivePollMs,
+    maxAttempts: input.config.maxPasteAttempts,
+    signal: input.signal,
+  });
+  if (!delivery.confirmed) return;
+
+  await input.convex.completeResetEvent(resetEventId, input.signal);
+  clearWipeMarker(input.config.wipeMarkerPath);
+}
+
+export async function brandElder(input: Pick<ResetFlowInput, "config" | "tmux">): Promise<void> {
+  const display = loadElderDisplayConfig(input.config.elderConfigPath, input.config.elderId);
+  await input.tmux.sendSlashCommand(`/rename Ælder ${display.displayName}`);
+  await input.tmux.sendSlashCommand(`/color ${display.color}`);
+}

--- a/packages/runner/src/restartDecision.ts
+++ b/packages/runner/src/restartDecision.ts
@@ -12,7 +12,18 @@ export function decideRestart(input: RestartDecisionInput): RestartDecision {
   if (input.lastReceivedTick === null) {
     return { kind: "reset", caseName: "D", reason: "late_join" };
   }
-  if (input.wipeMarkerTick === input.currentTick) {
+  // If a wipe marker is present at or beyond what we've already received,
+  // we crashed mid-reset and must replay it. Strict equality (was:
+  // === currentTick) missed the case where a tick advances between the
+  // crash and the restart for manual / late_join reasons that aren't
+  // aligned to memoryWipeTickInterval. Modulo-aligned scheduled wipes
+  // were still caught by containsMemoryWipeTick below, but non-aligned
+  // ticks slipped through and led to `claude --continue` launching with
+  // pre-wipe memory. The wider check rescues both.
+  if (
+    input.wipeMarkerTick !== null &&
+    input.wipeMarkerTick >= input.lastReceivedTick
+  ) {
     return { kind: "reset", caseName: "D", reason: "memory_wipe_gap" };
   }
 

--- a/packages/runner/src/restartDecision.ts
+++ b/packages/runner/src/restartDecision.ts
@@ -1,0 +1,61 @@
+import type { RestartDecision } from "./types.js";
+
+export interface RestartDecisionInput {
+  currentTick: number;
+  lastReceivedTick: number | null;
+  sentForCurrentTick: boolean;
+  memoryWipeTickInterval: number;
+  wipeMarkerTick: number | null;
+}
+
+export function decideRestart(input: RestartDecisionInput): RestartDecision {
+  if (input.lastReceivedTick === null) {
+    return { kind: "reset", caseName: "D", reason: "late_join" };
+  }
+  if (input.wipeMarkerTick === input.currentTick) {
+    return { kind: "reset", caseName: "D", reason: "memory_wipe_gap" };
+  }
+
+  const gap = input.currentTick - input.lastReceivedTick;
+  if (gap <= 0) {
+    return { kind: "wait", caseName: "A" };
+  }
+  if (gap === 1) {
+    return {
+      kind: "send-current",
+      caseName: input.sentForCurrentTick ? "C" : "B",
+      resend: input.sentForCurrentTick,
+    };
+  }
+  if (
+    containsMemoryWipeTick(
+      input.lastReceivedTick,
+      input.currentTick,
+      input.memoryWipeTickInterval,
+    )
+  ) {
+    return { kind: "reset", caseName: "D", reason: "memory_wipe_gap" };
+  }
+  return {
+    kind: "fast-forward",
+    caseName: "E",
+    fromTick: input.lastReceivedTick,
+    toTick: input.currentTick,
+  };
+}
+
+export function containsMemoryWipeTick(
+  lastReceivedTick: number,
+  currentTick: number,
+  interval: number,
+): boolean {
+  if (!Number.isFinite(interval) || interval <= 0) return false;
+  for (let tick = lastReceivedTick + 1; tick <= currentTick; tick++) {
+    if (isScheduledMemoryWipeTick(tick, interval)) return true;
+  }
+  return false;
+}
+
+export function isScheduledMemoryWipeTick(tick: number, interval: number): boolean {
+  return tick > 0 && interval > 0 && tick % interval === 0;
+}

--- a/packages/runner/src/retry.ts
+++ b/packages/runner/src/retry.ts
@@ -1,0 +1,58 @@
+export interface RetryOptions {
+  label: string;
+  signal?: AbortSignal;
+  onRecovered?: () => Promise<void>;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+export async function withBackoff<T>(
+  run: () => Promise<T>,
+  opts: RetryOptions,
+): Promise<T> {
+  let delayMs = opts.initialDelayMs ?? 1_000;
+  const maxDelayMs = opts.maxDelayMs ?? 60_000;
+  let failed = false;
+
+  while (true) {
+    opts.signal?.throwIfAborted();
+    try {
+      const result = await run();
+      if (failed && opts.onRecovered) {
+        await opts.onRecovered().catch((err) => {
+          console.warn(`[retry] recovery event failed after ${opts.label}:`, err);
+        });
+      }
+      return result;
+    } catch (err) {
+      failed = true;
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[retry] ${opts.label} failed; retrying in ${delayMs}ms: ${msg}`);
+      await sleep(delayMs, opts.signal);
+      delayMs = Math.min(maxDelayMs, delayMs * 2);
+    }
+  }
+}
+
+export async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise<void>((resolve, reject) => {
+    let onAbort: () => void = () => {};
+    const cleanup = () => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    onAbort = () => {
+      clearTimeout(timeout);
+      cleanup();
+      reject(new Error("aborted"));
+    };
+    if (signal) {
+      if (signal.aborted) onAbort();
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}

--- a/packages/runner/src/settingsCache.ts
+++ b/packages/runner/src/settingsCache.ts
@@ -1,0 +1,29 @@
+import type { GameSettings } from "./types.js";
+
+export function settingsEqual(a: GameSettings, b: GameSettings): boolean {
+  return JSON.stringify(stable(a)) === JSON.stringify(stable(b));
+}
+
+export function describeSettingsDrift(a: GameSettings, b: GameSettings): string {
+  const changed: string[] = [];
+  const left = stable(a) as unknown as Record<string, unknown>;
+  const right = stable(b) as unknown as Record<string, unknown>;
+  for (const key of Object.keys(left)) {
+    if (left[key] !== right[key]) {
+      changed.push(`${key}: boot=${String(left[key])} current=${String(right[key])}`);
+    }
+  }
+  return changed.length === 0 ? "no drift" : changed.join("; ");
+}
+
+function stable(settings: GameSettings): GameSettings {
+  return {
+    heartbeatIntervalSeconds: settings.heartbeatIntervalSeconds,
+    memoryWipeTickInterval: settings.memoryWipeTickInterval,
+    winterStartTick: settings.winterStartTick,
+    winterDurationTicks: settings.winterDurationTicks,
+    winterPeriodTicks: settings.winterPeriodTicks,
+    seasonDurationTicks: settings.seasonDurationTicks,
+    contractAddress: settings.contractAddress,
+  };
+}

--- a/packages/runner/src/startup.ts
+++ b/packages/runner/src/startup.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import { acquireFlock, type FlockHandle } from "./flockGuard.js";
+import { countClaudeProcesses } from "./oneClaudeCheck.js";
+import { decideRestart } from "./restartDecision.js";
+import { readWipeMarker } from "./wipeMarker.js";
+import type { RunnerConvexClient } from "./convexClient.js";
+import type { TmuxSink } from "./tmuxSink.js";
+import type { RestartDecision, RunnerConfig, RunnerStartupState } from "./types.js";
+
+export interface StartupResult {
+  flock: FlockHandle;
+  startupState: RunnerStartupState;
+  decision: RestartDecision;
+}
+
+export async function startup(
+  config: RunnerConfig,
+  convex: RunnerConvexClient,
+  tmux: TmuxSink,
+  signal?: AbortSignal,
+): Promise<StartupResult> {
+  fs.mkdirSync(config.stateDir, { recursive: true });
+  const flock = acquireFlock(config.lockPath);
+  const startupState = await convex.getStartupState(signal);
+  const claudeCount = await countClaudeProcesses();
+  if (claudeCount > 1) {
+    await convex.recordRunnerEvent("invariant_violation", `one-claude invariant violated: found ${claudeCount}`, signal);
+    throw new Error(`one-claude invariant violated: found ${claudeCount} claude processes`);
+  }
+
+  const hasSession = await tmux.hasSession();
+  if (!hasSession) {
+    await tmux.newSession(config.workspaceDir);
+  }
+
+  const decision = decideRestart({
+    currentTick: startupState.tickClock.tick,
+    lastReceivedTick: startupState.lastReceivedTick,
+    sentForCurrentTick: startupState.sentForCurrentTick,
+    memoryWipeTickInterval: startupState.gameSettings.memoryWipeTickInterval,
+    wipeMarkerTick: readWipeMarker(config.wipeMarkerPath),
+  });
+  if (decision.kind !== "reset" && claudeCount === 0) {
+    await tmux.launchClaude({
+      continue: true,
+      runScriptPath: config.runScriptPath,
+    });
+  }
+
+  fs.writeFileSync(config.readyPath, String(process.pid));
+  return { flock, startupState, decision };
+}

--- a/packages/runner/src/templateLoader.ts
+++ b/packages/runner/src/templateLoader.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ChainEvent, GameSettings, RunnerAuxiliary } from "./types.js";
+
+export interface SelectedTemplate {
+  fileName: string;
+  content: string;
+}
+
+const TEMPLATE_FILES = {
+  gameStart: "00_game_start.md",
+  preMemoryWipe5: "05_pre_memory_wipe_5ticks.md",
+  preMemoryWipe1: "06_pre_memory_wipe_1tick.md",
+  postMemoryWipe: "07_post_memory_wipe.md",
+  preWinter10: "10_pre_winter_10ticks.md",
+  winterStarted: "11_winter_started.md",
+  winterEnded: "12_winter_ended.md",
+  banditsAppeared: "20_bandits_appeared.md",
+  banditsAttacking: "21_bandits_attacking.md",
+  postBanditAttack: "22_post_bandit_attack.md",
+  clansmenRevived: "99_clansmen_revived_and_resources_injected.md",
+} as const;
+const BANDIT_STATE_ATTACKING = 3;
+
+export async function selectTemplates(
+  promptDir: string,
+  aux: RunnerAuxiliary,
+  opts: { forcePostMemoryWipe?: boolean } = {},
+): Promise<SelectedTemplate[]> {
+  const tick = aux.tickClock.tick;
+  const files = new Set<string>();
+  if (tick === 0) files.add(TEMPLATE_FILES.gameStart);
+  if (opts.forcePostMemoryWipe || isMemoryWipeTick(tick, aux.gameSettings)) {
+    files.add(TEMPLATE_FILES.postMemoryWipe);
+  }
+  if (ticksUntilNextMemoryWipe(tick, aux.gameSettings) === 5) {
+    files.add(TEMPLATE_FILES.preMemoryWipe5);
+  }
+  if (ticksUntilNextMemoryWipe(tick, aux.gameSettings) === 1) {
+    files.add(TEMPLATE_FILES.preMemoryWipe1);
+  }
+  if (aux.gameSettings.winterStartTick - tick === 10) files.add(TEMPLATE_FILES.preWinter10);
+  if (tick === aux.gameSettings.winterStartTick) files.add(TEMPLATE_FILES.winterStarted);
+  if (tick === aux.gameSettings.winterStartTick + aux.gameSettings.winterDurationTicks) {
+    files.add(TEMPLATE_FILES.winterEnded);
+  }
+
+  for (const file of eventDrivenFiles(aux)) files.add(file);
+
+  const ordered = [...files].sort();
+  const loaded = await Promise.all(
+    ordered.map(async (fileName) => ({
+      fileName,
+      content: await readOptionalTemplate(promptDir, fileName),
+    })),
+  );
+  return loaded.filter((template) => template.content.trim().length > 0);
+}
+
+async function readOptionalTemplate(promptDir: string, fileName: string): Promise<string> {
+  try {
+    return await fs.readFile(path.join(promptDir, fileName), "utf8");
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      console.warn(`[templates] missing prompt template ${fileName}`);
+      return "";
+    }
+    throw err;
+  }
+}
+
+function isMemoryWipeTick(tick: number, settings: GameSettings): boolean {
+  return tick > 0 && tick % settings.memoryWipeTickInterval === 0;
+}
+
+function ticksUntilNextMemoryWipe(tick: number, settings: GameSettings): number {
+  const interval = settings.memoryWipeTickInterval;
+  if (interval <= 0) return Number.POSITIVE_INFINITY;
+  const remainder = tick % interval;
+  return remainder === 0 ? interval : interval - remainder;
+}
+
+function eventDrivenFiles(aux: RunnerAuxiliary): string[] {
+  const files: string[] = [];
+  if (hasEvent(aux.chainEvents, "BanditSpawned")) files.push(TEMPLATE_FILES.banditsAppeared);
+  if (aux.banditView?.exists && aux.banditView.state === BANDIT_STATE_ATTACKING) {
+    files.push(TEMPLATE_FILES.banditsAttacking);
+  }
+  if (hasEvent(aux.chainEvents, "BanditAttackResolved")) {
+    files.push(TEMPLATE_FILES.postBanditAttack);
+  }
+  if (hasEvent(aux.chainEvents, "ClansmanRevived") || hasEvent(aux.chainEvents, "ResourcesInjected")) {
+    files.push(TEMPLATE_FILES.clansmenRevived);
+  }
+  return files;
+}
+
+function hasEvent(events: ChainEvent[], eventName: string): boolean {
+  return events.some((event) => event.eventName === eventName);
+}

--- a/packages/runner/src/thematicUid.ts
+++ b/packages/runner/src/thematicUid.ts
@@ -1,0 +1,47 @@
+import { randomBytes } from "node:crypto";
+
+const THEMES = [
+  ["booming", "hushed", "silver", "northward", "lantern", "thicket", "ember", "distant", "hollow", "bright", "quiet", "echoing"],
+  ["morning", "lark", "swooping", "sigh", "midnight", "raven", "calling", "dawn", "velvet", "sunset", "watchful", "song"],
+  ["stormbound", "fox", "creeping", "whisper", "rainlit", "mist", "thunder", "drizzle", "gale", "cloud", "frost", "murmur"],
+  ["autumn", "marsh", "otter", "summoning", "winter", "ridge", "spring", "brook", "summer", "meadow", "root", "bloom"],
+  ["wistful", "moonlit", "stoat", "summons", "solar", "ashen", "comet", "tender", "brave", "solemn", "starry", "call"],
+  ["crimson", "quartz", "magpie", "warning", "azure", "iron", "verdant", "amber", "copper", "jade", "scarlet", "chime"],
+] as const;
+
+export function generateThematicUid(): string {
+  const theme = THEMES[randomInt(THEMES.length)] ?? THEMES[0];
+  const words = pickRandom(theme, 3);
+  return `${words.join("-")}-${randomHex(4)}`;
+}
+
+export async function generateUniqueThematicUid(
+  isTaken: (uid: string) => Promise<boolean>,
+): Promise<string> {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const uid = generateThematicUid();
+    if (!(await isTaken(uid))) return uid;
+  }
+  throw new Error("thematic UID collision after 5 retries");
+}
+
+export function themeCount(): number {
+  return THEMES.length;
+}
+
+function pickRandom(words: readonly string[], count: number): string[] {
+  const picked: string[] = [];
+  while (picked.length < count) {
+    const word = words[randomInt(words.length)];
+    if (word && !picked.includes(word)) picked.push(word);
+  }
+  return picked;
+}
+
+function randomHex(chars: number): string {
+  return randomBytes(Math.ceil(chars / 2)).toString("hex").slice(0, chars);
+}
+
+function randomInt(maxExclusive: number): number {
+  return randomBytes(4).readUInt32BE(0) % maxExclusive;
+}

--- a/packages/runner/src/tickHandler.ts
+++ b/packages/runner/src/tickHandler.ts
@@ -31,7 +31,14 @@ export async function handleStartupDecision(
     : undefined);
 }
 
-export async function handleAuxiliaryUpdate(deps: TickHandlerDeps, aux: RunnerAuxiliary): Promise<void> {
+export interface TickDeliveryResult {
+  confirmed: boolean;
+}
+
+export async function handleAuxiliaryUpdate(
+  deps: TickHandlerDeps,
+  aux: RunnerAuxiliary,
+): Promise<TickDeliveryResult> {
   await assertNoSettingsDrift(deps, aux);
   if (
     isScheduledMemoryWipeTick(
@@ -39,10 +46,20 @@ export async function handleAuxiliaryUpdate(deps: TickHandlerDeps, aux: RunnerAu
       deps.cachedSettings.memoryWipeTickInterval,
     )
   ) {
+    // runResetFlow internally clears the wipe marker + resetEventLog
+    // completedAt only when delivery.confirmed (resetFlow.ts:48). If the
+    // first-tick wasn't received, the marker persists and the next
+    // startup's restartDecision catches it via the wipeMarker rescue.
+    // Returning confirmed:true here is "advance optimistically" — even
+    // if first-tick wasn't received, the loop will see the marker on next
+    // wakeup and retry the whole reset. Acceptable: scheduled-wipe ticks
+    // are rare enough that re-resetting is cheap and the marker keeps
+    // state consistent.
     await runResetFlow({ ...deps, aux, reason: "scheduled" });
-    return;
+    return { confirmed: true };
   }
-  await deliverCurrentTick(deps, aux);
+  const delivery = await deliverCurrentTick(deps, aux);
+  return { confirmed: delivery.confirmed };
 }
 
 export async function handlePendingMessages(deps: TickHandlerDeps, aux: RunnerAuxiliary): Promise<void> {
@@ -60,9 +77,9 @@ async function deliverCurrentTick(
   deps: TickHandlerDeps,
   aux: RunnerAuxiliary,
   fastForwardPrefix?: string,
-): Promise<void> {
+): Promise<{ confirmed: boolean }> {
   const templates = await selectTemplates(deps.config.promptDir, aux);
-  await deliverMessage(deps.convex, deps.tmux, {
+  const result = await deliverMessage(deps.convex, deps.tmux, {
     tickNumber: aux.tickClock.tick,
     receiveTickNumber: aux.tickClock.tick,
     templates,
@@ -73,6 +90,7 @@ async function deliverCurrentTick(
     maxAttempts: deps.config.maxPasteAttempts,
     signal: deps.signal,
   });
+  return { confirmed: result.confirmed };
 }
 
 async function assertNoSettingsDrift(deps: TickHandlerDeps, aux: RunnerAuxiliary): Promise<void> {

--- a/packages/runner/src/tickHandler.ts
+++ b/packages/runner/src/tickHandler.ts
@@ -1,0 +1,83 @@
+import { deliverMessage, deliverPendingOnly } from "./messageDelivery.js";
+import { runResetFlow } from "./resetFlow.js";
+import { isScheduledMemoryWipeTick } from "./restartDecision.js";
+import { describeSettingsDrift, settingsEqual } from "./settingsCache.js";
+import { selectTemplates } from "./templateLoader.js";
+import type { RunnerConvexClient } from "./convexClient.js";
+import type { TmuxSink } from "./tmuxSink.js";
+import type { GameSettings, RestartDecision, RunnerAuxiliary, RunnerConfig } from "./types.js";
+
+export interface TickHandlerDeps {
+  config: RunnerConfig;
+  convex: RunnerConvexClient;
+  tmux: TmuxSink;
+  cachedSettings: GameSettings;
+  signal?: AbortSignal;
+}
+
+export async function handleStartupDecision(
+  deps: TickHandlerDeps,
+  decision: RestartDecision,
+): Promise<void> {
+  if (decision.kind === "wait") return;
+  const aux = await deps.convex.getAuxiliary(deps.signal);
+  await assertNoSettingsDrift(deps, aux);
+  if (decision.kind === "reset") {
+    await runResetFlow({ ...deps, aux, reason: decision.reason });
+    return;
+  }
+  await deliverCurrentTick(deps, aux, decision.kind === "fast-forward"
+    ? `Fast-forwarding from tick ${decision.fromTick} to tick ${decision.toTick}.`
+    : undefined);
+}
+
+export async function handleAuxiliaryUpdate(deps: TickHandlerDeps, aux: RunnerAuxiliary): Promise<void> {
+  await assertNoSettingsDrift(deps, aux);
+  if (
+    isScheduledMemoryWipeTick(
+      aux.tickClock.tick,
+      deps.cachedSettings.memoryWipeTickInterval,
+    )
+  ) {
+    await runResetFlow({ ...deps, aux, reason: "scheduled" });
+    return;
+  }
+  await deliverCurrentTick(deps, aux);
+}
+
+export async function handlePendingMessages(deps: TickHandlerDeps, aux: RunnerAuxiliary): Promise<void> {
+  await assertNoSettingsDrift(deps, aux);
+  await deliverPendingOnly(deps.convex, deps.tmux, {
+    pendingMessages: aux.pendingMessages,
+    receiveTimeoutMs: deps.config.hookReceiveTimeoutMs,
+    receivePollMs: deps.config.hookReceivePollMs,
+    maxAttempts: deps.config.maxPasteAttempts,
+    signal: deps.signal,
+  });
+}
+
+async function deliverCurrentTick(
+  deps: TickHandlerDeps,
+  aux: RunnerAuxiliary,
+  fastForwardPrefix?: string,
+): Promise<void> {
+  const templates = await selectTemplates(deps.config.promptDir, aux);
+  await deliverMessage(deps.convex, deps.tmux, {
+    tickNumber: aux.tickClock.tick,
+    receiveTickNumber: aux.tickClock.tick,
+    templates,
+    fastForwardPrefix,
+    pendingMessages: aux.pendingMessages,
+    receiveTimeoutMs: deps.config.hookReceiveTimeoutMs,
+    receivePollMs: deps.config.hookReceivePollMs,
+    maxAttempts: deps.config.maxPasteAttempts,
+    signal: deps.signal,
+  });
+}
+
+async function assertNoSettingsDrift(deps: TickHandlerDeps, aux: RunnerAuxiliary): Promise<void> {
+  if (settingsEqual(deps.cachedSettings, aux.gameSettings)) return;
+  const message = describeSettingsDrift(deps.cachedSettings, aux.gameSettings);
+  await deps.convex.recordRunnerEvent("settings_drift_panic", message, deps.signal);
+  throw new Error(`game settings drift panic: ${message}`);
+}

--- a/packages/runner/src/tmuxSink.ts
+++ b/packages/runner/src/tmuxSink.ts
@@ -1,4 +1,7 @@
 import { execFile, spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -8,6 +11,19 @@ export class TmuxSink {
 
   constructor(sessionName: string) {
     this.session = sessionName;
+  }
+
+  target(): string {
+    return this.session;
+  }
+
+  async hasSession(): Promise<boolean> {
+    try {
+      await execFileAsync("tmux", ["has-session", "-t", this.session]);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async sendKeys(key: string): Promise<void> {
@@ -53,7 +69,49 @@ export class TmuxSink {
     }
   }
 
-  async newSession(runScript: string): Promise<void> {
+  async newSession(runScriptOrCwd = "/workspace"): Promise<void> {
+    const args = ["new-session", "-d", "-s", this.session];
+    if (runScriptOrCwd.startsWith("/")) {
+      args.push("-c", runScriptOrCwd);
+    } else {
+      args.push(runScriptOrCwd);
+    }
+    await execFileAsync("tmux", args);
+  }
+
+  async launchClaude(opts: { continue: boolean; runScriptPath: string }): Promise<void> {
+    const mode = opts.continue ? "always" : "never";
+    const command = `CLAN_WORLD_CLAUDE_CONTINUE=${mode} ${shellQuote(opts.runScriptPath)}`;
+    await this.sendLiteral(command);
+    await this.sendKeys("Enter");
+  }
+
+  async sendSlashCommand(command: string): Promise<void> {
+    await this.sendLiteral(command);
+    await this.sendKeys("Enter");
+    await delay(250);
+    await this.sendKeys("Enter");
+  }
+
+  async sendLiteral(content: string): Promise<void> {
+    await execFileAsync("tmux", ["send-keys", "-t", this.session, "-l", content]);
+  }
+
+  async pasteMessage(content: string): Promise<void> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "elder-runner-paste-"));
+    const file = path.join(dir, "message.txt");
+    const bufferName = `elder-input-${process.pid}`;
+    try {
+      await fs.writeFile(file, content, "utf8");
+      await execFileAsync("tmux", ["load-buffer", "-b", bufferName, file]);
+      await this.pasteBuffer(bufferName, this.session, { bracketed: true });
+      await this.sendKeys("Enter");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  async newSessionWithCommand(runScript: string): Promise<void> {
     await execFileAsync("tmux", [
       "new-session", "-d", "-s", this.session, runScript,
     ]);
@@ -64,4 +122,12 @@ export class TmuxSink {
     // ttyd stays attached to the session; the pane gets a fresh process.
     await execFileAsync("tmux", ["respawn-pane", "-k", "-t", `${this.session}:0.0`]);
   }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/packages/runner/src/types.ts
+++ b/packages/runner/src/types.ts
@@ -1,5 +1,14 @@
 export type ElderN = "elder-1" | "elder-2" | "elder-3" | "elder-4";
 export type Health = "green" | "yellow" | "red";
+export type PendingMessageSource = "admin-injection" | "user-message";
+export type RunnerEventKind =
+  | "hook_failure"
+  | "convex_outage_recovery"
+  | "settings_drift_panic"
+  | "invariant_violation"
+  | "ready_probe_timeout";
+export type ResetReason = "scheduled" | "manual" | "memory_wipe_gap" | "late_join";
+
 export type CommandKind =
   | "user_message"
   | "system_message"
@@ -29,4 +38,103 @@ export interface ElderRuntimeConfig {
   noncePollIntervalMs: number;
   nonceTimeoutMs: number;
   runScriptPath: string;
+}
+
+export interface RunnerConfig extends ElderRuntimeConfig {
+  runnerSecret: string;
+  lockPath: string;
+  wipeMarkerPath: string;
+  readyPath: string;
+  promptDir: string;
+  elderConfigPath: string;
+  workspaceDir: string;
+  appendSystemPromptFile: string;
+  hookReceiveTimeoutMs: number;
+  hookReceivePollMs: number;
+  maxPasteAttempts: number;
+}
+
+export interface TickClock {
+  tick: number;
+  blockNumber?: number;
+  tickEpochStartedAt: number;
+  tickEpochDurationMs: number;
+  heartbeatIntervalSeconds?: number;
+  currentSeasonNumber?: number;
+  seasonStartTick: number;
+  seasonEndTick: number;
+  winterActive: boolean;
+  winterStartsAtTick?: number;
+}
+
+export interface GameSettings {
+  heartbeatIntervalSeconds: number;
+  memoryWipeTickInterval: number;
+  winterStartTick: number;
+  winterDurationTicks: number;
+  winterPeriodTicks: number;
+  seasonDurationTicks: number;
+  contractAddress: string;
+}
+
+export interface PendingMessage {
+  _id: string;
+  targetElderId: ElderN;
+  text: string;
+  source: PendingMessageSource;
+  insertedAt: number;
+  consumedAt?: number;
+}
+
+export interface ChainEvent {
+  eventName: string;
+  tick?: number;
+  args: unknown;
+  [key: string]: unknown;
+}
+
+export interface BanditView {
+  exists: boolean;
+  id: number;
+  state: number;
+  stateEnteredTick: number;
+  nextActionTick: number;
+  [key: string]: unknown;
+}
+
+export interface RunnerAuxiliary {
+  tickClock: TickClock;
+  gameSettings: GameSettings;
+  banditView: BanditView | null;
+  chainEvents: ChainEvent[];
+  pendingMessages: PendingMessage[];
+}
+
+export interface RunnerStartupState {
+  tickClock: TickClock;
+  gameSettings: GameSettings;
+  lastReceivedTick: number | null;
+  sentForCurrentTick: boolean;
+}
+
+export interface ResetMetadata {
+  resetTick: number;
+  resetReason: ResetReason;
+  resetEventId: string;
+}
+
+export interface TickSendResult {
+  sendLogId: string;
+}
+
+export type RestartDecision =
+  | { kind: "wait"; caseName: "A" }
+  | { kind: "send-current"; caseName: "B" | "C"; resend: boolean }
+  | { kind: "reset"; caseName: "D"; reason: "memory_wipe_gap" | "late_join" }
+  | { kind: "fast-forward"; caseName: "E"; fromTick: number; toTick: number };
+
+export interface ElderDisplayConfig {
+  displayName: string;
+  color: string;
+  glyph: string;
 }

--- a/packages/runner/src/wipeMarker.ts
+++ b/packages/runner/src/wipeMarker.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export function readWipeMarker(markerPath: string): number | null {
+  try {
+    const raw = fs.readFileSync(markerPath, "utf8").trim();
+    const parsed = Number(raw);
+    return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeWipeMarker(markerPath: string, tick: number): void {
+  fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+  const tmpPath = `${markerPath}.tmp`;
+  const fd = fs.openSync(tmpPath, "w");
+  try {
+    fs.writeFileSync(fd, `${tick}\n`, "utf8");
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.renameSync(tmpPath, markerPath);
+}
+
+export function clearWipeMarker(markerPath: string): void {
+  try {
+    fs.unlinkSync(markerPath);
+  } catch {
+    // already clear
+  }
+}

--- a/packages/runner/test/fixtures/prompts/00_game_start.md
+++ b/packages/runner/test/fixtures/prompts/00_game_start.md
@@ -1,0 +1,1 @@
+game start

--- a/packages/runner/test/fixtures/prompts/05_pre_memory_wipe_5ticks.md
+++ b/packages/runner/test/fixtures/prompts/05_pre_memory_wipe_5ticks.md
@@ -1,0 +1,1 @@
+memory wipe in five

--- a/packages/runner/test/fixtures/prompts/06_pre_memory_wipe_1tick.md
+++ b/packages/runner/test/fixtures/prompts/06_pre_memory_wipe_1tick.md
@@ -1,0 +1,1 @@
+memory wipe in one

--- a/packages/runner/test/fixtures/prompts/07_post_memory_wipe.md
+++ b/packages/runner/test/fixtures/prompts/07_post_memory_wipe.md
@@ -1,0 +1,1 @@
+post memory wipe

--- a/packages/runner/test/fixtures/prompts/10_pre_winter_10ticks.md
+++ b/packages/runner/test/fixtures/prompts/10_pre_winter_10ticks.md
@@ -1,0 +1,1 @@
+winter in ten

--- a/packages/runner/test/fixtures/prompts/11_winter_started.md
+++ b/packages/runner/test/fixtures/prompts/11_winter_started.md
@@ -1,0 +1,1 @@
+winter started

--- a/packages/runner/test/fixtures/prompts/12_winter_ended.md
+++ b/packages/runner/test/fixtures/prompts/12_winter_ended.md
@@ -1,0 +1,1 @@
+winter ended

--- a/packages/runner/test/fixtures/prompts/20_bandits_appeared.md
+++ b/packages/runner/test/fixtures/prompts/20_bandits_appeared.md
@@ -1,0 +1,1 @@
+bandits appeared

--- a/packages/runner/test/fixtures/prompts/21_bandits_attacking.md
+++ b/packages/runner/test/fixtures/prompts/21_bandits_attacking.md
@@ -1,0 +1,1 @@
+bandits attacking

--- a/packages/runner/test/fixtures/prompts/22_post_bandit_attack.md
+++ b/packages/runner/test/fixtures/prompts/22_post_bandit_attack.md
@@ -1,0 +1,1 @@
+post bandit attack

--- a/packages/runner/test/fixtures/prompts/99_clansmen_revived_and_resources_injected.md
+++ b/packages/runner/test/fixtures/prompts/99_clansmen_revived_and_resources_injected.md
@@ -1,0 +1,1 @@
+clansmen revived

--- a/packages/runner/test/messageComposer.test.ts
+++ b/packages/runner/test/messageComposer.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { composeMessage } from "../src/messageComposer.js";
+
+describe("composeMessage", () => {
+  it("starts with tick prefix and uses separators only between sections", () => {
+    const result = composeMessage({
+      tickNumber: 42,
+      templates: [{ fileName: "00.md", content: "world update" }],
+      userMessages: [{
+        _id: "pendingMessages:1",
+        targetElderId: "elder-1",
+        text: "hello",
+        source: "user-message",
+        insertedAt: 1,
+        uid: "crimson-quartz-warning-a1b2",
+      }],
+    });
+
+    expect(result.text.startsWith("tick: 42")).toBe(true);
+    expect(result.text.startsWith("---")).toBe(false);
+    expect(result.text).toContain("\n---\nwhisper: crimson-quartz-warning-a1b2");
+    expect(result.pendingMessageIds).toEqual(["pendingMessages:1"]);
+    expect(result.messageHash).toHaveLength(64);
+  });
+
+  it("can compose a pending-only admin injection with special-msg first", () => {
+    const result = composeMessage({
+      adminMessages: [{
+        _id: "pendingMessages:2",
+        targetElderId: "elder-1",
+        text: "debug",
+        source: "admin-injection",
+        insertedAt: 1,
+        uid: "storm-fox-murmur-b2c3",
+      }],
+    });
+
+    expect(result.text).toBe("special-msg: storm-fox-murmur-b2c3\ndebug");
+  });
+});

--- a/packages/runner/test/oneClaudeCheck.test.ts
+++ b/packages/runner/test/oneClaudeCheck.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("oneClaudeCheck", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("counts zero processes when pgrep exits 1", async () => {
+    vi.doMock("node:child_process", () => ({
+      execFile: (_cmd: string, _args: string[], cb: (err: any) => void) => cb({ code: 1 }),
+    }));
+    const { countClaudeProcesses } = await import("../src/oneClaudeCheck.js");
+    expect(await countClaudeProcesses()).toBe(0);
+  });
+
+  it("fails loud when multiple claude processes exist", async () => {
+    vi.doMock("node:child_process", () => ({
+      execFile: (_cmd: string, _args: string[], cb: (err: any, stdout: string) => void) => cb(null, "1\n2\n"),
+    }));
+    const { assertOneClaudeProcess } = await import("../src/oneClaudeCheck.js");
+    await expect(assertOneClaudeProcess()).rejects.toThrow(/invariant/);
+  });
+});

--- a/packages/runner/test/resetFlow.test.ts
+++ b/packages/runner/test/resetFlow.test.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runResetFlow } from "../src/resetFlow.js";
+import type { RunnerAuxiliary, RunnerConfig } from "../src/types.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "reset-flow-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("runResetFlow", () => {
+  it("kills tmux, launches fresh claude, brands, sends reset metadata, and clears marker", async () => {
+    const promptDir = path.join(process.cwd(), "test/fixtures/prompts");
+    const elderConfigPath = path.join(dir, "elder-config.json");
+    fs.writeFileSync(elderConfigPath, JSON.stringify({
+      "elder-1": { displayName: "Storm Riders", color: "blue", glyph: "*" },
+    }));
+    const config = makeConfig(promptDir, elderConfigPath);
+    const calls: string[] = [];
+    const tmux = {
+      async killSession() { calls.push("kill"); },
+      async newSession() { calls.push("new"); },
+      async launchClaude(opts: { continue: boolean }) { calls.push(`claude:${opts.continue}`); },
+      async sendSlashCommand(cmd: string) { calls.push(cmd); },
+      async pasteMessage(text: string) { calls.push(`paste:${text.split("\n")[0]}`); },
+    } as any;
+    const convex = {
+      async recordResetEvent() { calls.push("reset-start"); return "resetEventLog:1"; },
+      async recordTickSend(_tick: number, _hash: string, metadata: any) {
+        calls.push(`send:${metadata.resetReason}`);
+        return { sendLogId: "tickSendLog:1" };
+      },
+      async hasTickReceive() { return true; },
+      async consumePendingMessages() {},
+      async completeResetEvent() { calls.push("reset-complete"); },
+      async isThematicUidTaken() { return false; },
+      async recordRunnerEvent() {},
+    } as any;
+
+    await runResetFlow({
+      config,
+      convex,
+      tmux,
+      aux: makeAux(50),
+      reason: "scheduled",
+    });
+
+    expect(calls).toContain("kill");
+    expect(calls).toContain("new");
+    expect(calls).toContain("claude:false");
+    expect(calls).toContain("/rename Ælder Storm Riders");
+    expect(calls).toContain("/color blue");
+    expect(calls).toContain("send:scheduled");
+    expect(calls).toContain("reset-complete");
+    expect(fs.existsSync(config.wipeMarkerPath)).toBe(false);
+  });
+});
+
+function makeConfig(promptDir: string, elderConfigPath: string): RunnerConfig {
+  return {
+    elderId: "elder-1",
+    convexUrl: "http://localhost",
+    busSecret: "s",
+    runnerSecret: "s",
+    stateDir: dir,
+    ancientWisdomPath: "/tmp/x",
+    pollIntervalMs: 1,
+    heartbeatIntervalMs: 1,
+    noncePollIntervalMs: 1,
+    nonceTimeoutMs: 1,
+    runScriptPath: "/tmp/run.sh",
+    lockPath: path.join(dir, "lock"),
+    wipeMarkerPath: path.join(dir, "last-wipe-tick"),
+    readyPath: path.join(dir, "ready"),
+    promptDir,
+    elderConfigPath,
+    workspaceDir: "/workspace",
+    appendSystemPromptFile: "/opt/prompt.md",
+    hookReceiveTimeoutMs: 1,
+    hookReceivePollMs: 1,
+    maxPasteAttempts: 1,
+  };
+}
+
+function makeAux(tick: number): RunnerAuxiliary {
+  return {
+    tickClock: { tick, tickEpochStartedAt: 0, tickEpochDurationMs: 60_000, seasonStartTick: 0, seasonEndTick: 360, winterActive: false },
+    gameSettings: { heartbeatIntervalSeconds: 60, memoryWipeTickInterval: 50, winterStartTick: 110, winterDurationTicks: 10, winterPeriodTicks: 110, seasonDurationTicks: 360, contractAddress: "0x0" },
+    banditView: null,
+    chainEvents: [],
+    pendingMessages: [],
+  };
+}

--- a/packages/runner/test/restartDecision.test.ts
+++ b/packages/runner/test/restartDecision.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { decideRestart } from "../src/restartDecision.js";
+
+const base = {
+  currentTick: 10,
+  lastReceivedTick: 9,
+  sentForCurrentTick: false,
+  memoryWipeTickInterval: 50,
+  wipeMarkerTick: null,
+};
+
+describe("decideRestart", () => {
+  it("case A waits when current tick was already received", () => {
+    expect(decideRestart({ ...base, currentTick: 9 })).toEqual({ kind: "wait", caseName: "A" });
+  });
+
+  it("case B sends fresh current tick", () => {
+    expect(decideRestart(base)).toEqual({ kind: "send-current", caseName: "B", resend: false });
+  });
+
+  it("case C resends when send log exists but receive log does not", () => {
+    expect(decideRestart({ ...base, sentForCurrentTick: true })).toEqual({
+      kind: "send-current",
+      caseName: "C",
+      resend: true,
+    });
+  });
+
+  it("case D resets when a memory wipe tick is in the gap", () => {
+    expect(decideRestart({
+      ...base,
+      currentTick: 55,
+      lastReceivedTick: 48,
+    })).toEqual({ kind: "reset", caseName: "D", reason: "memory_wipe_gap" });
+  });
+
+  it("case D late-joins when no receive log exists", () => {
+    expect(decideRestart({ ...base, lastReceivedTick: null })).toEqual({
+      kind: "reset",
+      caseName: "D",
+      reason: "late_join",
+    });
+  });
+
+  it("case E fast-forwards a non-wipe gap", () => {
+    expect(decideRestart({ ...base, currentTick: 20, lastReceivedTick: 10 })).toEqual({
+      kind: "fast-forward",
+      caseName: "E",
+      fromTick: 10,
+      toTick: 20,
+    });
+  });
+});

--- a/packages/runner/test/retry.test.ts
+++ b/packages/runner/test/retry.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { withBackoff } from "../src/retry.js";
+
+describe("withBackoff", () => {
+  it("backs off and calls recovery hook after a failed call succeeds", async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    let recovered = 0;
+    const promise = withBackoff(async () => {
+      attempts++;
+      if (attempts === 1) throw new Error("down");
+      return "ok";
+    }, {
+      label: "test",
+      initialDelayMs: 10,
+      onRecovered: async () => { recovered++; },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    await expect(promise).resolves.toBe("ok");
+    expect(recovered).toBe(1);
+    vi.useRealTimers();
+  });
+});

--- a/packages/runner/test/settingsCache.test.ts
+++ b/packages/runner/test/settingsCache.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { describeSettingsDrift, settingsEqual } from "../src/settingsCache.js";
+import type { GameSettings } from "../src/types.js";
+
+const settings: GameSettings = {
+  heartbeatIntervalSeconds: 60,
+  memoryWipeTickInterval: 50,
+  winterStartTick: 110,
+  winterDurationTicks: 10,
+  winterPeriodTicks: 110,
+  seasonDurationTicks: 360,
+  contractAddress: "0xabc",
+};
+
+describe("settings cache drift", () => {
+  it("detects identical settings", () => {
+    expect(settingsEqual(settings, { ...settings })).toBe(true);
+  });
+
+  it("describes drift", () => {
+    const changed = { ...settings, memoryWipeTickInterval: 60 };
+    expect(settingsEqual(settings, changed)).toBe(false);
+    expect(describeSettingsDrift(settings, changed)).toContain("memoryWipeTickInterval");
+  });
+});

--- a/packages/runner/test/templateLoader.test.ts
+++ b/packages/runner/test/templateLoader.test.ts
@@ -1,0 +1,61 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { selectTemplates } from "../src/templateLoader.js";
+import type { RunnerAuxiliary } from "../src/types.js";
+
+const promptDir = path.join(process.cwd(), "test/fixtures/prompts");
+
+function aux(tick: number, overrides: Partial<RunnerAuxiliary> = {}): RunnerAuxiliary {
+  return {
+    tickClock: {
+      tick,
+      tickEpochStartedAt: 0,
+      tickEpochDurationMs: 60_000,
+      heartbeatIntervalSeconds: 60,
+      seasonStartTick: 0,
+      seasonEndTick: 360,
+      winterActive: false,
+      winterStartsAtTick: 110,
+    },
+    gameSettings: {
+      heartbeatIntervalSeconds: 60,
+      memoryWipeTickInterval: 50,
+      winterStartTick: 110,
+      winterDurationTicks: 10,
+      winterPeriodTicks: 110,
+      seasonDurationTicks: 360,
+      contractAddress: "0x0",
+    },
+    banditView: null,
+    chainEvents: [],
+    pendingMessages: [],
+    ...overrides,
+  };
+}
+
+describe("selectTemplates", () => {
+  it("selects game start at tick zero", async () => {
+    const templates = await selectTemplates(promptDir, aux(0));
+    expect(templates.map(t => t.fileName)).toContain("00_game_start.md");
+  });
+
+  it("selects memory-wipe warning and post-wipe templates", async () => {
+    expect((await selectTemplates(promptDir, aux(45))).map(t => t.fileName))
+      .toContain("05_pre_memory_wipe_5ticks.md");
+    expect((await selectTemplates(promptDir, aux(49))).map(t => t.fileName))
+      .toContain("06_pre_memory_wipe_1tick.md");
+    expect((await selectTemplates(promptDir, aux(50))).map(t => t.fileName))
+      .toContain("07_post_memory_wipe.md");
+  });
+
+  it("selects event-driven bandit templates", async () => {
+    const templates = await selectTemplates(promptDir, aux(10, {
+      chainEvents: [{ eventName: "BanditSpawned", tick: 10, args: {} }],
+      banditView: { exists: true, id: 1, state: 3, stateEnteredTick: 10, nextActionTick: 13 },
+    }));
+    expect(templates.map(t => t.fileName)).toEqual([
+      "20_bandits_appeared.md",
+      "21_bandits_attacking.md",
+    ]);
+  });
+});

--- a/packages/runner/test/thematicUid.test.ts
+++ b/packages/runner/test/thematicUid.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { generateThematicUid, generateUniqueThematicUid, themeCount } from "../src/thematicUid.js";
+
+describe("thematic UID", () => {
+  it("uses six theme pools and appends a four-hex suffix", () => {
+    expect(themeCount()).toBe(6);
+    expect(generateThematicUid()).toMatch(/^[a-z]+-[a-z]+-[a-z]+-[0-9a-f]{4}$/);
+  });
+
+  it("retries collisions and panics after five taken IDs", async () => {
+    let calls = 0;
+    await expect(generateUniqueThematicUid(async () => {
+      calls++;
+      return true;
+    })).rejects.toThrow(/collision/);
+    expect(calls).toBe(5);
+  });
+});

--- a/packages/runner/test/wipeMarker.test.ts
+++ b/packages/runner/test/wipeMarker.test.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearWipeMarker, readWipeMarker, writeWipeMarker } from "../src/wipeMarker.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "wipe-marker-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("wipe marker", () => {
+  it("writes, reads, and clears the last wipe tick", () => {
+    const marker = path.join(dir, "last-wipe-tick");
+    expect(readWipeMarker(marker)).toBe(null);
+    writeWipeMarker(marker, 50);
+    expect(readWipeMarker(marker)).toBe(50);
+    clearWipeMarker(marker);
+    expect(readWipeMarker(marker)).toBe(null);
+  });
+});


### PR DESCRIPTION
## Bundle 4 PR2 of 6 — Runner core rewrite

Replaces the old elder-runtime supervisor with the new per-elder runner architecture. This is the largest sub-PR (2017 insertions across 48 files).

Closes #564.

## Architecture

**Thin orchestrator + named modules:**
- `packages/runner/src/main.ts` — startup + tick loop + shutdown only
- `packages/runner/src/lifecycle/{startup,restartDecision,tickHandler,resetFlow,wipeMarker}.ts`
- `packages/runner/src/helpers/{flockGuard,oneClaudeCheck,settingsCache,thematicUid,templateLoader,messageComposer,messageDelivery,retry}.ts`
- `packages/runner/src/convexClient.ts` — wraps queries/mutations with retry-backoff
- `apps/server/convex/runner.ts` — runner-facing public mutations + queries

## 5-case restart decision table

| Case | Condition | Action |
|---|---|---|
| A | current == last_received | no-op, wait |
| B | current == last+1 && !sent | fresh send |
| C | current == last+1 && sent | re-send (trust receive log) |
| D | gap with memory_wipe OR late_join | kill-tmux + spawn + claude no-continue + `07_post_memory_wipe.md` |
| E | gap without wipe | fast-forward prefix + current message |

## Two-phase commit
- `tickSendLog` written BEFORE paste (captures `messageHash` + optional `resetMetadata`)
- `pendingMessages` consumed ONLY after `tickReceiveLog` row confirms hook receipt
- Resend cap 3 + HOOK_FAILURE alert if hook doesn't confirm
- Double-paste on restart race is acceptable per Liam's design ("no locking bullshit")

## Reset flow
- `last_wipe_tick` marker written atomically at `/home/elder/.runner-state/last-wipe-tick` BEFORE kill-tmux
- `resetEventLog` row inserted with `startedAt`
- tmux killed; fresh session spawned via `run.sh`; claude launched WITHOUT `--continue`
- `/rename` + `/color` slash commands branded from `agents/shared/runner/elder-config.json`
- First-tick sent with `resetMetadata`
- Reset event completion + marker clearing ONLY on successful first-tick delivery (preserves audit trail of incomplete resets)

## Invariants
- flock at `/var/run/elder-runner.lock` via POSIX `flock` on inherited FD
- one-claude check via `pgrep`, fails loud + exits non-zero if >1 (no recovery attempt)
- Game settings cached at boot; drift check on every per-tick query; panic on drift
- Container healthcheck LOCAL ONLY (runner + tmux + claude alive — Convex NOT in check)
- Convex outage: infinite retry exponential backoff capped at 60s, logs `convex_outage_recovery`
- Thematic UID: 6 themed pools, 3 words + 4-hex, DB collision check 5 retries

## Entrypoint behavior change
- `agents/entrypoint.sh` now launches the runner (not claude directly)
- Runner handles tmux lifecycle + claude launch internally
- Prevents pre-runner claude launch from violating the wipe-marker no-continue rule

## Validation
- ✅ `pnpm --filter @clan-world/server typecheck`
- ✅ `pnpm --filter @clan-world/runner typecheck`
- ✅ `pnpm --filter @clan-world/heartbeat typecheck`
- ✅ `pnpm --filter @clan-world/runner test`: 42 pass
- ✅ `pnpm --filter @clan-world/server test`: 122 pass

## Process

Codex 5-stage (xhigh reasoning):
- Stage 1: comprehensive plan with risk register + state machine diagram
- Stage 2: implement (sandbox network issues blocked typecheck — orchestrator validated)
- Stage 3: fix-round on 3 typecheck errors + 1 test failure + self-critique pass (codex tightened reset-completion semantics during critique — only confirms on successful first-tick delivery)

Targets integration branch `dev-phase-4-simplified-comms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)