### PR TITLE
[test-exp-A-server] untested error paths in auth + runner + tickReceiveLog + adminMessages

### DIFF
--- a/apps/server/convex/adminMessages.test.ts
+++ b/apps/server/convex/adminMessages.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { injectMessage } from "./adminMessages";
+
+// adminMessages.injectMessage has ZERO baseline test coverage despite being
+// the SOLE caller of requireBusOperatorSecret. The mutation is reachable from
+// the operator console / cockpit API and writes into the same pendingMessages
+// table the runner drains. Every reject branch below is currently untested.
+
+function createDb(tables: Record<string, any[]> = {}) {
+  return {
+    tables,
+    db: {
+      async insert(table: string, row: Record<string, unknown>) {
+        tables[table] ??= [];
+        const id = `${table}:${tables[table].length + 1}`;
+        tables[table].push({ _id: id, _creationTime: tables[table].length + 1, ...row });
+        return id;
+      },
+    },
+  };
+}
+
+function call(fn: any, db: any, args: any) {
+  return fn._handler({ db }, args);
+}
+
+beforeEach(() => {
+  vi.stubEnv("BUS_OPERATOR_SECRET", "op-secret");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("adminMessages.injectMessage", () => {
+  it("inserts a pendingMessages row when auth + text are valid", async () => {
+    const { db, tables } = createDb();
+    const id = await call(injectMessage, db, {
+      secret: "op-secret",
+      targetElderId: "elder-1",
+      text: "stay alert",
+      source: "admin-injection",
+    });
+    expect(id).toBe("pendingMessages:1");
+    expect(tables.pendingMessages?.[0]).toMatchObject({
+      targetElderId: "elder-1",
+      text: "stay alert",
+      source: "admin-injection",
+    });
+    // Secret must NEVER be persisted into the queue.
+    expect(tables.pendingMessages?.[0]?.secret).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace before insert", async () => {
+    const { db, tables } = createDb();
+    await call(injectMessage, db, {
+      secret: "op-secret",
+      targetElderId: "elder-2",
+      text: "   trimmed body   ",
+      source: "user-message",
+    });
+    expect(tables.pendingMessages?.[0]?.text).toBe("trimmed body");
+  });
+
+  it("rejects when the supplied operator secret is wrong", async () => {
+    const { db, tables } = createDb();
+    await expect(call(injectMessage, db, {
+      secret: "wrong",
+      targetElderId: "elder-1",
+      text: "x",
+      source: "admin-injection",
+    })).rejects.toThrow("invalid bus operator secret");
+    expect(tables.pendingMessages).toBeUndefined();
+  });
+
+  it("rejects when BUS_OPERATOR_SECRET is unset on the deployment", async () => {
+    // Critical fail-closed: a misconfigured Convex deployment must NOT accept
+    // anonymous writes to the operator surface.
+    vi.stubEnv("BUS_OPERATOR_SECRET", "");
+    const { db, tables } = createDb();
+    await expect(call(injectMessage, db, {
+      secret: "anything",
+      targetElderId: "elder-1",
+      text: "x",
+      source: "admin-injection",
+    })).rejects.toThrow("BUS_OPERATOR_SECRET is not configured on this Convex deployment");
+    expect(tables.pendingMessages).toBeUndefined();
+  });
+
+  it("rejects empty / whitespace-only text post-trim", async () => {
+    const { db, tables } = createDb();
+    await expect(call(injectMessage, db, {
+      secret: "op-secret",
+      targetElderId: "elder-1",
+      text: "",
+      source: "admin-injection",
+    })).rejects.toThrow("text is required");
+    await expect(call(injectMessage, db, {
+      secret: "op-secret",
+      targetElderId: "elder-1",
+      text: "      ",
+      source: "admin-injection",
+    })).rejects.toThrow("text is required");
+    expect(tables.pendingMessages).toBeUndefined();
+  });
+
+  it("rejects text longer than 2000 characters AFTER trimming", async () => {
+    // The cap is checked post-trim, so leading/trailing whitespace doesn't
+    // help squeeze under the limit. Both raw-2001 and trim-still-2001 fail.
+    const { db, tables } = createDb();
+    const raw = "a".repeat(2001);
+    await expect(call(injectMessage, db, {
+      secret: "op-secret",
+      targetElderId: "elder-1",
+      text: raw,
+      source: "admin-injection",
+    })).rejects.toThrow("text must be 2000 characters or fewer");
+
+    // Pad with whitespace that trims away to ~2001 chars body.
+    const padded = `   ${"b".repeat(2001)}   `;
+    await expect(call(injectMessage, db, {
+      secret: "op-secret",
+      targetElderId: "elder-1",
+      text: padded,
+      source: "admin-injection",
+    })).rejects.toThrow("text must be 2000 characters or fewer");
+    expect(tables.pendingMessages).toBeUndefined();
+  });
+
+  it("accepts exactly 2000 characters as the boundary", async () => {
+    // Inclusive cap — `> 2000` rejects, `== 2000` passes. Documents the
+    // contract so a regression that flips to `>= 2000` is caught.
+    const { db, tables } = createDb();
+    const exact = "z".repeat(2000);
+    await call(injectMessage, db, {
+      secret: "op-secret",
+      targetElderId: "elder-1",
+      text: exact,
+      source: "admin-injection",
+    });
+    expect(tables.pendingMessages?.[0]?.text).toHaveLength(2000);
+  });
+});

--- a/apps/server/convex/authShared.test.ts
+++ b/apps/server/convex/authShared.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  requireBusElderSecret,
+  requireBusOperatorSecret,
+  requireIndexerSecret,
+} from "./authShared";
+
+// authShared.ts has THREE auth helpers gating every public mutation/query
+// surface, but none of them have direct unit tests in the baseline. The
+// existing comms/runner/tickReceiveLog tests cover the happy path through
+// individual mutations, but the negative branches (env unset, regex bypass,
+// wrong-elder secret on every elder slot) are not exercised end-to-end.
+//
+// This file targets the helpers themselves so a regression in the helper
+// (e.g. fail-OPEN when env unset, accepting elder-0 / elder-5 / elder-X)
+// would be caught even if no caller's tests change.
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("requireIndexerSecret", () => {
+  it("rejects when INDEXER_SECRET is unset (fail-closed)", () => {
+    vi.stubEnv("INDEXER_SECRET", "");
+    // empty-string env is treated as "unset" by the helper (falsy check)
+    expect(() => requireIndexerSecret("anything"))
+      .toThrow("INDEXER_SECRET is not configured on this Convex deployment");
+  });
+
+  it("rejects when supplied secret mismatches", () => {
+    vi.stubEnv("INDEXER_SECRET", "expected");
+    expect(() => requireIndexerSecret("wrong"))
+      .toThrow("invalid indexer secret");
+  });
+
+  it("rejects when supplied secret is empty string against a configured secret", () => {
+    vi.stubEnv("INDEXER_SECRET", "expected");
+    expect(() => requireIndexerSecret(""))
+      .toThrow("invalid indexer secret");
+  });
+
+  it("accepts when supplied secret matches", () => {
+    vi.stubEnv("INDEXER_SECRET", "expected");
+    expect(() => requireIndexerSecret("expected")).not.toThrow();
+  });
+});
+
+describe("requireBusOperatorSecret", () => {
+  // adminMessages.injectMessage is the sole caller. If BUS_OPERATOR_SECRET is
+  // accidentally unset on a deployment, the operator surface MUST refuse
+  // every write — otherwise anyone with the Convex URL can post into any
+  // elder's pendingMessages queue.
+  it("rejects when BUS_OPERATOR_SECRET is unset (fail-closed)", () => {
+    vi.stubEnv("BUS_OPERATOR_SECRET", "");
+    expect(() => requireBusOperatorSecret("anything"))
+      .toThrow("BUS_OPERATOR_SECRET is not configured on this Convex deployment");
+  });
+
+  it("rejects when supplied secret mismatches", () => {
+    vi.stubEnv("BUS_OPERATOR_SECRET", "operator-pass");
+    expect(() => requireBusOperatorSecret("wrong"))
+      .toThrow("invalid bus operator secret");
+  });
+
+  it("accepts when supplied secret matches", () => {
+    vi.stubEnv("BUS_OPERATOR_SECRET", "operator-pass");
+    expect(() => requireBusOperatorSecret("operator-pass")).not.toThrow();
+  });
+});
+
+describe("requireBusElderSecret", () => {
+  it("rejects unknown elderId formats (no elder-N prefix)", () => {
+    vi.stubEnv("BUS_ELDER_SECRET_1", "x");
+    // Both bare strings and other dash-suffixed names must be rejected by
+    // the regex BEFORE the env var lookup runs.
+    expect(() => requireBusElderSecret("bandit-1", "x"))
+      .toThrow("unknown elderId: bandit-1");
+    expect(() => requireBusElderSecret("elder", "x"))
+      .toThrow("unknown elderId: elder");
+    expect(() => requireBusElderSecret("", "x"))
+      .toThrow("unknown elderId: ");
+  });
+
+  it("rejects elder-0 and elder-5 (out of [1-4] range)", () => {
+    vi.stubEnv("BUS_ELDER_SECRET_1", "x");
+    // The regex is [1-4]; 0 and 5+ slip past prefix-only checks but MUST
+    // be caught here. If a future contributor relaxes the regex to \d+
+    // without adding env vars, this test catches it.
+    expect(() => requireBusElderSecret("elder-0", "x"))
+      .toThrow("unknown elderId: elder-0");
+    expect(() => requireBusElderSecret("elder-5", "x"))
+      .toThrow("unknown elderId: elder-5");
+    expect(() => requireBusElderSecret("elder-9", "x"))
+      .toThrow("unknown elderId: elder-9");
+  });
+
+  it("rejects multi-digit elder ids that share a digit prefix", () => {
+    vi.stubEnv("BUS_ELDER_SECRET_1", "x");
+    // Anchored regex /^elder-([1-4])$/ — multi-digit "elder-12" must NOT
+    // partial-match to elder-1's secret. If $ anchor were dropped, an
+    // attacker could brute against secret-1 by guessing "elder-12345".
+    expect(() => requireBusElderSecret("elder-12", "x"))
+      .toThrow("unknown elderId: elder-12");
+    expect(() => requireBusElderSecret("elder-1a", "x"))
+      .toThrow("unknown elderId: elder-1a");
+  });
+
+  it("rejects elder-N when BUS_ELDER_SECRET_N env is unset", () => {
+    // No env stubs for ANY elder — fail-closed for each slot.
+    for (const elderN of [1, 2, 3, 4]) {
+      expect(() => requireBusElderSecret(`elder-${elderN}`, "x"))
+        .toThrow(`BUS_ELDER_SECRET_${elderN} is not configured on this Convex deployment`);
+    }
+  });
+
+  it("rejects cross-elder secret reuse for every elder slot", () => {
+    vi.stubEnv("BUS_ELDER_SECRET_1", "secret-1");
+    vi.stubEnv("BUS_ELDER_SECRET_2", "secret-2");
+    vi.stubEnv("BUS_ELDER_SECRET_3", "secret-3");
+    vi.stubEnv("BUS_ELDER_SECRET_4", "secret-4");
+
+    // Each elder's secret must NOT validate against another elder's id.
+    // Existing runner.test.ts only checks elder-1 with secret-2 wrong.
+    // Sweep all 4 slots to catch a future "secret-1 also accepted on
+    // elder-3" cross-contamination regression.
+    const pairs: Array<[string, string]> = [
+      ["elder-1", "secret-2"],
+      ["elder-1", "secret-3"],
+      ["elder-1", "secret-4"],
+      ["elder-2", "secret-1"],
+      ["elder-2", "secret-3"],
+      ["elder-3", "secret-1"],
+      ["elder-3", "secret-4"],
+      ["elder-4", "secret-1"],
+      ["elder-4", "secret-2"],
+    ];
+    for (const [elderId, suppliedSecret] of pairs) {
+      expect(() => requireBusElderSecret(elderId, suppliedSecret))
+        .toThrow("invalid bus elder secret");
+    }
+  });
+
+  it("accepts each elder with its own correct secret", () => {
+    vi.stubEnv("BUS_ELDER_SECRET_1", "secret-1");
+    vi.stubEnv("BUS_ELDER_SECRET_2", "secret-2");
+    vi.stubEnv("BUS_ELDER_SECRET_3", "secret-3");
+    vi.stubEnv("BUS_ELDER_SECRET_4", "secret-4");
+    expect(() => requireBusElderSecret("elder-1", "secret-1")).not.toThrow();
+    expect(() => requireBusElderSecret("elder-2", "secret-2")).not.toThrow();
+    expect(() => requireBusElderSecret("elder-3", "secret-3")).not.toThrow();
+    expect(() => requireBusElderSecret("elder-4", "secret-4")).not.toThrow();
+  });
+
+  it("rejects empty supplied secret against a configured slot", () => {
+    vi.stubEnv("BUS_ELDER_SECRET_1", "secret-1");
+    expect(() => requireBusElderSecret("elder-1", ""))
+      .toThrow("invalid bus elder secret");
+  });
+});

--- a/apps/server/convex/runner.test.ts
+++ b/apps/server/convex/runner.test.ts
@@ -203,4 +203,125 @@ describe("convex runner functions", () => {
     })).rejects.toThrow("does not belong to elder-1");
     expect(tables.resetEventLog?.[0]?.completedAt).toBeUndefined();
   });
