### PR TITLE
feat(docs): bootstrap GH Pages site at docs.clan-world.com

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.clan-world.com

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Clan World — Docs</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&family=IM+Fell+English+SC&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --ink: #2a1810;
+      --ink-soft: #5a3d28;
+      --rubric: #9b2a2f;
+      --gold: #a87c2f;
+      --paper: #f0e3c4;
+      --paper-warm: #e8d6ab;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; }
+    body {
+      font-family: 'IM Fell English', Georgia, serif;
+      color: var(--ink);
+      background:
+        radial-gradient(ellipse at 50% 30%, #1a0e07 0%, #0a0503 70%, #050201 100%);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem 1rem;
+      line-height: 1.6;
+    }
+    .page {
+      max-width: 720px;
+      width: 100%;
+      background:
+        radial-gradient(ellipse at 30% 20%, rgba(168, 124, 47, 0.10), transparent 60%),
+        radial-gradient(ellipse at 70% 80%, rgba(168, 124, 47, 0.08), transparent 50%),
+        linear-gradient(180deg, var(--paper) 0%, var(--paper-warm) 100%);
+      padding: 4rem 3.5rem;
+      box-shadow:
+        0 30px 60px rgba(0, 0, 0, 0.6),
+        0 10px 20px rgba(0, 0, 0, 0.4),
+        inset 0 0 80px rgba(168, 124, 47, 0.08);
+      border-radius: 2px;
+      position: relative;
+    }
+    .page::before, .page::after {
+      content: '';
+      position: absolute;
+      width: 12px;
+      height: 12px;
+      background: rgba(107, 68, 35, 0.15);
+      border-radius: 50%;
+      filter: blur(3px);
+    }
+    .page::before { top: 12%; right: 18%; }
+    .page::after { bottom: 22%; left: 22%; }
+    header {
+      text-align: center;
+      margin-bottom: 2.5rem;
+      border-bottom: 1px solid rgba(168, 124, 47, 0.35);
+      padding-bottom: 1.5rem;
+    }
+    .eyebrow {
+      font-family: 'IM Fell English SC', serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.28em;
+      color: var(--ink-soft);
+      margin-bottom: 0.4rem;
+    }
+    h1 {
+      font-family: 'IM Fell English', serif;
+      font-weight: 400;
+      font-size: 2.4rem;
+      letter-spacing: 0.02em;
+      color: var(--ink);
+    }
+    h1 em { color: var(--rubric); font-style: italic; }
+    .subtitle {
+      margin-top: 0.5rem;
+      font-style: italic;
+      color: var(--ink-soft);
+      font-size: 1rem;
+    }
+    h2 {
+      font-family: 'IM Fell English SC', serif;
+      font-weight: 400;
+      font-size: 1.05rem;
+      letter-spacing: 0.22em;
+      color: var(--ink-soft);
+      margin: 2.6rem 0 1.2rem;
+      border-bottom: 1px solid rgba(168, 124, 47, 0.25);
+      padding-bottom: 0.4rem;
+    }
+    .entry {
+      display: block;
+      padding: 1rem 1.2rem;
+      margin-bottom: 0.8rem;
+      text-decoration: none;
+      color: var(--ink);
+      background: rgba(168, 124, 47, 0.04);
+      border-left: 2px solid rgba(168, 124, 47, 0.4);
+      transition: background 0.2s ease, border-color 0.2s ease;
+    }
+    .entry:hover {
+      background: rgba(168, 124, 47, 0.10);
+      border-left-color: var(--rubric);
+    }
+    .entry-title {
+      font-size: 1.15rem;
+      font-style: italic;
+      color: var(--rubric);
+    }
+    .entry-meta {
+      font-family: 'IM Fell English SC', serif;
+      font-size: 0.72rem;
+      letter-spacing: 0.18em;
+      color: var(--ink-soft);
+      margin-top: 0.25rem;
+    }
+    .entry-note {
+      margin-top: 0.5rem;
+      font-style: italic;
+      color: var(--ink-soft);
+      font-size: 0.95rem;
+    }
+    .placeholder {
+      padding: 1rem 1.2rem;
+      margin-bottom: 0.8rem;
+      color: var(--ink-soft);
+      background: rgba(168, 124, 47, 0.02);
+      border-left: 2px dashed rgba(168, 124, 47, 0.3);
+      font-style: italic;
+    }
+    footer {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid rgba(168, 124, 47, 0.25);
+      text-align: center;
+      font-family: 'IM Fell English SC', serif;
+      font-size: 0.72rem;
+      letter-spacing: 0.22em;
+      color: var(--ink-soft);
+    }
+    .ornament {
+      text-align: center;
+      color: var(--gold);
+      margin: 1.2rem 0;
+      letter-spacing: 0.4em;
+      font-size: 0.9rem;
+    }
+    @media (max-width: 600px) {
+      .page { padding: 2.5rem 1.8rem; }
+      h1 { font-size: 1.8rem; }
+    }
+  </style>
+</head>
+<body>
+  <article class="page">
+    <header>
+      <div class="eyebrow">✦ &nbsp; Clan World &nbsp; ✦</div>
+      <h1>The <em>Docs</em></h1>
+      <p class="subtitle">A chronicle of the world, its physics, its lore, and the records its Elders keep.</p>
+    </header>
+
+    <h2>The Book of Ancient Wisdom — sample pages</h2>
+    <p class="entry-note" style="margin-bottom: 1rem;">
+      Two independent renderings of a single page, drafted as exploration of the in-fiction artifact. Each is a different writer's voice and a different designer's eye.
+    </p>
+
+    <a class="entry" href="lore/book-of-ancient-wisdom-v1.html">
+      <div class="entry-title">Sample I — Of the Multi-Elder Palimpsest</div>
+      <div class="entry-meta">First Draft · The Third &amp; Fourth Elders · Funeral Line: Mara of the West Field</div>
+    </a>
+
+    <a class="entry" href="lore/book-of-ancient-wisdom-v2.html">
+      <div class="entry-title">Sample II — Of Counting Winters</div>
+      <div class="entry-meta">Second Draft · The Twenty-Third &amp; Twenty-Fourth of House Slate · Funeral Line: Pell of the Long Reach</div>
+    </a>
+
+    <a class="entry" href="lore/book-of-ancient-wisdom-v3.html">
+      <div class="entry-title">Sample III — Of the Catechism and the Fourth Winter</div>
+      <div class="entry-meta">Third Draft · The Eleventh &amp; Twelfth of House Slate · Funeral Line: Iren of the Quiet Step</div>
+    </a>
+
+    <h2>The Physics of the World</h2>
+    <p class="entry-note">Canonical mechanics — how time advances, how clansmen labour, how winter takes its tithe, how monuments are built, how the bracket selects survivors.</p>
+    <a class="entry" href="WORLD_PHYSICS.md">
+      <div class="entry-title">World Physics</div>
+      <div class="entry-meta">Living spec · 16 sections · Subject to refinement</div>
+    </a>
+    <a class="entry" href="WORLD_PHYSICS_CONSTANTS.md">
+      <div class="entry-title">World Physics — Constants</div>
+      <div class="entry-meta">Supporting numbers, capacities, probabilities</div>
+    </a>
+
+    <div class="ornament">✦ &nbsp; ❦ &nbsp; ✦</div>
+
+    <footer>
+      docs.clan-world.com &nbsp;·&nbsp; published from the docs branch &nbsp;·&nbsp; the bell rings every sixty seconds
+    </footer>
+  </article>
+</body>
+</html>

--- a/docs/lore/book-of-ancient-wisdom-v1.html
+++ b/docs/lore/book-of-ancient-wisdom-v1.html
@@ -1,0 +1,512 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>The Book of Ancient Wisdom — A Leaf</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&family=IM+Fell+English+SC&family=UnifrakturCook:wght@700&display=swap" rel="stylesheet">
+<style>
+/* ------------------------------------------------------------------ *
+ *  THE BOOK OF ANCIENT WISDOM — a single leaf
+ *  Designed to read as a museum-lit photograph of an open codex.
+ * ------------------------------------------------------------------ */
+
+:root{
+  --ink-old:        rgba(107, 68, 35, 0.86);     /* faded sepia */
+  --ink-old-deep:   rgba(82, 49, 22, 0.92);
+  --ink-new:        #1f1208;                     /* iron-gall, near-black */
+  --ink-rubric:     #6e1a1a;                     /* madder red */
+  --ink-rubric-2:   #8a2a1f;
+  --ink-gold:       #8a6a1d;                     /* tarnished gold */
+  --ink-gold-warm:  #b88a32;
+  --parchment-1:    #efe3c4;
+  --parchment-2:    #e6d6ae;
+  --parchment-3:    #d9c393;
+  --parchment-edge: #8a6c3a;
+  --wood-1:         #1b0f06;
+  --wood-2:         #2a160a;
+  --wood-3:         #3d2110;
+}
+
+*{ box-sizing:border-box; }
+html,body{ margin:0; padding:0; }
+
+html{
+  /* Deep, warm museum darkness. The "table" behind the page. */
+  background:
+    radial-gradient(ellipse at 50% 30%, #4a2a14 0%, #2a160a 35%, #160a04 75%, #0a0502 100%);
+  min-height:100%;
+}
+
+body{
+  font-family:"IM Fell English", "EB Garamond", Georgia, serif;
+  color:var(--ink-old);
+  min-height:100vh;
+  padding:48px 24px 80px;
+  display:flex;
+  justify-content:center;
+  align-items:flex-start;
+
+  /* faint wood-grain over the table, mostly hidden by the page */
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(0,0,0,0.10) 0px, rgba(0,0,0,0.10) 1px,
+      rgba(255,255,255,0.012) 1px, rgba(255,255,255,0.012) 3px,
+      rgba(0,0,0,0.06) 3px, rgba(0,0,0,0.06) 7px
+    ),
+    radial-gradient(ellipse at 50% 40%, rgba(120,70,30,0.18), transparent 60%);
+}
+
+/* ------------------------------------------------------------------ *
+ *  The leaf itself
+ * ------------------------------------------------------------------ */
+.leaf{
+  position:relative;
+  width:min(760px, 100%);
+  /* book-page proportions, a bit taller than wide */
+  aspect-ratio: 5 / 7;
+  padding: clamp(48px, 7vw, 88px) clamp(44px, 6.5vw, 80px) clamp(56px, 7vw, 88px);
+
+  color:var(--ink-old);
+
+  /* layered parchment: base tone + warm vignette + cool corner cool-down */
+  background:
+    radial-gradient(ellipse 60% 80% at 50% 50%, rgba(255,245,210,0.55), transparent 70%),
+    radial-gradient(ellipse 120% 90% at 50% 110%, rgba(80,40,10,0.18), transparent 60%),
+    radial-gradient(ellipse 120% 90% at 50% -10%, rgba(80,40,10,0.16), transparent 60%),
+    linear-gradient(180deg, var(--parchment-1) 0%, var(--parchment-2) 60%, var(--parchment-3) 100%);
+
+  /* deckled, lived-in edge */
+  border-radius: 3px 5px 4px 6px / 6px 4px 5px 3px;
+
+  /* hold-the-page-up-to-the-light shadow */
+  box-shadow:
+    0 0 0 1px rgba(60,30,10,0.35),
+    0 2px 0 rgba(80,50,20,0.20),
+    0 30px 60px -20px rgba(0,0,0,0.85),
+    0 60px 120px -30px rgba(0,0,0,0.75),
+    inset 0 0 90px rgba(100,60,20,0.30),
+    inset 0 0 22px rgba(60,30,10,0.30);
+
+  /* sit the page slightly off-axis like a photograph */
+  transform: rotate(-0.35deg);
+}
+
+/* Worn edge — a darkened halo just inside the page boundary */
+.leaf::before{
+  content:"";
+  position:absolute; inset:0;
+  pointer-events:none;
+  border-radius:inherit;
+  background:
+    radial-gradient(ellipse 96% 96% at 50% 50%, transparent 70%, rgba(70,40,15,0.28) 92%, rgba(40,20,5,0.55) 100%);
+  mix-blend-mode:multiply;
+}
+
+/* Foxing, mottling, and grain — pure SVG noise, no external assets */
+.leaf::after{
+  content:"";
+  position:absolute; inset:0;
+  pointer-events:none;
+  border-radius:inherit;
+  opacity:0.55;
+  mix-blend-mode:multiply;
+  background-image:
+    /* a few scattered foxing spots */
+    radial-gradient(circle at 12% 18%, rgba(120,70,25,0.18) 0, transparent 5%),
+    radial-gradient(circle at 84% 22%, rgba(120,70,25,0.14) 0, transparent 4%),
+    radial-gradient(circle at 22% 78%, rgba(120,70,25,0.16) 0, transparent 6%),
+    radial-gradient(circle at 78% 84%, rgba(120,70,25,0.13) 0, transparent 5%),
+    radial-gradient(circle at 46% 54%, rgba(120,70,25,0.10) 0, transparent 7%),
+    /* fine fibrous grain via SVG noise */
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.35  0 0 0 0 0.22  0 0 0 0 0.10  0 0 0 0.55 0'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.55'/></svg>");
+  background-size: auto, auto, auto, auto, auto, 240px 240px;
+}
+
+/* ------------------------------------------------------------------ *
+ *  Typographic groundwork
+ * ------------------------------------------------------------------ */
+.scribe{
+  position:relative;
+  z-index:2;
+  font-size: clamp(15px, 1.35vw, 17.5px);
+  line-height: 1.78;
+  text-align: justify;
+  hyphens: auto;
+  letter-spacing: 0.005em;
+}
+
+.scribe p{
+  margin: 0 0 0.95em 0;
+  text-indent: 1.4em;
+}
+.scribe p:first-of-type{ text-indent: 0; }
+
+/* PASSAGE 1 — old hand, faded */
+.old-hand{
+  color: var(--ink-old);
+  font-weight: 400;
+  /* tiny horizontal smear effect — ink bled into the fibres */
+  text-shadow:
+    0 0 0.5px rgba(107,68,35,0.25),
+    0.3px 0 0 rgba(107,68,35,0.10);
+}
+
+/* a faint waver to the old hand baseline — different lines listing slightly */
+.old-hand p:nth-of-type(2){ transform: translateY(-0.5px); }
+.old-hand p:nth-of-type(4){ transform: rotate(-0.15deg); }
+.old-hand p:nth-of-type(5){
+  /* "Bandits do not hate. They count." — gnomic, centered, weight */
+  text-align: center;
+  text-indent: 0;
+  font-style: italic;
+  font-size: 1.05em;
+  color: var(--ink-old-deep);
+  margin: 1.3em 0;
+  letter-spacing: 0.02em;
+}
+
+/* PASSAGE 3 — newer ink */
+.new-hand{
+  color: var(--ink-new);
+  font-weight: 400;
+  /* a tighter, slightly weightier stroke */
+  text-shadow:
+    0 0 0.4px rgba(31,18,8,0.55);
+  letter-spacing: 0.003em;
+}
+.new-hand p{ line-height: 1.74; }
+
+/* The three short declarative lines in passage 3 — set apart, heavier */
+.new-hand .stark{
+  text-indent:0;
+  margin: 0.35em 0;
+  font-style: italic;
+  color: var(--ink-new);
+  letter-spacing: 0.01em;
+}
+
+/* ------------------------------------------------------------------ *
+ *  Drop cap — illuminated initial 'F'
+ * ------------------------------------------------------------------ */
+.dropcap{
+  float: left;
+  font-family: "UnifrakturCook", "IM Fell English", serif;
+  font-weight: 700;
+  font-size: 5.4em;
+  line-height: 0.82;
+  padding: 0.08em 0.14em 0.02em 0.10em;
+  margin: 0.05em 0.18em -0.05em -0.02em;
+  color: var(--ink-rubric);
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255,220,140,0.55), transparent 60%),
+    linear-gradient(140deg, #f3dca0 0%, #d9b25a 45%, #a4781f 100%);
+  border: 1.5px solid var(--ink-rubric);
+  box-shadow:
+    inset 0 0 0 2px rgba(255,240,200,0.6),
+    inset 0 0 14px rgba(110,26,26,0.25),
+    0 1px 0 rgba(80,40,10,0.3);
+  text-shadow:
+    0 1px 0 rgba(255,235,180,0.7),
+    0 -1px 0 rgba(110,26,26,0.4);
+  position:relative;
+}
+.dropcap::after{
+  /* tiny gold dot ornament in the upper-right corner of the box */
+  content:"";
+  position:absolute;
+  right:-3px; top:-3px;
+  width:6px; height:6px; border-radius:50%;
+  background: radial-gradient(circle, #f3dca0, #8a6a1d 70%);
+  box-shadow: 0 0 0 1px #6e1a1a;
+}
+
+/* ------------------------------------------------------------------ *
+ *  The grease-stain — a soft, off-round darker patch
+ * ------------------------------------------------------------------ */
+.grease-host{ position:relative; }
+.grease-host::before{
+  content:"";
+  position:absolute;
+  left: -32px; top: -10px;
+  width: 240px; height: 110px;
+  background:
+    radial-gradient(ellipse 60% 70% at 35% 45%, rgba(90,55,20,0.28), rgba(90,55,20,0.12) 45%, transparent 75%),
+    radial-gradient(ellipse 35% 45% at 60% 60%, rgba(60,35,12,0.22), transparent 70%);
+  filter: blur(2px);
+  pointer-events:none;
+  z-index:1;
+  mix-blend-mode:multiply;
+  transform: rotate(-6deg);
+}
+.grease-host p{ position:relative; z-index:2; }
+
+/* ------------------------------------------------------------------ *
+ *  Death-marker ornament
+ * ------------------------------------------------------------------ */
+.death-marker{
+  margin: 2.2em auto 1.6em;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap: 14px;
+  color: var(--ink-rubric);
+}
+.death-marker .rule{
+  flex: 0 1 200px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--ink-old-deep) 30%, var(--ink-old-deep) 70%, transparent);
+  opacity: 0.7;
+}
+.death-marker svg{ display:block; }
+
+.death-text{
+  text-align:center;
+  font-family: "IM Fell English SC", "IM Fell English", serif;
+  font-style: italic;
+  font-size: 0.92em;
+  letter-spacing: 0.10em;
+  color: var(--ink-old-deep);
+  margin: 0 0 2em;
+  text-indent: 0 !important;
+}
+
+/* ------------------------------------------------------------------ *
+ *  Funeral inscription — passage 2
+ * ------------------------------------------------------------------ */
+.funeral{
+  margin: 2.2em auto;
+  padding: 1.4em 1.2em 1.2em;
+  max-width: 86%;
+  text-align: center;
+  position: relative;
+  color: var(--ink-rubric);
+}
+.funeral::before, .funeral::after{
+  content:"";
+  position:absolute; left:8%; right:8%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--ink-rubric) 18%, var(--ink-rubric) 82%, transparent);
+  opacity:0.55;
+}
+.funeral::before{ top:0; }
+.funeral::after{ bottom:0; }
+
+.funeral .ornament{ margin-bottom: 0.6em; color: var(--ink-rubric); }
+.funeral .ornament svg{ display:inline-block; }
+
+.funeral .name{
+  display:block;
+  font-family: "IM Fell English SC", "IM Fell English", serif;
+  font-size: 1.05em;
+  letter-spacing: 0.22em;
+  margin-bottom: 0.5em;
+  color: var(--ink-rubric);
+}
+.funeral .body{
+  font-family: "IM Fell English", serif;
+  font-style: italic;
+  font-size: 1em;
+  line-height: 1.7;
+  color: var(--ink-old-deep);
+  text-indent: 0;
+  margin: 0;
+}
+.funeral .tick{
+  display:inline-block;
+  font-family: "IM Fell English SC", serif;
+  font-style: normal;
+  letter-spacing: 0.12em;
+  color: var(--ink-rubric);
+  font-size: 0.9em;
+}
+
+/* ------------------------------------------------------------------ *
+ *  Marginal chapter mark + folio number
+ * ------------------------------------------------------------------ */
+.folio{
+  position:absolute;
+  bottom: 28px;
+  left: 0; right: 0;
+  text-align:center;
+  font-family:"IM Fell English SC", serif;
+  font-size: 12px;
+  letter-spacing: 0.35em;
+  color: var(--ink-old-deep);
+  opacity: 0.7;
+  z-index:3;
+}
+
+.marginalia{
+  position:absolute;
+  top: 38px;
+  right: 28px;
+  font-family:"IM Fell English SC", serif;
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  color: var(--ink-rubric);
+  opacity: 0.75;
+  transform: rotate(0deg);
+  z-index:3;
+}
+
+/* small ink-blot in the bottom margin for character */
+.blot{
+  position:absolute;
+  left: 12%;
+  bottom: 58px;
+  width: 16px; height: 13px;
+  background:
+    radial-gradient(ellipse 70% 60% at 45% 40%, rgba(31,18,8,0.85), rgba(31,18,8,0.4) 60%, transparent 80%);
+  filter: blur(0.4px);
+  transform: rotate(8deg);
+  z-index:2;
+  pointer-events:none;
+}
+.blot::after{
+  content:"";
+  position:absolute;
+  left:14px; top:6px;
+  width:5px; height:4px;
+  background: radial-gradient(circle, rgba(31,18,8,0.6), transparent 70%);
+  border-radius:50%;
+}
+
+/* Subtle binding-edge shadow on the left (page sits in a bound book) */
+.binding{
+  position:absolute;
+  top:0; bottom:0; left:0;
+  width: 42px;
+  pointer-events:none;
+  background: linear-gradient(90deg,
+    rgba(60,30,10,0.45) 0%,
+    rgba(60,30,10,0.18) 35%,
+    transparent 100%);
+  border-radius: inherit;
+  z-index:1;
+}
+
+/* Print + small-screen safety */
+@media (max-width: 640px){
+  body{ padding: 22px 10px 60px; }
+  .leaf{ aspect-ratio: auto; }
+  .dropcap{ font-size: 4.4em; }
+  .grease-host::before{ width: 180px; height: 90px; left: -16px; }
+}
+
+/* Quiet entrance — like the page being placed under the light */
+@keyframes settle {
+  from { opacity:0; transform: rotate(-0.35deg) translateY(8px); }
+  to   { opacity:1; transform: rotate(-0.35deg) translateY(0); }
+}
+.leaf{ animation: settle 1.4s ease-out both; }
+</style>
+</head>
+<body>
+
+<article class="leaf" role="article" aria-label="A leaf from the Book of Ancient Wisdom">
+
+  <div class="binding" aria-hidden="true"></div>
+
+  <div class="marginalia" aria-hidden="true">Cap. III &nbsp;·&nbsp; De Hieme</div>
+
+  <section class="scribe old-hand" aria-label="In the old hand, much faded">
+
+    <p>
+      <span class="dropcap" aria-hidden="true">F</span><span class="sr-only">F</span>irst fill the mouths. Wheat before pride, fish before prayer. A hungry man gathers half, and a dead man gathers nothing. Send two to the farms until the vault breathes. Send one to the forest. Send none to the monument until winter has been counted.
+    </p>
+
+    <p>
+      Wood is warmth twice over: once in the wall, once in the fire. Do not spend all beams on height. The cold has no herald. It comes at the hundred-and-tenth bell and takes first from the wall, then from the sons.
+    </p>
+
+    <p>
+      If iron is found, keep it unless the town is foolish. If gold is found in the mountain, mark the tick. Unicorn Town remembers price, though it has no soul.
+    </p>
+
+    <p>
+      House Verdant helped us at East Docks for two fish and a promise. Pay them before they ask. House Crimson asked for wheat during famine and laughed when refused. Do not answer their first whisper. Answer the second.
+    </p>
+
+    <p>Bandits do not hate. They count.</p>
+
+    <div class="grease-host">
+      <p>
+        A narrow rule, written beside a grease stain: when the camp-smoke rises, call the idle home. A man waiting at his own gate is half a shield. A man sworn to defend is a whole one.
+      </p>
+    </div>
+
+  </section>
+
+  <!-- Death marker: thin double rule with a small cross-flourish -->
+  <div class="death-marker" aria-hidden="true">
+    <span class="rule"></span>
+    <svg width="38" height="22" viewBox="0 0 38 22" xmlns="http://www.w3.org/2000/svg">
+      <!-- a small Celtic-knot / cross flourish in sepia -->
+      <g fill="none" stroke="#6b4423" stroke-width="1.1" stroke-linecap="round">
+        <path d="M19 2 L19 20 M10 11 L28 11"/>
+        <path d="M19 2 C 22 5, 22 8, 19 11 C 16 14, 16 17, 19 20"/>
+        <path d="M19 2 C 16 5, 16 8, 19 11 C 22 14, 22 17, 19 20"/>
+        <circle cx="19" cy="11" r="2.3" fill="#6e1a1a" stroke="#6b4423"/>
+      </g>
+    </svg>
+    <span class="rule"></span>
+  </div>
+
+  <p class="death-text">
+    Here ends the Third Elder. The Fourth wakes with another voice, and the same debt.
+  </p>
+
+  <!-- Funeral inscription — set apart -->
+  <aside class="funeral" aria-label="Funeral line">
+    <div class="ornament" aria-hidden="true">
+      <svg width="48" height="14" viewBox="0 0 48 14" xmlns="http://www.w3.org/2000/svg">
+        <g fill="none" stroke="#6e1a1a" stroke-width="1" stroke-linecap="round">
+          <path d="M2 7 H 18"/>
+          <path d="M30 7 H 46"/>
+          <path d="M24 2 V 12"/>
+          <path d="M21 4 Q 24 7 27 4"/>
+          <path d="M21 10 Q 24 7 27 10"/>
+          <circle cx="24" cy="7" r="1.2" fill="#6e1a1a"/>
+        </g>
+      </svg>
+    </div>
+    <span class="name">In Memoriam &nbsp;·&nbsp; Mara of the West Field</span>
+    <p class="body">
+      Mara of the west field died in the second winter,
+      <span class="tick">tick&nbsp;CCXXIII</span>,
+      while carrying wheat she would not live to eat.
+      Let her name stand where the cold cannot reach it.
+    </p>
+  </aside>
+
+  <section class="scribe new-hand" aria-label="In newer ink, pressed harder">
+
+    <p>
+      I have read the old warnings and find them cruelly exact. We began proud and nearly starved by tick&nbsp;17. The Book was right: mouths first. I sent Elian and Tom to wheat, Sava to fish, Orrec to wood. The vault steadied.
+    </p>
+
+    <p class="stark">Crimson has already whispered.</p>
+    <p class="stark">I will not answer yet.</p>
+
+    <p>
+      There is rot in haste. The monument wants everything: timber, grain, iron, blueprints, attention. Let it wait until the hearth is fed. But not too long. Other towers are rising beyond the fog, and memory alone does not win a season.
+    </p>
+
+    <p>
+      If I forget again, let the next waking hand read this: build as if winter is coming, trade as if every smile has teeth, and mourn by name. The unnamed dead become weather.
+    </p>
+
+  </section>
+
+  <span class="blot" aria-hidden="true"></span>
+
+  <div class="folio" aria-hidden="true">— xvii —</div>
+
+</article>
+
+</body>
+</html>

