### PR TITLE
[test-exp-A-web] untested error paths — admin inject-message + snapshot shape

### DIFF
--- a/apps/web/src/adminInjectMessage.test.ts
+++ b/apps/web/src/adminInjectMessage.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Error-path coverage for the admin inject-message HTTP handler.
+ *
+ * Targets failures the cockpit UI (AdminMessageTab) and any other API consumer
+ * can hit: method rejection, missing/invalid auth, body validation rejections,
+ * downstream Convex rejection, and the partial-failure "all elders" path.
+ *
+ * Tests are pure Node (no DOM) — vitest env is `node` in apps/web and there is
+ * no @testing-library installed. The handler under test (`handleInjectMessage`)
+ * is itself pure Node — it accepts IncomingMessage + ServerResponse — so we
+ * fake those with small in-memory shims rather than spinning up a real http
+ * server.
+ *
+ * Mocks: `./convex` (so we don't pull ConvexHttpClient + read /etc/clan-world
+ * operator secret) and `@clerk/backend` (so the auth path is deterministic).
+ */
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the convex module BEFORE importing handleInjectMessage — vitest hoists
+// vi.mock calls automatically. The mock state is reset between tests via the
+// vi.mocked() controls below.
+vi.mock('../server/admin/convex', () => ({
+  injectPendingMessage: vi.fn(),
+}));
+
+// Mock @clerk/backend so any path that calls verifyToken is deterministic
+// without needing a real Clerk secret + signed JWT.
+vi.mock('@clerk/backend', () => ({
+  verifyToken: vi.fn(),
+}));
+
+import { handleInjectMessage } from '../server/admin/injectMessage';
+import { injectPendingMessage } from '../server/admin/convex';
+import { verifyToken } from '@clerk/backend';
+
+type FakeReq = {
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+};
+
+/**
+ * Build a Readable stream + IncomingMessage-shaped object that
+ * `handleInjectMessage`'s `readBody` helper can consume.
+ */
+function fakeRequest({ method, headers, body }: FakeReq): import('node:http').IncomingMessage {
+  // Readable.from + assigning the additional IncomingMessage fields gives us
+  // everything `handleInjectMessage` touches (method, headers, on('data'),
+  // on('end'), setEncoding, destroy).
+  const stream = Readable.from(body ?? '');
+  // setEncoding is a no-op on Readable.from — but the handler calls it.
+  // Override with an empty fn so the assertion doesn't trip the wrong path.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (stream as any).setEncoding = () => undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (stream as any).method = method;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (stream as any).headers = headers;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return stream as any;
+}
+
+/**
+ * Minimal ServerResponse shim that captures statusCode + body. Mirrors the
+ * shape of the calls `sendJson` makes (statusCode setter, setHeader, end).
+ */
+function fakeResponse() {
+  let statusCode = 200;
+  let body = '';
+  const headers: Record<string, string> = {};
+  const res = {
+    get statusCode() {
+      return statusCode;
+    },
+    set statusCode(code: number) {
+      statusCode = code;
+    },
+    setHeader(name: string, value: string) {
+      headers[name.toLowerCase()] = value;
+    },
+    end(payload?: string) {
+      body = payload ?? '';
+    },
+    // Expose captured state for assertions.
+    get body() {
+      return body;
+    },
+    get json(): unknown {
+      try {
+        return JSON.parse(body);
+      } catch {
+        return null;
+      }
+    },
+    get headers() {
+      return headers;
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return res as any;
+}
+
+const VALID_BODY = JSON.stringify({
+  targetElderId: 'elder-1',
+  text: 'hello world',
+  source: 'admin-injection',
+});
+
+// Save + restore the env so tests don't leak NODE_ENV / CLERK_SECRET_KEY /
+// ADMIN_ALLOWED_USER_IDS / ADMIN_AUTH_BYPASS into sibling tests.
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default to "auth fully configured + caller is admin" so individual tests
+  // only override what they need.
+  process.env.NODE_ENV = 'test';
+  process.env.CLERK_SECRET_KEY = 'sk_test_anything';
+  process.env.ADMIN_ALLOWED_USER_IDS = 'user_admin_1';
+  delete process.env.ADMIN_AUTH_BYPASS;
+  vi.mocked(verifyToken).mockResolvedValue({ sub: 'user_admin_1' } as never);
+  vi.mocked(injectPendingMessage).mockResolvedValue('pending_xyz');
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('handleInjectMessage — error paths', () => {
+  it('rejects non-POST with 405 method_not_allowed', async () => {
+    const req = fakeRequest({ method: 'GET', headers: {} });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(405);
+    expect(res.json).toEqual({
+      error: { code: 'method_not_allowed', message: 'Use POST' },
+    });
+    // Auth must NOT run before the method gate — otherwise a GET probe leaks
+    // CLERK_SECRET_KEY-bound timing differences.
+    expect(verifyToken).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 clerk_not_configured when CLERK_SECRET_KEY is unset', async () => {
+    delete process.env.CLERK_SECRET_KEY;
+    const req = fakeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer anything' },
+      body: VALID_BODY,
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(401);
+    expect(res.json).toMatchObject({
+      error: { code: 'clerk_not_configured' },
+    });
+  });
+
+  it('returns 401 missing_session when bearer header is absent', async () => {
+    const req = fakeRequest({
+      method: 'POST',
+      headers: {},
+      body: VALID_BODY,
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(401);
+    expect(res.json).toMatchObject({
+      error: { code: 'missing_session' },
+    });
+    // Downstream MUST NOT be invoked when auth fails — otherwise a malformed
+    // bearer call would still write to Convex.
+    expect(injectPendingMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 not_admin when caller is signed in but not on allowlist', async () => {
+    vi.mocked(verifyToken).mockResolvedValue({ sub: 'user_random_42' } as never);
+    const req = fakeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer tok' },
+      body: VALID_BODY,
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(403);
+    expect(res.json).toMatchObject({ error: { code: 'not_admin' } });
+    expect(injectPendingMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 admin_allowlist_unconfigured when allowlist env is empty', async () => {
+    // Empty allowlist must FAIL CLOSED — a successful Clerk verify is necessary
+    // but not sufficient for admin access.
+    process.env.ADMIN_ALLOWED_USER_IDS = '   ,  , ';
+    const req = fakeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer tok' },
+      body: VALID_BODY,
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(503);
+    expect(res.json).toMatchObject({
+      error: { code: 'admin_allowlist_unconfigured' },
+    });
+  });
+
+  it('returns 400 validation_error on invalid JSON body', async () => {
+    const req = fakeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer tok' },
+      body: '{ not json',
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.json).toMatchObject({
+      error: { code: 'validation_error', message: expect.stringMatching(/JSON/i) },
+    });
+  });
+
+  it('returns 400 when targetElderId is not in allowlist', async () => {
+    const body = JSON.stringify({
+      targetElderId: 'elder-99',
+      text: 'hello',
+      source: 'admin-injection',
+    });
+    const req = fakeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer tok' },
+      body,
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(400);
+    expect((res.json as { error?: { message?: string } }).error?.message).toMatch(/targetElderId/);
+  });
+
+  it('returns 400 when text is whitespace-only', async () => {
+    // Trim-then-check guards against "   " bypassing the empty-string check.
+    const body = JSON.stringify({
+      targetElderId: 'elder-1',
+      text: '     ',
+      source: 'admin-injection',
+    });
+    const req = fakeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer tok' },
+      body,
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(400);
+    expect((res.json as { error?: { message?: string } }).error?.message).toMatch(/text is required/);
+  });
+
+  it('returns 400 when text exceeds MAX_TEXT_LENGTH (2000)', async () => {
+    const body = JSON.stringify({
+      targetElderId: 'elder-1',
+      text: 'a'.repeat(2001),
+      source: 'admin-injection',
+    });
+    const req = fakeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer tok' },
+      body,
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(400);
+    expect((res.json as { error?: { message?: string } }).error?.message).toMatch(/2000/);
+  });
+
+  it('returns 400 when source is unrecognized', async () => {
+    const body = JSON.stringify({
+      targetElderId: 'elder-1',
+      text: 'hello',
+      source: 'system-bus', // not in admin-injection / user-message
+    });
+    const req = fakeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer tok' },
+      body,
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(400);
+    expect((res.json as { error?: { message?: string } }).error?.message).toMatch(/source/);
+  });
+
+  it('returns 500 when Convex rejects the only target', async () => {
+    vi.mocked(injectPendingMessage).mockRejectedValue(new Error('convex out of quota'));
+    const req = fakeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer tok' },
+      body: VALID_BODY,
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    // Single-target failure path: slugs.length === 0, errors.length > 0 → 500.
+    expect(res.statusCode).toBe(500);
+    const json = res.json as { slugs: unknown[]; errors: Array<{ message: string }> };
+    expect(json.slugs).toEqual([]);
+    expect(json.errors).toHaveLength(1);
+    expect(json.errors[0]?.message).toMatch(/convex out of quota/);
+  });
+
+  it('returns 207 partial-success when "all" target sees mixed Convex outcomes', async () => {
+    // First elder succeeds, second rejects, third + fourth succeed —
+    // exercises the multi-status path that single-target callers never hit.
+    let call = 0;
+    vi.mocked(injectPendingMessage).mockImplementation(async () => {
+      call += 1;
+      if (call === 2) throw new Error('elder-2 convex burst');
+      return `pending_${call}`;
+    });
+    const body = JSON.stringify({
+      targetElderId: 'all',
+      text: 'broadcast',
+      source: 'admin-injection',
+    });
+    const req = fakeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer tok' },
+      body,
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(207);
+    const json = res.json as {
+      slugs: Array<{ targetElderId: string; pendingMessageId: string }>;
+      errors: Array<{ targetElderId: string; message: string }>;
+    };
+    expect(json.slugs.map((s) => s.targetElderId)).toEqual(['elder-1', 'elder-3', 'elder-4']);
+    expect(json.errors).toHaveLength(1);
+    expect(json.errors[0]?.targetElderId).toBe('elder-2');
+    expect(json.errors[0]?.message).toMatch(/elder-2 convex burst/);
+  });
+
+  it('honors dev bypass ONLY when NODE_ENV=development AND ADMIN_AUTH_BYPASS=true', async () => {
+    // The bypass guard is positive — anything other than the exact pair must
+    // still require a valid bearer. This pins the "no NODE_ENV in prod" hole.
+    process.env.NODE_ENV = 'development';
+    process.env.ADMIN_AUTH_BYPASS = 'true';
+    // Remove CLERK_SECRET_KEY to prove the bypass short-circuits BEFORE the
+    // clerk_not_configured check.
+    delete process.env.CLERK_SECRET_KEY;
+    const req = fakeRequest({
+      method: 'POST',
+      headers: {}, // no bearer
+      body: VALID_BODY,
+    });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(200);
+    expect((res.json as { pendingMessageId?: string }).pendingMessageId).toBe('pending_xyz');
+    expect(verifyToken).not.toHaveBeenCalled();
+
+    // Negative: same env but ADMIN_AUTH_BYPASS unset → falls through to the
+    // CLERK_SECRET_KEY check and returns 401.
+    delete process.env.ADMIN_AUTH_BYPASS;
+    const res2 = fakeResponse();
+    await handleInjectMessage(
+      fakeRequest({ method: 'POST', headers: {}, body: VALID_BODY }),
+      res2,
+    );
+    expect(res2.statusCode).toBe(401);
+    expect((res2.json as { error?: { code?: string } }).error?.code).toBe('clerk_not_configured');
+  });
+
+  it('returns 204 with empty body for CORS preflight (OPTIONS)', async () => {
+    // Important so the in-browser fetch from AdminMessageTab survives
+    // preflight when the cockpit subdomain ever diverges from the API host.
+    const req = fakeRequest({ method: 'OPTIONS', headers: {} });
+    const res = fakeResponse();
+    await handleInjectMessage(req, res);
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
+    expect(verifyToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/cachedSnapshotShape.test.ts
+++ b/apps/web/src/cachedSnapshotShape.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Error-path coverage for `isValidSnapshotShape` — the runtime guard the
+ * snapshot localStorage cache uses BEFORE hydrating React state.
+ *
+ * Why these tests matter: if a malformed payload sneaks through the
+ * envelope-version check (e.g. partial schema migration where v didn't bump,
+ * or a poisoned localStorage entry from an old build), downstream consumers
+ * do `clan.id.split(...)` / `for (const c of snapshot.clans)` against a
+ * shape they don't expect → crash inside the WorldMap render path → the
+ * outer CockpitErrorBoundary trips and the user sees the global "COCKPIT
+ * OFFLINE" screen instead of the placeholder.
+ *
+ * The validator is the choke point that converts schema drift into a silent
+ * cache miss. Tests pin BOTH the happy shape AND the malformed paths the
+ * UI must never hydrate.
+ */
+import { describe, expect, it } from 'vitest';
+import { isValidSnapshotShape } from './hooks/useCachedSnapshot';
+
+describe('isValidSnapshotShape — malformed payload rejection', () => {
+  it('accepts the happy-path shape with multiple clan entries', () => {
+    expect(
+      isValidSnapshotShape({
+        tick: 42,
+        clans: [
+          { id: '1', name: 'Storm Riders' },
+          { id: '2', name: 'Iron Guard' },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts an empty clans array (legitimate post-reset state)', () => {
+    // Empty-clans is a valid runtime shape — the realm can briefly have zero
+    // clans during a full-game-reset. The validator must let it through so
+    // the last-known-good guard upstream (not the validator) decides whether
+    // to surface it.
+    expect(isValidSnapshotShape({ tick: 0, clans: [] })).toBe(true);
+  });
+
+  it('rejects null', () => {
+    expect(isValidSnapshotShape(null)).toBe(false);
+  });
+
+  it('rejects non-object scalars', () => {
+    expect(isValidSnapshotShape(42)).toBe(false);
+    expect(isValidSnapshotShape('snapshot')).toBe(false);
+    expect(isValidSnapshotShape(true)).toBe(false);
+    expect(isValidSnapshotShape(undefined)).toBe(false);
+  });
+
+  it('rejects payload missing tick', () => {
+    expect(isValidSnapshotShape({ clans: [] })).toBe(false);
+  });
+
+  it('rejects payload where tick is a numeric string ("42") not a number', () => {
+    // Catches accidental JSON-stringified-tick migrations — downstream
+    // arithmetic (tick - lastTick) would silently produce NaN.
+    expect(isValidSnapshotShape({ tick: '42', clans: [] })).toBe(false);
+  });
+
+  it('rejects payload missing clans', () => {
+    expect(isValidSnapshotShape({ tick: 1 })).toBe(false);
+  });
+
+  it('rejects payload where clans is an object map (not array)', () => {
+    // Catches a future "keyed clans by id" migration that landed without a
+    // PAYLOAD_VERSION bump.
+    expect(isValidSnapshotShape({ tick: 1, clans: { '1': { id: '1', name: 'x' } } })).toBe(false);
+  });
+
+  it('rejects payload where clan id is a number not a string', () => {
+    expect(
+      isValidSnapshotShape({
+        tick: 1,
+        clans: [{ id: 1, name: 'Storm Riders' }],
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects payload where clan name is missing', () => {
+    expect(
+      isValidSnapshotShape({
+        tick: 1,
+        clans: [{ id: '1' }],
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects when first clan is valid but second is malformed — regression for "only-check-first" validators', () => {
+    // This is the "every clan" check that the validator's docstring explicitly
+    // promises. A naive earlier validator might only have inspected clans[0];
+    // pinning this prevents silently re-introducing that bug.
+    expect(
+      isValidSnapshotShape({
+        tick: 1,
+        clans: [
+          { id: '1', name: 'Storm Riders' },
+          { id: '2', name: 99 }, // bad
+          { id: '3', name: 'Crimson' },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects when a clan entry is itself null', () => {
+    // Convex never emits a null entry, but a poisoned cache might. The loop
+    // does `typeof c === "object"` — `typeof null === "object"` in JS is the
+    // classic footgun, so we pin that null is rejected (the validator handles
+    // it with an explicit `c === null` check).
+    expect(
+      isValidSnapshotShape({
+        tick: 1,
+        clans: [{ id: '1', name: 'Storm Riders' }, null],
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Parallel test-improvement experiment (Agent A — apps/web segment, untested error paths approach). 26 new error-path tests added, no source modifications.

### Scope choice

`apps/web` vitest env is `node` (no `jsdom`, no `@testing-library/react` installed). Pragmatic call: target the **pure-Node error surfaces** that actually carry production risk rather than try to bootstrap a DOM stack for component-render tests. The two highest-value error-path gaps:

1. **`server/admin/injectMessage.ts`** — the admin HTTP handler the AdminMessageTab calls. Before this PR, zero tests covered auth rejection, body validation, Convex rejection, or the partial-failure "all elders" 207 path.
2. **`hooks/useCachedSnapshot.ts::isValidSnapshotShape`** — the runtime guard that prevents poisoned localStorage from crashing the WorldMap render path. Documented to validate every clan entry but had no regression test pinning that promise.

### Test files

**`apps/web/src/adminInjectMessage.test.ts`** (14 tests)

- 405 method rejection (auth must NOT run for non-POST — timing-leak guard)
- 401 `clerk_not_configured` when `CLERK_SECRET_KEY` unset
- 401 `missing_session` when bearer header absent (and downstream Convex MUST NOT be invoked)
- 403 `not_admin` when caller is signed in but not on allowlist
- 503 `admin_allowlist_unconfigured` on empty `ADMIN_ALLOWED_USER_IDS` (fail-closed contract)
- 400 `validation_error` for: invalid JSON, bad `targetElderId`, whitespace-only text, `>2000` chars, unknown source
- 500 with `errors[]` when Convex rejects the only target
- **207 multi-status** when `targetElderId: "all"` sees mixed Convex outcomes — pins both `slugs[]` and `errors[]` populated with correct elder-id pairing (elders 1+3+4 succeed, elder-2 fails)
- Dev bypass fires **ONLY** for the exact `NODE_ENV=development` + `ADMIN_AUTH_BYPASS=true` pair (includes negative case — closes the "NODE_ENV unset in preview deploy" hole codex flagged on R1)
- 204 OPTIONS preflight with empty body, auth not invoked

Mocks `./convex` (avoids real `ConvexHttpClient` + `/etc/clan-world/secrets/bus-operator.key` read) and `@clerk/backend` (deterministic `verifyToken`).

**`apps/web/src/cachedSnapshotShape.test.ts`** (12 tests)

- Happy + empty-clans paths (legitimate post-reset state)
- `null` / scalar / `undefined` rejection
- `tick` missing + `tick` as numeric-string `"42"` rejection (catches accidental JSON-stringified-tick migrations)
- `clans` missing + `clans` as object-map rejection (catches "keyed clans by id" migration without `PAYLOAD_VERSION` bump)
- `clan.id` wrong type + `clan.name` missing
- `null` entry inside `clans` (`typeof null === "object"` footgun pin)
- **Regression test: valid first entry + malformed second entry** — pins the "validates every clan entry" promise from the validator's docstring, catches the "only-check-first" anti-pattern

### Findings / gaps

- No bugs found in handler or validator — both are well-written.
- Real surface gap: **`useSafeQuery`** and **`useConnectionStatus`** would benefit from tests but need DOM/react-hooks-testing-library which isn't installed. Recommend a separate infra PR to add `@testing-library/react` + `jsdom` so component-level error paths (Convex query rejection rendering, Clerk session-missing UI state, WebSocket disconnect overlay) get covered.
- Auth `verifyAdminRequest` returns `401 invalid_session` from caught `verifyToken` throws — verified path via the existing tests' mock infrastructure but no dedicated test for catch-branch coverage; could be added later.

### Test plan
- [x] `pnpm --filter @clan-world/web test --run` → 34 passed (8 pre-existing + 26 new)
- [x] `pnpm --filter @clan-world/web typecheck` → clean
- [x] No source files modified
- [x] Draft PR — for experiment review, not for merge

## Experiment context

Part of parallel test-improvement experiment dispatched 2026-05-24 06:30 ET. Agents A-E hit apps/web with different test approaches (A: error paths, B: boundaries, C: races, D: integration, E: property-based).