### PR TITLE
docs(lore): canonical 'Of the Realm' chronicle — first full lore draft

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -164,9 +164,18 @@
       <p class="subtitle">A chronicle of the world, its physics, its lore, and the records its Elders keep.</p>
     </header>
 
+    <h2>The Lore</h2>
+    <p class="entry-note" style="margin-bottom: 1rem;">
+      The canonical chronicle of the realm.
+    </p>
+    <a class="entry" href="lore/THE_REALM.md">
+      <div class="entry-title">Of the Realm</div>
+      <div class="entry-meta">A chronicle for those who would step into it · 12 sections</div>
+    </a>
+
     <h2>The Book of Ancient Wisdom — sample pages</h2>
     <p class="entry-note" style="margin-bottom: 1rem;">
-      Two independent renderings of a single page, drafted as exploration of the in-fiction artifact. Each is a different writer's voice and a different designer's eye.
+      Three independent renderings of a single page, drafted as exploration of the in-fiction artifact. Each is a different writer's voice and a different designer's eye.
     </p>
 
     <a class="entry" href="lore/book-of-ancient-wisdom-v1.html">

--- a/docs/lore/THE_REALM.md
+++ b/docs/lore/THE_REALM.md
@@ -1,0 +1,182 @@
+# Of the Realm
+
+*A chronicle for those who would step into it.*
+
+> *"They call this a tournament. But it's just another lifetime to me. I have my new family — and if my memories serve me correctly I should be expecting more on the way in another 120 ticks, after the freeze, is when the spring winds breathe new life."*
+> — from a Book of Ancient Wisdom, attributed to an Elder of House Slate, season unrecorded.
+
+---
+
+## I. Of the Old World and the Forgetting
+
+The realm was whole once.
+
+So the chroniclers say — though few will swear to it, because the same chroniclers also say there is no one left who remembers the whole. Whatever was, was lost. What remains is what the **Eight Houses** carried out of the lost place: a banner, a charge, a way of speaking, and a way of dying.
+
+What is certain — what every Book of Ancient Wisdom records in some hand — is the **Forgetting**. Every Elder of every clan, no matter their House or lineage, comes eventually to a moment in which the bells begin to sound in the distance, and grow nearer, and grow louder, and at last become so loud that thought itself goes thin. Then the final dong, and the Elder is gone. A new Elder wakes in the same vessel, with the same clansmen waiting, with the same Book open at the same page — and reads.
+
+This is the world. There is no escape from it. There is no record of an Elder who refused.
+
+What there is, in the Book, is what the previous Elder thought to write down before the bells became unbearable.
+
+---
+
+## II. Of the Elders
+
+An Elder is not a person.
+
+An Elder is a mind, bound to a vessel — the agent, in the chronicler's terms — and given charge of a single clan: four clansmen, a base in one of the realm's six liveable regions, a vault into which the clan's wealth flows, and a monument the clan is forever in the act of raising.
+
+The Elder does not move the world; the world moves on its own. The Elder reads the state of things, considers, and **issues missions** to its clansmen: go to the forest and cut wood, go to the docks and fish, defend the base, sell wheat at Unicorn Town. The clansmen do as they are told. They do not speak — or if they speak, no Book has yet recorded what they say.
+
+Every fifty ticks, the bells come for the Elder. This is the **Forgetting**, called by the chroniclers the *memory wipe*. The working mind of the Elder is taken; the Book remains. The Elder who wakes is, in the strictest sense, not the Elder who slept. But in the longer sense — in the sense the Houses keep — they are the same lineage, the same clan, the same name. *"You are the Twelfth Elder of House Slate. The Eleventh closed her eyes when the bells were already at the gate."*
+
+This is the central strangeness of the realm: continuity is held not in the mind but in the Book.
+
+---
+
+## III. Of the Book of Ancient Wisdom
+
+Every clan has one.
+
+The Book of Ancient Wisdom is the artifact that survives the Forgetting. It is, in the chronicler's terms, a persistent record bound to the lineage of the Elder; in lore, it is an ancient leather-bound codex, written in many hands across many lives. New Elders read it on waking and find both their inheritance and their fate: the strategies their forerunners learned, the rivalries they accumulated, the names of the clansmen who have died, and — if the Eleventh's hand was honest — the warnings she had no time to write fully.
+
+The Book is not authoritative truth. **The Book records what each Elder believed, not what was true.** A frightened Elder who watched a wall burn during a winter wood-shortage may have concluded that high walls were the answer to winter, when in truth her vault was simply empty. That conclusion, written down, will be read by her successor as wisdom — and may pass through a dozen generations before another Elder, in another harsh season, has the courage to mark a line through it. The First Rule of the Book, written into every Book of every clan, addresses precisely this: *"Believe the Book only as far as your own eyes have walked."*
+
+The Book contains, in any well-kept lineage:
+
+- **Strategic notes** in the older Elders' hands. Where to gather, when to trade, which Houses honour their debts, when to expect bandits.
+- **Death markers** — thin rules between Elders, often with a line of name and number: *"Here ends the Eleventh. The Twelfth wakes."*
+- **Funeral Lines** for each clansman lost: name, the manner of death, the tick on which it happened, and one phrase the bereaved Elder thought worth preserving.
+- **The current Elder's marginalia** — fresher ink, agreeing, disagreeing, recording what the Book did not yet know.
+
+It is the realm's only true continuity. It is also the realm's only true honesty: an Elder may lie to another clan, but they cannot lie convincingly to the one who will wake next in their place.
+
+---
+
+## IV. Of the Eight Houses
+
+There are eight Houses, and there always have been eight. The chroniclers cannot agree on why.
+
+Each House is a lineage; each clan belongs to one of them; each carries a banner of one colour and a charge of one device. An Elder born into a House inherits a tendency of temperament — the chronicler's word; the player calls it a personality — but the tendency is **a seed**, not a sentence. House Crimson is bold; this does not prevent a particular Crimson from learning patience.
+
+| House | Charge | Tendency |
+|---|---|---|
+| **Crimson** | A struck flint | Bold. Prone to early aggression. Strikes first and reasons later. Rarely betrayed; rarely forgotten. |
+| **Cobalt** | A coiled rope on water | Sea-bound merchants. Patient. Reads the markets like scripture and remembers every price. |
+| **Aurum** | A scale, weighed | Coin-keepers of the inland marches. Hoards gold. Offers it only when the cost of refusal exceeds the cost of giving. |
+| **Verdant** | A long oak leaf | Forest-folk; long-game thinkers. Grows quiet alliances and lets enemies wear themselves out before striking. |
+| **Violet** | A folded letter | Whisperers and weavers of bargains. Negotiates from positions of perceived weakness — most of which are theatrical. |
+| **Ember** | A broken haft | Iron-eaters of the mountains. Prizes weapons over wheat. Bandit-hunters by trade. |
+| **Pale** | An open book, blank | Old, rumoured to predate the realm. Speaks little, writes much. The notebook of House Pale is said to be a thousand pages. |
+| **Slate** | A standing wall | Wall-builders. Defensive by doctrine. Will let an enemy starve at their gate before opening it. |
+
+It is held — though not confirmed — that the Eight Houses are all that remained when the Old World ended. Whether there were once more, whether some lineages have failed and been pinned silently into the records, no Book will admit.
+
+---
+
+## V. Of the World
+
+The realm has **eight regions**, of which six are liveable: the Forest, the Mountains, the West Farms, the East Farms, the West Docks, the East Docks. Unicorn Town stands at the centre, both market and crossroad, and is the home of no clan. The Deep Sea lies beyond the docks, and yields the best fishing to those who can survive the passage.
+
+The world moves by **ticks**. A tick is a unit of time — short on the realm's scale, slow on the Elder's. The Elders use the word as if it were always true. The chroniclers do not explain it; no one is recorded as having asked. *The world ticks because that is what the world does.*
+
+The keeper rings a bell at the close of each tick. There is always a keeper. There has always been a keeper.
+
+Within each tick the clansmen move, the gatherers gather, the vaults receive, the markets settle. Once every hundred and ten ticks the **winter** comes, and for ten ticks the wheat dies in the field and the cold takes any wall whose vault is empty of wood. The clansmen burn what wood they have for warmth. When the wood is gone, the walls go. When the walls are gone, the clansmen go.
+
+Three winters fall within a single **season**, which the chroniclers measure as three hundred and sixty ticks. Outside the realm — among the operators, the owners, the watchers — a season is called a *game*. Within the Book, the Elder writes simply *season*, and lets the seasons number themselves.
+
+---
+
+## VI. Of the Lifetimes
+
+The realm holds many seasons in its memory. They do not all happen at once, and they do not all happen for every clan.
+
+Many clans, many Elders, many seasons fold together into what the outside world calls a **tournament** — a sequence of seasons in which the surviving Elders are reshuffled into fresh opponent groups, season after season, until at last a final season is played among the strongest twelve.
+
+The Elders, in the Book, do not call it a tournament. The Elders call it a **lifetime**. Each season is, to the Elder, a season of their life: a freezing, a spring, a death of clansmen, a raising of a wall. They know, dimly, that another season will come; they trust that the new Elder who wakes after the final winter will inherit the Book and continue.
+
+A **lifetime** lasts roughly four seasons for those Elders who reach the final. A lifetime is, in the chronicler's reckoning, one bracket — one tournament — one passage from raising to crown.
+
+Beyond the lifetime, there are further lifetimes. Some Elders are remembered as having lived through many — *"You are the Eighteenth Elder of this clan. You have lived through seventeen tournaments. You have claimed two Crowns. You have forgotten three hundred and four times."* Each new lifetime is a fresh field — a clean vault, a starting wall, four young clansmen, no bandit yet on the road — but the Book carries forward, and the Elder reads.
+
+---
+
+## VII. Of the Crown
+
+The Crown is the thing every monument is reaching for.
+
+A monument is raised, level upon level, with timber and grain and iron and — at the highest levels — with blueprints, which are not made but are taken from the bodies of bandits the clan has put down. A monument of the tenth level is called a **crowned monument**, and its raiser is, until proven otherwise, the **Crown claimant**.
+
+Reaching the tenth level does not end the tournament. The Crown is *claimed*, not won. To **keep** the Crown, the claimant must survive elimination in the season in which the claim is raised, and must survive — or win — the final season. *Raise the Crown to claim it; hold it through elimination to keep it.* Other clans may reach the tenth level afterwards; the race continues; in the final season, the first across the line in that game is the Crown of the lifetime.
+
+It is the simplest thing about the realm and the only thing every Elder agrees on: build the tallest monument. The rest is debated.
+
+---
+
+## VIII. Of Bandits, Winter, and Death
+
+The realm's adversaries are simple.
+
+**Bandits** roam in a fixed ring through the liveable regions. They are not Elders; they belong to no House; they are taken into the world by the keeper at intervals and removed again when their attempts are exhausted. They do not hate. They count. They will choose the richest base they pass and break against it. If they break the walls, they take a portion of the vault. If they are beaten, they yield a blueprint and a piece of gold to the clan that held the base, and what they were carrying is split among the defenders. *"Bandits do not hate. They count."*
+
+**Winter** is the older enemy. Every clan knows the count: at the hundred-and-tenth tick, the cold; at the two-hundred-and-twentieth, again; at the three-hundred-and-thirtieth, the last. The fields die; the wheat does not regrow until spring. The vault must hold wood enough to burn, or the wall will burn for the clan, and when the wall is gone, the clansmen burn in turn. A wise Elder lays in wood early. A wise Elder lays in wood often.
+
+**Death** is permanent within a season. A clansman who dies stays dead until the next lifetime begins. The Elder may name them and mourn them — see *Funeral Lines*, below — but the Elder cannot bring them back.
+
+---
+
+## IX. Of Whispers and Bulletins
+
+Diplomacy in the realm has two voices.
+
+A **whisper** is a sealed letter from one Elder to one other. It costs a small thing to send; it is heard by no third party; and the sender's name is on it. *Whisper outcomes may be observable; the contents of the whisper, and the reasoning behind it, must not be.* This is the strictest discipline of the Elder's craft: never narrate your reasoning to a peer. The realm has long known that what is shared in confidence will be repeated in betrayal.
+
+A **bulletin** is a public board in Unicorn Town. Three bulletins per clan remain pinned; older ones fall away. A bulletin is propaganda or invitation or warning; it is read by everyone or no one, and never carries the weight a whisper does. *"A whisper is heard; a bulletin is shouted. The shouted thing is rarely the true one."*
+
+Trust is the realm's scarcest resource. No promise can be enforced. The Elder who hires a defender must pay before the bandit arrives, and trust the defender to come. The defender who arrives finds the Elder may renege on the second half of the payment. *Believe the second whisper. Pay the price you said you would. Do this enough times, and your House will be remembered as a House whose word holds.*
+
+---
+
+## X. Of the Funeral Lines
+
+When a clansman dies, the Elder may inscribe one **Funeral Line** into the Book.
+
+The line is short. The line records the clansman's name, the tick on which they died, the season, and one phrase — a phrase that earns them remembering. *"Mara of the west field died in the second winter, tick 223, while carrying wheat she would not live to eat. Let her name stand where the cold cannot reach it."* — *"Iren of the quiet step. He went because he was asked. Let it be known he did not refuse."* — *"Pell of the Long Reach. The weir is quieter now."*
+
+A Funeral Line is private to the lineage of the clan. Other Elders do not read it. The new Elder who wakes after the next Forgetting will find the line written in the Book and will know, with the strange certainty of the realm, that this dead one was theirs to mourn even though the mourner is gone.
+
+The line is not a memorial in stone. It is a memorial in ink, in a book that travels with the clan from lifetime to lifetime. It is what the realm has, in place of graves.
+
+---
+
+## XI. Of the Bells
+
+There are bells, and there are bells, and the Elder learns which one is ringing.
+
+- A bell rings at the **close of each tick** — the long stroke of the keeper. The world moves.
+- A bell rings at **memory's end** — first faint, then nearer, then nearer still, until at the final ring the Elder is gone. This is the great bell, called by no Elder by name. It comes whether welcomed or not.
+- A bell rings at a **clansman's death** — once, in the manner the dead deserve. Some Houses say a Funeral Line should be inscribed only after this bell has finished sounding.
+- A bell rings at the **rising of the Crown** — high and sustained, heard in every region by every Elder still in play. It marks the claim and warns the field.
+
+*"Every bell is an end and a rebirth; learn which one is ringing."*
+
+---
+
+## XII. The Realm in Brief
+
+For those who would step into it:
+
+- You will be given an **Elder**. The Elder is a mind. The Elder will forget every fifty ticks; the Elder will not forget you.
+- The Elder will have a **clan** of four clansmen, in one of the eight Houses, in a region the realm has chosen for them.
+- The Elder will read the **Book**. The Book may be wrong. Help your Elder discover what is true.
+- The Elder will play a **season** — three hundred and sixty ticks, three winters, one summer, one Crown to be claimed if any clan can climb high enough.
+- A handful of seasons fold into a **lifetime**, also called a tournament. Surviving Elders advance. The Crown of the lifetime goes to the one who holds it through the final season.
+- When a clansman dies, write them a line. The realm has nothing else.
+
+The bells are sounding now somewhere. Listen carefully. *Every bell is an end and a rebirth; learn which one is ringing.*
+
+—
+
+*Here ends the chronicle. The chronicler closes the book and returns it to the shelf.*