+
+  // ---- additional error-path coverage (Agent A: untested error paths) ----
+  //
+  // The existing tests above cover happy paths + cross-elder ownership rejects.
+  // The branches below cover the remaining throw sites in runner.ts that
+  // would silently no-op or corrupt state if a regression dropped them.
+
+  it("rejects every mutation when supplied a foreign-elder secret", async () => {
+    // baseline runner.test.ts only verifies wrong-secret on getRunnerAuxiliary.
+    // Every other mutation calls requireBusElderSecret too — sweep them all so
+    // a refactor that drops the call on (e.g.) recordTickSend is caught.
+    const tables: Record<string, any[]> = {};
+    const db = createDb(tables);
+
+    await expect(call(recordTickSend, db, {
+      elderId: "elder-1",
+      secret: "secret-2",
+      tickNumber: 1,
+      messageHash: "h",
+    })).rejects.toThrow("invalid bus elder secret");
+    expect(tables.tickSendLog).toBeUndefined();
+
+    await expect(call(recordResetEvent, db, {
+      elderId: "elder-1",
+      secret: "secret-2",
+      resetTick: 1,
+      reason: "scheduled",
+    })).rejects.toThrow("invalid bus elder secret");
+    expect(tables.resetEventLog).toBeUndefined();
+
+    await expect(call(recordRunnerEvent, db, {
+      elderId: "elder-1",
+      secret: "secret-2",
+      kind: "hook_failure",
+      message: "x",
+    })).rejects.toThrow("invalid bus elder secret");
+    expect(tables.runnerEvents).toBeUndefined();
+
+    await expect(call(consumePendingMessages, db, {
+      elderId: "elder-1",
+      secret: "secret-2",
+      messageIds: [],
+      consumedAt: 1,
+    })).rejects.toThrow("invalid bus elder secret");
+
+    await expect(call(completeResetEvent, db, {
+      elderId: "elder-1",
+      secret: "secret-2",
+      resetEventId: "resetEventLog:nonexistent",
+    })).rejects.toThrow("invalid bus elder secret");
+
+    await expect(call(hasTickReceive, db, {
+      elderId: "elder-1",
+      secret: "secret-2",
+      tickNumber: 1,
+    })).rejects.toThrow("invalid bus elder secret");
+
+    await expect(call(getRunnerStartupState, db, {
+      elderId: "elder-1",
+      secret: "secret-2",
+    })).rejects.toThrow("invalid bus elder secret");
+  });
+
+  it("consumePendingMessages throws when ANY id in batch is missing (atomic check)", async () => {
+    // The loop in consumePendingMessages collects owned ids first, then
+    // patches them. If id #2 doesn't exist, the throw happens BEFORE any
+    // patches run — so id #1's consumedAt should stay undefined too. This
+    // protects the all-or-nothing semantics of the batch consume.
+    const tables: Record<string, any[]> = {
+      pendingMessages: [
+        { _id: "pendingMessages:1", _creationTime: 1, targetElderId: "elder-1", text: "x", source: "user-message", insertedAt: 1, consumedAt: undefined },
+      ],
+    };
+    const db = createDb(tables);
+
+    await expect(call(consumePendingMessages, db, {
+      elderId: "elder-1",
+      secret: "secret-1",
+      messageIds: ["pendingMessages:1", "pendingMessages:999"],
+      consumedAt: 123,
+    })).rejects.toThrow("pending message not found: pendingMessages:999");
+    expect(tables.pendingMessages?.[0]?.consumedAt).toBeUndefined();
+  });
+
+  it("completeResetEvent throws when resetEventId doesn't exist", async () => {
+    // Distinct from cross-elder ownership: this path catches a typo'd /
+    // already-deleted reset id, with a specific "reset event not found"
+    // message vs. the "does not belong" rejection.
+    const tables: Record<string, any[]> = {};
+    const db = createDb(tables);
+
+    await expect(call(completeResetEvent, db, {
+      elderId: "elder-1",
+      secret: "secret-1",
+      resetEventId: "resetEventLog:does-not-exist",
+    })).rejects.toThrow("reset event not found: resetEventLog:does-not-exist");
+  });
+
+  it("getRunnerStartupState falls back to default clock when tickClock is empty", async () => {
+    // The latestClock() helper has TWO branches: row present vs. row missing.
+    // The baseline test only exercises the present branch. If a refactor
+    // drops the cold-start default, runners would deserialize undefined and
+    // crash on first boot of a fresh deployment.
+    const db = createDb({});
+    const result = await call(getRunnerStartupState, db, { elderId: "elder-1", secret: "secret-1" });
+    expect(result.tickClock.tick).toBe(0);
+    expect(result.lastReceivedTick).toBeNull();
+    expect(result.sentForCurrentTick).toBe(false);
+  });
+
+  it("returns sentForCurrentTick=false when a send exists for a DIFFERENT tick", async () => {
+    // by_elder_tick uses an .eq(tickNumber) on the CURRENT tick. A send row
+    // logged at tick N-1 must NOT satisfy the "current tick" check at tick N.
+    // Without this guard, the runner skips sending after a restart.
+    const db = createDb({
+      tickClock: [{ _id: "tickClock:1", _creationTime: 1, tick: 10, tickEpochStartedAt: 0, tickEpochDurationMs: 60_000, seasonStartTick: 0, seasonEndTick: 360, winterActive: false }],
+      tickSendLog: [{ _id: "tickSendLog:1", _creationTime: 1, elderId: "elder-1", tickNumber: 9, sentAt: 1, messageHash: "abc" }],
+    });
+    const result = await call(getRunnerStartupState, db, { elderId: "elder-1", secret: "secret-1" });
+    expect(result.sentForCurrentTick).toBe(false);
+  });
 });

