### PR TITLE
[test-exp-B-web] boundary conditions in apps/web

### DIFF
--- a/apps/web/src/components/cockpit/resetOverlayState.test.ts
+++ b/apps/web/src/components/cockpit/resetOverlayState.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Boundary tests for resetOverlayState — covers all four discriminated values
+ * of `TerminalFrameStatus` and pins the elder-id format so a string-template
+ * refactor surfaces as a test failure (the id is used as a React key and as
+ * a DOM selector in Playwright tests under tests/e2e).
+ *
+ * Authored by Agent B in the 2026-05-24 parallel test-improvement experiment.
+ * Approach: BOUNDARY CONDITIONS — every discrete enum value, plus invariants
+ * on the overlay-window constants (must be positive, fade < max-display).
+ */
+import { describe, expect, it } from 'vitest';
+import type { TerminalFrameStatus } from '../../hooks/useTerminalFrameReconnect';
+import {
+  RESET_DETECTION_WINDOW_MS,
+  RESET_OVERLAY_FADE_MS,
+  RESET_OVERLAY_MAX_DISPLAY_MS,
+  getElderResetId,
+  shouldCheckForReset,
+} from './resetOverlayState';
+
+describe('shouldCheckForReset — every TerminalFrameStatus enum value', () => {
+  // Test the full enum surface so adding a new status without updating this
+  // predicate is caught. Boundary case: a typo'd status (`'reconect'`) would
+  // silently never trigger reset detection in production.
+
+  it.each<{ status: TerminalFrameStatus; expected: boolean }>([
+    { status: 'connecting',   expected: false },
+    { status: 'connected',    expected: false },
+    { status: 'reconnecting', expected: true  },
+    { status: 'disconnected', expected: true  },
+  ])('status="$status" → $expected', ({ status, expected }) => {
+    expect(shouldCheckForReset(status)).toBe(expected);
+  });
+});
+
+describe('getElderResetId — boundary clan ids', () => {
+  it('formats the expected `elder-${id}` shape for normal ids (1..5)', () => {
+    expect(getElderResetId(1)).toBe('elder-1');
+    expect(getElderResetId(5)).toBe('elder-5');
+  });
+
+  it('handles clanId = 0 (defensive fallback during indexing)', () => {
+    // Snapshot data CAN momentarily include clanId=0 during convex hydration.
+    // The id must still be a string (used as React key + DOM selector) and
+    // must not contain "undefined" or "NaN".
+    const id = getElderResetId(0);
+    expect(typeof id).toBe('string');
+    expect(id).toBe('elder-0');
+    expect(id).not.toContain('undefined');
+  });
+
+  it('handles negative / huge clanIds without losing the prefix', () => {
+    // Boundary: ensure the function template-literal'd correctly (a refactor
+    // to `elder-${String(clanId)}` would still pass these but a refactor to
+    // `getElderResetId(clanId.toFixed(0))` would silently truncate negatives.
+    expect(getElderResetId(-1)).toBe('elder--1');
+    expect(getElderResetId(Number.MAX_SAFE_INTEGER)).toBe(
+      `elder-${Number.MAX_SAFE_INTEGER}`,
+    );
+  });
+});
+
+describe('reset overlay window constants — invariants', () => {
+  // These three constants gate UX timing of the reset overlay: a regression
+  // that makes the overlay never fade out (FADE_MS > MAX_DISPLAY_MS) or never
+  // appear (FADE_MS = 0) would be invisible in CI but obvious in production.
+
+  it('all three timing constants are positive finite numbers', () => {
+    expect(RESET_DETECTION_WINDOW_MS).toBeGreaterThan(0);
+    expect(RESET_OVERLAY_MAX_DISPLAY_MS).toBeGreaterThan(0);
+    expect(RESET_OVERLAY_FADE_MS).toBeGreaterThan(0);
+    expect(Number.isFinite(RESET_DETECTION_WINDOW_MS)).toBe(true);
+    expect(Number.isFinite(RESET_OVERLAY_MAX_DISPLAY_MS)).toBe(true);
+    expect(Number.isFinite(RESET_OVERLAY_FADE_MS)).toBe(true);
+  });
+
+  it('FADE_MS is strictly less than MAX_DISPLAY_MS (otherwise overlay never settles)', () => {
+    // If FADE_MS >= MAX_DISPLAY_MS the fade-out would never complete inside
+    // the display window — the overlay would either pop out or get clipped.
+    expect(RESET_OVERLAY_FADE_MS).toBeLessThan(RESET_OVERLAY_MAX_DISPLAY_MS);
+  });
+
+  it('MAX_DISPLAY is at least as long as the detection window (else we miss the reset)', () => {
+    // The detection window is the time we have to spot the reset; the
+    // overlay must stay up at least that long so the user sees it.
+    expect(RESET_OVERLAY_MAX_DISPLAY_MS).toBeGreaterThanOrEqual(RESET_DETECTION_WINDOW_MS);
+  });
+});

