### PR TITLE
fix(docs): 404 shows CDIV with '404' gloss underneath

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -73,11 +73,20 @@
     .number {
       font-family: 'Cormorant SC', serif;
       font-weight: 500;
-      font-size: 3.2rem;
+      font-size: 3.6rem;
       color: var(--rubric);
-      letter-spacing: 0.04em;
+      letter-spacing: 0.06em;
       line-height: 1;
-      margin: 0.4rem 0 0.8rem;
+      margin: 0.5rem 0 0.2rem;
+      font-feature-settings: "lnum", "tnum";
+    }
+    .number-gloss {
+      font-family: 'IM Fell English SC', serif;
+      font-size: 0.85rem;
+      letter-spacing: 0.28em;
+      color: var(--ink-soft);
+      line-height: 1;
+      margin-bottom: 0.9rem;
       font-feature-settings: "lnum", "tnum";
     }
     h1 {
@@ -172,7 +181,8 @@
     </div>
 
     <div class="eyebrow">✦ &nbsp; A Page Misplaced &nbsp; ✦</div>
-    <div class="number">IV · 0 · IV</div>
+    <div class="number">CDIV</div>
+    <div class="number-gloss">404</div>
     <h1>This page is not in the Book.</h1>
 
     <p class="prose">


### PR DESCRIPTION
Per Liam 2026-05-30. Previous IV·0·IV transliteration wasn't valid Roman numerals (no 0). CDIV (CD + IV = 400 + 4) is the actual Roman numeral for 404 — both correct AND cleaner. Adds a small SC '404' gloss below for readers who don't read Roman at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)