### PR TITLE
fix(heartbeat): detect viem-wrapped rate-limit reverts + schedule instrumentation

### DIFF
--- a/packages/heartbeat/src/heartbeatScheduler.ts
+++ b/packages/heartbeat/src/heartbeatScheduler.ts
@@ -115,10 +115,16 @@ async function runHeartbeatScheduler(
       continue;
     }
 
-    await sleepWithSignal(
-      computeHeartbeatDelayMs(nextHeartbeatAtTs, nowMs()),
-      deps.signal,
+    // Instrumentation: surface the scheduling time-basis so we can confirm
+    // whether the on-chain nextHeartbeatAtTs (chain time) and the local wall
+    // clock diverge (e.g. on an anvil-fork whose block.timestamp drifts ahead),
+    // which would skew computedDelayMs. Cheap (no extra RPC); read from logs.
+    const wallNowMs = nowMs();
+    const delayMs = computeHeartbeatDelayMs(nextHeartbeatAtTs, wallNowMs);
+    deps.log.info(
+      `heartbeat schedule: nextHeartbeatAtTs=${nextHeartbeatAtTs}s wallNowMs=${wallNowMs} computedDelayMs=${delayMs}`,
     );
+    await sleepWithSignal(delayMs, deps.signal);
     if (deps.signal.aborted) break;
 
     const result = await attemptHeartbeatWithBackoff({

--- a/packages/heartbeat/src/runnerCastHeartbeat.ts
+++ b/packages/heartbeat/src/runnerCastHeartbeat.ts
@@ -1,4 +1,5 @@
 import {
+  BaseError,
   ContractFunctionRevertedError,
   createPublicClient,
   createWalletClient,
@@ -151,12 +152,23 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
           `heartbeat tx receipt timed out after ${this.receiptTimeoutMs}ms`,
         );
       }
-      // Attempt to upgrade only simulation-level contract reverts to
-      // HeartbeatRateLimitedError; pre-flight/RPC errors must surface unchanged.
-      if (!(err instanceof ContractFunctionRevertedError)) throw err;
+      // Upgrade simulation-level contract reverts to HeartbeatRateLimitedError.
+      // viem wraps the revert in ContractFunctionExecutionError (and similar
+      // BaseError subclasses), so a bare `instanceof ContractFunctionRevertedError`
+      // MISSES it and the rate-limit revert leaks out as a generic error — which
+      // sends the scheduler down its retry-with-backoff path instead of cleanly
+      // waiting for the window. Walk the cause chain to find the real revert.
+      // Pre-flight / RPC errors (no contract revert) must surface unchanged.
+      const revert = extractContractRevert(err);
+      if (!revert) throw err;
+      // The contract's rate-limit revert reason is the authoritative, clock-basis
+      // independent signal; fall back to the nextHeartbeatAtTs timestamp check.
       const next = await this.readNextHeartbeatAtTs().catch(() => undefined);
-      if (next !== undefined && next > Math.floor(Date.now() / 1000)) {
-        throw new HeartbeatRateLimitedError(next);
+      if (
+        isRateLimitRevert(revert) ||
+        (next !== undefined && next > Math.floor(Date.now() / 1000))
+      ) {
+        throw new HeartbeatRateLimitedError(next ?? 0);
       }
       throw err;
     }
@@ -226,6 +238,38 @@ export class HeartbeatTimeoutError extends Error {
     super(message);
     this.name = 'HeartbeatTimeoutError';
   }
+}
+
+/** ClanWorld.heartbeat() rate-limit revert reason (see IClanWorld.sol). */
+const RATE_LIMIT_REVERT_REASON = 'heartbeat rate limited';
+
+/**
+ * viem wraps contract reverts in ContractFunctionExecutionError (a BaseError
+ * subclass), so a bare `instanceof ContractFunctionRevertedError` misses them.
+ * Walk the error cause chain to find the underlying revert, returning it (or
+ * undefined for non-contract errors like RPC/network failures).
+ */
+function extractContractRevert(err: unknown): ContractFunctionRevertedError | undefined {
+  if (err instanceof ContractFunctionRevertedError) return err;
+  if (err instanceof BaseError) {
+    const walked = err.walk(e => e instanceof ContractFunctionRevertedError);
+    if (walked instanceof ContractFunctionRevertedError) return walked;
+  }
+  return undefined;
+}
+
+/**
+ * True when the revert is the contract's rate-limit guard (basis-independent).
+ * Scans reason + shortMessage + message rather than `??`-picking one field,
+ * because viem may populate a generic shortMessage while the decoded reason
+ * carries the actual `ClanWorld: heartbeat rate limited` string.
+ */
+function isRateLimitRevert(revert: ContractFunctionRevertedError): boolean {
+  const haystack = [revert.reason, revert.shortMessage, revert.message]
+    .filter((s): s is string => typeof s === 'string')
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(RATE_LIMIT_REVERT_REASON);
 }
 
 function normalizePk(pk: string): `0x${string}` {

--- a/packages/heartbeat/src/runnerCastHeartbeat.ts
+++ b/packages/heartbeat/src/runnerCastHeartbeat.ts
@@ -132,6 +132,12 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
         // Mined-but-reverted. Most common cause is the rate-limit window
         // hadn't elapsed yet (when simulation succeeded but execution didn't).
         // Re-read state to upgrade to HeartbeatRateLimitedError when applicable.
+        // NOTE (intentional asymmetry vs. the simulation-revert catch below): a
+        // mined-revert receipt carries no decoded reason string without a trace
+        // call, so we can only use the nextHeartbeatAtTs timestamp heuristic here.
+        // If a real chain-vs-wall clock skew is confirmed (the scheduler
+        // instrumentation diagnoses this), revisit with decodeErrorResult on the
+        // receipt revert data.
         const next = await this.readNextHeartbeatAtTs().catch(() => undefined);
         if (next !== undefined && next > Math.floor(Date.now() / 1000)) {
           throw new HeartbeatRateLimitedError(next);
@@ -161,14 +167,22 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
       // Pre-flight / RPC errors (no contract revert) must surface unchanged.
       const revert = extractContractRevert(err);
       if (!revert) throw err;
-      // The contract's rate-limit revert reason is the authoritative, clock-basis
-      // independent signal; fall back to the nextHeartbeatAtTs timestamp check.
-      const next = await this.readNextHeartbeatAtTs().catch(() => undefined);
-      if (
-        isRateLimitRevert(revert) ||
-        (next !== undefined && next > Math.floor(Date.now() / 1000))
-      ) {
+      // Classify by the DECODED revert reason first — it is the authoritative,
+      // clock-basis-independent signal. heartbeat() runs _requireWorldNotPaused()
+      // (and other guards) BEFORE the rate-limit check, so a paused world / other
+      // require produces a decoded reason that is NOT the rate-limit string. We
+      // must surface those unchanged: letting the nextHeartbeatAtTs timestamp
+      // heuristic fire for them would mask a real fault as a (false) rate-limit.
+      if (isRateLimitRevert(revert)) {
+        const next = await this.readNextHeartbeatAtTs().catch(() => undefined);
         throw new HeartbeatRateLimitedError(next ?? 0);
+      }
+      if (decodedRevertReason(revert) !== undefined) throw err;
+      // No decoded reason (e.g. a custom error with no ABI match) — only here do
+      // we fall back to the timestamp heuristic for the rate-limit case.
+      const next = await this.readNextHeartbeatAtTs().catch(() => undefined);
+      if (next !== undefined && next > Math.floor(Date.now() / 1000)) {
+        throw new HeartbeatRateLimitedError(next);
       }
       throw err;
     }
@@ -270,6 +284,18 @@ function isRateLimitRevert(revert: ContractFunctionRevertedError): boolean {
     .join(' ')
     .toLowerCase();
   return haystack.includes(RATE_LIMIT_REVERT_REASON);
+}
+
+/**
+ * The decoded Solidity `Error(string)` revert reason, if viem decoded one.
+ * A non-empty value means the revert is an identified `require`/`revert` reason
+ * (not the rate-limit one, once isRateLimitRevert has been ruled out) and should
+ * surface unchanged rather than falling through to the timestamp heuristic.
+ */
+function decodedRevertReason(revert: ContractFunctionRevertedError): string | undefined {
+  return typeof revert.reason === 'string' && revert.reason.length > 0
+    ? revert.reason
+    : undefined;
 }
 
 function normalizePk(pk: string): `0x${string}` {

--- a/packages/heartbeat/test/runnerCastHeartbeat.test.ts
+++ b/packages/heartbeat/test/runnerCastHeartbeat.test.ts
@@ -30,11 +30,17 @@ vi.mock('viem/accounts', () => ({
   })),
 }));
 
+import { BaseError, ContractFunctionRevertedError } from 'viem';
+import { HeartbeatRateLimitedError } from '@clan-world/agents/seams';
 import {
   configFromEnv,
   RunnerCastHeartbeat,
 } from '../src/runnerCastHeartbeat';
 import { writeHeartbeatSuccessFile } from '../src/heartbeatSuccessFile';
+
+const HEARTBEAT_ABI_FRAGMENT = [
+  { type: 'function', name: 'heartbeat', inputs: [], outputs: [], stateMutability: 'nonpayable' },
+] as const;
 
 let heartbeatSuccessDir = '';
 let heartbeatSuccessFile = '';
@@ -323,4 +329,55 @@ describe('RunnerCastHeartbeat', () => {
     );
     warn.mockRestore();
   }, 7_000);