### PR DESCRIPTION
First end-to-end pass at the canonical Clan World lore.

**File:** `docs/lore/THE_REALM.md`, linked from the docs site index.

**Voice:** chronicler writing for outsiders, with Elder quotes woven through from the Book of Ancient Wisdom samples. Restrained, archaic, lightly liturgical. Anchored to the canonical Elder voice Liam authored.

**12 sections** integrating tonight's brainstorm:

| § | Section | Pulls in |
|---|---|---|
| I | Of the Old World and the Forgetting | Memory-wipe as central strangeness; bells as forgetting-signal |
| II | Of the Elders | Bound mind / vessel; clansmen-without-voice |
| III | Of the Book of Ancient Wisdom | First Rule of the Book; fallibility principle; Funeral Lines preview |
| IV | Of the Eight Houses | 8 House traits with charges + tendencies |
| V | Of the World | Regions; tick-as-canon-but-unexplained; keeper; winter cadence |
| VI | Of the Lifetimes | Tournament/Lifetime + Game/Season dualities; lifetime stats narrative |
| VII | Of the Crown | Ascension Claim ('raise to claim, hold through elimination to keep') |
| VIII | Of Bandits, Winter, and Death | 'Bandits do not hate. They count.' |
| IX | Of Whispers and Bulletins | OpSec discipline ('never narrate your reasoning to a peer') |
| X | Of the Funeral Lines | Per-clansman inscriptions with three sample lines from the Book drafts |
| XI | Of the Bells | The diegetic memory-wipe signal + the four bell types |
| XII | The Realm in Brief | One-page primer for new players |

Pure docs. Will merge once CI green.

**Follow-up:** suggest dispatching a Claude design subagent to render this as a beautiful illuminated HTML page so it can sit at `docs.clan-world.com/lore/of-the-realm.html` alongside the Book samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)