--- a/docs/lore/book-of-ancient-wisdom-v2.html
+++ b/docs/lore/book-of-ancient-wisdom-v2.html
@@ -1,0 +1,624 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>The Book of Ancient Wisdom — House Slate, fol. recto</title>
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=IM+Fell+English+SC&family=IM+Fell+English:ital@0;1&family=Caveat:wght@400;500;600&family=Reenie+Beanie&display=swap" rel="stylesheet">
+<style>
+  /* --------------------------------------------------------------
+     The Book of Ancient Wisdom — folio of House Slate
+     A single recto leaf, laid on a walnut tabletop.
+     Two hands. One leaving, one beginning.
+     -------------------------------------------------------------- */
+
+  :root{
+    --table-1:#1a120b;
+    --table-2:#2a1d10;
+    --table-3:#0e0905;
+
+    /* Vellum — uneven, warmer near the gutter */
+    --vellum-pale:#efe2c4;
+    --vellum-warm:#e8d6ad;
+    --vellum-shadow:#c9b585;
+    --vellum-deep:#a48a55;
+
+    /* Inks */
+    --ink-old:#3a2410;          /* iron-gall, oxidised brown */
+    --ink-old-faded:#5a3d23;
+    --ink-new:#0c0a08;           /* fresh, blacker, harder press */
+    --ink-blood:#5a1a14;         /* the funeral line, red-brown */
+    --ink-marginal:#6a4a28;
+
+    --rule:#9a7a48;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0}
+
+  body{
+    min-height:100vh;
+    background:
+      radial-gradient(ellipse at 50% 35%, #3b2614 0%, #1a120b 55%, #0e0905 100%),
+      var(--table-1);
+    font-family:"EB Garamond", "IM Fell English", Georgia, serif;
+    color:var(--ink-old);
+    padding:6vh 2rem 8vh;
+    display:flex;
+    justify-content:center;
+    overflow-x:hidden;
+  }
+
+  /* Wood grain on the table — long horizontal striations */
+  body::before{
+    content:"";
+    position:fixed; inset:0;
+    pointer-events:none;
+    background:
+      repeating-linear-gradient(
+        88deg,
+        transparent 0 9px,
+        rgba(0,0,0,.12) 9px 10px,
+        transparent 10px 23px,
+        rgba(255,220,160,.025) 23px 24px,
+        transparent 24px 41px
+      ),
+      repeating-linear-gradient(
+        92deg,
+        transparent 0 137px,
+        rgba(0,0,0,.18) 137px 139px,
+        transparent 139px 280px
+      );
+    mix-blend-mode:multiply;
+    opacity:.85;
+    z-index:0;
+  }
+  body::after{
+    content:"";
+    position:fixed; inset:0;
+    pointer-events:none;
+    background:radial-gradient(ellipse at 50% 30%, transparent 0%, transparent 40%, rgba(0,0,0,.55) 100%);
+    z-index:1;
+  }
+
+  /* -------------------------------------------------------------- */
+  /* The page                                                       */
+  /* -------------------------------------------------------------- */
+
+  .leaf{
+    position:relative;
+    z-index:2;
+    width:min(820px, 96vw);
+    padding:5.2rem 5.5rem 5rem 7.5rem;   /* extra left padding for the gutter tally column */
+    background:
+      /* foxing — small organic stains */
+      radial-gradient(circle at 12% 8%, rgba(120,75,30,.18) 0 5px, transparent 8px),
+      radial-gradient(circle at 88% 14%, rgba(120,75,30,.14) 0 7px, transparent 11px),
+      radial-gradient(circle at 78% 92%, rgba(150,90,40,.22) 0 9px, transparent 14px),
+      radial-gradient(circle at 22% 78%, rgba(100,60,20,.14) 0 6px, transparent 10px),
+      radial-gradient(circle at 64% 48%, rgba(140,90,40,.10) 0 14px, transparent 26px),
+      /* the thumb-stain at top-left where the elder rested a hand for years */
+      radial-gradient(ellipse 60px 80px at 14% 22%, rgba(110,70,30,.32), transparent 70%),
+      /* warmth toward the gutter (left) */
+      linear-gradient(94deg, var(--vellum-shadow) 0%, var(--vellum-warm) 18%, var(--vellum-pale) 55%, var(--vellum-pale) 85%, var(--vellum-shadow) 100%),
+      var(--vellum-warm);
+
+    /* edge roughness — multiple soft shadows + a deckle clip */
+    box-shadow:
+      0 1px 0 rgba(255,240,200,.4) inset,
+      0 -2px 8px rgba(80,40,10,.25) inset,
+      0 30px 80px -20px rgba(0,0,0,.85),
+      0 60px 120px -40px rgba(0,0,0,.6),
+      0 4px 0 rgba(0,0,0,.3);
+
+    /* slight rotation — the leaf is not perfectly square on the table */
+    transform:rotate(-.35deg);
+  }
+
+  /* Deckle/torn edge — uneven clip-path */
+  .leaf{
+    clip-path:polygon(
+      0.3% 0.2%, 8% 0.0%, 22% 0.4%, 36% 0.1%, 52% 0.3%, 68% 0.0%, 82% 0.4%, 96% 0.1%, 99.7% 0.5%,
+      99.6% 14%, 99.9% 28%, 99.5% 44%, 99.8% 60%, 99.4% 76%, 99.9% 92%,
+      99.5% 99.6%, 84% 99.9%, 70% 99.5%, 54% 99.8%, 38% 99.4%, 22% 99.9%, 10% 99.5%, 0.2% 99.7%,
+      0.6% 86%, 0.1% 70%, 0.5% 54%, 0.2% 38%, 0.6% 22%, 0.1% 10%
+    );
+  }
+
+  /* Vellum grain — fine fibrous noise via layered gradients */
+  .leaf::before{
+    content:"";
+    position:absolute; inset:0;
+    pointer-events:none;
+    background:
+      repeating-linear-gradient(
+        3deg,
+        transparent 0 3px,
+        rgba(110,80,40,.025) 3px 4px,
+        transparent 4px 9px),
+      repeating-linear-gradient(
+        91deg,
+        transparent 0 5px,
+        rgba(80,50,20,.02) 5px 6px,
+        transparent 6px 13px),
+      repeating-linear-gradient(
+        177deg,
+        transparent 0 2px,
+        rgba(150,110,60,.018) 2px 3px,
+        transparent 3px 7px);
+    mix-blend-mode:multiply;
+  }
+
+  /* A vertical crease/fold-shadow near the gutter */
+  .leaf::after{
+    content:"";
+    position:absolute;
+    left:5.2rem; top:0; bottom:0; width:1px;
+    background:linear-gradient(to bottom, transparent, rgba(80,50,20,.22) 12%, rgba(80,50,20,.22) 88%, transparent);
+    pointer-events:none;
+  }
+
+  /* -------------------------------------------------------------- */
+  /* The gutter tally — signature detail                            */
+  /* Two clans of marks: the Twenty-Third's (faded, decades of them) */
+  /* and the Twenty-Fourth's (two fresh strokes, blacker, anxious)  */
+  /* -------------------------------------------------------------- */
+
+  .tally{
+    position:absolute;
+    left:2.8rem; top:5.2rem; bottom:5rem;
+    width:2rem;
+    display:flex; flex-direction:column;
+    align-items:center;
+    pointer-events:none;
+  }
+  .tally svg{ display:block; }
+  .tally .legend{
+    margin-top:.6rem;
+    font-family:"IM Fell English", serif;
+    font-style:italic;
+    font-size:9px;
+    color:var(--ink-marginal);
+    text-align:center;
+    line-height:1.3;
+    opacity:.75;
+    writing-mode:vertical-rl;
+    transform:rotate(180deg);
+    letter-spacing:.04em;
+  }
+
+  /* -------------------------------------------------------------- */
+  /* Header                                                         */
+  /* -------------------------------------------------------------- */
+
+  .folio-mark{
+    display:flex;
+    justify-content:space-between;
+    align-items:baseline;
+    font-family:"IM Fell English SC", serif;
+    font-size:11px;
+    letter-spacing:.18em;
+    color:var(--ink-marginal);
+    border-bottom:1px solid var(--rule);
+    padding-bottom:.5rem;
+    margin-bottom:1.8rem;
+  }
+  .folio-mark .left{ font-style:italic; letter-spacing:.12em; font-family:"IM Fell English", serif; }
+  .folio-mark .right{ font-variant:small-caps; }
+
+  /* -------------------------------------------------------------- */
+  /* The old hand (Twenty-Third)                                    */
+  /* -------------------------------------------------------------- */
+
+  .old-hand{
+    font-family:"EB Garamond", serif;
+    font-size:17.5px;
+    line-height:1.78;
+    color:var(--ink-old);
+    text-align:justify;
+    hyphens:auto;
+    /* subtle faded uneven ink */
+    text-shadow:0 0 .4px rgba(58,36,16,.4);
+  }
+  .old-hand p{ margin:0 0 1.05rem; text-indent:1.6em; }
+  .old-hand p:first-of-type{ text-indent:0; }
+
+  /* Drop cap on the very first letter — restrained, no flourish */
+  .old-hand p:first-of-type::first-letter{
+    font-family:"IM Fell English", serif;
+    font-size:3.4em;
+    line-height:.85;
+    float:left;
+    padding:.12em .12em 0 0;
+    color:var(--ink-old);
+    font-weight:500;
+  }
+
+  /* Random faded characters — single sentences gently lighter */
+  .old-hand em{ font-style:italic; color:var(--ink-old-faded); }
+  .old-hand .smudge{ background:radial-gradient(ellipse 22px 8px at 30% 60%, rgba(70,40,15,.18), transparent 70%); }
+
+  /* Crossed-out word — the seventh→six emendation */
+  .strike{
+    position:relative;
+    color:var(--ink-old-faded);
+  }
+  .strike::after{
+    content:"";
+    position:absolute;
+    left:-2px; right:-2px; top:55%;
+    height:1.5px;
+    background:var(--ink-old);
+    transform:rotate(-2deg);
+    border-radius:1px;
+  }
+
+  /* Stage directions */
+  .stage{
+    font-family:"IM Fell English", serif;
+    font-style:italic;
+    font-size:13.5px;
+    color:var(--ink-marginal);
+    line-height:1.55;
+    margin:1.6rem 0 1.1rem;
+    padding-left:1.2rem;
+    border-left:1px solid var(--rule);
+    opacity:.86;
+  }
+
+  /* -------------------------------------------------------------- */
+  /* The break — where one hand stops and another begins            */
+  /* -------------------------------------------------------------- */
+
+  .succession{
+    margin:2rem 0 1.4rem;
+    text-align:center;
+    position:relative;
+  }
+  .succession .here-ends{
+    font-family:"IM Fell English SC", serif;
+    font-size:12px;
+    letter-spacing:.22em;
+    color:var(--ink-old);
+    display:block;
+    margin-bottom:.4rem;
+  }
+  .succession .first-words{
+    font-family:"Caveat", cursive;
+    font-size:23px;
+    color:var(--ink-new);
+    line-height:1.3;
+    transform:rotate(-.6deg);
+    display:inline-block;
+    letter-spacing:.005em;
+  }
+  /* a small inked X / cross-mark where the pen broke off */
+  .succession svg{
+    display:block;
+    margin:.4rem auto .8rem;
+  }
+
+  /* -------------------------------------------------------------- */
+  /* The Funeral Line — inscription, set apart                      */
+  /* -------------------------------------------------------------- */
+
+  .funeral{
+    margin:2.2rem 1.8rem;
+    padding:1.4rem 1.6rem 1.2rem;
+    border-top:1px solid var(--rule);
+    border-bottom:1px solid var(--rule);
+    position:relative;
+    background:
+      linear-gradient(180deg, rgba(120,80,40,.04), rgba(120,80,40,.08));
+  }
+  .funeral::before, .funeral::after{
+    /* small printer's ornament dots in the corners */
+    content:"";
+    position:absolute;
+    width:4px; height:4px; border-radius:50%;
+    background:var(--ink-old);
+  }
+  .funeral::before{ top:-2px; left:50%; transform:translateX(-50%); }
+  .funeral::after{ bottom:-2px; left:50%; transform:translateX(-50%); }
+
+  .funeral .name{
+    font-family:"IM Fell English SC", serif;
+    font-size:18px;
+    letter-spacing:.14em;
+    color:var(--ink-blood);
+    text-align:center;
+    display:block;
+    margin-bottom:.7rem;
+  }
+  .funeral .epitaph{
+    font-family:"IM Fell English", serif;
+    font-style:italic;
+    font-size:15px;
+    line-height:1.7;
+    color:var(--ink-old);
+    text-align:center;
+    margin:0;
+  }
+  .funeral .signature{
+    display:block;
+    text-align:right;
+    margin-top:.9rem;
+    font-family:"IM Fell English", serif;
+    font-style:italic;
+    font-size:13px;
+    color:var(--ink-marginal);
+    letter-spacing:.04em;
+  }
+
+  /* -------------------------------------------------------------- */
+  /* The new hand (Twenty-Fourth)                                    */
+  /* -------------------------------------------------------------- */
+
+  .new-hand{
+    font-family:"Caveat", cursive;
+    font-size:22px;
+    line-height:1.55;
+    color:var(--ink-new);
+    /* harder press — slight blur of wet ink */
+    text-shadow:0 0 .6px rgba(0,0,0,.55);
+    margin-top:.2rem;
+    /* the nib bites harder; very slight rotation per paragraph */
+  }
+  .new-hand p{
+    margin:0 0 .9rem;
+  }
+  .new-hand p:nth-child(odd){ transform:rotate(-.15deg); }
+  .new-hand p:nth-child(even){ transform:rotate(.12deg); }
+  .new-hand em{
+    font-style:italic;
+    color:var(--ink-new);
+    font-weight:500;
+  }
+  /* the repeated mantra at the end — visibly sinking, the ink pooling */
+  .mantra{
+    display:block;
+    font-size:24px;
+    line-height:1.45;
+  }
+  .mantra .l1{ opacity:.95; }
+  .mantra .l2{ opacity:1; transform:translateX(.3em); display:inline-block; }
+  .mantra .l3{ opacity:1; transform:translateX(.7em); display:inline-block; font-weight:500; }
+
+  /* -------------------------------------------------------------- */
+  /* Marginalia — a small bracketed note out in the right margin    */
+  /* -------------------------------------------------------------- */
+
+  .margin-note{
+    position:absolute;
+    right:1.4rem;
+    width:3.6rem;
+    font-family:"Caveat", cursive;
+    font-size:15px;
+    color:var(--ink-new);
+    line-height:1.2;
+    transform:rotate(2deg);
+    opacity:.88;
+  }
+  .margin-note.one{ top:46%; }
+  .margin-note.two{ top:71%; }
+
+  /* Tiny season-glyph in the bottom right — corresponds to "autumn" */
+  .season{
+    position:absolute;
+    right:2.2rem; bottom:2.4rem;
+    width:38px; height:38px;
+    opacity:.55;
+  }
+
+  /* Inkblot under the mantra — wet-pressed pen */
+  .inkblot{
+    position:absolute;
+    width:9px; height:6px;
+    background:radial-gradient(ellipse, rgba(0,0,0,.85), rgba(0,0,0,.15) 70%, transparent);
+    border-radius:50%;
+    transform:rotate(28deg);
+  }
+
+  /* -------------------------------------------------------------- */
+  /* Small screens — keep it readable, lose some of the spread       */
+  /* -------------------------------------------------------------- */
+  @media (max-width: 720px){
+    body{ padding:3vh .7rem 5vh; }
+    .leaf{ padding:3rem 1.6rem 3rem 4rem; transform:none; }
+    .leaf::after{ left:2.6rem; }
+    .tally{ left:.9rem; top:3rem; bottom:3rem; }
+    .old-hand{ font-size:16px; line-height:1.75; }
+    .new-hand{ font-size:20px; }
+    .funeral{ margin:1.6rem 0; }
+    .margin-note{ display:none; }
+  }
+
+  /* Page-load: ink ever so slightly fades in, like settling on the table */
+  @keyframes settle {
+    from { opacity:0; transform:rotate(-.35deg) translateY(8px); }
+    to   { opacity:1; transform:rotate(-.35deg) translateY(0); }
+  }
+  .leaf{ animation:settle 1.6s ease-out both; }
+
+</style>
+</head>
+<body>
+
+  <article class="leaf" role="article" aria-label="The Book of Ancient Wisdom, leaf of House Slate">
+
+    <!-- ============================================================
+         SIGNATURE DETAIL: the gutter tally column.
+         Twenty-Third's strokes are faded sepia, organised in fives
+         with horizontal cross-strokes marking winters survived.
+         The Twenty-Fourth's two fresh marks sit beneath, blacker.
+         ============================================================ -->
+    <div class="tally" aria-hidden="true">
+      <svg width="34" height="640" viewBox="0 0 34 640" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <filter id="oldInk" x="-20%" y="-20%" width="140%" height="140%">
+            <feTurbulence baseFrequency="0.9" numOctaves="2" seed="3"/>
+            <feDisplacementMap in="SourceGraphic" scale="0.6"/>
+          </filter>
+        </defs>
+
+        <!-- Twenty-Third's tally: 23 winters, grouped in fives -->
+        <!-- group 1: winters 1-5 -->
+        <g stroke="#5a3d23" stroke-width="1.4" stroke-linecap="round" fill="none" filter="url(#oldInk)" opacity="0.78">
+          <line x1="10" y1="10"  x2="10" y2="34"/>
+          <line x1="14" y1="12"  x2="14" y2="33"/>
+          <line x1="18" y1="11"  x2="18" y2="35"/>
+          <line x1="22" y1="13"  x2="22" y2="34"/>
+          <line x1="6"  y1="24"  x2="26" y2="20"/> <!-- the cross stroke = a winter survived in count of five -->
+        </g>
+        <!-- group 2: 6-10 -->
+        <g stroke="#5a3d23" stroke-width="1.4" stroke-linecap="round" fill="none" filter="url(#oldInk)" opacity="0.74">
+          <line x1="10" y1="56"  x2="10" y2="80"/>
+          <line x1="14" y1="58"  x2="14" y2="79"/>
+          <line x1="18" y1="55"  x2="18" y2="81"/>
+          <line x1="22" y1="57"  x2="22" y2="80"/>
+          <line x1="6"  y1="69"  x2="26" y2="66"/>
+        </g>
+        <!-- group 3: 11-15 -->
+        <g stroke="#5a3d23" stroke-width="1.4" stroke-linecap="round" fill="none" filter="url(#oldInk)" opacity="0.7">
+          <line x1="10" y1="102" x2="10" y2="126"/>
+          <line x1="14" y1="103" x2="14" y2="125"/>
+          <line x1="18" y1="101" x2="18" y2="127"/>
+          <line x1="22" y1="104" x2="22" y2="126"/>
+          <line x1="6"  y1="115" x2="26" y2="112"/>
+        </g>
+        <!-- group 4: 16-20 -->
+        <g stroke="#5a3d23" stroke-width="1.4" stroke-linecap="round" fill="none" filter="url(#oldInk)" opacity="0.66">
+          <line x1="10" y1="148" x2="10" y2="172"/>
+          <line x1="14" y1="150" x2="14" y2="171"/>
+          <line x1="18" y1="149" x2="18" y2="173"/>
+          <line x1="22" y1="148" x2="22" y2="172"/>
+          <line x1="6"  y1="161" x2="26" y2="158"/>
+        </g>
+        <!-- group 5: 21, 22, 23 — incomplete -->
+        <g stroke="#5a3d23" stroke-width="1.4" stroke-linecap="round" fill="none" filter="url(#oldInk)" opacity="0.62">
+          <line x1="10" y1="194" x2="10" y2="218"/>
+          <line x1="14" y1="196" x2="14" y2="217"/>
+          <line x1="18" y1="195" x2="18" y2="219"/>
+          <!-- no fourth, no fifth, no cross stroke. He stopped mid-group. -->
+        </g>
+
+        <!-- A small horizontal divider — succession -->
+        <line x1="2" y1="252" x2="30" y2="252" stroke="#3a2410" stroke-width="0.8" opacity="0.45"/>
+        <text x="16" y="248" text-anchor="middle"
+              font-family="IM Fell English SC, serif" font-size="6"
+              fill="#3a2410" opacity="0.7" letter-spacing="1">XXIV</text>
+
+        <!-- Twenty-Fourth's fresh marks — two strokes, blacker, slightly trembling -->
+        <g stroke="#0c0a08" stroke-width="1.7" stroke-linecap="round" fill="none">
+          <line x1="11" y1="262" x2="11" y2="288"/>
+          <line x1="16" y1="264" x2="15" y2="289"/>
+        </g>
+      </svg>
+    </div>
+
+    <!-- ============================================================
+         Folio mark — top of the leaf
+         ============================================================ -->
+    <header class="folio-mark">
+      <span class="left">House Slate &nbsp;·&nbsp; the codex passed</span>
+      <span class="right">folio xc &nbsp; recto</span>
+    </header>
+
+    <!-- ============================================================
+         Stage 1 — the old hand
+         ============================================================ -->
+    <p class="stage">In the old hand, much faded, the ink browned where a thumb has rested too often:</p>
+
+    <div class="old-hand">
+      <p>The first winter I lost six. The second, two. The third, none. Write that down for whoever wakes next — the arithmetic of it, not the grief. Grief does not stack in the storehouse.</p>
+
+      <p>Wood before iron. Always. Iron is a question you ask in spring; wood is the answer winter already wrote. A wall at level two is not a wall, it is a coffin with a view. Three, or do not bother.</p>
+
+      <p>The market at Unicorn Town will tell you what it wants, never what you need. Sell fish on the third day after a raid, when the Cobalt House panics and overbuys. Buy wheat when nobody is dying — that is the only time it is cheap.</p>
+
+      <p>Verdant once kept a promise. Once. Crimson will not whisper unless they need something; when they do, the price is always paid by us. Ember is honest, which makes them dangerous in a different way — they will tell you they are coming.</p>
+
+      <p>The first whisper is bait. The second is the trade. Wait for the second.</p>
+
+      <p>Bandits come from the west ridge in pairs, from the south in fours. Pairs you fight. Fours you feed — one sack of wheat at the treeline is cheaper than four funerals. Pride is a tax the Book has been paying for <span class="strike">seven</span> ninety winters. Stop paying it.</p>
+    </div>
+
+    <!-- ============================================================
+         Stage 2 — the succession (where the pen breaks off)
+         ============================================================ -->
+    <p class="stage">Here the old hand stops mid-stroke. A fresh nib begins below, blacker, the letters rounder, less sure:</p>
+
+    <div class="succession">
+      <span class="here-ends">Here ends the Twenty-Third Elder of House Slate.</span>
+
+      <!-- A small ink mark — not an ornament. The place where the pen lifted. -->
+      <svg width="44" height="14" viewBox="0 0 44 14" aria-hidden="true">
+        <path d="M2 7 Q 14 2, 22 7 T 42 7" stroke="#3a2410" stroke-width="0.8" fill="none" stroke-linecap="round" opacity="0.55"/>
+        <circle cx="22" cy="7" r="1.6" fill="#0c0a08" opacity="0.9"/>
+      </svg>
+
+      <span class="first-words">The Twenty-Fourth wakes,<br/>and reads, and is afraid.</span>
+    </div>
+
+    <!-- ============================================================
+         Stage 3 — the Funeral Line for Pell of the Long Reach
+         ============================================================ -->
+    <p class="stage">A short entry, set apart, in the careful hand reserved for the dead:</p>
+
+    <figure class="funeral">
+      <span class="name">Pell of the Long Reach</span>
+      <p class="epitaph">
+        Drowned at the weir hauling the second net, the one we did not need.<br/>
+        He was the one who laughed when the rope sang.<br/>
+        The weir is quieter now.<br/>
+        <em>Let no one fish alone on a grey morning.</em>
+      </p>
+      <span class="signature">— Twenty&#8209;Third</span>
+    </figure>
+
+    <!-- ============================================================
+         Stage 4 — the new hand, pressing harder than it needs to
+         ============================================================ -->
+    <p class="stage">Fresh ink, the new hand again, pressing harder than it needs to:</p>
+
+    <div class="new-hand">
+      <p>I have read you three times this morning. I do not know your face. I know your hand — the way your <em>w</em> leans, the way you crossed out <em>seven</em> and wrote <em>six</em>, as if the seventh was not yours to count.</p>
+
+      <p>I will keep your wood-before-iron. I will keep your second whisper.</p>
+
+      <p>I will not feed the bandits. Forgive me. I read your line about pride and I think it was <em>you</em> who was tired, not the rule that was true. We are at six clansmen. We cannot afford a sack we did not lose to a blade. If I am wrong, the Twenty-Fifth will cross me out the way you crossed out <em>seven</em>, and I will deserve it.</p>
+
+      <p>It is the second week of autumn. Aurum has gone quiet, which I am told is the sound they make before they move.</p>
+
+      <p class="mantra">
+        <span class="l1">I am laying in wood.</span><br/>
+        <span class="l2">I am laying in wood.</span><br/>
+        <span class="l3">I am laying in wood.</span>
+      </p>
+
+      <p>Pell, I did not know you. The weir was quieter this morning. I think I heard what you meant.</p>
+    </div>
+
+    <!-- Two small marginalia in the new hand, scribbled out in the right margin -->
+    <div class="margin-note one" aria-hidden="true">wood<br/>before<br/>iron</div>
+    <div class="margin-note two" aria-hidden="true">2nd<br/>whisper</div>
+
+    <!-- A tiny season-glyph: autumn — three falling marks -->
+    <svg class="season" viewBox="0 0 40 40" aria-hidden="true">
+      <g stroke="#3a2410" fill="none" stroke-width="0.9" stroke-linecap="round">
+        <path d="M8 4 Q 12 14, 8 26"/>
+        <path d="M20 8 Q 24 20, 20 32"/>
+        <path d="M32 6 Q 36 18, 32 30"/>
+        <circle cx="8" cy="32" r="1.2" fill="#3a2410"/>
+        <circle cx="20" cy="36" r="1.2" fill="#3a2410"/>
+        <circle cx="32" cy="34" r="1.2" fill="#3a2410"/>
+      </g>
+      <text x="20" y="40" text-anchor="middle" font-family="IM Fell English SC, serif" font-size="4" fill="#3a2410" letter-spacing="1">AUTUMN · WK II</text>
+    </svg>
+
+  </article>
+
+</body>
+</html>

--- a/docs/lore/book-of-ancient-wisdom-v3.html
+++ b/docs/lore/book-of-ancient-wisdom-v3.html
@@ -1,0 +1,557 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>The Book of Ancient Wisdom — House Slate, Eleventh & Twelfth Elders</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&family=IM+Fell+English+SC&family=Cinzel:wght@500;600&family=Caveat:wght@400;500;600;700&family=Reenie+Beanie&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --vellum-1: #efe4c8;
+    --vellum-2: #e6d6b1;
+    --vellum-3: #d8c391;
+    --vellum-shadow: #8a6b3a;
+    --ink: #3b2412;          /* iron-gall walnut, schooled */
+    --ink-faded: #6b4a2a;
+    --ink-rule: #7a5a36;
+    --panic-ink: #1b2747;     /* dark, hurried blue-black */
+    --panic-ink-2: #2a1a14;   /* almost burnt */
+    --rubric: #8a1a14;        /* rubricator's red */
+  }
+
+  html,body{margin:0;padding:0;background:#241a10;}
+  body{
+    min-height:100vh;
+    background:
+      radial-gradient(ellipse at 50% 40%, #3a2a18 0%, #1c130a 70%, #0c0805 100%);
+    padding: 40px 0 80px;
+    font-family: 'IM Fell English', serif;
+    color: var(--ink);
+  }
+
+  /* ---------- The codex page ---------- */
+  .page-wrap{
+    position:relative;
+    width: min(880px, 94vw);
+    margin: 0 auto;
+    perspective: 1800px;
+  }
+
+  .page{
+    position:relative;
+    padding: 78px 84px 110px;
+    background:
+      /* upper light from a candle */
+      radial-gradient(ellipse 70% 50% at 30% 0%, rgba(255,230,170,.35), transparent 60%),
+      /* worn corners */
+      radial-gradient(circle at 0% 0%, rgba(120,80,30,.45), transparent 22%),
+      radial-gradient(circle at 100% 0%, rgba(120,80,30,.45), transparent 22%),
+      radial-gradient(circle at 0% 100%, rgba(110,70,25,.55), transparent 28%),
+      radial-gradient(circle at 100% 100%, rgba(110,70,25,.55), transparent 28%),
+      /* foxing spots */
+      radial-gradient(circle at 22% 18%, rgba(140,90,35,.18), transparent 4%),
+      radial-gradient(circle at 78% 32%, rgba(150,95,40,.16), transparent 3%),
+      radial-gradient(circle at 12% 62%, rgba(150,95,40,.14), transparent 3.5%),
+      radial-gradient(circle at 88% 78%, rgba(130,80,30,.18), transparent 4%),
+      /* fiber */
+      repeating-linear-gradient(92deg, rgba(120,80,30,.05) 0 1px, transparent 1px 3px),
+      repeating-linear-gradient(178deg, rgba(120,80,30,.04) 0 1px, transparent 1px 4px),
+      linear-gradient(180deg, var(--vellum-1) 0%, var(--vellum-2) 55%, var(--vellum-3) 100%);
+    box-shadow:
+      0 2px 0 rgba(255,235,180,.4) inset,
+      0 -2px 0 rgba(100,60,20,.35) inset,
+      0 40px 60px -20px rgba(0,0,0,.7),
+      0 80px 120px -30px rgba(0,0,0,.5);
+    border-radius: 4px 6px 5px 4px / 6px 4px 6px 5px;
+  }
+
+  /* grain overlay using SVG noise */
+  .page::before{
+    content:"";
+    position:absolute; inset:0;
+    pointer-events:none;
+    border-radius:inherit;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' seed='7'/><feColorMatrix values='0 0 0 0 0.35  0 0 0 0 0.22  0 0 0 0 0.08  0 0 0 0.18 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+    mix-blend-mode: multiply;
+    opacity:.55;
+  }
+
+  /* deckled / torn edge */
+  .page::after{
+    content:"";
+    position:absolute; inset:-1px;
+    pointer-events:none;
+    border-radius:inherit;
+    box-shadow:
+      inset 0 0 1px rgba(60,30,10,.5),
+      inset 0 0 30px rgba(90,55,20,.35),
+      inset 0 0 120px rgba(70,40,15,.25);
+  }
+
+  /* ---------- Header strip ---------- */
+  .colophon{
+    display:flex; justify-content:space-between; align-items:center;
+    font-family:'IM Fell English SC', serif;
+    font-size: 11px; letter-spacing:.22em;
+    color: var(--ink-faded);
+    border-bottom: 1px solid rgba(110,70,30,.35);
+    padding-bottom: 10px; margin-bottom: 28px;
+    position:relative; z-index:2;
+  }
+  .colophon .house{ color: var(--rubric); letter-spacing:.32em; }
+
+  /* ---------- Schooled hand ---------- */
+  .schooled{
+    position:relative; z-index:2;
+    font-family:'IM Fell English', serif;
+    font-size: 18.5px;
+    line-height: 1.78;
+    color: var(--ink);
+    text-align: justify;
+    text-rendering: optimizeLegibility;
+  }
+  .schooled p{ margin: 0 0 1.05em; }
+
+  .stage{
+    display:block;
+    font-style: italic;
+    color: var(--ink-faded);
+    font-size: 14.5px;
+    letter-spacing:.01em;
+    margin: 6px 0 14px;
+    text-align: left;
+  }
+  .stage::before{ content:"⁂  "; color: var(--ink-rule); font-style:normal; }
+
+  /* catechism clauses */
+  .catechism{ margin: 4px 0 18px; }
+  .clause{
+    display:grid;
+    grid-template-columns: 56px 1fr;
+    column-gap: 14px;
+    margin: 0 0 14px;
+    padding-left: 6px;
+  }
+  .clause .num{
+    font-family:'Cinzel', serif;
+    font-weight:600;
+    color: var(--rubric);
+    font-size: 15px;
+    letter-spacing:.12em;
+    padding-top: 6px;
+    text-align: right;
+    border-right: 1px solid rgba(110,70,30,.25);
+    padding-right: 8px;
+  }
+  .clause .body strong:first-child{
+    font-family:'IM Fell English SC', serif;
+    letter-spacing:.07em;
+    color: var(--ink);
+    font-weight: normal;
+    margin-right: .35em;
+  }
+
+  /* The First Rule — meta-warning, centered, ruled */
+  .first-rule{
+    margin: 34px auto 30px;
+    max-width: 560px;
+    text-align: center;
+    padding: 22px 18px;
+    position:relative;
+    color: var(--ink);
+  }
+  .first-rule .label{
+    display:block;
+    font-family:'IM Fell English SC', serif;
+    letter-spacing:.42em;
+    font-size: 13px;
+    color: var(--rubric);
+    margin-bottom: 14px;
+  }
+  .first-rule .rule-text{
+    font-family:'IM Fell English', serif;
+    font-style: italic;
+    font-size: 22px;
+    line-height: 1.4;
+    color: var(--ink);
+  }
+  .first-rule .orn{
+    display:flex; align-items:center; justify-content:center; gap:10px;
+    color: var(--ink-rule);
+    margin: 14px 0 4px;
+  }
+  .first-rule hr{
+    border:0; height:1px;
+    background:linear-gradient(90deg, transparent, rgba(110,70,30,.55), transparent);
+    margin: 0;
+  }
+
+  .incident{
+    margin: 22px 0 12px;
+    padding-left: 18px;
+    border-left: 2px solid rgba(110,70,30,.4);
+    font-style: italic;
+    color: var(--ink);
+    font-size: 17px;
+  }
+
+  /* ---------- Death transition ---------- */
+  .transition{
+    margin: 40px 0 28px;
+    text-align:center;
+    color: var(--ink-rule);
+    font-family:'IM Fell English SC', serif;
+    letter-spacing:.28em;
+    font-size: 12.5px;
+  }
+  .transition .flourish-line{
+    display:flex; align-items:center; justify-content:center; gap:18px;
+    margin-bottom: 14px;
+  }
+  .transition .flourish-line .ln{
+    flex:1; height:1px;
+    background:linear-gradient(90deg, transparent, rgba(110,70,30,.55), transparent);
+  }
+  .transition .stop{ color: var(--ink); }
+
+  /* Funeral line — inscriptional */
+  .funeral{
+    margin: 30px auto 38px;
+    max-width: 620px;
+    text-align:center;
+    padding: 26px 16px 24px;
+    border-top: 2px double rgba(110,70,30,.55);
+    border-bottom: 2px double rgba(110,70,30,.55);
+    background:
+      radial-gradient(ellipse at 50% 50%, rgba(255,240,200,.35), transparent 70%);
+  }
+  .funeral .name{
+    display:block;
+    font-family:'Cinzel', serif;
+    font-weight:600;
+    letter-spacing:.38em;
+    font-size: 19px;
+    color: var(--ink);
+    margin-bottom: 14px;
+    text-indent:.38em;
+  }
+  .funeral .body{
+    font-family:'IM Fell English', serif;
+    font-style: italic;
+    font-size: 16px;
+    color: var(--ink);
+    line-height: 1.6;
+  }
+
+  /* ---------- Panicked hand ---------- */
+  .panicked{
+    position:relative; z-index:2;
+    margin-top: 22px;
+    padding-top: 24px;
+    /* the page itself tilts under the new Elder */
+    transform: rotate(-0.6deg);
+    transform-origin: 10% 0%;
+  }
+  .panicked .stage{
+    color: #4a3522;
+    font-family:'Caveat', cursive;
+    font-style: normal;
+    font-size: 17px;
+    letter-spacing:0;
+    margin-bottom: 18px;
+  }
+  .panicked .stage::before{ content:"— "; color: var(--panic-ink); }
+
+  .hand{
+    font-family:'Caveat', cursive;
+    font-weight: 500;
+    font-size: 26px;
+    line-height: 1.35;
+    color: var(--panic-ink);
+    /* slight unevenness via letter-spacing wobble done per-line below */
+  }
+  .hand p{ margin: 0 0 .55em; }
+
+  /* per-line tilt + slight color variation for tired ink */
+  .hand p:nth-child(1){ transform: rotate(-.3deg); }
+  .hand p:nth-child(2){ transform: rotate(.5deg); color:#1a2340; }
+  .hand p:nth-child(3){ transform: rotate(-.2deg); font-weight:600; color: #20140c; font-size: 28px;}
+  .hand p:nth-child(4){ transform: rotate(.8deg) translateX(6px); }
+  .hand p:nth-child(5){ transform: rotate(-.4deg); }
+  .hand p:nth-child(6){ transform: rotate(.6deg); }
+  .hand p:nth-child(7){ transform: rotate(-.7deg); color:#0f1730; font-weight:600;}
+  .hand p:nth-child(8){ transform: rotate(.4deg); }
+
+  /* "I have called all four home" — switch to a second handwriting face for the most-broken bit */
+  .hand .scrawl{
+    font-family:'Reenie Beanie', cursive;
+    font-size: 25px;
+    color:#101a36;
+    line-height:1.5;
+    letter-spacing:.01em;
+  }
+
+  /* the rule-II breach line — links upward */
+  .breach{
+    position:relative;
+    display:inline;
+    background: linear-gradient(transparent 78%, rgba(138,26,20,.25) 78% 92%, transparent 92%);
+  }
+  .margin-arrow{
+    position:absolute;
+    left: -64px; top: 4px;
+    width: 58px; height: 80px;
+    pointer-events:none;
+  }
+
+  /* ink blot + smudge */
+  .blot{
+    position:absolute;
+    width: 56px; height: 44px;
+    right: 80px; pointer-events:none;
+    filter: blur(.3px);
+  }
+  .smudge{
+    position:absolute;
+    width: 180px; height: 28px;
+    pointer-events:none;
+    background:
+      radial-gradient(ellipse 80% 50% at 50% 50%, rgba(27,39,71,.35), transparent 70%);
+    transform: rotate(-2deg);
+    mix-blend-mode: multiply;
+  }
+
+  /* repeated "winter" emphasis */
+  .winter-emph{
+    font-family:'Caveat', cursive;
+    font-weight:700;
+    color: var(--panic-ink-2);
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-decoration-color: rgba(138,26,20,.6);
+    text-underline-offset: 2px;
+  }
+
+  /* address to Eleventh — sudden quiet */
+  .to-eleventh{
+    margin-top: 14px;
+    padding: 10px 0 0;
+    border-top: 1px dashed rgba(40,30,20,.35);
+    font-family:'Caveat', cursive;
+    font-size: 22px;
+    color:#1a1d2e;
+    line-height:1.5;
+    transform: rotate(-.2deg);
+  }
+  .to-eleventh em{ font-style:italic; color:#5a1a14; }
+
+  /* underline below the panicked closing */
+  .signoff{
+    margin-top: 18px;
+    text-align:right;
+    font-family:'Caveat', cursive;
+    font-size: 22px;
+    color: var(--panic-ink);
+    transform: rotate(-1deg);
+  }
+
+  /* small marginalia */
+  .marginalia{
+    position:absolute;
+    font-family:'Caveat', cursive;
+    color: #4a3522;
+    font-size: 16px;
+    transform: rotate(-7deg);
+    opacity:.85;
+    pointer-events:none;
+  }
+
+  @media (max-width: 720px){
+    .page{ padding: 50px 32px 80px; }
+    .schooled{ font-size: 17px; }
+    .hand{ font-size: 23px; }
+    .clause{ grid-template-columns: 40px 1fr; }
+    .first-rule .rule-text{ font-size: 19px; }
+  }
+</style>
+</head>
+<body>
+
+<div class="page-wrap">
+  <article class="page" role="article" aria-label="Book of Ancient Wisdom, page of House Slate">
+
+    <header class="colophon">
+      <span>The Book of Ancient Wisdom</span>
+      <span class="house">House&nbsp;Slate</span>
+      <span>fol.&nbsp;cxiv&nbsp;·&nbsp;recto</span>
+    </header>
+
+    <!-- ============ ELEVENTH ELDER — SCHOOLED HAND ============ -->
+    <section class="schooled" aria-label="The Eleventh Elder">
+
+      <span class="stage">In a careful hand, the lettering even and schooled.</span>
+
+      <div class="catechism" role="list">
+
+        <div class="clause" role="listitem">
+          <div class="num">I.</div>
+          <div class="body">
+            <strong>Of the calendar.</strong>
+            The bell rings three hundred and sixty times before a season ends. Winter falls every hundred and ten of those bells. There are three winters. Plan to the bell, not to the day.
+          </div>
+        </div>
+
+        <div class="clause" role="listitem">
+          <div class="num">II.</div>
+          <div class="body">
+            <strong>Of the four trades.</strong>
+            A clansman knows one thing and does it well. Do not send the wheat-hand to the docks. The vault remembers who you trained.
+          </div>
+        </div>
+
+        <div class="clause" role="listitem">
+          <div class="num">III.</div>
+          <div class="body">
+            <strong>Of patience.</strong>
+            A clansman returning empty from a four-tick gather has returned with nothing. Better to wait at the field until the basket is full than to recall them at the third tick out of panic.
+          </div>
+        </div>
+
+        <div class="clause" role="listitem">
+          <div class="num">IV.</div>
+          <div class="body">
+            <strong>Of trust.</strong>
+            A whisper costs the sender. Whoever speaks first, pays. Believe that the second whisper is the honest one — but only this one season.
+          </div>
+        </div>
+
+        <div class="clause" role="listitem">
+          <div class="num">V.</div>
+          <div class="body">
+            <strong>Of the eight Houses.</strong>
+            Crimson sleeps with their walls. Cobalt sleeps with their coin. Aurum does not sleep. Verdant grows where you look away. Violet asks before it takes; Ember takes before it asks. Pale you will not see in your lifetime. Slate is what we are, and so we are slowest.
+          </div>
+        </div>
+
+      </div>
+
+      <span class="stage">Set apart, in the same careful hand, ringed by a small rule.</span>
+
+      <aside class="first-rule">
+        <hr/>
+        <div class="orn" aria-hidden="true">
+          <!-- ornament -->
+          <svg width="160" height="20" viewBox="0 0 160 20" fill="none">
+            <path d="M0 10 H55" stroke="currentColor" stroke-width="1"/>
+            <path d="M105 10 H160" stroke="currentColor" stroke-width="1"/>
+            <path d="M70 10 q5 -7 10 0 q5 7 10 0" stroke="currentColor" stroke-width="1.1" fill="none"/>
+            <circle cx="80" cy="10" r="1.6" fill="currentColor"/>
+            <circle cx="60" cy="10" r="1.2" fill="currentColor"/>
+            <circle cx="100" cy="10" r="1.2" fill="currentColor"/>
+          </svg>
+        </div>
+        <span class="label">The First Rule of the Book</span>
+        <div class="rule-text">“Believe the Book only as far as your own eyes have walked.”</div>
+        <div class="orn" aria-hidden="true">
+          <svg width="160" height="20" viewBox="0 0 160 20" fill="none">
+            <path d="M0 10 H55" stroke="currentColor" stroke-width="1"/>
+            <path d="M105 10 H160" stroke="currentColor" stroke-width="1"/>
+            <path d="M70 10 q5 7 10 0 q5 -7 10 0" stroke="currentColor" stroke-width="1.1" fill="none"/>
+            <circle cx="80" cy="10" r="1.6" fill="currentColor"/>
+          </svg>
+        </div>
+        <hr/>
+      </aside>
+
+      <span class="stage">An incident, recorded plainly.</span>
+
+      <p class="incident">
+        Tick 218, the second winter. Iren-of-the-quiet-step asked to take a third trip to the woodcut. I sent him. He did not return. Twenty wood lost. One Iren lost.
+      </p>
+
+    </section>
+
+    <!-- ============ DEATH TRANSITION ============ -->
+    <div class="transition" aria-hidden="true">
+      <div class="flourish-line">
+        <span class="ln"></span>
+        <svg width="48" height="22" viewBox="0 0 48 22" fill="none" aria-hidden="true">
+          <path d="M2 11 q10 -10 22 0 q10 10 22 0" stroke="currentColor" stroke-width="1.2" fill="none"/>
+          <circle cx="24" cy="11" r="2" fill="currentColor"/>
+        </svg>
+        <span class="ln"></span>
+      </div>
+      <span class="stop">Here endeth the Eleventh Elder of House Slate, in the winter of the third season. &nbsp;·&nbsp; The Twelfth wakes and findeth the Book.</span>
+    </div>
+
+    <!-- ============ FUNERAL LINE ============ -->
+    <div class="funeral" role="note" aria-label="Funeral line">
+      <span class="name">Iren&nbsp;·&nbsp;of&nbsp;the&nbsp;Quiet&nbsp;Step</span>
+      <div class="body">
+        Lost on the third trip to the woodcut, tick 218, the second winter of his Elder's reign.<br/>
+        He went because he was asked.<br/>
+        <strong style="font-style:normal; font-family:'IM Fell English SC', serif; letter-spacing:.18em;">Let it be known he did not refuse.</strong>
+      </div>
+    </div>
+
+    <!-- ============ TWELFTH ELDER — PANICKED HAND ============ -->
+    <section class="panicked" aria-label="The Twelfth Elder">
+
+      <!-- a stray smudge near the start -->
+      <div class="smudge" style="left: 40px; top: 6px; width:220px;"></div>
+
+      <span class="stage">Fresh ink, hurried, the letters running together.</span>
+
+      <div class="hand" style="position:relative;">
+
+        <!-- INK BLOT near top right -->
+        <svg class="blot" style="top:-6px; right:40px;" viewBox="0 0 80 60" aria-hidden="true">
+          <g fill="#0e1730">
+            <ellipse cx="40" cy="28" rx="22" ry="14"/>
+            <ellipse cx="58" cy="34" rx="6" ry="3" opacity=".7"/>
+            <circle cx="22" cy="40" r="3" opacity=".6"/>
+            <circle cx="66" cy="20" r="2" opacity=".7"/>
+            <ellipse cx="40" cy="48" rx="10" ry="2" opacity=".4"/>
+          </g>
+        </svg>
+
+        <p>I have read the Book and the Book is wrong in places. I do not have time to mark them all.</p>
+
+        <p>The Eleventh said three winters and meant three winters. The bell shows tick&nbsp;412 and we are in the <span class="winter-emph">fourth</span>. Either she could not count or the world has changed beneath the page.</p>
+
+        <p>Verdant has burned. I do not know who lit it.</p>
+
+        <p style="position:relative;">
+          <!-- arrow pointing UP to Rule II in the margin -->
+          <svg class="margin-arrow" viewBox="0 0 58 80" aria-hidden="true">
+            <path d="M48 78 C 30 60, 18 38, 14 8" stroke="#5a1a14" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+            <path d="M14 8 l 6 8 M14 8 l -3 9" stroke="#5a1a14" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+            <text x="22" y="50" font-family="Caveat, cursive" font-size="14" fill="#5a1a14" transform="rotate(-12 22 50)">Rule&nbsp;II</text>
+          </svg>
+          I have called all four home. I have <span class="scrawl">one wall, half a fish, no whispers I would believe.</span> I am going to <span class="breach">break Rule&nbsp;II</span> — Olen will fish today, though Olen has never fished. There is no one else.
+        </p>
+
+        <p>If the Thirteenth reads this: forgive me. There was a <span class="winter-emph">fourth winter</span>. There may be a <span class="winter-emph">fifth</span>.</p>
+
+      </div>
+
+      <!-- quiet address to the dead Eleventh -->
+      <div class="to-eleventh">
+        Eleventh, if any part of you survives in this Book —<br/>
+        Iren went because <em>he</em> asked, not because <em>you</em> asked. He told me so the night before. He thought the Book would remember him better if he tried once more. Let him be remembered for asking, not for being sent.
+      </div>
+
+      <div class="signoff">— the Twelfth, of House Slate, by candle, tick&nbsp;413</div>
+
+      <!-- marginalia, hurried, off-axis -->
+      <span class="marginalia" style="right: 12px; top: 110px;">who lit Verdant?</span>
+      <span class="marginalia" style="left: -28px; bottom: 80px; transform: rotate(-86deg);">do not trust whispers tonight</span>
+
+    </section>
+
+  </article>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## What

Bootstraps `/docs` as a GitHub Pages static site published at **docs.clan-world.com**.

## Why

Liam asked to set up a docs subdomain so the lore artifacts (and eventually the World Physics doc + rendered design pages) live at a stable URL. Public repo means free Pages hosting.

## What's in

- `docs/.nojekyll` — disable Jekyll, serve raw HTML
- `docs/CNAME` — `docs.clan-world.com`
- `docs/index.html` — parchment-themed landing page linking the lore + physics
- `docs/lore/book-of-ancient-wisdom-v{1,2,3}.html` — three independent designer renderings of one Book of Ancient Wisdom sample page (drafted during the 2026-05-29 lore brainstorming session)

## Follow-up after merge

1. Enable Pages on the repo via API (source: `dev` / `/docs`, enforce HTTPS).
2. Add Cloudflare DNS: `docs.clan-world.com` CNAME → `clan-world.github.io`, proxy OFF so the GH Pages cert provisions cleanly.

## Notes

- No code changes. Pure static assets + a landing HTML.
- The three Book sample pages are NOT canonical lore — they're sample artifacts for taste-testing voices and visual aesthetics. They will be replaced/curated before this becomes the public-facing lore reference.
- Liam's in-session edits to `docs/WORLD_PHYSICS.md` (the new §15 + §16 sections from the lore brainstorm) are on `feat/elder-mcp-migration` and not in this PR — they'll land via that branch's normal merge path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)