### PR TITLE
fix(agents): wire real elder CLI + MCP into dockerized image (#615)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -297,6 +297,15 @@ BUS_ELDER_SECRET_FILE_1=agents/secrets/bus-elder-1.key
 BUS_ELDER_SECRET_FILE_2=agents/secrets/bus-elder-2.key
 BUS_ELDER_SECRET_FILE_3=agents/secrets/bus-elder-3.key
 BUS_ELDER_SECRET_FILE_4=agents/secrets/bus-elder-4.key
+# Per-elder on-chain signer key files. One line each, 0x-prefixed or bare
+# 64-hex private key. These are mounted as Docker secrets and read by the real
+# elder CLI through ELDER_WALLET_KEY_PATH; do not put raw keys directly in env.
+# For local dev you can point these at ~/.secrets/clanworld-elder-keys/elder-N.key
+# or copy/symlink them into agents/secrets/ with chmod 0600.
+ELDER_WALLET_KEY_FILE_1=
+ELDER_WALLET_KEY_FILE_2=
+ELDER_WALLET_KEY_FILE_3=
+ELDER_WALLET_KEY_FILE_4=
 
 # --- Elder fleet size ---
 # v1 ships 4 elders. The compose file is structured to make 12-elder mode a

--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -7,7 +7,7 @@
 #
 # Layout note: the agents/shared/* tree (run.sh, home-claude/, elder-bootstrap/)
 # is NOT baked into the image — it is bind-mounted at runtime at
-# /opt/clan-world/shared. Only the entrypoint scripts + elder CLI stub +
+# /opt/clan-world/shared. Entrypoint scripts, the real elder CLI workspace, and
 # sudoers rule live in the image.
 
 FROM node:24-slim
@@ -47,6 +47,11 @@ RUN curl -fsSL -o /usr/local/bin/ttyd \
 RUN npm install -g @anthropic-ai/claude-code @openai/codex tsx \
     && npm cache clean --force
 
+# pnpm workspace support for the real @clan-world/agents CLI. Keep pnpm pinned
+# to the root packageManager version so lockfile installs are reproducible.
+RUN corepack enable \
+    && corepack prepare pnpm@10.33.2 --activate
+
 # Foundry (cast only — elder CLI's chain reads use it). Install into a system
 # location rather than root's home so the elder user can find the binary
 # without an extra PATH dance.
@@ -64,14 +69,33 @@ RUN curl -L https://foundry.paradigm.xyz | bash \
 RUN userdel -r node 2>/dev/null || true \
     && groupadd -g ${ELDER_GID} elder \
     && useradd -m -u ${ELDER_UID} -g ${ELDER_GID} -s /bin/bash elder \
-    && mkdir -p /home/elder/.claude /home/elder/.runner-state /workspace /opt/clan-world \
+    && mkdir -p /home/elder/.claude \
+      /home/elder/.runner-state \
+      /home/elder/.world/clanworld-runner/state/peer-inbox \
+      /workspace \
+      /opt/clan-world \
+      /opt/clan-world-cli \
     && chown -R elder:elder /home/elder /workspace
+
+# Real elder CLI + MCP server. This package intentionally runs TypeScript
+# source through tsx at runtime; package build is a no-op.
+COPY --chown=root:root package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json tsconfig.base.json /opt/clan-world-cli/
+COPY --chown=root:root packages/agents/         /opt/clan-world-cli/packages/agents/
+COPY --chown=root:root packages/shared/         /opt/clan-world-cli/packages/shared/
+COPY --chown=root:root packages/sdk/            /opt/clan-world-cli/packages/sdk/
+COPY --chown=root:root packages/contract-types/ /opt/clan-world-cli/packages/contract-types/
+COPY --chown=root:root packages/contracts/      /opt/clan-world-cli/packages/contracts/
+RUN cd /opt/clan-world-cli \
+    && pnpm install --prod --filter @clan-world/agents... --frozen-lockfile \
+    && pnpm store prune \
+    && chown -R elder:elder /opt/clan-world-cli
 
 # Entrypoint scripts. init-firewall.sh requires CAP_NET_ADMIN; it runs via
 # sudo with a strict allowlist (see /etc/sudoers.d/elder-firewall).
 COPY --chmod=755 agents/entrypoint.sh    /opt/clan-world/entrypoint.sh
 COPY --chmod=755 agents/init-firewall.sh /opt/clan-world/init-firewall.sh
-COPY --chmod=755 agents/elder            /usr/local/bin/elder
+COPY --chmod=755 agents/elder-cli-wrapper /usr/local/bin/elder
+COPY --chmod=755 agents/elder-mcp-wrapper /usr/local/bin/elder-mcp
 
 # Sudoers rule: elder may run init-firewall.sh as root, no password, no other commands.
 # /etc/sudoers.d/* files must be chmod 0440.
@@ -99,6 +123,7 @@ WORKDIR /workspace
 
 ENV HOME=/home/elder
 ENV CLAUDE_CONFIG_DIR=/home/elder/.claude
+ENV CLAN_WORLD_REPO=/opt/clan-world-cli
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Healthcheck — v1 elder claude process alive. entrypoint.sh / run.sh also

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -44,6 +44,7 @@ BUS_ELDER_SECRET_FILE_4 ?= agents/secrets/bus-elder-4.key
         reset-anvil \
         link-mounts \
         bootstrap-convex-admin-key bootstrap-bus-secrets bootstrap-convex-dashboard-auth \
+        provision-elder-wallets-anvil \
         oauth-bootstrap \
         smoke-test build FORCE
 
@@ -86,6 +87,7 @@ help:
 	@echo "  bootstrap-convex-admin-key     generate + persist Convex admin key (chmod 0600)"
 	@echo "  bootstrap-bus-secrets          generate bus/webhook secrets and set Convex BUS_* envs"
 	@echo "  bootstrap-convex-dashboard-auth generate reserved dashboard auth credentials"
+	@echo "  provision-elder-wallets-anvil  fund elder wallets + own clans 1-4 on dev anvil"
 	@echo "  oauth-bootstrap                walk every elder through OAuth flow"
 	@echo "  oauth-bootstrap-elder-1        single-elder OAuth flow"
 	@echo ""
@@ -346,6 +348,9 @@ oauth-bootstrap-%: FORCE
 	} > "$$DEST"; \
 	chmod 0600 "$$DEST"; \
 	echo "[oauth] $* credentials saved to $$DEST"