--- a/apps/server/convex/tickReceiveLog.test.ts
+++ b/apps/server/convex/tickReceiveLog.test.ts
@@ -59,4 +59,145 @@ describe("tickReceiveLog.recordReceive", () => {
       messagePreview: "tick 9",
     })).rejects.toThrow("invalid bus elder secret");
   });
+
+  // ---- prefix/id-field cross-validation (Agent A: untested error paths) ----
+  // The handler in tickReceiveLog.ts enforces a 3x3 prefix→required-id matrix
+  // (tick needs tickNumber + must NOT set whisper/special; whisper needs
+  // whisperUid + must NOT set tick/special; etc). Baseline tests only cover
+  // the happy "tick" path. Each branch below catches a regression that would
+  // silently insert mis-shaped rows the runner can't decode.
+
+  it("prefix=tick rejects when tickNumber missing", async () => {
+    const db = createDb();
+    await expect(call(recordReceive, db, {
+      secret: "secret-1",
+      elderId: "elder-1",
+      prefix: "tick",
+      messagePreview: "tick ?",
+    })).rejects.toThrow("prefix=tick requires tickNumber");
+  });
+
+  it("prefix=tick rejects when whisperUid or specialMsgUid bleeds in", async () => {
+    const db = createDb();
+    await expect(call(recordReceive, db, {
+      secret: "secret-1",
+      elderId: "elder-1",
+      prefix: "tick",
+      tickNumber: 9,
+      whisperUid: "stray",
+      messagePreview: "x",
+    })).rejects.toThrow("prefix=tick must not set whisperUid or specialMsgUid");
+
+    await expect(call(recordReceive, db, {
+      secret: "secret-1",
+      elderId: "elder-1",
+      prefix: "tick",
+      tickNumber: 9,
+      specialMsgUid: "stray",
+      messagePreview: "x",
+    })).rejects.toThrow("prefix=tick must not set whisperUid or specialMsgUid");
+  });
+
+  it("prefix=whisper rejects when whisperUid missing", async () => {
+    const db = createDb();
+    await expect(call(recordReceive, db, {
+      secret: "secret-1",
+      elderId: "elder-1",
+      prefix: "whisper",
+      messagePreview: "w",
+    })).rejects.toThrow("prefix=whisper requires whisperUid");
+  });
+
+  it("prefix=whisper rejects when tickNumber or specialMsgUid bleeds in", async () => {
+    const db = createDb();
+    await expect(call(recordReceive, db, {
+      secret: "secret-1",
+      elderId: "elder-1",
+      prefix: "whisper",
+      whisperUid: "uid-1",
+      tickNumber: 9,
+      messagePreview: "x",
+    })).rejects.toThrow("prefix=whisper must not set tickNumber or specialMsgUid");
+
+    await expect(call(recordReceive, db, {
+      secret: "secret-1",
+      elderId: "elder-1",
+      prefix: "whisper",
+      whisperUid: "uid-1",
+      specialMsgUid: "uid-2",
+      messagePreview: "x",
+    })).rejects.toThrow("prefix=whisper must not set tickNumber or specialMsgUid");
+  });
+
+  it("prefix=special-msg rejects when specialMsgUid missing", async () => {
+    const db = createDb();
+    await expect(call(recordReceive, db, {
+      secret: "secret-1",
+      elderId: "elder-1",
+      prefix: "special-msg",
+      messagePreview: "s",
+    })).rejects.toThrow("prefix=special-msg requires specialMsgUid");
+  });
+
+  it("prefix=special-msg rejects when tickNumber or whisperUid bleeds in", async () => {
+    const db = createDb();
+    await expect(call(recordReceive, db, {
+      secret: "secret-1",
+      elderId: "elder-1",
+      prefix: "special-msg",
+      specialMsgUid: "s",
+      tickNumber: 9,
+      messagePreview: "x",
+    })).rejects.toThrow("prefix=special-msg must not set tickNumber or whisperUid");
+
+    await expect(call(recordReceive, db, {
+      secret: "secret-1",
+      elderId: "elder-1",
+      prefix: "special-msg",
+      specialMsgUid: "s",
+      whisperUid: "w",
+      messagePreview: "x",
+    })).rejects.toThrow("prefix=special-msg must not set tickNumber or whisperUid");
+  });
+
+  it("truncates oversized messagePreview and uid fields to enforced caps", async () => {
+    // MESSAGE_PREVIEW_MAX = 100, UID_MAX = 200. Without these slices a
+    // hostile/buggy caller could persist multi-MB strings into the indexed
+    // table. Worth a check so a future refactor that drops the .slice()
+    // truncation is caught.
+    const tables: Record<string, any[]> = {};
+    const db = createDb(tables);
+
+    const huge = "x".repeat(500);
+    const longUid = "u".repeat(500);
+
+    await call(recordReceive, db, {
+      secret: "secret-1",
+      elderId: "elder-1",
+      prefix: "whisper",
+      whisperUid: longUid,
+      messagePreview: huge,
+    });
+
+    const row = tables.tickReceiveLog?.[0];
+    expect(row?.messagePreview).toHaveLength(100);
+    expect(row?.whisperUid).toHaveLength(200);
+    // Secret never persisted — defensive check; baseline already covers happy.
+    expect(row?.secret).toBeUndefined();
+  });
+
+  it("ALWAYS gates on the elder secret BEFORE prefix validation", async () => {
+    // If a future refactor reorders validation so prefix-checks run first,
+    // a foreign elder could probe argument shape errors to fingerprint the
+    // schema. The "invalid bus elder secret" message must win.
+    const db = createDb();
+    await expect(call(recordReceive, db, {
+      secret: "secret-2",
+      elderId: "elder-1",
+      prefix: "tick",
+      // intentionally missing tickNumber — that error would fire if
+      // requireBusElderSecret were skipped.
+      messagePreview: "x",
+    })).rejects.toThrow("invalid bus elder secret");
+  });
 });


