### PR TITLE
feat(bundle4): paste verification layer — pre-paste readiness + post-paste stuck-input retry (#566)

### DIFF
--- a/packages/runner/src/messageDelivery.ts
+++ b/packages/runner/src/messageDelivery.ts
@@ -40,7 +40,10 @@ export async function deliverMessage(
       return { ...composed, confirmed: false };
     }
     await tmux.pasteMessage(composed.text);
-    await postPasteSubmitted(tmux);
+    if (!(await postPasteSubmitted(tmux))) {
+      await convex.recordRunnerEvent("invariant_violation", `post-paste input stuck for tick ${input.tickNumber ?? "message"}`, input.signal);
+      return { ...composed, confirmed: false };
+    }
 
     if (input.receiveTickNumber === undefined) {
       await convex.consumePendingMessages(composed.pendingMessageIds, Date.now(), input.signal);
@@ -77,7 +80,10 @@ export async function deliverPendingOnly(
       return { ...composed, confirmed: false };
     }
     await tmux.pasteMessage(composed.text);
-    await postPasteSubmitted(tmux);
+    if (!(await postPasteSubmitted(tmux))) {
+      await convex.recordRunnerEvent("invariant_violation", "post-paste input stuck for pending message", input.signal);
+      return { ...composed, confirmed: false };
+    }
     if (receiveUid && await waitForUidReceive(convex, receiveUid, input.receiveTimeoutMs, input.receivePollMs, input.signal)) {
       await convex.consumePendingMessages(composed.pendingMessageIds, Date.now(), input.signal);
       return { ...composed, confirmed: true };

--- a/packages/runner/src/pasteVerification.ts
+++ b/packages/runner/src/pasteVerification.ts
@@ -1,11 +1,56 @@
 import type { TmuxSink } from "./tmuxSink.js";
+import { sleep } from "./retry.js";
 
-export async function prePasteReady(_tmux: TmuxSink): Promise<boolean> {
-  // TODO(PR4): pre-paste readiness probe via tmux capture-pane.
-  return true;
+export const READY_PROBE_TIMEOUT_MS = 10_000;
+export const READY_PROBE_INTERVAL_MS = 250;
+export const STUCK_INPUT_MAX_RETRIES = 3;
+export const STUCK_INPUT_RETRY_DELAY_MS = 500;
+
+const PRE_PASTE_CAPTURE_LINES = 20;
+const POST_PASTE_CAPTURE_LINES = 20;
+const INPUT_REGION_LINES = 5;
+
+export async function prePasteReady(tmux: TmuxSink): Promise<boolean> {
+  const deadline = Date.now() + READY_PROBE_TIMEOUT_MS;
+  while (true) {
+    if (hasReadyPrompt(await tmux.capturePane(PRE_PASTE_CAPTURE_LINES))) {
+      return true;
+    }
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) return false;
+    await sleep(Math.min(READY_PROBE_INTERVAL_MS, remainingMs));
+  }
 }
 
-export async function postPasteSubmitted(_tmux: TmuxSink): Promise<boolean> {
-  // TODO(PR4): post-paste stuck-input detection and Enter retry.
-  return true;
+export async function postPasteSubmitted(tmux: TmuxSink): Promise<boolean> {
+  for (let retry = 0; retry <= STUCK_INPUT_MAX_RETRIES; retry++) {
+    if (!hasStuckInput(await tmux.capturePane(POST_PASTE_CAPTURE_LINES))) {
+      return true;
+    }
+    if (retry === STUCK_INPUT_MAX_RETRIES) return false;
+    await tmux.sendKeys("Enter");
+    await sleep(STUCK_INPUT_RETRY_DELAY_MS);
+  }
+  return false;
+}
+
+function hasReadyPrompt(pane: string): boolean {
+  return inputRegion(pane).some((line) => inputPromptText(line) === "");
+}
+
+function hasStuckInput(pane: string): boolean {
+  return inputRegion(pane).some((line) => {
+    const text = inputPromptText(line);
+    return text !== null && text.length > 0;
+  });
+}
+
+function inputRegion(pane: string): string[] {
+  return pane.split(/\r?\n/).slice(-INPUT_REGION_LINES);
+}
+
+function inputPromptText(line: string): string | null {
+  const withoutCursor = line.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "");
+  const match = /^\s*(?:[\u2502\u2503|]\s*)?>\s*(.*?)\s*$/.exec(withoutCursor);
+  return match?.[1] ?? null;
 }

--- a/packages/runner/src/pasteVerification.ts
+++ b/packages/runner/src/pasteVerification.ts
@@ -5,6 +5,10 @@ export const READY_PROBE_TIMEOUT_MS = 10_000;
 export const READY_PROBE_INTERVAL_MS = 250;
 export const STUCK_INPUT_MAX_RETRIES = 3;
 export const STUCK_INPUT_RETRY_DELAY_MS = 500;
+// Initial settle before first post-paste check: pasteMessage's terminating
+// Enter may not have rendered yet, so the first capturePane otherwise
+// races against TUI render lag and can fire a spurious Enter retry.
+export const POST_PASTE_INITIAL_SETTLE_MS = 200;
 
 const PRE_PASTE_CAPTURE_LINES = 20;
 const POST_PASTE_CAPTURE_LINES = 20;
@@ -23,8 +27,12 @@ export async function prePasteReady(tmux: TmuxSink): Promise<boolean> {
 }
 
 export async function postPasteSubmitted(tmux: TmuxSink): Promise<boolean> {
+  // Give the TUI time to render the paste's terminating Enter before the
+  // first stuck-input check. Without this, fast-running tests + real
+  // delivery both race against TUI render lag and trigger spurious retries.
+  await sleep(POST_PASTE_INITIAL_SETTLE_MS);
   for (let retry = 0; retry <= STUCK_INPUT_MAX_RETRIES; retry++) {
-    if (!hasStuckInput(await tmux.capturePane(POST_PASTE_CAPTURE_LINES))) {
+    if (isInputSubmitted(await tmux.capturePane(POST_PASTE_CAPTURE_LINES))) {
       return true;
     }
     if (retry === STUCK_INPUT_MAX_RETRIES) return false;
@@ -38,11 +46,20 @@ function hasReadyPrompt(pane: string): boolean {
   return inputRegion(pane).some((line) => inputPromptText(line) === "");
 }
 
-function hasStuckInput(pane: string): boolean {
-  return inputRegion(pane).some((line) => {
-    const text = inputPromptText(line);
-    return text !== null && text.length > 0;
-  });
+/**
+ * Returns true ONLY if the input box is visible AND empty. False-positives
+ * from a blank/crashed pane (no prompt visible at all) used to read as
+ * "submitted" — gemini R1 MED. Now we require positive evidence of an
+ * empty prompt before claiming success. If the TUI disappeared, runner
+ * retries via the resend cap, and the upstream healthcheck catches a truly
+ * dead tmux/claude.
+ */
+function isInputSubmitted(pane: string): boolean {
+  const promptLines = inputRegion(pane)
+    .map(inputPromptText)
+    .filter((text): text is string => text !== null);
+  if (promptLines.length === 0) return false;
+  return promptLines.every((text) => text.length === 0);
 }
 
 function inputRegion(pane: string): string[] {

--- a/packages/runner/test/pasteVerification.test.ts
+++ b/packages/runner/test/pasteVerification.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TmuxSink } from "../src/tmuxSink.js";
+import {
+  postPasteSubmitted,
+  prePasteReady,
+  READY_PROBE_INTERVAL_MS,
+  READY_PROBE_TIMEOUT_MS,
+  STUCK_INPUT_MAX_RETRIES,
+  STUCK_INPUT_RETRY_DELAY_MS,
+} from "../src/pasteVerification.js";
+
+describe("paste verification", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("pre-paste returns true when the prompt is visible immediately", async () => {
+    const tmux = mockTmux([
+      pane("Claude is ready", "\u2502 > "),
+    ]);
+
+    await expect(prePasteReady(tmux)).resolves.toBe(true);
+    expect(tmux.capturePane).toHaveBeenCalledTimes(1);
+  });
+
+  it("pre-paste waits until the prompt appears", async () => {
+    vi.useFakeTimers();
+    const tmux = mockTmux([
+      pane("Starting Claude...", "Loading session"),
+      pane("Still warming up"),
+      pane("Claude is ready", "\u2502 > "),
+    ]);
+
+    const promise = prePasteReady(tmux);
+    await vi.advanceTimersByTimeAsync(READY_PROBE_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(READY_PROBE_INTERVAL_MS);
+
+    await expect(promise).resolves.toBe(true);
+    expect(tmux.capturePane).toHaveBeenCalledTimes(3);
+  });
+
+  it("pre-paste returns false when the prompt never appears before timeout", async () => {
+    vi.useFakeTimers();
+    const tmux = mockTmux([
+      pane("Starting Claude...", "Loading session"),
+    ]);
+
+    const promise = prePasteReady(tmux);
+    await vi.advanceTimersByTimeAsync(READY_PROBE_TIMEOUT_MS);
+
+    await expect(promise).resolves.toBe(false);
+    expect(tmux.capturePane).toHaveBeenCalled();
+  });
+
+  it("post-paste returns true when the input is empty", async () => {
+    const tmux = mockTmux([
+      pane("Submitted", "\u2502 > "),
+    ]);
+
+    await expect(postPasteSubmitted(tmux)).resolves.toBe(true);
+    expect(tmux.capturePane).toHaveBeenCalledTimes(1);
+    expect(tmux.sendKeys).not.toHaveBeenCalled();
+  });
+
+  it("post-paste resends Enter and returns true when the input clears", async () => {
+    vi.useFakeTimers();
+    const tmux = mockTmux([
+      pane("\u2502 > tick: 12"),
+      pane("Thinking...", "\u2502 > "),
+    ]);
+
+    const promise = postPasteSubmitted(tmux);
+    await vi.advanceTimersByTimeAsync(STUCK_INPUT_RETRY_DELAY_MS);
+
+    await expect(promise).resolves.toBe(true);
+    expect(tmux.sendKeys).toHaveBeenCalledTimes(1);
+    expect(tmux.sendKeys).toHaveBeenCalledWith("Enter");
+    expect(tmux.capturePane).toHaveBeenCalledTimes(2);
+  });
+
+  it("post-paste returns false when the input remains stuck after all retries", async () => {
+    vi.useFakeTimers();
+    const tmux = mockTmux([
+      pane("\u2502 > tick: 12"),
+    ]);
+
+    const promise = postPasteSubmitted(tmux);
+    await vi.advanceTimersByTimeAsync(STUCK_INPUT_RETRY_DELAY_MS * STUCK_INPUT_MAX_RETRIES);
+
+    await expect(promise).resolves.toBe(false);
+    expect(tmux.sendKeys).toHaveBeenCalledTimes(STUCK_INPUT_MAX_RETRIES);
+    expect(tmux.capturePane).toHaveBeenCalledTimes(STUCK_INPUT_MAX_RETRIES + 1);
+  });
+});
+
+function mockTmux(captures: string[]): TmuxSink & {
+  capturePane: ReturnType<typeof vi.fn>;
+  sendKeys: ReturnType<typeof vi.fn>;
+} {
+  let index = 0;
+  const capturePane = vi.fn(async () => {
+    const paneText = captures[Math.min(index, captures.length - 1)] ?? "";
+    index++;
+    return paneText;
+  });
+  const sendKeys = vi.fn(async () => {});
+  return { capturePane, sendKeys } as unknown as TmuxSink & {
+    capturePane: ReturnType<typeof vi.fn>;
+    sendKeys: ReturnType<typeof vi.fn>;
+  };
+}
+
+function pane(...lines: string[]): string {
+  return lines.join("\n");
+}

--- a/packages/runner/test/pasteVerification.test.ts
+++ b/packages/runner/test/pasteVerification.test.ts
@@ -3,6 +3,7 @@ import type { TmuxSink } from "../src/tmuxSink.js";
 import {
   postPasteSubmitted,
   prePasteReady,
+  POST_PASTE_INITIAL_SETTLE_MS,
   READY_PROBE_INTERVAL_MS,
   READY_PROBE_TIMEOUT_MS,
   STUCK_INPUT_MAX_RETRIES,
@@ -71,7 +72,8 @@ describe("paste verification", () => {
     ]);
 
     const promise = postPasteSubmitted(tmux);
-    await vi.advanceTimersByTimeAsync(STUCK_INPUT_RETRY_DELAY_MS);
+    // Skip past the initial-settle sleep + one retry sleep.
+    await vi.advanceTimersByTimeAsync(POST_PASTE_INITIAL_SETTLE_MS + STUCK_INPUT_RETRY_DELAY_MS);
 
     await expect(promise).resolves.toBe(true);
     expect(tmux.sendKeys).toHaveBeenCalledTimes(1);
@@ -86,11 +88,28 @@ describe("paste verification", () => {
     ]);
 
     const promise = postPasteSubmitted(tmux);
-    await vi.advanceTimersByTimeAsync(STUCK_INPUT_RETRY_DELAY_MS * STUCK_INPUT_MAX_RETRIES);
+    await vi.advanceTimersByTimeAsync(
+      POST_PASTE_INITIAL_SETTLE_MS + STUCK_INPUT_RETRY_DELAY_MS * STUCK_INPUT_MAX_RETRIES,
+    );
 
     await expect(promise).resolves.toBe(false);
     expect(tmux.sendKeys).toHaveBeenCalledTimes(STUCK_INPUT_MAX_RETRIES);
     expect(tmux.capturePane).toHaveBeenCalledTimes(STUCK_INPUT_MAX_RETRIES + 1);
+  });
+
+  it("post-paste returns false when no prompt is visible (gemini R1 MED \u2014 defends crashed pane)", async () => {
+    vi.useFakeTimers();
+    // No input-box-prompt line at all (TUI crashed / blank pane).
+    const tmux = mockTmux([
+      pane("(some garbled output)", "no recognizable prompt here"),
+    ]);
+
+    const promise = postPasteSubmitted(tmux);
+    await vi.advanceTimersByTimeAsync(
+      POST_PASTE_INITIAL_SETTLE_MS + STUCK_INPUT_RETRY_DELAY_MS * STUCK_INPUT_MAX_RETRIES,
+    );
+
+    await expect(promise).resolves.toBe(false);
   });
 });
 

--- a/packages/runner/test/resetFlow.test.ts
+++ b/packages/runner/test/resetFlow.test.ts
@@ -30,6 +30,7 @@ describe("runResetFlow", () => {
       async launchClaude(opts: { continue: boolean }) { calls.push(`claude:${opts.continue}`); },
       async sendSlashCommand(cmd: string) { calls.push(cmd); },
       async pasteMessage(text: string) { calls.push(`paste:${text.split("\n")[0]}`); },
+      async capturePane() { return "\u2502 > "; },
     } as any;
     const convex = {
       async recordResetEvent() { calls.push("reset-start"); return "resetEventLog:1"; },


### PR DESCRIPTION
## Bundle 4 PR4 of 6 — Paste verification

Fills the two `TODO(PR4)` stubs PR2 left in `packages/runner/src/pasteVerification.ts` with real tmux-based detection.

Closes #566. Final sub-PR of Bundle 4 — all 6 sub-PRs will be merged after this lands.

## Changes

**`packages/runner/src/pasteVerification.ts`** — real implementations of the two probes:
- `prePasteReady(tmux)`: poll `capture-pane` for Claude TUI input prompt (`>` at start of input-box region, tolerating box-drawing prefix + ANSI color codes). Times out at 10s with 250ms polling.
- `postPasteSubmitted(tmux)`: poll `capture-pane` for empty input box. If still has text, send `Enter` again. Retries up to 3 times with 500ms delay.

**`packages/runner/src/messageDelivery.ts`** — records `runnerEvents` kind `invariant_violation` + halts delivery when post-paste verification fails. Returns `confirmed: false` so the main loop's retry path fires next tick.

**`packages/runner/test/pasteVerification.test.ts`** — 6 unit tests with mocked TmuxSink:
- prePasteReady: immediate-ready, delayed-ready, never-ready (timeout → false)
- postPasteSubmitted: input-clear (immediate true), input-stuck-then-recovers, input-stuck-all-retries-fail

**`packages/runner/test/resetFlow.test.ts`** — mock updated for the now-real pre/post probes.

## Implementation notes

- ANSI escape sequence stripping before regex (handles colored TUI)
- Box-drawing prefix tolerance (`│`/`┃`/`|`) before the `>` sigil
- `inputRegion` lookback last 5 lines
- All constants exported (`READY_PROBE_TIMEOUT_MS=10_000`, `READY_PROBE_INTERVAL_MS=250`, `STUCK_INPUT_MAX_RETRIES=3`, `STUCK_INPUT_RETRY_DELAY_MS=500`) for future tuning

## Validation

- ✅ `pnpm --filter @clan-world/runner typecheck`
- ✅ `pnpm --filter @clan-world/runner test`: 48 pass / 16 files (+6 new from this PR)
- ✅ Existing resetFlow tests still pass with updated mock

## Process

Codex single-stage implement (high reasoning) — small focused PR, skipped stage 1 plan. Codex reported clean implementation; orchestrator-side validation confirmed.

Targets integration branch `dev-phase-4-simplified-comms`. After this lands, the full Bundle 4 stack (PR1+2+3+5+6+4 all integrated) is ready for super-swarm gate before opening release PR to `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)