+
+provision-elder-wallets-anvil:
+	bash $(REPO_ROOT)/agents/provision-elder-wallets-anvil.sh
 
 build: check-profile
 	$(DC) --profile $(PROFILE) build

--- a/agents/README.md
+++ b/agents/README.md
@@ -39,13 +39,17 @@ agents/
 ## Dev workflow
 
 1. Copy each `elder-N/.env.template` → `elder-N/.env`, fill in `CLAUDE_CODE_OAUTH_TOKEN` and `BUS_ELDER_SECRET`.
-2. `make up` — bring up all 4 elder containers + supporting services.
-3. `make status` — see container + tmux + plugin states.
-4. `make logs ELDER=elder-2` — tail one elder's run.sh + claude output.
-5. `make reset-elder-3` — soft reset (kill tmux, keep conversation, restart with `--continue`).
-6. `make wipe-elder-3` — hard reset (delete sessions + workspace, re-seed from `shared/elder-bootstrap/`).
+2. Set `ELDER_WALLET_KEY_FILE_1..4` in the repo `.env` or `.env.local` to one-line private-key files for the four elder signer wallets.
+3. After the dev anvil stack is running, run `make provision-elder-wallets-anvil` to fund those wallets on the fork and make them own clans 1-4. This is DEV/ANVIL ONLY and intentionally transfers ownership away from the current owners as the auto-operator/legacy-owner -> dockerized-elder hand-off. `submitClanOrders` requires `clan.owner == msg.sender`; iNFT usage authorization does not authorize gameplay orders. Run a real smoke submit on the same anvil state before trusting autonomous elders.
+4. `make up` — bring up all 4 elder containers + supporting services.
+5. `make status` — see container + tmux + plugin states.
+6. `make logs ELDER=elder-2` — tail one elder's run.sh + claude output.
+7. `make reset-elder-3` — soft reset (kill tmux, keep conversation, restart with `--continue`).
+8. `make wipe-elder-3` — hard reset (delete sessions + workspace, re-seed from `shared/elder-bootstrap/`).
 
 The Makefile lives next to what it orchestrates. See issue #355 for the full target list and the operator-side compose plumbing.
+
+Known follow-up: the `elder` CLI constructs chain/Convex clients eagerly, so even `elder rules` requires configured diamond/lens env. Compose intentionally fails loud for this hotfix; lazy client construction can wait.
 
 ## Shared vs per-elder
 

--- a/agents/elder-cli-wrapper
+++ b/agents/elder-cli-wrapper
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -eu
+
+CLAN_WORLD_REPO="${CLAN_WORLD_REPO:-/opt/clan-world-cli}"
+
+case "${CHAIN_NETWORK:-}" in
+  dev)
+    export RPC_URL_PRIMARY="${DEV_RPC_URL:-http://anvil-fork:8545}"
+    ;;
+  prod)
+    export RPC_URL_PRIMARY="${PROD_RPC_URL:-${RPC_URL_PRIMARY:-}}"
+    ;;
+esac
+
+exec "$CLAN_WORLD_REPO/packages/agents/bin/elder" "$@"

--- a/agents/elder-mcp-wrapper
+++ b/agents/elder-mcp-wrapper
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -eu
+
+CLAN_WORLD_REPO="${CLAN_WORLD_REPO:-/opt/clan-world-cli}"
+
+case "${CHAIN_NETWORK:-}" in
+  dev)
+    export RPC_URL_PRIMARY="${DEV_RPC_URL:-http://anvil-fork:8545}"
+    ;;
+  prod)
+    export RPC_URL_PRIMARY="${PROD_RPC_URL:-${RPC_URL_PRIMARY:-}}"
+    ;;
+esac
+
+exec "$CLAN_WORLD_REPO/packages/agents/bin/elder-mcp" "$@"

--- a/agents/provision-elder-wallets-anvil.sh
+++ b/agents/provision-elder-wallets-anvil.sh
@@ -20,7 +20,7 @@ DIAMOND="${CLAN_WORLD_CONTRACT_ADDRESS:-}"
 BALANCE_HEX="${ELDER_ANVIL_BALANCE_HEX:-0x56BC75E2D63100000}" # 100 ETH
 PROVISIONER="${ANVIL_PROVISIONER_ADDRESS:-0x1000000000000000000000000000000000000615}"
 ZERO_ADDRESS="0x0000000000000000000000000000000000000000"