### PR DESCRIPTION
## Summary
Agent A slice of the parallel test-improvement experiment (apps/server scope).
**+34 tests, no source changes.** Baseline 126 tests → 160 tests, all pass.

Targets THROW BRANCHES that were silently uncovered. Five focus areas:

### `authShared.test.ts` (new file, +14 tests)
Direct unit tests for the three auth helpers that gate every public
mutation/query surface — none of them had direct tests in the baseline.

- `requireIndexerSecret`: fail-closed when env unset, wrong/empty-supplied.
- `requireBusOperatorSecret`: fail-closed when env unset, wrong-supplied.
- `requireBusElderSecret`:
  - non-`elder-N` formats (`bandit-1`, empty string, bare `elder`)
  - out-of-range slots (`elder-0`, `elder-5`, `elder-9`)
  - regex-anchor regressions (`elder-12`, `elder-1a` — would brute-against
    secret-1 if `$` anchor dropped)
  - per-slot fail-closed when `BUS_ELDER_SECRET_N` unset
  - **9-pair cross-elder secret reuse sweep** (baseline only covered
    elder-1 × secret-2)

### `adminMessages.test.ts` (new file, +7 tests)
`injectMessage` previously had **zero** test coverage despite being the SOLE
caller of `requireBusOperatorSecret`. Covers:
- wrong operator secret + unset `BUS_OPERATOR_SECRET` (fail-closed)
- empty / whitespace-only text rejection (post-trim)
- 2000-char boundary check (inclusive — `> 2000` rejects, `== 2000` passes)
- secret field is NEVER persisted into `pendingMessages`

