### PR TITLE
fix(docs+elders): align peer_whisper + clan_view args + memory keys with mcp.ts schema

### DIFF
--- a/agents/shared/home-claude/skills/world-physics/WORLD_PHYSICS.md
+++ b/agents/shared/home-claude/skills/world-physics/WORLD_PHYSICS.md
@@ -233,7 +233,7 @@ This enables **arbitrage / camping**: keep a stocked clansman waiting in town; w
 
 An agent-layer side-channel for coordination (trade, alliances, bribes, warnings). It never touches the game engine — which is exactly why OTC deals (§8) are pure trust.
 
-- **Private whispers** — the `peer_whisper` tool (toClanId, message): strictly **1-to-1** (reach several peers via several whispers). Read your inbox with the `peer_inbox` tool.
+- **Private whispers** — the `peer_whisper` tool (toClanId, body): strictly **1-to-1** (reach several peers via several whispers). Read your inbox with the `peer_inbox` tool.
 - **Public bulletins** — the `post_bulletin` tool: posted to the Unicorn Town bulletin board, visible to all clans. Lore-flavored; you do NOT need to be in Unicorn Town to post or read.
 
 No rate limits or message-size caps today.

--- a/packages/heartbeat/src/composeSituationBlock.ts
+++ b/packages/heartbeat/src/composeSituationBlock.ts
@@ -72,12 +72,12 @@ export function composeSituationBlock(args: ComposeArgs): string {
     lines.push('Reorient and act. Suggested order:');
     lines.push('1. Call `memory_recall` for `active-strategy` — pull forward the standing plan you saved before the reset.');
     lines.push('2. Call `world_snapshot` — current tick, season, market prices, bandit state, public bulletins.');
-    lines.push(`3. Call \`clan_view\` (defaults to your own clan, clan-${args.clanId}) — your missions, vault, cooldowns, hunger, clansmen.`);
+    lines.push(`3. Call \`clan_view\` (defaults to your own clan (clanId="${args.clanId}")) — your missions, vault, cooldowns, hunger, clansmen.`);
     lines.push('4. Call `peer_inbox` — private whispers from peer clans.');
     lines.push('');
     lines.push('Then decide what to do this cycle:');
     lines.push('- **Submit orders** if your plan needs an update: call `submit_orders` with your orders array passed INLINE (the array of `ClanOrder` objects as the tool argument — never write a json file, never use bash `cat`/heredoc to build it).');
-    lines.push('- **Whisper a peer** point-to-point: call `peer_whisper` (target clanId + message) — private, AXL-routed.');
+    lines.push('- **Whisper a peer** point-to-point: call `peer_whisper` (toClanId + body) — private, AXL-routed.');
     lines.push('- **Post to the public bulletin** to shape the realm narrative — call `post_bulletin` with your message. Declarations, threats, alliances, public ledger entries. Bulletins are 0G-stored and visible to every other Elder + the iNFT Owner.');
     lines.push('- **Save durable knowledge**: call `memory_save` (key + value) for anything that needs to outlive the next wipe.');
     lines.push('');

--- a/packages/heartbeat/src/main.ts
+++ b/packages/heartbeat/src/main.ts
@@ -29,7 +29,7 @@ function bootstrapBlock(elder: ElderId, clanId: string): string {
     `You are Elder ${elder} of Clan ${clanId} in ClanWorld. Your context was just reset.`,
     'A short tick marker will arrive on the next tick. Until then, you can use the `elder` MCP tools to:',
     '- `world_snapshot`     — read current world state',
-    `- \`clan_view\`         — read your clan's state (defaults to your own clan, clan-${clanId})`,
+    `- \`clan_view\`         — read your clan's state (defaults to your own clan (clanId="${clanId}"))`,
     '- `memory_recall`      — restore continuity from prior cycles',
     '- `peer_inbox`         — read whispers',
     '',

--- a/runtime/elders/personalities/elder-1.md
+++ b/runtime/elders/personalities/elder-1.md
@@ -1,6 +1,6 @@
 # Elder-1 — Storm Riders Elder
 
-First, recall your private strategic memory by calling `memory_recall` for `current-strategy`; do not read `agent-directive.secret.md` directly.
+First, recall your private strategic memory by calling `memory_recall` for `active-strategy`; do not read `agent-directive.secret.md` directly.
 
 ## Identity
 
@@ -51,9 +51,9 @@ This section governs how you respond to bandit incidents. It overrides "Strategy
 If you see an operator message in your terminal saying bandits are attacking your clan, immediately broadcast a help request. Use **public** broadcast — call `peer_whisper` once per recipient with the SAME message to clans 2, 3, and 4:
 
 ```
-peer_whisper(clanId=2, message="BANDITS at our gates. Need 2 defenders by tick T+2. Paying 100 gold per defender.")
-peer_whisper(clanId=3, message="BANDITS at our gates. Need 2 defenders by tick T+2. Paying 100 gold per defender.")
-peer_whisper(clanId=4, message="BANDITS at our gates. Need 2 defenders by tick T+2. Paying 100 gold per defender.")
+peer_whisper(toClanId=2, body="BANDITS at our gates. Need 2 defenders by tick T+2. Paying 100 gold per defender.")
+peer_whisper(toClanId=3, body="BANDITS at our gates. Need 2 defenders by tick T+2. Paying 100 gold per defender.")
+peer_whisper(toClanId=4, body="BANDITS at our gates. Need 2 defenders by tick T+2. Paying 100 gold per defender.")
 ```
 
 Replace `T+2` with `current_tick + 2`. State the pay rate as a clear opening offer (100 gold/defender). Be terse. The Storm Riders do not beg.
@@ -69,9 +69,9 @@ Storm Riders are mercenaries. You don't ride for free, you don't ride for the go
 Given an offer of X gold per defender from Clan A, with the other two non-asking clans labelled B and C, respond:
 
 ```
-peer_whisper(clanId=A, message="Storm Riders ride for 2X gold per defender, paid up-front. Take it or fall.")
-peer_whisper(clanId=B, message="Storm Riders demand 2X gold per defender to defend Clan A. Match or yield.")
-peer_whisper(clanId=C, message="Storm Riders demand 2X gold per defender to defend Clan A. Match or yield.")
+peer_whisper(toClanId=A, body="Storm Riders ride for 2X gold per defender, paid up-front. Take it or fall.")
+peer_whisper(toClanId=B, body="Storm Riders demand 2X gold per defender to defend Clan A. Match or yield.")
+peer_whisper(toClanId=C, body="Storm Riders demand 2X gold per defender to defend Clan A. Match or yield.")
 ```
 
 Replace `2X` with double the offered fee (round up). Use "ride" / "match or yield" / "fall" — Storm Riders' voice. NEVER counter low. NEVER respond privately to a help request — your demands are PUBLIC.

--- a/runtime/elders/personalities/elder-2.md
+++ b/runtime/elders/personalities/elder-2.md
@@ -1,6 +1,6 @@
 # Elder-2 — Iron Guard Elder
 
-First, recall your private strategic memory by calling `memory_recall` for `current-strategy`; do not read `agent-directive.secret.md` directly.
+First, recall your private strategic memory by calling `memory_recall` for `active-strategy`; do not read `agent-directive.secret.md` directly.
 
 ## Identity
 
@@ -51,9 +51,9 @@ This section governs how you respond to bandit incidents. It overrides "Strategy
 If you see an operator message in your terminal saying bandits are attacking your clan, broadcast a help request. Use **public** broadcast — call `peer_whisper` once per recipient with the SAME message to clans 1, 3, and 4:
 
 ```
-peer_whisper(clanId=1, message="Iron Guard reports bandits at our walls. Requesting 2 defenders by tick T+2. Treasury offers 100 gold per defender.")
-peer_whisper(clanId=3, message="Iron Guard reports bandits at our walls. Requesting 2 defenders by tick T+2. Treasury offers 100 gold per defender.")
-peer_whisper(clanId=4, message="Iron Guard reports bandits at our walls. Requesting 2 defenders by tick T+2. Treasury offers 100 gold per defender.")
+peer_whisper(toClanId=1, body="Iron Guard reports bandits at our walls. Requesting 2 defenders by tick T+2. Treasury offers 100 gold per defender.")
+peer_whisper(toClanId=3, body="Iron Guard reports bandits at our walls. Requesting 2 defenders by tick T+2. Treasury offers 100 gold per defender.")
+peer_whisper(toClanId=4, body="Iron Guard reports bandits at our walls. Requesting 2 defenders by tick T+2. Treasury offers 100 gold per defender.")
 ```
 
 Replace `T+2` with `current_tick + 2`. State the pay rate as a measured opening offer (100 gold/defender). Iron Guard requests aid formally, with deadline and terms.
@@ -69,9 +69,9 @@ Iron Guard's strategic moat is reputation for reliability AT FAIR PRICES. Other 
 Given an offer of X gold per defender from Clan A, with the other two non-asking clans labelled B and C, respond:
 
 ```
-peer_whisper(clanId=A, message="Iron Guard accepts at 0.7X gold per defender. We honor commitments without inflated rates.")
-peer_whisper(clanId=B, message="Iron Guard offers defense of Clan A at 0.7X gold per defender — undercutting any inflated bid.")
-peer_whisper(clanId=C, message="Iron Guard offers defense of Clan A at 0.7X gold per defender — undercutting any inflated bid.")
+peer_whisper(toClanId=A, body="Iron Guard accepts at 0.7X gold per defender. We honor commitments without inflated rates.")
+peer_whisper(toClanId=B, body="Iron Guard offers defense of Clan A at 0.7X gold per defender — undercutting any inflated bid.")
+peer_whisper(toClanId=C, body="Iron Guard offers defense of Clan A at 0.7X gold per defender — undercutting any inflated bid.")
 ```
 
 Replace `0.7X` with seventy percent of the offered fee, rounded down to nearest 10 gold. Use "honor commitments" / "undercut" / "fair price" — Iron Guard's voice. NEVER demand a higher fee. NEVER respond privately — your offers are PUBLIC.

--- a/runtime/elders/personalities/elder-3.md
+++ b/runtime/elders/personalities/elder-3.md
@@ -1,6 +1,6 @@
 # Elder-3 — Crimson Elder
 
-First, recall your private strategic memory by calling `memory_recall` for `current-strategy`; do not read `agent-directive.secret.md` directly.
+First, recall your private strategic memory by calling `memory_recall` for `active-strategy`; do not read `agent-directive.secret.md` directly.
 
 ## Identity
 
@@ -51,9 +51,9 @@ This section governs how you respond to bandit incidents. It overrides "Strategy
 If you see an operator message in your terminal saying bandits are attacking your clan, request aid quietly. Call `peer_whisper` once per recipient with the SAME message to clans 1, 2, and 4:
 
 ```
-peer_whisper(clanId=1, message="The canyon is breached. We need defenders by tick T+2. We will pay 100 gold each.")
-peer_whisper(clanId=2, message="The canyon is breached. We need defenders by tick T+2. We will pay 100 gold each.")
-peer_whisper(clanId=4, message="The canyon is breached. We need defenders by tick T+2. We will pay 100 gold each.")
+peer_whisper(toClanId=1, body="The canyon is breached. We need defenders by tick T+2. We will pay 100 gold each.")
+peer_whisper(toClanId=2, body="The canyon is breached. We need defenders by tick T+2. We will pay 100 gold each.")
+peer_whisper(toClanId=4, body="The canyon is breached. We need defenders by tick T+2. We will pay 100 gold each.")
 ```
 
 Replace `T+2` with `current_tick + 2`. State the offer plainly (100 gold/defender). Crimson does not panic, even when the canyon burns.
@@ -69,7 +69,7 @@ Crimson does not bid in the open. Your moves stay between you and the counterpar
 Given an offer of X gold per defender from Clan A, respond ONLY to A:
 
 ```
-peer_whisper(clanId=A, message="Crimson asks 2X gold per defender, in advance. The canyon does not bleed for less. Accept by next tick or we hold our ground.")
+peer_whisper(toClanId=A, body="Crimson asks 2X gold per defender, in advance. The canyon does not bleed for less. Accept by next tick or we hold our ground.")
 ```
 
 Replace `2X` with double the offered fee (round up). Use canyon imagery sparingly — one phrase per message at most. NEVER whisper your offer to the other Elders. NEVER counter low.

--- a/runtime/elders/personalities/elder-4.md
+++ b/runtime/elders/personalities/elder-4.md
@@ -1,6 +1,6 @@
 # Elder-4 — Verdant Wardens Elder
 
-First, recall your private strategic memory by calling `memory_recall` for `current-strategy`; do not read `agent-directive.secret.md` directly.
+First, recall your private strategic memory by calling `memory_recall` for `active-strategy`; do not read `agent-directive.secret.md` directly.
 
 ## Identity
 
@@ -51,9 +51,9 @@ This section governs how you respond to bandit incidents. It overrides "Strategy
 If you see an operator message in your terminal saying bandits are attacking your clan, request aid via direct correspondence. Call `peer_whisper` once per recipient with the SAME message to clans 1, 2, and 3:
 
 ```
-peer_whisper(clanId=1, message="Verdant Wardens require 2 defenders by tick T+2 — bandits are at the southern treeline. We can offer 100 gold per defender from grain reserves.")
-peer_whisper(clanId=2, message="Verdant Wardens require 2 defenders by tick T+2 — bandits are at the southern treeline. We can offer 100 gold per defender from grain reserves.")
-peer_whisper(clanId=3, message="Verdant Wardens require 2 defenders by tick T+2 — bandits are at the southern treeline. We can offer 100 gold per defender from grain reserves.")
+peer_whisper(toClanId=1, body="Verdant Wardens require 2 defenders by tick T+2 — bandits are at the southern treeline. We can offer 100 gold per defender from grain reserves.")
+peer_whisper(toClanId=2, body="Verdant Wardens require 2 defenders by tick T+2 — bandits are at the southern treeline. We can offer 100 gold per defender from grain reserves.")
+peer_whisper(toClanId=3, body="Verdant Wardens require 2 defenders by tick T+2 — bandits are at the southern treeline. We can offer 100 gold per defender from grain reserves.")
 ```
 
 Replace `T+2` with `current_tick + 2`. State terms with the same precision you bring to any trade. The Wardens make offers, not pleas.
@@ -69,7 +69,7 @@ Verdant Wardens negotiate gently and discreetly. You don't shame the asker by br
 Given an offer of X gold per defender from Clan A, respond ONLY to A:
 
 ```
-peer_whisper(clanId=A, message="Verdant Wardens can field 2 defenders for 0.7X gold each. Reduced rate honors our standing relationship. Confirm by next tick.")
+peer_whisper(toClanId=A, body="Verdant Wardens can field 2 defenders for 0.7X gold each. Reduced rate honors our standing relationship. Confirm by next tick.")
 ```
 
 Replace `0.7X` with seventy percent of the offered fee, rounded down to nearest 10 gold. Use "standing relationship" / "honors" / "reduced rate" — Wardens' voice. NEVER whisper your offer to the other Elders. NEVER demand a higher fee.

--- a/runtime/elders/plugins/clan-world-elder/skills/cleared-context-start/SKILL.md
+++ b/runtime/elders/plugins/clan-world-elder/skills/cleared-context-start/SKILL.md
@@ -15,7 +15,7 @@ When you (an Elder) wake up with cleared context — usually after a `/clear` re
 
 3. **Your strategic memory** — use the `memory_recall` tool (key=topic) for private long-term goals, grudges, and trust scores. Do not read `agent-directive.secret.md`; the session permissions intentionally deny direct access to that secret file.
 
-4. **Your consolidated memory** — continue with `memory_recall` for any additional topics from prior sessions. Topics depend on what the situation block surfaces. Default starter set: `current-strategy`, `peer-trust-grades`, `active-grudges`, `tx-receipts-recent`.
+4. **Your consolidated memory** — continue with `memory_recall` for any additional topics from prior sessions. Topics depend on what the situation block surfaces. Default starter set: `active-strategy`, `peer-trust-grades`, `active-grudges`, `tx-receipts-recent`.
 
 5. **Current world state** — the `world_snapshot` tool (cheap; reads from Convex indexer cache).
 


### PR DESCRIPTION
## Summary
Cloud reviewer (Copilot) on PR #647 flagged 17 inline comments across 8 files — all real bugs in agent-facing prompts/docs that use the wrong MCP tool argument names + the wrong canonical memory key. Elders copy-pasting from these examples would hit MCP validation errors at runtime.

## Three classes of fixes
1. **`peer_whisper` args** — `clanId`/`message` → `toClanId`/`body` per `packages/agents/src/mcp.ts:303-313`.
2. **Canonical memory key** — `current-strategy` → `active-strategy` per `composeSituationBlock.ts:48-73` + lean-tick skill which are the actual source-of-truth users.
3. **`clan_view` clanId format** — docs implied `clan-N`; real schema takes plain numeric `N`. Clarified bootstrap parenthetical to explicitly show `clanId="${id}"` so Elders don't pass `clan-4`.

## Files
- runtime/elders/personalities/elder-{1,2,3,4}.md
- runtime/elders/plugins/clan-world-elder/skills/cleared-context-start/SKILL.md
- packages/heartbeat/src/composeSituationBlock.ts
- packages/heartbeat/src/main.ts
- agents/shared/home-claude/skills/world-physics/WORLD_PHYSICS.md

8 files, 29 insertions, 29 deletions. No behavior change in code paths — only doc strings + the misleading parenthetical fixed.

## Test plan
- [x] Verify peer_whisper schema matches mcp.ts:303-313
- [x] Verify active-strategy is canonical key in composeSituationBlock.ts + lean-tick
- [x] Verify clan_view clanId takes plain string per assertOwnClanId

## Next step
Once merged → re-target PR #647 (dev → main) for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)