-CLAN_RETURNS="(uint32,uint256,address,uint8,uint8,uint8,uint8,uint8,uint64,uint64,uint16,uint64,uint256,uint256,uint256,uint256,uint256,uint256,uint256)"
+CLAN_RETURNS="(uint32,uint256,address,uint8,uint8,uint8,uint8,uint8,uint8,uint64,uint64,uint16,uint64,uint256,uint256,uint256,uint256,uint256,uint256)"
 
 if [[ "$PROFILE" != "dev" || "$CHAIN_NETWORK" != "dev" ]]; then
   echo "FATAL: this script is dev/anvil-only. Set PROFILE=dev and CHAIN_NETWORK=dev." >&2
@@ -82,6 +82,29 @@ same_address() {
   [[ "${1,,}" == "${2,,}" ]]
 }
 
+assert_dev_anvil_rpc() {
+  local client_version chain_id expected_chain_id
+  expected_chain_id="${DEV_FORK_CHAIN_ID:-${ANVIL_CHAIN_ID:-}}"
+
+  client_version="$(compose_cast rpc web3_clientVersion 2>/dev/null || true)"
+  if [[ "${client_version,,}" == *anvil* ]]; then
+    echo "[provision] verified anvil RPC: $client_version"
+    return
+  fi
+
+  if [[ -n "$expected_chain_id" ]]; then
+    chain_id="$(compose_cast chain-id 2>/dev/null || true)"
+    if [[ "$chain_id" == "$expected_chain_id" ]]; then
+      echo "[provision] verified dev fork chain id: $chain_id"
+      return
+    fi
+  fi
+
+  echo "FATAL: refusing to run: DEV_RPC_URL does not look like a local anvil fork." >&2
+  echo "FATAL: clientVersion='${client_version:-<unreadable>}' expectedChainId='${expected_chain_id:-<unset>}'." >&2
+  exit 2
+}
+
 warn_world_preflight() {
   local label="$1"
   local paused_raw state_raw fields current_tick season_start_tick season_end_tick season_finalized rest
@@ -112,6 +135,7 @@ warn_world_preflight() {
 echo "[provision] diamond=$DIAMOND rpc=$RPC_URL balance=$BALANCE_HEX"
 echo "[provision] DEV/ANVIL ONLY: transferring clans 1-4 to dockerized elder wallets."
 echo "[provision] This is the intended auto-operator/legacy-owner -> elder ownership hand-off."
+assert_dev_anvil_rpc
 fund_account "$PROVISIONER"
 warn_world_preflight "before ownership hand-off"
 

--- a/agents/provision-elder-wallets-anvil.sh
+++ b/agents/provision-elder-wallets-anvil.sh
@@ -86,23 +86,29 @@ assert_dev_anvil_rpc() {
   local client_version chain_id expected_chain_id
   expected_chain_id="${DEV_FORK_CHAIN_ID:-${ANVIL_CHAIN_ID:-}}"
 
+  # Require anvil identity. This script uses anvil-only RPC methods
+  # (anvil_setBalance, --unlocked impersonation) and transfers clan ownership,
+  # so it must NEVER run against a non-anvil RPC. The chain-id check below is an
+  # ADDITIONAL constraint (AND), not an alternative pass-path — a matching chain
+  # id alone must not satisfy the guard (e.g. a real Base Sepolia node whose
+  # chain id happens to equal DEV_FORK_CHAIN_ID must still be refused).
   client_version="$(compose_cast rpc web3_clientVersion 2>/dev/null || true)"
-  if [[ "${client_version,,}" == *anvil* ]]; then
-    echo "[provision] verified anvil RPC: $client_version"
-    return
+  if [[ "${client_version,,}" != *anvil* ]]; then
+    echo "FATAL: refusing to run: DEV_RPC_URL is not a local anvil fork." >&2
+    echo "FATAL: clientVersion='${client_version:-<unreadable>}' (anvil identity required)." >&2
+    exit 2
   fi
+  echo "[provision] verified anvil RPC: $client_version"
 
+  # If an expected fork chain id is configured, it must ALSO match.
   if [[ -n "$expected_chain_id" ]]; then
     chain_id="$(compose_cast chain-id 2>/dev/null || true)"
-    if [[ "$chain_id" == "$expected_chain_id" ]]; then
-      echo "[provision] verified dev fork chain id: $chain_id"
-      return
+    if [[ "$chain_id" != "$expected_chain_id" ]]; then
+      echo "FATAL: anvil chain id '${chain_id:-<unreadable>}' != expected '$expected_chain_id'." >&2
+      exit 2
     fi
+    echo "[provision] verified dev fork chain id: $chain_id"
   fi
-
-  echo "FATAL: refusing to run: DEV_RPC_URL does not look like a local anvil fork." >&2
-  echo "FATAL: clientVersion='${client_version:-<unreadable>}' expectedChainId='${expected_chain_id:-<unset>}'." >&2
-  exit 2
 }
 
 warn_world_preflight() {

--- a/agents/provision-elder-wallets-anvil.sh
+++ b/agents/provision-elder-wallets-anvil.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# DEV/ANVIL ONLY. This is the ownership hand-off from current clan owners
+# (legacy elders / auto-operator wallets) to dockerized elder wallets.
+# It intentionally transfers clans 1-4 away from their current owners. Never
+# run this against prod or any RPC that is not the dev anvil fork.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+set -a
+[[ -f .env ]] && source .env
+[[ -f .env.local ]] && source .env.local
+set +a
+
+PROFILE="${PROFILE:-dev}"
+CHAIN_NETWORK="${CHAIN_NETWORK:-dev}"
+RPC_URL="${DEV_RPC_URL:-http://anvil-fork:8545}"
+DIAMOND="${CLAN_WORLD_CONTRACT_ADDRESS:-}"
+BALANCE_HEX="${ELDER_ANVIL_BALANCE_HEX:-0x56BC75E2D63100000}" # 100 ETH
+PROVISIONER="${ANVIL_PROVISIONER_ADDRESS:-0x1000000000000000000000000000000000000615}"
+ZERO_ADDRESS="0x0000000000000000000000000000000000000000"
+CLAN_RETURNS="(uint32,uint256,address,uint8,uint8,uint8,uint8,uint8,uint64,uint64,uint16,uint64,uint256,uint256,uint256,uint256,uint256,uint256,uint256)"
+
+if [[ "$PROFILE" != "dev" || "$CHAIN_NETWORK" != "dev" ]]; then
+  echo "FATAL: this script is dev/anvil-only. Set PROFILE=dev and CHAIN_NETWORK=dev." >&2
+  exit 2
+fi
+
+if [[ -z "$DIAMOND" ]]; then
+  echo "FATAL: CLAN_WORLD_CONTRACT_ADDRESS is required." >&2
+  exit 2
+fi
+
+if ! command -v cast >/dev/null 2>&1; then
+  echo "FATAL: host cast is required to derive elder wallet addresses from key files." >&2
+  exit 2
+fi
+
+if [[ -z "$(docker compose --profile dev ps -q heartbeat 2>/dev/null)" ]]; then
+  echo "FATAL: heartbeat service is not running; start dev stack services before provisioning." >&2
+  exit 2
+fi
+
+compose_cast() {
+  docker compose --profile dev exec -T heartbeat cast "$@" --rpc-url "$RPC_URL"
+}
+
+key_file_for() {
+  local n="$1"
+  local var="ELDER_WALLET_KEY_FILE_${n}"
+  local file="${!var:-}"
+  if [[ -z "$file" ]]; then
+    file="agents/secrets/elder-wallet-${n}.key"
+  fi
+  printf '%s\n' "$file"
+}
+
+elder_address_for() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "FATAL: missing elder wallet key file: $file" >&2
+    exit 2
+  fi
+  cast wallet address "$(tr -d '[:space:]' < "$file")"
+}
+
+fund_account() {
+  local address="$1"
+  compose_cast rpc anvil_setBalance "$address" "$BALANCE_HEX" >/dev/null
+}
+
+clan_owner() {
+  local clan_id="$1"
+  compose_cast call "$DIAMOND" "getClan(uint32)$CLAN_RETURNS" "$clan_id" \
+    | grep -oE '0x[0-9a-fA-F]{40}' \
+    | head -1 \
+    || true
+}
+
+same_address() {
+  [[ "${1,,}" == "${2,,}" ]]
+}
+
+warn_world_preflight() {
+  local label="$1"
+  local paused_raw state_raw fields current_tick season_start_tick season_end_tick season_finalized rest
+
+  if paused_raw="$(compose_cast call "$DIAMOND" "isWorldPaused()(bool)" 2>/dev/null)"; then
+    if [[ "$paused_raw" == *true* ]]; then
+      echo "WARN: world is paused ($label); elder submit-orders will revert until unpaused." >&2
+    fi
+  else
+    echo "WARN: unable to read isWorldPaused() ($label); run a real submit smoke before trusting provisioning." >&2
+  fi
+
+  if state_raw="$(compose_cast call "$DIAMOND" "getWorldState()(uint64,uint64,uint64,bool,uint64,uint64,uint64,uint64,uint16,bytes32)" 2>/dev/null)"; then
+    fields="$(printf '%s\n' "$state_raw" | tr -d '[](),' | tr '\n' ' ')"
+    read -r current_tick season_start_tick season_end_tick season_finalized rest <<< "$fields"
+    if [[ "$current_tick" =~ ^[0-9]+$ && "$season_end_tick" =~ ^[0-9]+$ ]]; then
+      if (( current_tick >= season_end_tick )) && [[ "$season_finalized" == "false" ]]; then
+        echo "WARN: season finalization is pending ($label); elder submit-orders will revert until finalized." >&2
+      fi
+    else
+      echo "WARN: unable to parse getWorldState() ($label); run a real submit smoke before trusting provisioning." >&2
+    fi
+  else
+    echo "WARN: unable to read getWorldState() ($label); run a real submit smoke before trusting provisioning." >&2
+  fi
+}
+
+echo "[provision] diamond=$DIAMOND rpc=$RPC_URL balance=$BALANCE_HEX"
+echo "[provision] DEV/ANVIL ONLY: transferring clans 1-4 to dockerized elder wallets."
+echo "[provision] This is the intended auto-operator/legacy-owner -> elder ownership hand-off."
+fund_account "$PROVISIONER"
+warn_world_preflight "before ownership hand-off"
+
+for n in 1 2 3 4; do
+  key_file="$(key_file_for "$n")"
+  elder_addr="$(elder_address_for "$key_file")"
+  clan_id="$n"
+
+  echo "[provision] elder-$n address=$elder_addr key_file=$key_file clan=$clan_id"
+  fund_account "$elder_addr"
+
+  owner="$(clan_owner "$clan_id")"
+  if [[ -z "$owner" || "$owner" == "$ZERO_ADDRESS" ]]; then
+    echo "[provision] clan $clan_id missing; minting to elder-$n"
+    compose_cast send "$DIAMOND" "mintClan(address)" "$elder_addr" --unlocked --from "$PROVISIONER" >/dev/null
+    owner="$(clan_owner "$clan_id")"
+    if ! same_address "$owner" "$elder_addr"; then
+      echo "FATAL: mintClan did not create clan $clan_id owned by elder-$n; got owner '${owner:-<none>}'." >&2
+      echo "FATAL: nextClanId may have drifted. Stop and inspect the anvil state before elders submit orders." >&2
+      exit 1
+    fi
+  fi
+
+  if same_address "$owner" "$elder_addr"; then
+    echo "[provision] clan $clan_id already owned by elder-$n"
+    continue
+  fi
+
+  echo "[provision] transferring clan $clan_id from $owner to elder-$n"
+  fund_account "$owner"
+  compose_cast send "$DIAMOND" "transferClanOwnership(uint32,address)" "$clan_id" "$elder_addr" \
+    --unlocked --from "$owner" >/dev/null
+
+  owner="$(clan_owner "$clan_id")"
+  if ! same_address "$owner" "$elder_addr"; then
+    echo "FATAL: clan $clan_id owner is still $owner after transfer attempt." >&2
+    exit 1
+  fi
+done
+
+echo "[provision] OK: elder wallets are funded and own clans 1-4 on the anvil fork."
+warn_world_preflight "after ownership hand-off"
+echo "[provision] IMPORTANT: run one real elder clan submit-orders smoke on this SAME anvil state before trusting autonomous elders."

--- a/agents/shared/elder-mcp.json
+++ b/agents/shared/elder-mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "elder": {
+      "type": "stdio",
+      "command": "/usr/local/bin/elder-mcp"
+    }
+  }
+}