+
+  it('upgrades a viem-wrapped rate-limit revert to HeartbeatRateLimitedError', async () => {
+    // viem surfaces the on-chain revert wrapped in a BaseError (e.g.
+    // ContractFunctionExecutionError) whose cause is the ContractFunctionRevertedError.
+    // A bare `instanceof ContractFunctionRevertedError` misses the wrapper and the
+    // rate-limit revert leaks out as a generic error, sending the scheduler down its
+    // retry-with-backoff path instead of cleanly waiting for the window. The caller
+    // must walk the cause chain + match the rate-limit reason.
+    const reverted = new ContractFunctionRevertedError({
+      abi: HEARTBEAT_ABI_FRAGMENT,
+      functionName: 'heartbeat',
+      message: 'ClanWorld: heartbeat rate limited',
+    });
+    const wrapped = new BaseError('Execution reverted for an unknown reason.', { cause: reverted });
+    viemMocks.writeContract.mockRejectedValue(wrapped);
+    viemMocks.readContract.mockResolvedValue({ nextHeartbeatAtTs: 9_999_999_999n });
+
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'https://rpc.example',
+    });
+
+    const err = await heartbeat.callHeartbeat().then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(HeartbeatRateLimitedError);
+  });
+
+  it('surfaces a non-rate-limit contract revert unchanged', async () => {
+    vi.useFakeTimers();
+    // Wall clock far ahead of nextHeartbeatAtTs below, so the timestamp fallback
+    // does NOT mis-classify this as rate-limited.
+    vi.setSystemTime(10_000_000_000_000);
+    const reverted = new ContractFunctionRevertedError({
+      abi: HEARTBEAT_ABI_FRAGMENT,
+      functionName: 'heartbeat',
+      message: 'ClanWorld: world paused',
+    });
+    const wrapped = new BaseError('Execution reverted for an unknown reason.', { cause: reverted });
+    viemMocks.writeContract.mockRejectedValue(wrapped);
+    viemMocks.readContract.mockResolvedValue({ nextHeartbeatAtTs: 1n });
+
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'https://rpc.example',
+    });
+
+    const err = await heartbeat.callHeartbeat().then(() => null, (e: unknown) => e);
+    expect(err).not.toBeInstanceOf(HeartbeatRateLimitedError);
+    expect(err).toBe(wrapped);
+  });
 });

