### PR TITLE
fix(heartbeat): node:22-slim (glibc) base so foundry cast runs (cherry-pick from #608)

### DIFF
--- a/agents/heartbeat/Dockerfile
+++ b/agents/heartbeat/Dockerfile
@@ -1,8 +1,15 @@
 FROM ghcr.io/foundry-rs/foundry:v1.2.0 AS foundry
 
-FROM node:22-alpine
+# node:22-slim (Debian, glibc) chosen over node:22-alpine (musl) so cast —
+# a glibc-linked Rust binary copied from the foundry image — runs without
+# musl/glibc ABI mismatch (validated 2026-05-24 self-hosted Convex cutover:
+# alpine + foundry cast → "/bin/sh: cast: not found" because musl's dynamic
+# loader can't resolve the glibc ELF).
+FROM node:22-slim
 
-RUN apk add --no-cache ca-certificates libgcc libstdc++ \
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/* \
   && corepack enable \
   && corepack prepare pnpm@10.33.2 --activate
 


### PR DESCRIPTION
## What
Switch the heartbeat container base from `node:22-alpine` (musl) to `node:22-slim` (Debian, glibc).

## Why
The heartbeat container `COPY --from=foundry`s `cast` — a **glibc-linked Rust binary**. On alpine (musl), musl's dynamic loader can't resolve the glibc ELF, so `cast` fails at runtime (`cast: not found`). Validated during the 2026-05-24 v2.15.0 self-hosted Convex cutover. `node:22-slim` provides glibc natively; drops the unnecessary musl-compat `libgcc/libstdc++` and uses apt for ca-certificates.

## Provenance
Cherry-picked (the heartbeat-Dockerfile piece only) from the superseded **PR #608** (`v2.15.0-self-hosted-cutover-blockers`). #608's other still-relevant fixes — the Convex `node:fs` bundle blocker and the `❯` Claude-TUI prompt-glyph fix — are independently covered by **PR #620**. This PR + #620 together fully restore the dockerized self-hosted backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)