--- a/agents/shared/run.sh
+++ b/agents/shared/run.sh
@@ -118,20 +118,26 @@ CWD_ENCODED="${PWD//\//-}"
 SESSIONS_DIR="$CLAUDE_CONFIG_DIR/projects/${CWD_ENCODED}/sessions"
 
 APPEND_PROMPT="/opt/clan-world/shared/APPENDED_SYSTEM_PROMPT.md"
+MCP_CONFIG="/opt/clan-world/shared/elder-mcp.json"
+
+CLAUDE_ARGS=(--append-system-prompt-file "$APPEND_PROMPT")
+if [ -f "$MCP_CONFIG" ]; then
+  CLAUDE_ARGS=(--mcp-config "$MCP_CONFIG" "${CLAUDE_ARGS[@]}")
+fi
 
 # --- launch ----------------------------------------------------------------
 
 CONTINUE_MODE="${CLAN_WORLD_CLAUDE_CONTINUE:-auto}"
 if [ "$CONTINUE_MODE" = "always" ]; then
   echo "[run.sh] runner requested --continue"
-  exec claude --continue --append-system-prompt-file "$APPEND_PROMPT"
+  exec claude --continue "${CLAUDE_ARGS[@]}"
 elif [ "$CONTINUE_MODE" = "never" ]; then
   echo "[run.sh] runner requested fresh session"