--- a/apps/web/src/components/mapGeometry.test.ts
+++ b/apps/web/src/components/mapGeometry.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Boundary tests for mapGeometry — focused on the stepwise `baseVisualScale`
+ * level function and the readonly lookup tables (region centers + base PNGs)
+ * that downstream layers rely on. These are read by both WorldMap.tsx (Pixi
+ * canvas) and MapGhostLayer.tsx (static ghost) — disagreement causes a visible
+ * pop on map mount, so the boundaries here are visual-correctness boundaries.
+ *
+ * Authored by Agent B in the 2026-05-24 parallel test-improvement experiment.
+ * Approach: BOUNDARY CONDITIONS — extreme + edge values for numeric inputs.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  BASE_PNG_BY_VISUAL_INDEX,
+  FALLBACK_HOME_REGION_BY_INDEX,
+  LIVE_CLAN_REGION_BY_ID,
+  MAP_HEIGHT,
+  MAP_WIDTH,
+  REGION_CENTERS_BY_KEY,
+  baseVisualScale,
+} from './mapGeometry';
+
+describe('baseVisualScale — stepwise level → scalar', () => {
+  // The function source (mapGeometry.ts) explicitly documents:
+  //   "Levels 1-2 → 0.675, 3-4 → 0.81, 5 → 0.9"
+  // Boundary risks: off-by-one at each step (level==2 vs level==3, level==4
+  // vs level==5), and undocumented behaviour at <=0 / >5 / fractional.
+
+  it('returns small scale (0.675) at level 1 — lower documented bound', () => {
+    expect(baseVisualScale(1)).toBe(0.675);
+  });
+
+  it('returns small scale (0.675) at level 2 — upper edge of step 1', () => {
+    expect(baseVisualScale(2)).toBe(0.675);
+  });
+
+  it('jumps to mid scale (0.81) at level 3 — step boundary', () => {
+    // If `<=` were `<` this would regress to 0.675 — boundary-pinning assertion.
+    expect(baseVisualScale(3)).toBe(0.81);
+  });
+
+  it('returns mid scale (0.81) at level 4 — upper edge of step 2', () => {
+    expect(baseVisualScale(4)).toBe(0.81);
+  });
+
+  it('jumps to large scale (0.9) at level 5 — final documented step', () => {
+    expect(baseVisualScale(5)).toBe(0.9);
+  });
+
+  it('clamps high levels (6, 10, 1000) to the largest documented scale', () => {
+    // The current implementation is open-ended above 4 (returns 0.9). Pin that
+    // so a future bug like `level === 5 ? 0.9 : ???` is caught.
+    expect(baseVisualScale(6)).toBe(0.9);
+    expect(baseVisualScale(10)).toBe(0.9);
+    expect(baseVisualScale(1000)).toBe(0.9);
+  });
+
+  it('does not crash and returns smallest scale for non-positive levels (0, -1)', () => {
+    // Defensive: snapshot data CAN arrive with level=0 during indexing or
+    // before any upgrade. The function should still return a real number so
+    // PixiJS containers don't get NaN.scale and disappear.
+    expect(baseVisualScale(0)).toBe(0.675);
+    expect(baseVisualScale(-1)).toBe(0.675);
+    expect(Number.isFinite(baseVisualScale(0))).toBe(true);
+  });
+
+  it('returns a finite number for fractional levels (1.5, 2.5, 4.001)', () => {
+    // Levels are integers in the live game but the function takes `number`.
+    // Step is `<=`, so 2.5 falls into the middle band (0.81). Pin actual
+    // behaviour so a refactor to floor/ceil is a visible diff.
+    expect(baseVisualScale(1.5)).toBe(0.675);
+    expect(baseVisualScale(2.5)).toBe(0.81);
+    // 4.001 > 4 → falls through both bands → 0.9. Verifies the boundary at
+    // level 4 is correctly inclusive (not 4.999 — that's > 4 so goes to 0.9).
+    expect(baseVisualScale(4.001)).toBe(0.9);
+  });
+});
+
+describe('mapGeometry constants — invariants', () => {
+  // These constants are NOT recomputed per render and are dereferenced by
+  // index inside hot Pixi loops. Empty / wrong-length tables silently break
+  // map rendering with no console error — these tests turn that into a
+  // unit-test failure on the next regression.
+
+  it('MAP_WIDTH and MAP_HEIGHT are positive finite numbers', () => {
+    expect(MAP_WIDTH).toBeGreaterThan(0);
+    expect(MAP_HEIGHT).toBeGreaterThan(0);
+    expect(Number.isFinite(MAP_WIDTH)).toBe(true);
+    expect(Number.isFinite(MAP_HEIGHT)).toBe(true);
+  });
+
+  it('REGION_CENTERS_BY_KEY entries all fall within [0, 1] normalised coords', () => {
+    // Any entry with nx/ny outside [0,1] would place a region marker off the
+    // canvas. Catches typos like dividing by MAP_HEIGHT for the X coordinate.
+    for (const [key, { nx, ny }] of Object.entries(REGION_CENTERS_BY_KEY)) {
+      expect(nx, `${key} nx`).toBeGreaterThanOrEqual(0);
+      expect(nx, `${key} nx`).toBeLessThanOrEqual(1);
+      expect(ny, `${key} ny`).toBeGreaterThanOrEqual(0);
+      expect(ny, `${key} ny`).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('BASE_PNG_BY_VISUAL_INDEX has 5 entries (matches LIVE_CLAN_META in WorldMap)', () => {
+    // The visual index goes 0..4 (Iron Guard, Ember Hand, Dawn Watch, Storm
+    // Riders, Deployer Keep). Out-of-bounds access returns undefined and
+    // PixiJS renders a missing texture box.
+    expect(BASE_PNG_BY_VISUAL_INDEX.length).toBe(5);
+    BASE_PNG_BY_VISUAL_INDEX.forEach((path, i) => {
+      expect(path, `index ${i}`).toMatch(/^\/bases\/.+\.png$/);
+    });
+  });
+
+  it('FALLBACK_HOME_REGION_BY_INDEX agrees in length with BASE_PNG_BY_VISUAL_INDEX', () => {
+    // Defensive: if these drift, a clan with no snapshot baseRegion gets
+    // either undefined (crash) or the wrong fallback region.
+    expect(FALLBACK_HOME_REGION_BY_INDEX.length).toBe(BASE_PNG_BY_VISUAL_INDEX.length);
+  });
+
+  it('every FALLBACK_HOME_REGION_BY_INDEX entry maps to a known region key', () => {
+    const knownKeys = new Set(Object.keys(REGION_CENTERS_BY_KEY));
+    FALLBACK_HOME_REGION_BY_INDEX.forEach((key, i) => {
+      expect(knownKeys.has(key), `fallback[${i}] = ${key}`).toBe(true);
+    });
+  });
+
+  it('every LIVE_CLAN_REGION_BY_ID value maps to a known region key', () => {
+    // Boundary case: shared/generated/constants could rename a REGION_*; the
+    // lookup would still type-check (key is a number) but the value string
+    // would not exist in REGION_CENTERS_BY_KEY. Catch that drift here.
+    const knownKeys = new Set(Object.keys(REGION_CENTERS_BY_KEY));
+    for (const [id, key] of Object.entries(LIVE_CLAN_REGION_BY_ID)) {
+      expect(knownKeys.has(key), `region id ${id} → ${key}`).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/effects/clansmanSpriteSheet.test.ts
+++ b/apps/web/src/effects/clansmanSpriteSheet.test.ts
@@ -133,10 +133,11 @@ describe('clansmanSpriteSheet — sheet geometry invariants', () => {
   // Boundary case: if SHEET_COLS or SHEET_ROWS drifts from the actual PNG,
   // every frame is sliced wrong and the sprite blinks garbage.
   it('SHEET_COLS × FRAME_WIDTH equals SHEET_PIXEL_WIDTH (no leftover pixels)', () => {
-    expect(SHEET_COLS * FRAME_WIDTH).toBeCloseTo(SHEET_COLS * FRAME_WIDTH, 6);
-    // Tautological by construction but pins the relationship — if someone
-    // hard-codes FRAME_WIDTH later, this assertion ALSO breaks if the
-    // multiplication overflows or NaN's.
+    // Hard-pin the product against the real sheet pixel width (1122). This is a
+    // genuine regression guard: bump SHEET_COLS (4) or the underlying
+    // SHEET_PIXEL_WIDTH (1122 → FRAME_WIDTH 280.5) and the slice math goes
+    // wrong — this assertion catches the drift instead of silently passing.
+    expect(SHEET_COLS * FRAME_WIDTH).toBe(1122);
     expect(Number.isFinite(FRAME_WIDTH)).toBe(true);
     expect(FRAME_WIDTH).toBeGreaterThan(0);
   });

--- a/apps/web/src/effects/clansmanSpriteSheet.test.ts
+++ b/apps/web/src/effects/clansmanSpriteSheet.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Boundary tests for clansmanSpriteSheet — `directionForVector` is a pure
+ * angle-bucketing function with 8 explicit 22.5° wide windows. Off-by-one at
+ * any boundary visibly flips a sprite to face the wrong way during walks.
+ *
+ * Authored by Agent B in the 2026-05-24 parallel test-improvement experiment.
+ * Approach: BOUNDARY CONDITIONS — exact angle boundaries (±22.5°, ±67.5°,
+ * ±112.5°, ±157.5°), zero vector, extreme magnitudes, and floating-point
+ * dust just above/below each boundary.
+ *
+ * Coord convention reminder (per the source file docs): screen / PixiJS axes
+ * — +x right, +y DOWN. So "screen-up = N" means dy<0.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  directionForVector,
+  framesForDirection,
+  makeClansmanAnimState,
+  SHEET_COLS,
+  SHEET_ROWS,
+  FRAME_WIDTH,
+  FRAME_HEIGHT,
+  WALK_EPSILON_PX,
+  WALK_FRAME_MS,
+} from './clansmanSpriteSheet';
+import type { ClansmanFrameSet } from './clansmanSpriteSheet';
+
+describe('directionForVector — angle bucket boundaries', () => {
+  it('returns S for the zero vector (idle)', () => {
+    // Documented contract: zero-vector → 'S' so an idle clansman has a
+    // stable last-direction. If a future refactor changes this to throw or
+    // return null the marker would crash on render.
+    expect(directionForVector(0, 0)).toBe('S');
+  });
+
+  it('E for pure +x with multiple magnitudes (1, 1e-9, 1e9)', () => {
+    // Magnitude must not affect the bucket — only angle matters. A sub-pixel
+    // motion of 1e-9 should still pick the same direction as a 1e9 vector.
+    expect(directionForVector(1, 0)).toBe('E');
+    expect(directionForVector(1e-9, 0)).toBe('E');
+    expect(directionForVector(1e9, 0)).toBe('E');
+  });
+
+  it('N for pure screen-up (dy = -1)', () => {
+    // dy<0 = screen up; atan2(-(-1), 0) = atan2(1, 0) = π/2 → 90° → N bucket.
+    expect(directionForVector(0, -1)).toBe('N');
+  });
+
+  it('S for pure screen-down (dy = +1)', () => {
+    expect(directionForVector(0, 1)).toBe('S');
+  });
+
+  it('W for pure -x', () => {
+    expect(directionForVector(-1, 0)).toBe('W');
+  });
+
+  it('picks NE on the +45° diagonal (boundary of E and N buckets)', () => {
+    // 45° is well inside the NE window (22.5..67.5). Insulates the test
+    // against tiny refactors of the cutoffs while still pinning the diagonal.
+    expect(directionForVector(1, -1)).toBe('NE');
+  });
+
+  it('picks SE on the -45° diagonal', () => {
+    // dx>0, dy>0 (screen down-right). atan2(-1, 1) = -45° → SE bucket.
+    expect(directionForVector(1, 1)).toBe('SE');
+  });
+
+  it('picks NW on the -135° screen diagonal (up-left)', () => {
+    // dx<0, dy<0. atan2(-(-1), -1) = atan2(1, -1) = 135° → NW bucket.
+    expect(directionForVector(-1, -1)).toBe('NW');
+  });
+
+  it('picks SW on the +135° screen diagonal (down-left)', () => {
+    // dx<0, dy>0. atan2(-1, -1) = -135° → SW bucket.
+    expect(directionForVector(-1, 1)).toBe('SW');
+  });
+
+  it('returns a valid direction even for huge displacement vectors', () => {
+    // Regression guard: if someone replaces atan2 with a manual formula that
+    // overflows for huge numbers, this catches NaN-bucketing.
+    const result = directionForVector(1e308, -1e308);
+    expect(['N', 'NE', 'E']).toContain(result);
+    expect(typeof result).toBe('string');
+  });
+
+  it('exact ±22.5° angle boundary lands in the bucket the source says (inclusive lower)', () => {
+    // The source uses `deg >= -22.5 && deg < 22.5` for 'E', so exactly +22.5°
+    // should belong to 'NE' (inclusive lower edge of NE). This pins the
+    // intentional half-open-window choice — flipping it to `<=` would silently
+    // change the diagonal-walking sprite at exactly NE-pointing motion.
+    // angle 22.5° → deg = 22.5 → dx = cos, dy = -sin (screen-flip).
+    const a = (22.5 * Math.PI) / 180;
+    const dir = directionForVector(Math.cos(a), -Math.sin(a));
+    expect(dir).toBe('NE');
+  });
+});
+
+describe('framesForDirection — every direction returns a frame array', () => {
+  // Build a minimal mock ClansmanFrameSet — we don't need real Pixi textures,
+  // just verify the function picks a non-empty row + mirror flag for every
+  // direction in the 8-bucket enum. This is a boundary case for the lookup
+  // table itself: a missing row would crash the walker at runtime.
+  const mockSet: ClansmanFrameSet = {
+    rows: {
+      N:  ['n0', 'n1', 'n2', 'n3'] as unknown as ClansmanFrameSet['rows']['N'],
+      NE: ['ne0', 'ne1', 'ne2', 'ne3'] as unknown as ClansmanFrameSet['rows']['NE'],
+      E:  ['e0', 'e1', 'e2', 'e3'] as unknown as ClansmanFrameSet['rows']['E'],
+      SE: ['se0', 'se1', 'se2', 'se3'] as unknown as ClansmanFrameSet['rows']['SE'],
+      S:  ['s0', 's1', 's2', 's3'] as unknown as ClansmanFrameSet['rows']['S'],
+    },
+  };
+
+  it.each(['N', 'NE', 'E', 'SE', 'S'] as const)(
+    'native direction %s is not mirrored',
+    (dir) => {
+      const result = framesForDirection(mockSet, dir);
+      expect(result.mirror).toBe(false);
+      expect(result.frames.length).toBe(4);
+    },
+  );
+
+  it.each(['NW', 'W', 'SW'] as const)(
+    'mirrored direction %s reuses a native row + flips horizontally',
+    (dir) => {
+      const result = framesForDirection(mockSet, dir);
+      expect(result.mirror).toBe(true);
+      expect(result.frames.length).toBe(4);
+    },
+  );
+});
+
+describe('clansmanSpriteSheet — sheet geometry invariants', () => {
+  // Boundary case: if SHEET_COLS or SHEET_ROWS drifts from the actual PNG,
+  // every frame is sliced wrong and the sprite blinks garbage.
+  it('SHEET_COLS × FRAME_WIDTH equals SHEET_PIXEL_WIDTH (no leftover pixels)', () => {
+    expect(SHEET_COLS * FRAME_WIDTH).toBeCloseTo(SHEET_COLS * FRAME_WIDTH, 6);
+    // Tautological by construction but pins the relationship — if someone
+    // hard-codes FRAME_WIDTH later, this assertion ALSO breaks if the
+    // multiplication overflows or NaN's.
+    expect(Number.isFinite(FRAME_WIDTH)).toBe(true);
+    expect(FRAME_WIDTH).toBeGreaterThan(0);
+  });
+
+  it('SHEET_ROWS × FRAME_HEIGHT yields a positive finite frame height', () => {
+    expect(SHEET_ROWS * FRAME_HEIGHT).toBeGreaterThan(0);
+    expect(Number.isFinite(FRAME_HEIGHT)).toBe(true);
+  });
+
+  it('WALK_FRAME_MS is positive (1000/FPS — guards against FPS=0 div-by-zero)', () => {
+    expect(WALK_FRAME_MS).toBeGreaterThan(0);
+    expect(Number.isFinite(WALK_FRAME_MS)).toBe(true);
+  });
+
+  it('WALK_EPSILON_PX is positive but sub-pixel (guards the idle detector)', () => {
+    // If this were 0, the slightest float jitter would unpause the walk
+    // animation. If it were >=1 px, slow real walks would look frozen.
+    expect(WALK_EPSILON_PX).toBeGreaterThan(0);
+    expect(WALK_EPSILON_PX).toBeLessThan(1);
+  });
+});
+
+describe('makeClansmanAnimState — fresh-state defaults', () => {
+  it('starts with null position so the first update establishes the anchor', () => {
+    const s = makeClansmanAnimState();
+    expect(s.lastX).toBeNull();
+    expect(s.lastY).toBeNull();
+    expect(s.frame).toBe(0);
+    expect(s.frameAccumMs).toBe(0);
+    expect(s.wasWalking).toBe(false);
+    expect(s.direction).toBe('S');
+  });
+
+  it('lastTickMs is a finite number (performance.now())', () => {
+    const s = makeClansmanAnimState();
+    expect(Number.isFinite(s.lastTickMs)).toBe(true);
+  });
+});

--- a/apps/web/src/eventTickerFormat.boundaries.test.ts
+++ b/apps/web/src/eventTickerFormat.boundaries.test.ts
@@ -137,7 +137,7 @@ describe('formatChainEvent — numeric extremes', () => {
     expect(entry?.text).toBe('World paused at tick 42');
   });
 
-  it('formats huge resource amounts using wei-scale heuristic (≥1e12 → divide by 1e18)', () => {
+  it("formats huge resource amounts using wei-scale heuristic (≥1e12 → divide by 1e18) (KNOWN BUG: pins current '5.0' output)", () => {
     // resourceAmount() switches to wei-scale division when raw value ≥1e12
     // (a heuristic for "this looks like an 18-decimal token amount"). Boundary:
     // 1e18 wei should render as 1 unit. 5e18 → 5 units.
@@ -157,8 +157,9 @@ describe('formatChainEvent — numeric extremes', () => {
     }));
 
     expect(entry).not.toBeNull();
-    // Pins CURRENT (buggy) behaviour: "5.0 wood" not "5 wood". Convert this
-    // to '.toBe(\'Clan 1 gathered 5 wood\')' once the regex is fixed.
+    // ⚠ KNOWN BUG (wei-scale .0 double-escape in eventTickerFormat): asserts
+    // CURRENT buggy output. When the source regex is fixed, flip this to
+    // 'Clan 1 gathered 5 wood'. Do NOT just delete.
     expect(entry?.text).toBe('Clan 1 gathered 5.0 wood');
     // The important invariants still hold even with the regex bug — no
     // scientific notation or raw wei leak through:

--- a/apps/web/src/eventTickerFormat.boundaries.test.ts
+++ b/apps/web/src/eventTickerFormat.boundaries.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Boundary tests for formatChainEvent — covers numeric edges, missing fields,
+ * and out-of-range enum values that the existing eventTickerFormat.test.ts
+ * (which focuses on happy-path formatting) does not exercise.
+ *
+ * Authored by Agent B in the 2026-05-24 parallel test-improvement experiment.
+ * Approach: BOUNDARY CONDITIONS — empty/missing args, clanId/tick at 0,
+ * Number.MAX_SAFE_INTEGER, BigInt inputs (chain events arrive as BigInts
+ * before convex JSON-ifies them), unknown enum/region ids.
+ *
+ * Agent E is running property-based tests on formatters in parallel — these
+ * boundary tests complement that by pinning specific edge BEHAVIOURS (the
+ * exact string output) rather than invariants.
+ */
+import { describe, expect, it } from 'vitest';
+import { formatChainEvent, type ChainEventForTicker } from './eventTickerFormat';
+
+const event = (input: ChainEventForTicker): ChainEventForTicker => input;
+
+describe('formatChainEvent — empty / missing fields', () => {
+  it('handles a fully-empty args object without crashing (BuildingUpgraded)', () => {
+    // Defensive: snapshot from a buggy emit could lack `args.building` and
+    // `args.newLevel`. We expect a sensible fallback ('structure', level 0),
+    // not undefined or 'NaN' in the rendered ticker text.
+    const entry = formatChainEvent(event({
+      eventName: 'BuildingUpgraded',
+      args: {},
+      clanId: 1,
+    }));
+
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toBe('Clan 1 upgraded structure → level 0');
+    expect(entry?.text).not.toContain('undefined');
+    expect(entry?.text).not.toContain('NaN');
+  });
+
+  it('handles missing clanId gracefully (renders "Unknown" instead of "Clan 0")', () => {
+    // Boundary: chain event with no clan attribution. Renders "Unknown" per
+    // line 112 — `clanId > 0 ? \`Clan ${clanId}\` : 'Unknown'`. Pin that exact
+    // fallback string so a future change doesn't silently say "Clan 0".
+    const entry = formatChainEvent(event({
+      eventName: 'WorkerArrived',
+      args: { region: 1 },
+    }));
+
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toContain('Unknown');
+    expect(entry?.text).not.toContain('Clan 0');
+  });
+
+  it('returns null for ResourcesGathered with zero deltas', () => {
+    // Boundary case: chain emitted the event but all gather deltas are 0
+    // (clansman walked to region but actual gather failed / was capped).
+    // Documented contract: empty parts → null (no ticker entry).
+    const entry = formatChainEvent(event({
+      eventName: 'ResourcesGathered',
+      args: { woodGained: 0, ironGained: 0, wheatGained: 0, fishGained: 0 },
+      clanId: 1,
+    }));
+
+    expect(entry).toBeNull();
+  });
+
+  it('returns null for ResourcesGathered with all-null/undefined deltas', () => {
+    // Per-resource keys may be entirely missing from the args object. The
+    // formatter treats this identically to "0" — `args[key] ?? args[r]` ->
+    // safeNum -> 0 -> resourceAmount returns ''. Net: null entry.
+    const entry = formatChainEvent(event({
+      eventName: 'ResourcesGathered',
+      args: {},
+      clanId: 1,
+    }));
+
+    expect(entry).toBeNull();
+  });
+
+  it('renders a generic message for ResourcesDeposited with no parts', () => {
+    // Different contract from Gathered: Deposited returns a generic
+    // "deposited resources" string instead of null. Pin that distinction.
+    const entry = formatChainEvent(event({
+      eventName: 'ResourcesDeposited',
+      args: {},
+      clanId: 2,
+    }));
+
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toBe('Clan 2 deposited resources');
+  });
+
+  it('returns null when ImmediateMarketActionExecuted has -1 resourceIn (missing arg)', () => {
+    // Sentinel: the formatter sets safeNum default to -1 specifically to
+    // detect "this arg is genuinely absent" vs "value is 0". Pin that
+    // detection here so a refactor doesn't silently default to 0 instead.
+    const entry = formatChainEvent(event({
+      eventName: 'ImmediateMarketActionExecuted',
+      args: { amountIn: 5, amountOut: 5 },
+      clanId: 1,
+    }));
+
+    expect(entry).toBeNull();
+  });
+});
+
+describe('formatChainEvent — numeric extremes', () => {
+  it('handles tick = 0 (genesis tick) without dropping the suffix', () => {
+    const entry = formatChainEvent(event({
+      eventName: 'WorldPaused',
+      args: { tick: 0 },
+    }));
+
+    expect(entry?.text).toBe('World paused at tick 0');
+  });
+
+  it('handles Number.MAX_SAFE_INTEGER tick (defensive vs uint256 conversion overflow)', () => {
+    // BigInt → Number conversion at MAX_SAFE_INTEGER is the documented safe
+    // upper bound. Above this, precision is lost but the function should
+    // still produce a valid string — not "Infinity" or "NaN".
+    const huge = Number.MAX_SAFE_INTEGER;
+    const entry = formatChainEvent(event({
+      eventName: 'WorldUnpaused',
+      args: {},
+      tick: huge,
+    }));
+
+    expect(entry?.text).toContain(String(huge));
+    expect(entry?.text).not.toContain('Infinity');
+    expect(entry?.text).not.toContain('NaN');
+  });
+
+  it('handles BigInt tick value (raw chain emit before JSON serialisation)', () => {
+    // safeNum() explicitly handles bigint inputs via `Number(v)`. Pin that.
+    const entry = formatChainEvent(event({
+      eventName: 'WorldPaused',
+      args: { tick: 42n as unknown as number },
+    }));
+
+    expect(entry?.text).toBe('World paused at tick 42');
+  });
+
+  it('formats huge resource amounts using wei-scale heuristic (≥1e12 → divide by 1e18)', () => {
+    // resourceAmount() switches to wei-scale division when raw value ≥1e12
+    // (a heuristic for "this looks like an 18-decimal token amount"). Boundary:
+    // 1e18 wei should render as 1 unit. 5e18 → 5 units.
+    //
+    // FINDING (Agent B 2026-05-24): The current source has a regex bug:
+    //   .replace(/\\.0$/, '')
+    // The author intended `/\.0$/` (strip trailing ".0") but typed a double-
+    // escaped backslash that matches the literal text `\.0` instead. So 5e18
+    // renders as "5.0 wood" rather than the intended "5 wood". Same bug
+    // appears on line 106 for the `<1` branch. Pinned here as the OBSERVED
+    // behaviour — flip the assertion when the source bug is fixed. See
+    // research log entry under PR description.
+    const entry = formatChainEvent(event({
+      eventName: 'ResourcesGathered',
+      args: { woodGained: 5e18, ironGained: 0, wheatGained: 0, fishGained: 0 },
+      clanId: 1,
+    }));
+
+    expect(entry).not.toBeNull();
+    // Pins CURRENT (buggy) behaviour: "5.0 wood" not "5 wood". Convert this
+    // to '.toBe(\'Clan 1 gathered 5 wood\')' once the regex is fixed.
+    expect(entry?.text).toBe('Clan 1 gathered 5.0 wood');
+    // The important invariants still hold even with the regex bug — no
+    // scientific notation or raw wei leak through:
+    expect(entry?.text).not.toContain('e+');
+    expect(entry?.text).not.toContain('5000000000000000000');
+  });
+
+  it('formats sub-1 unit resource amounts with two decimal places', () => {
+    // resourceAmount() returns 2-decimal precision when human < 1 (after
+    // the wei-scale conversion). E.g. 0.5e18 wei → 0.5 → "0.5".
+    const entry = formatChainEvent(event({
+      eventName: 'ResourcesGathered',
+      args: { woodGained: 5e17, ironGained: 0, wheatGained: 0, fishGained: 0 },
+      clanId: 1,
+    }));
+
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toMatch(/0\.5/);
+  });
+
+  it('uses string numerics in args via safeNum parse path', () => {
+    // The contract sometimes emits stringified BigInts ("12345"). safeNum
+    // accepts string via Number() parse — pin that path.
+    const entry = formatChainEvent(event({
+      eventName: 'WorldPaused',
+      args: { tick: '12345' as unknown as number },
+    }));
+
+    expect(entry?.text).toBe('World paused at tick 12345');
+  });
+});
+
+describe('formatChainEvent — unknown / out-of-range enums', () => {
+  it('renders "Region N" fallback for unknown region id', () => {
+    // Boundary: region id present but not in REGION_NAMES table (e.g. a new
+    // region added on-chain but front-end not redeployed yet). Should fall
+    // back to a numeric label, NOT crash or render "undefined".
+    const entry = formatChainEvent(event({
+      eventName: 'WorkerArrived',
+      args: { region: 999 },
+      clanId: 1,
+    }));
+
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toBe('Clan 1 worker arrived at Region 999');
+    expect(entry?.text).not.toContain('undefined');
+  });
+
+  it('renders ACTION enum name fallback for unknown action', () => {
+    // MissionAssigned with an out-of-range action int. The ACTION_LABELS
+    // map is built from the generated enum so anything beyond the highest
+    // value should hit the `?? 'act'` fallback.
+    const entry = formatChainEvent(event({
+      eventName: 'MissionAssigned',
+      args: { action: 99999, region: 1 },
+      clanId: 1,
+    }));
+
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toContain('to act');
+    expect(entry?.text).not.toContain('undefined');
+  });
+
+  it('returns null for completely unknown eventName (forward-compat for new emits)', () => {
+    // Boundary: chain emits a new event the front-end doesn't recognise. The
+    // formatter MUST return null so the ticker silently skips it instead of
+    // rendering "[object Object]" or crashing the render loop.
+    const entry = formatChainEvent(event({
+      eventName: 'BrandNewFutureEvent2027',
+      args: { foo: 'bar' },
+    }));
+
+    expect(entry).toBeNull();
+  });
+
+  it('rotates clan colors safely beyond the 8-slot palette (clanId=9)', () => {
+    // slotColor() uses `(clanId - 1) % CLAN_SLOT_COLORS.length`. Boundary:
+    // clan 9 should wrap to slot 0's color (red), not return undefined.
+    const entry = formatChainEvent(event({
+      eventName: 'WorkerArrived',
+      args: { region: 1 },
+      clanId: 9,
+    }));
+
+    expect(entry).not.toBeNull();
+    expect(entry?.clanColor).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+
+  it('handles BanditStateChanged with unknown newState as null (silent drop)', () => {
+    // The formatter only handles the Attacking state explicitly; everything
+    // else returns null. Pin that — a future "Retreating" state should NOT
+    // accidentally print "Bandits attacking" with a different number.
+    const entry = formatChainEvent(event({
+      eventName: 'BanditStateChanged',
+      args: { newState: 99 },
+      clanId: 1,
+    }));
+
+    expect(entry).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Agent B segment of the 2026-05-24 parallel test-improvement experiment. Approach: **boundary conditions** — numeric input edges, missing/null props, extreme magnitudes, enum boundaries.

Adds 66 boundary tests across 4 new files in `apps/web/src/`. All 74 tests (8 pre-existing + 66 new) pass in ~830ms with the existing vitest node-env config (no infra changes required).

## Files added

| File | Tests | Focus |
|------|------:|-------|
| `src/components/mapGeometry.test.ts` | 14 | `baseVisualScale` stepwise level boundaries (1/2/3/4/5 transitions, level<=0 defensive, fractional, >5 clamping) + invariants on REGION_CENTERS / FALLBACK_HOME / BASE_PNG tables (lengths must agree, region keys must resolve) |
| `src/effects/clansmanSpriteSheet.test.ts` | 25 | `directionForVector` angle bucket boundaries (zero vector, pure cardinals, ±45° diagonals, exact ±22.5° boundary, huge 1e308 magnitudes) + `framesForDirection` coverage of all 8 directions (native + mirrored) + sheet geometry invariants |
| `src/eventTickerFormat.boundaries.test.ts` | 17 | Empty/missing args, tick=0, MAX_SAFE_INTEGER, BigInt + string numeric inputs, unknown region/action enums, clan slot color rotation beyond 8-slot palette |
| `src/components/cockpit/resetOverlayState.test.ts` | 10 | Every `TerminalFrameStatus` enum value, edge clanIds (0, negative, MAX_SAFE_INTEGER) for `getElderResetId`, overlay timing invariants |

## Bug found (no source modified — flagged for fix)

`resourceAmount()` in `apps/web/src/eventTickerFormat.ts` has a **regex bug** on lines 105–106:

```ts
if (human >= 1) return human.toFixed(1).replace(/\\.0$/, '');     // line 105
return human.toFixed(2).replace(/0+$/, '').replace(/\\.$/, '');   // line 106
```

The `\\.` is double-escaped — these patterns match the literal text `\.0` / `\.` instead of the intended trailing `.0` / `.` characters. Net effect: 5e18 wei of wood gathered renders as `"5.0 wood"` instead of the intended `"5 wood"`. Sub-1 amounts like 0.10 wood render as `"0.1"` because the `0+$` regex (correctly single-escaped) handles that path.

Per experiment constraints, no source change in this PR — the boundary test pins the **current (buggy)** behaviour with a comment pointing to the fix path. When the regex is fixed, flip the assertion.

## Test infra notes

- `vitest.config.ts` restricts collection to `src/**/*.test.ts` in **node env** (no jsdom). All new tests are pure-function / pure-data assertions to fit this constraint.
- Component-render boundary tests (e.g. `<EventTicker entries={[]} />` with 0/1/many items) would need jsdom + React Testing Library — flagged as future infra work, not blocked.
- Hooks like `useTimeouts` / `useCachedSnapshot` likewise need jsdom + `@testing-library/react`.

## Coordination with other agents

Independent branch off `dev`. No source changes, only new test files in non-overlapping paths.

- Agent A (error paths in apps/web) — different test files, no conflict
- Agent C (race conditions in apps/web) — different test files
- Agent D codex (integration tests) — different scope
- Agent E codex (property-based on formatters) — complementary; my boundaries pin specific edge BEHAVIOURS while E's property tests will assert INVARIANTS

## Status

**READY_FOR_REVIEW** — draft PR. All 74 tests pass.