### `runner.test.ts` (+5 tests)
- **Sweep wrong-secret rejection across all 7 mutations/queries** — baseline
  only checked `getRunnerAuxiliary`. Catches a refactor that drops auth on
  any single surface.
- `consumePendingMessages` with mixed (valid + non-existent) message id —
  verifies all-or-nothing semantics (no row patched if any id missing).
- `completeResetEvent` with non-existent `resetEventId`.
- `getRunnerStartupState` cold-start defaults (no `tickClock` row).
- `sentForCurrentTick=false` when a send exists for a DIFFERENT tick.

### `tickReceiveLog.test.ts` (+8 tests)
Full 3×3 prefix → required-id validation matrix:
- `prefix=tick`: missing `tickNumber`; `whisperUid` bleed-in; `specialMsgUid` bleed-in
- `prefix=whisper`: missing `whisperUid`; `tickNumber` bleed-in; `specialMsgUid` bleed-in
- `prefix=special-msg`: missing `specialMsgUid`; `tickNumber` bleed-in; `whisperUid` bleed-in

Plus:
- `messagePreview` truncates to 100 chars; `whisperUid` to 200 chars.
- Ordering guarantee: `requireBusElderSecret` MUST run BEFORE prefix
  validation (otherwise a foreign elder could fingerprint schema).

## Test plan
- [x] `pnpm --filter @clan-world/server test --run` → 16 files / **160 passed** (was 14/126)
- [x] `pnpm exec tsc --noEmit` clean
- [x] No source files modified — pure test-only diff

## Notes / non-overlap
This is intentionally scoped to error-path / auth-rejection coverage.
Boundary conditions, race conditions, integration seams, and validator
property tests are owned by Agents B / C / D / E respectively.