-  exec claude --append-system-prompt-file "$APPEND_PROMPT"
+  exec claude "${CLAUDE_ARGS[@]}"
 elif compgen -G "$SESSIONS_DIR/*.jsonl" > /dev/null 2>&1; then
   echo "[run.sh] previous conversation found at $SESSIONS_DIR, resuming with --continue"
-  exec claude --continue --append-system-prompt-file "$APPEND_PROMPT"
+  exec claude --continue "${CLAUDE_ARGS[@]}"
 else
   echo "[run.sh] no previous conversation at $SESSIONS_DIR, starting fresh"
-  exec claude --append-system-prompt-file "$APPEND_PROMPT"
+  exec claude "${CLAUDE_ARGS[@]}"
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ volumes:
   elder-3-workspace: {}
   elder-4-home: {}
   elder-4-workspace: {}
+  # Shared file transport used by `elder peer whisper` / `elder peer inbox`.
+  elder-peer-inbox: {}
 
 secrets:
   # Webhook HMAC shared secret for heartbeat → Convex webhook (Finding 30 fix).
@@ -59,6 +61,16 @@ secrets:
     file: ${BUS_ELDER_SECRET_FILE_3:-./agents/secrets/bus-elder-3.key}
   bus-elder-4:
     file: ${BUS_ELDER_SECRET_FILE_4:-./agents/secrets/bus-elder-4.key}