--- a/packages/heartbeat/test/runnerCastHeartbeat.test.ts
+++ b/packages/heartbeat/test/runnerCastHeartbeat.test.ts
@@ -30,7 +30,7 @@ vi.mock('viem/accounts', () => ({
   })),
 }));
 
-import { BaseError, ContractFunctionRevertedError } from 'viem';
+import { BaseError, ContractFunctionRevertedError, encodeErrorResult } from 'viem';
 import { HeartbeatRateLimitedError } from '@clan-world/agents/seams';
 import {
   configFromEnv,
@@ -40,6 +40,12 @@ import { writeHeartbeatSuccessFile } from '../src/heartbeatSuccessFile';
 
 const HEARTBEAT_ABI_FRAGMENT = [
   { type: 'function', name: 'heartbeat', inputs: [], outputs: [], stateMutability: 'nonpayable' },
+] as const;
+
+// Solidity `Error(string)` selector ABI — encodes a require/revert reason the way
+// the chain actually returns it, so ContractFunctionRevertedError decodes `.reason`.
+const ERROR_STRING_ABI = [
+  { type: 'error', name: 'Error', inputs: [{ type: 'string', name: 'reason' }] },
 ] as const;
 
 let heartbeatSuccessDir = '';
@@ -330,17 +336,48 @@ describe('RunnerCastHeartbeat', () => {
     warn.mockRestore();
   }, 7_000);
 
-  it('upgrades a viem-wrapped rate-limit revert to HeartbeatRateLimitedError', async () => {
-    // viem surfaces the on-chain revert wrapped in a BaseError (e.g.
-    // ContractFunctionExecutionError) whose cause is the ContractFunctionRevertedError.
-    // A bare `instanceof ContractFunctionRevertedError` misses the wrapper and the
-    // rate-limit revert leaks out as a generic error, sending the scheduler down its
-    // retry-with-backoff path instead of cleanly waiting for the window. The caller
-    // must walk the cause chain + match the rate-limit reason.
+  it('detects a viem-wrapped rate-limit revert by reason ALONE (no timestamp help)', async () => {
+    // viem wraps the on-chain revert in a BaseError (e.g. ContractFunctionExecutionError)
+    // whose cause is the ContractFunctionRevertedError; a bare `instanceof` misses it.
+    // Crucially: the readNextHeartbeatAtTs() read FAILS here, so the timestamp fallback
+    // cannot fire — only the reason-based detection can. This is the load-bearing case
+    // (the prod failure mode) and it fails on pre-fix code.
     const reverted = new ContractFunctionRevertedError({
       abi: HEARTBEAT_ABI_FRAGMENT,
       functionName: 'heartbeat',
-      message: 'ClanWorld: heartbeat rate limited',
+      data: encodeErrorResult({
+        abi: ERROR_STRING_ABI,
+        errorName: 'Error',
+        args: ['ClanWorld: heartbeat rate limited'],
+      }),
+    });
+    const wrapped = new BaseError('Execution reverted for an unknown reason.', { cause: reverted });
+    viemMocks.writeContract.mockRejectedValue(wrapped);
+    viemMocks.readContract.mockRejectedValue(new Error('rpc unavailable'));
+
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'https://rpc.example',
+    });
+
+    const err = await heartbeat.callHeartbeat().then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(HeartbeatRateLimitedError);
+  });
+
+  it('does NOT mis-classify a world-paused revert as rate-limited even when nextHeartbeatAtTs is in the future', async () => {
+    // heartbeat() runs _requireWorldNotPaused() BEFORE the rate-limit guard, so a
+    // paused world reverts with a DIFFERENT decoded reason. With nextHeartbeatAtTs
+    // far in the future, a naive timestamp-fallback would wrongly upgrade this to a
+    // rate-limit (masking the real fault). The decoded reason must win.
+    const reverted = new ContractFunctionRevertedError({
+      abi: HEARTBEAT_ABI_FRAGMENT,
+      functionName: 'heartbeat',
+      data: encodeErrorResult({
+        abi: ERROR_STRING_ABI,
+        errorName: 'Error',
+        args: ['ClanWorld: world paused'],
+      }),
     });
     const wrapped = new BaseError('Execution reverted for an unknown reason.', { cause: reverted });
     viemMocks.writeContract.mockRejectedValue(wrapped);
@@ -353,22 +390,22 @@ describe('RunnerCastHeartbeat', () => {
     });
 
     const err = await heartbeat.callHeartbeat().then(() => null, (e: unknown) => e);
-    expect(err).toBeInstanceOf(HeartbeatRateLimitedError);
+    expect(err).not.toBeInstanceOf(HeartbeatRateLimitedError);
+    expect(err).toBe(wrapped);
   });
 
-  it('surfaces a non-rate-limit contract revert unchanged', async () => {
-    vi.useFakeTimers();
-    // Wall clock far ahead of nextHeartbeatAtTs below, so the timestamp fallback
-    // does NOT mis-classify this as rate-limited.
-    vi.setSystemTime(10_000_000_000_000);
+  it('falls back to the timestamp heuristic for an UNDECODED revert (no reason)', async () => {
+    // A custom error with no ABI match has no decoded reason; only here may the
+    // nextHeartbeatAtTs timestamp heuristic classify it as rate-limited.
     const reverted = new ContractFunctionRevertedError({
       abi: HEARTBEAT_ABI_FRAGMENT,
       functionName: 'heartbeat',
-      message: 'ClanWorld: world paused',
+      data: '0xdeadbeef',
     });
+    expect(reverted.reason).toBeUndefined(); // guards the test's premise
     const wrapped = new BaseError('Execution reverted for an unknown reason.', { cause: reverted });
     viemMocks.writeContract.mockRejectedValue(wrapped);
-    viemMocks.readContract.mockResolvedValue({ nextHeartbeatAtTs: 1n });
+    viemMocks.readContract.mockResolvedValue({ nextHeartbeatAtTs: 9_999_999_999n });
 
     const heartbeat = new RunnerCastHeartbeat({
       privateKey: '1'.repeat(64),
@@ -377,7 +414,6 @@ describe('RunnerCastHeartbeat', () => {
     });
 
     const err = await heartbeat.callHeartbeat().then(() => null, (e: unknown) => e);
-    expect(err).not.toBeInstanceOf(HeartbeatRateLimitedError);
-    expect(err).toBe(wrapped);
+    expect(err).toBeInstanceOf(HeartbeatRateLimitedError);
   });
 });


### PR DESCRIPTION
## Problem
The heartbeat keeper was spamming `heartbeat attempt 3/4/5 failed (revert): ClanWorld: heartbeat rate limited` in prod and burning its retry-with-backoff budget on every rate-limited cycle.

Root cause (NOT a missing scheduler feature — the scheduler **already** sleeps until `nextHeartbeatAtTs`+jitter and handles `HeartbeatRateLimitedError` gracefully): `callHeartbeat` detected the rate-limit via `err instanceof ContractFunctionRevertedError`, but **viem wraps contract reverts in `ContractFunctionExecutionError`**, so that check is `false`. The rate-limit revert leaked out as a generic error → classified `'revert'` → 5-retry backoff (`[1s,2s,5s,10s]`) + alert spam, instead of the clean "wait for the window" path.

## Fix (scoped + safe)
- `extractContractRevert()` walks the viem error **cause chain** to find the underlying `ContractFunctionRevertedError` (the bare `instanceof` missed the wrapper).
- `isRateLimitRevert()` classifies by the **revert reason string** (`ClanWorld: heartbeat rate limited`) — clock-basis independent — scanning reason + shortMessage + message; the `nextHeartbeatAtTs` timestamp check is retained as a fallback.
- Added scheduler **instrumentation** logging (`nextHeartbeatAtTs` / `wallNowMs` / `computedDelayMs`) to diagnose a **suspected-but-unproven** chain-vs-wall clock skew (the anvil-fork `block.timestamp` runs ~1489s ahead of wall). The scheduling math is **deliberately NOT changed** in this PR — instrument first, then decide if the skew is a real second bug or a measurement-context mismatch.

## Tests
- viem-wrapped rate-limit revert → `HeartbeatRateLimitedError` (no retry burst)
- non-rate-limit contract revert → surfaces unchanged
- 14/14 pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)