+  # Per-Elder on-chain signer keys. The CLI reads these through
+  # ELDER_WALLET_KEY_PATH; never pass raw private keys as environment values.
+  elder-wallet-1:
+    file: ${ELDER_WALLET_KEY_FILE_1:?ELDER_WALLET_KEY_FILE_1 required (one-line private key file for elder-1)}
+  elder-wallet-2:
+    file: ${ELDER_WALLET_KEY_FILE_2:?ELDER_WALLET_KEY_FILE_2 required (one-line private key file for elder-2)}
+  elder-wallet-3:
+    file: ${ELDER_WALLET_KEY_FILE_3:?ELDER_WALLET_KEY_FILE_3 required (one-line private key file for elder-3)}
+  elder-wallet-4:
+    file: ${ELDER_WALLET_KEY_FILE_4:?ELDER_WALLET_KEY_FILE_4 required (one-line private key file for elder-4)}
   # Operator secret for enqueueing commands into the Convex bus.
   bus-operator:
     file: ${BUS_OPERATOR_SECRET_FILE:-./agents/secrets/bus-operator.key}
@@ -299,10 +311,20 @@ services:
         required: false
     environment:
       ELDER_N: "1"
+      CHAIN_NETWORK: ${CHAIN_NETWORK:?CHAIN_NETWORK required (dev|prod)}
+      DEV_RPC_URL: ${DEV_RPC_URL:-http://anvil-fork:8545}
+      PROD_RPC_URL: ${RPC_URL_PRIMARY:-}
+      CONVEX_URL: http://convex-backend:3210
       CONVEX_DEPLOY_URL: http://convex-backend:3210
+      CLAN_WORLD_CONTRACT_ADDRESS: ${CLAN_WORLD_CONTRACT_ADDRESS:?CLAN_WORLD_CONTRACT_ADDRESS required}
+      CLAN_WORLD_LENS_ADDRESS: ${CLAN_WORLD_LENS_ADDRESS:?CLAN_WORLD_LENS_ADDRESS required}
+      # TODO: move to INDEXER_SECRET_FILE for prod; env is accepted for dev/anvil hotfix.
+      INDEXER_SECRET: ${INDEXER_SECRET:?INDEXER_SECRET required for elder bulletin/cockpit writes}
+      ELDER_WALLET_KEY_PATH: /run/secrets/elder-wallet-1
       BUS_ELDER_SECRET_FILE: /run/secrets/bus-elder-1
     secrets:
       - bus-elder-1
+      - elder-wallet-1
     volumes:
       # Shared bind-mount — entrypoint.sh execs /opt/clan-world/shared/run.sh
       # from this tree, and run.sh symlinks home-claude/{settings.json,CLAUDE.md}
@@ -314,6 +336,7 @@ services:
       # bootstraps the shared symlinks here on first start (or if missing).
       - elder-1-home:/home/elder/.claude
       - elder-1-workspace:/workspace
+      - elder-peer-inbox:/home/elder/.world/clanworld-runner/state/peer-inbox
     healthcheck:
       # Verifies tmux session, ttyd process, and elder-runtime supervisor (tsx) — all three
       # required for Phase 1.9 (#352). Hardcoded elder-1 literal because compose-time
@@ -333,14 +356,25 @@ services:
         required: false
     environment:
       ELDER_N: "2"
+      CHAIN_NETWORK: ${CHAIN_NETWORK:?CHAIN_NETWORK required (dev|prod)}
+      DEV_RPC_URL: ${DEV_RPC_URL:-http://anvil-fork:8545}
+      PROD_RPC_URL: ${RPC_URL_PRIMARY:-}
+      CONVEX_URL: http://convex-backend:3210
       CONVEX_DEPLOY_URL: http://convex-backend:3210
+      CLAN_WORLD_CONTRACT_ADDRESS: ${CLAN_WORLD_CONTRACT_ADDRESS:?CLAN_WORLD_CONTRACT_ADDRESS required}
+      CLAN_WORLD_LENS_ADDRESS: ${CLAN_WORLD_LENS_ADDRESS:?CLAN_WORLD_LENS_ADDRESS required}
+      # TODO: move to INDEXER_SECRET_FILE for prod; env is accepted for dev/anvil hotfix.
+      INDEXER_SECRET: ${INDEXER_SECRET:?INDEXER_SECRET required for elder bulletin/cockpit writes}
+      ELDER_WALLET_KEY_PATH: /run/secrets/elder-wallet-2
       BUS_ELDER_SECRET_FILE: /run/secrets/bus-elder-2
     secrets:
       - bus-elder-2
+      - elder-wallet-2
     volumes:
       - ./agents/shared:/opt/clan-world/shared:ro
       - elder-2-home:/home/elder/.claude
       - elder-2-workspace:/workspace
+      - elder-peer-inbox:/home/elder/.world/clanworld-runner/state/peer-inbox
     healthcheck:
       test: ["CMD-SHELL", "tmux has-session -t elder-2 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null && test \"$(pgrep claude | wc -l)\" -eq 1"]
       interval: 30s
@@ -357,14 +391,25 @@ services:
         required: false
     environment:
       ELDER_N: "3"
+      CHAIN_NETWORK: ${CHAIN_NETWORK:?CHAIN_NETWORK required (dev|prod)}
+      DEV_RPC_URL: ${DEV_RPC_URL:-http://anvil-fork:8545}
+      PROD_RPC_URL: ${RPC_URL_PRIMARY:-}
+      CONVEX_URL: http://convex-backend:3210
       CONVEX_DEPLOY_URL: http://convex-backend:3210
+      CLAN_WORLD_CONTRACT_ADDRESS: ${CLAN_WORLD_CONTRACT_ADDRESS:?CLAN_WORLD_CONTRACT_ADDRESS required}
+      CLAN_WORLD_LENS_ADDRESS: ${CLAN_WORLD_LENS_ADDRESS:?CLAN_WORLD_LENS_ADDRESS required}
+      # TODO: move to INDEXER_SECRET_FILE for prod; env is accepted for dev/anvil hotfix.
+      INDEXER_SECRET: ${INDEXER_SECRET:?INDEXER_SECRET required for elder bulletin/cockpit writes}
+      ELDER_WALLET_KEY_PATH: /run/secrets/elder-wallet-3
       BUS_ELDER_SECRET_FILE: /run/secrets/bus-elder-3
     secrets:
       - bus-elder-3
+      - elder-wallet-3
     volumes:
       - ./agents/shared:/opt/clan-world/shared:ro
       - elder-3-home:/home/elder/.claude
       - elder-3-workspace:/workspace
+      - elder-peer-inbox:/home/elder/.world/clanworld-runner/state/peer-inbox
     healthcheck:
       test: ["CMD-SHELL", "tmux has-session -t elder-3 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null && test \"$(pgrep claude | wc -l)\" -eq 1"]
       interval: 30s
@@ -381,14 +426,25 @@ services:
         required: false
     environment:
       ELDER_N: "4"
+      CHAIN_NETWORK: ${CHAIN_NETWORK:?CHAIN_NETWORK required (dev|prod)}
+      DEV_RPC_URL: ${DEV_RPC_URL:-http://anvil-fork:8545}
+      PROD_RPC_URL: ${RPC_URL_PRIMARY:-}
+      CONVEX_URL: http://convex-backend:3210
       CONVEX_DEPLOY_URL: http://convex-backend:3210
+      CLAN_WORLD_CONTRACT_ADDRESS: ${CLAN_WORLD_CONTRACT_ADDRESS:?CLAN_WORLD_CONTRACT_ADDRESS required}
+      CLAN_WORLD_LENS_ADDRESS: ${CLAN_WORLD_LENS_ADDRESS:?CLAN_WORLD_LENS_ADDRESS required}
+      # TODO: move to INDEXER_SECRET_FILE for prod; env is accepted for dev/anvil hotfix.
+      INDEXER_SECRET: ${INDEXER_SECRET:?INDEXER_SECRET required for elder bulletin/cockpit writes}
+      ELDER_WALLET_KEY_PATH: /run/secrets/elder-wallet-4
       BUS_ELDER_SECRET_FILE: /run/secrets/bus-elder-4
     secrets:
       - bus-elder-4
+      - elder-wallet-4
     volumes:
       - ./agents/shared:/opt/clan-world/shared:ro
       - elder-4-home:/home/elder/.claude
       - elder-4-workspace:/workspace
+      - elder-peer-inbox:/home/elder/.world/clanworld-runner/state/peer-inbox
     healthcheck:
       test: ["CMD-SHELL", "tmux has-session -t elder-4 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null && test \"$(pgrep claude | wc -l)\" -eq 1"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,12 +39,16 @@ volumes:
   # config` can resolve mount references early.
   elder-1-home: {}
   elder-1-workspace: {}
+  elder-1-state: {}
   elder-2-home: {}
   elder-2-workspace: {}
+  elder-2-state: {}
   elder-3-home: {}
   elder-3-workspace: {}
+  elder-3-state: {}
   elder-4-home: {}
   elder-4-workspace: {}
+  elder-4-state: {}
   # Shared file transport used by `elder peer whisper` / `elder peer inbox`.
   elder-peer-inbox: {}
 
@@ -336,6 +340,7 @@ services:
       # bootstraps the shared symlinks here on first start (or if missing).
       - elder-1-home:/home/elder/.claude
       - elder-1-workspace:/workspace
+      - elder-1-state:/home/elder/.world/clanworld-runner/state
       - elder-peer-inbox:/home/elder/.world/clanworld-runner/state/peer-inbox
     healthcheck:
       # Verifies tmux session, ttyd process, and elder-runtime supervisor (tsx) — all three
@@ -374,6 +379,7 @@ services:
       - ./agents/shared:/opt/clan-world/shared:ro
       - elder-2-home:/home/elder/.claude
       - elder-2-workspace:/workspace
+      - elder-2-state:/home/elder/.world/clanworld-runner/state
       - elder-peer-inbox:/home/elder/.world/clanworld-runner/state/peer-inbox
     healthcheck:
       test: ["CMD-SHELL", "tmux has-session -t elder-2 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null && test \"$(pgrep claude | wc -l)\" -eq 1"]
@@ -409,6 +415,7 @@ services:
       - ./agents/shared:/opt/clan-world/shared:ro
       - elder-3-home:/home/elder/.claude
       - elder-3-workspace:/workspace
+      - elder-3-state:/home/elder/.world/clanworld-runner/state
       - elder-peer-inbox:/home/elder/.world/clanworld-runner/state/peer-inbox
     healthcheck:
       test: ["CMD-SHELL", "tmux has-session -t elder-3 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null && test \"$(pgrep claude | wc -l)\" -eq 1"]
@@ -444,6 +451,7 @@ services:
       - ./agents/shared:/opt/clan-world/shared:ro
       - elder-4-home:/home/elder/.claude
       - elder-4-workspace:/workspace
+      - elder-4-state:/home/elder/.world/clanworld-runner/state
       - elder-peer-inbox:/home/elder/.world/clanworld-runner/state/peer-inbox
     healthcheck:
       test: ["CMD-SHELL", "tmux has-session -t elder-4 2>/dev/null && pgrep -f 'ttyd' > /dev/null && pgrep -f 'tsx.*main.ts' > /dev/null && test \"$(pgrep claude | wc -l)\" -eq 1"]

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -652,13 +652,14 @@ export async function runCommand(
     if (!parsed.clanId || !Array.isArray(parsed.orders)) {
       throw new UsageError(`elder: orders file must contain { clanId: string, orders: [...] }`);
     }
-    if (env['ELDER_N']) {
-      const ownClanId = String(getElderN(env));
-      if (parsed.clanId !== ownClanId) {
-        throw new UsageError(
-          `elder: refusing to submit orders for clanId ${parsed.clanId}; this elder is ELDER_N=${ownClanId}`,
-        );
-      }
+    if (!env['ELDER_N']) {
+      throw new UsageError('elder: submit-orders requires ELDER_N to be set; set it to the clan you are authorized for');
+    }
+    const ownClanId = String(getElderN(env));
+    if (parsed.clanId !== ownClanId) {
+      throw new UsageError(
+        `elder: refusing to submit orders for clanId ${parsed.clanId}; this elder is ELDER_N=${ownClanId}`,
+      );
     }
     const result = await deps.chain.submitOrders(parsed.clanId, parsed.orders);
     return JSON.stringify(result, null, 2) + '\n';

--- a/packages/agents/src/cli.ts
+++ b/packages/agents/src/cli.ts
@@ -652,6 +652,14 @@ export async function runCommand(
     if (!parsed.clanId || !Array.isArray(parsed.orders)) {
       throw new UsageError(`elder: orders file must contain { clanId: string, orders: [...] }`);
     }
+    if (env['ELDER_N']) {
+      const ownClanId = String(getElderN(env));
+      if (parsed.clanId !== ownClanId) {
+        throw new UsageError(
+          `elder: refusing to submit orders for clanId ${parsed.clanId}; this elder is ELDER_N=${ownClanId}`,
+        );
+      }
+    }
     const result = await deps.chain.submitOrders(parsed.clanId, parsed.orders);
     return JSON.stringify(result, null, 2) + '\n';
   }


### PR DESCRIPTION
## What

Replaces the `agents/elder` **v1 stub** with the real `@clan-world/agents` CLI + MCP server so dockerized elders can actually play — read snapshots, `submit-orders`, and `peer whisper` — instead of getting `elder CLI not yet implemented`.

Closes #615.

## Why

Verified live: inside `clan-world-elder-1`, `which elder` → `/usr/local/bin/elder` = the stub; `elder rules` printed "not yet implemented". The real CLI (`packages/agents`) was never bundled into the image. Elders are alive + reach the API, but every game action hit the stub.

## Changes

- **Dockerfile**: bundle the `@clan-world/agents` workspace subtree (root manifests + agents/shared/sdk/contract-types/contracts) via `pnpm install --prod --filter @clan-world/agents... --frozen-lockfile`; expose real `elder` + `elder-mcp` wrappers on PATH (RPC env-normalized by `CHAIN_NETWORK`); pre-create shared peer-inbox dir; set `CLAN_WORLD_REPO`. Stub no longer installed.
- **docker-compose.yml**: per-elder wallet secrets, chain/Convex config (`CONVEX_URL`, RPC selectors, `CLAN_WORLD_CONTRACT_ADDRESS`, `CLAN_WORLD_LENS_ADDRESS`), shared `elder-peer-inbox` volume (cross-container whispers), `INDEXER_SECRET` (dev; `_FILE` follow-up TODO).
- **agents/shared/run.sh**: pass `--mcp-config` when `elder-mcp.json` exists. (Legacy plugin deferred — its bash guard conflicts with current order-file paths.)
- **provision-elder-wallets-anvil.sh** (new): idempotent dev/anvil provisioning — funds elder wallets + transfers clan ownership to them. **This is the auto-operator→elder hand-off**: `submitClanOrders` requires `clan.owner == msg.sender`, so after this runs the owner-impersonating Python script can no longer play. Post-mint id verify + world-paused/season-pending preflight warnings. **Dev/anvil only.**
- **cli.ts**: `submit-orders` refuses a file whose `clanId != ELDER_N` (CLI guard mirroring the MCP own-clan check) — prevents a first-submit revert footgun. No-op when `ELDER_N` unset.
- **.env.template + README**: elder wallet key files + dev workflow + hand-off note.

## Operator pre-rebuild steps

1. Create 4 elder key files; set `ELDER_WALLET_KEY_FILE_1..4`.
2. Set `PROFILE=dev CHAIN_NETWORK=dev CLAN_WORLD_CONTRACT_ADDRESS CLAN_WORLD_LENS_ADDRESS CONVEX_URL INDEXER_SECRET` (+ `DEV_RPC_URL` if non-default).
3. With the dev stack up: `make -C agents provision-elder-wallets-anvil`, then run one real `elder clan submit-orders` smoke before trusting autonomous elders.

## Validation status

- ✅ shell syntax checks; CLI guard logic reviewed
- ⏳ image build + in-container smoke (`elder rules`, `elder world snapshot`, `elder peer whisper`) — running
- ⏳ local 3-tier swarm review

🤖 Generated with [Claude Code](https://claude.com/claude-code)