### PR TITLE
fix: anvil chain-clock heartbeat scheduling + CC 2.1.x placeholder-hint ready-probe

### DIFF
--- a/packages/heartbeat/src/heartbeatLoopMain.ts
+++ b/packages/heartbeat/src/heartbeatLoopMain.ts
@@ -2,6 +2,36 @@ import { createConvexClient } from '@clan-world/shared/adapters';
 import { startHeartbeatScheduler } from './heartbeatScheduler';
 import { configFromEnv, RunnerCastHeartbeat } from './runnerCastHeartbeat';
 
+/**
+ * On anvil forks the chain clock can carry a persistent offset from wall time
+ * (see RunnerCastHeartbeat.readChainNowMs). nextHeartbeatAtTs is chain time,
+ * so when HEARTBEAT_SCHEDULE_FROM_CHAIN=1 the scheduler clock is anchored to
+ * chain time via a boot-time offset; otherwise (and on any anchor failure)
+ * wall-clock scheduling is unchanged. The offset is boot-static: anvil's
+ * offset persists for the node's lifetime, so a single anchor suffices and a
+ * process restart re-anchors. Returns undefined for wall-clock scheduling.
+ */
+export async function resolveSchedulerNowMs(
+  caller: { readChainNowMs(): Promise<number> },
+  env: Record<string, string | undefined> = process.env,
+): Promise<(() => number) | undefined> {
+  if (env['HEARTBEAT_SCHEDULE_FROM_CHAIN'] !== '1') return undefined;
+  try {
+    const offsetMs = (await caller.readChainNowMs()) - Date.now();
+    console.log(`[heartbeat-loop] chain-clock scheduling enabled; offsetMs=${offsetMs}`);
+    return () => Date.now() + offsetMs;
+  } catch (err) {
+    // Degrade, don't die: a transient RPC blip at boot must not crash-loop
+    // the daemon. Wall-clock scheduling over-sleeps on offset forks but
+    // still ticks; the loud log makes the degradation observable.
+    console.error(
+      '[heartbeat-loop] chain-clock anchor failed; falling back to wall-clock scheduling:',
+      err,
+    );
+    return undefined;
+  }
+}
+
 async function main(): Promise<void> {
   console.log(`[heartbeat-loop] starting at ${new Date().toISOString()}`);
   const abort = new AbortController();
@@ -17,16 +47,7 @@ async function main(): Promise<void> {
 
   const convex = createConvexClient();
   const heartbeatCaller = new RunnerCastHeartbeat(configFromEnv());
-
-  // On anvil forks the chain clock can carry a persistent offset from wall
-  // time (see readChainNowMs). nextHeartbeatAtTs is chain time, so schedule
-  // against a chain-anchored clock when enabled; otherwise wall clock.
-  let nowMs: (() => number) | undefined;
-  if (process.env['HEARTBEAT_SCHEDULE_FROM_CHAIN'] === '1') {
-    const offsetMs = (await heartbeatCaller.readChainNowMs()) - Date.now();
-    console.log(`[heartbeat-loop] chain-clock scheduling enabled; offsetMs=${offsetMs}`);
-    nowMs = () => Date.now() + offsetMs;
-  }
+  const nowMs = await resolveSchedulerNowMs(heartbeatCaller);
 
   startHeartbeatScheduler({
     heartbeatCaller,

--- a/packages/heartbeat/src/heartbeatLoopMain.ts
+++ b/packages/heartbeat/src/heartbeatLoopMain.ts
@@ -16,12 +16,24 @@ async function main(): Promise<void> {
   process.on('SIGINT', () => onSignal('SIGINT'));
 
   const convex = createConvexClient();
+  const heartbeatCaller = new RunnerCastHeartbeat(configFromEnv());
+
+  // On anvil forks the chain clock can carry a persistent offset from wall
+  // time (see readChainNowMs). nextHeartbeatAtTs is chain time, so schedule
+  // against a chain-anchored clock when enabled; otherwise wall clock.
+  let nowMs: (() => number) | undefined;
+  if (process.env['HEARTBEAT_SCHEDULE_FROM_CHAIN'] === '1') {
+    const offsetMs = (await heartbeatCaller.readChainNowMs()) - Date.now();
+    console.log(`[heartbeat-loop] chain-clock scheduling enabled; offsetMs=${offsetMs}`);
+    nowMs = () => Date.now() + offsetMs;
+  }
 
   startHeartbeatScheduler({
-    heartbeatCaller: new RunnerCastHeartbeat(configFromEnv()),
+    heartbeatCaller,
     convex,
     signal: abort.signal,
     runnerId: process.env['RUNNER_ID'] ?? 'clanworld-heartbeat-loop',
+    nowMs,
   });
 
   await new Promise<void>(resolve => {

--- a/packages/heartbeat/src/heartbeatLoopMain.ts
+++ b/packages/heartbeat/src/heartbeatLoopMain.ts
@@ -66,7 +66,17 @@ async function main(): Promise<void> {
   });
 }
 
-main().catch(err => {
-  console.error('[heartbeat-loop] fatal:', err);
-  process.exit(1);
-});
+// Only run when executed directly — not when imported (tests import
+// resolveSchedulerNowMs; an unguarded main() would process.exit(1) the
+// test runner). Same pattern as packages/agents/src/cli.ts.
+const isMain =
+  process.argv[1] !== undefined &&
+  (process.argv[1].endsWith('/heartbeatLoopMain.ts') ||
+    process.argv[1].endsWith('/heartbeatLoopMain.js'));
+
+if (isMain) {
+  main().catch(err => {
+    console.error('[heartbeat-loop] fatal:', err);
+    process.exit(1);
+  });
+}

--- a/packages/heartbeat/src/runnerCastHeartbeat.ts
+++ b/packages/heartbeat/src/runnerCastHeartbeat.ts
@@ -198,6 +198,18 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     return Number(interval);
   }
 
+  async readChainNowMs(): Promise<number> {
+    // Latest block timestamp — anvil forks keep a persistent internal clock
+    // offset (evm_increaseTime survives for the node's lifetime), so chain
+    // time can sit minutes ahead of wall time while still advancing at wall
+    // pace. Scheduling against wall time then over-sleeps by the offset every
+    // cycle. Measured from the latest block, so it under-estimates by the age
+    // of that block — which only delays the next fire, never causes a
+    // rate-limited revert.
+    const block = await this.publicClient.getBlock({ blockTag: 'latest' });
+    return Number(block.timestamp) * 1000;
+  }
+
   async readNextHeartbeatAtTs(): Promise<number> {
     const state = await this.publicClient.readContract({
       address: this.contractAddress,

--- a/packages/heartbeat/test/resolveSchedulerNowMs.test.ts
+++ b/packages/heartbeat/test/resolveSchedulerNowMs.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveSchedulerNowMs } from "../src/heartbeatLoopMain";
+
+describe("resolveSchedulerNowMs", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns undefined (wall-clock scheduling) when the flag is unset", async () => {
+    const caller = { readChainNowMs: vi.fn() };
+    await expect(resolveSchedulerNowMs(caller, {})).resolves.toBeUndefined();
+    expect(caller.readChainNowMs).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when the flag is set to anything but '1'", async () => {
+    const caller = { readChainNowMs: vi.fn() };
+    await expect(
+      resolveSchedulerNowMs(caller, { HEARTBEAT_SCHEDULE_FROM_CHAIN: "true" }),
+    ).resolves.toBeUndefined();
+    expect(caller.readChainNowMs).not.toHaveBeenCalled();
+  });
+
+  it("anchors the clock to the chain offset when enabled", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const wallNow = Date.now();
+    const chainNow = wallNow + 1_490_000; // anvil ~25min ahead (the live 2026-06-12 shape)
+    const caller = { readChainNowMs: vi.fn(async () => chainNow) };
+
+    const nowMs = await resolveSchedulerNowMs(caller, { HEARTBEAT_SCHEDULE_FROM_CHAIN: "1" });
+
+    expect(nowMs).toBeTypeOf("function");
+    // The anchored clock should read ~chain time, not wall time. Allow slack
+    // for the wall-clock ms elapsed between the two Date.now() samples.
+    const drift = Math.abs(nowMs!() - chainNow);
+    expect(drift).toBeLessThan(5_000);
+  });
+
+  it("falls back to wall-clock scheduling (undefined) when the anchor read fails", async () => {
+    // Mutation guard: replacing the try/catch with a bare await makes this
+    // test fail with an unhandled rejection instead of a clean undefined.
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const caller = {
+      readChainNowMs: vi.fn(async () => {
+        throw new Error("boot RPC blip");
+      }),
+    };
+
+    await expect(
+      resolveSchedulerNowMs(caller, { HEARTBEAT_SCHEDULE_FROM_CHAIN: "1" }),
+    ).resolves.toBeUndefined();
+    expect(error).toHaveBeenCalled();
+  });
+});

--- a/packages/runner/src/pasteVerification.ts
+++ b/packages/runner/src/pasteVerification.ts
@@ -54,6 +54,14 @@ function hasReadyPrompt(pane: string): boolean {
  * dies with ready_probe_timeout — the same silent-pipeline failure mode as
  * the stale ">"-only glyph regex documented on inputPromptText (caught live
  * 2026-06-12 after the elder image refresh bundled Claude Code 2.1.175).
+ *
+ * Precision boundary (assessed, not accidental): a lone `Try "..."` line of
+ * REAL stuck input would also match, but no current path can produce one —
+ * ttyd is read-only (operators cannot type into the box) and the runner's
+ * own writes are multi-line situation blocks, envelope-wrapped messages, or
+ * slash commands, never a single quoted Try-line. Hint copy verified against
+ * Claude Code 2.1.175 (ASCII double quotes); revisit if a CLI bump restyles
+ * the hint — this probe family breaks on TUI copy changes, see test file.
  */
 function isEmptyPrompt(text: string | null): boolean {
   if (text === null) return false;

--- a/packages/runner/src/pasteVerification.ts
+++ b/packages/runner/src/pasteVerification.ts
@@ -43,7 +43,21 @@ export async function postPasteSubmitted(tmux: TmuxSink): Promise<boolean> {
 }
 
 function hasReadyPrompt(pane: string): boolean {
-  return inputRegion(pane).some((line) => inputPromptText(line) === "");
+  return inputRegion(pane).some((line) => isEmptyPrompt(inputPromptText(line)));
+}
+
+/**
+ * Claude Code >=2.1.x renders a placeholder hint INSIDE the empty input box
+ * (e.g. `❯ Try "fix typecheck errors"`). The hint vanishes the moment real
+ * text is typed, so a hint-bearing prompt IS an empty prompt. Without this,
+ * the readiness probe reads the hint as typed text and every per-tick paste
+ * dies with ready_probe_timeout — the same silent-pipeline failure mode as
+ * the stale ">"-only glyph regex documented on inputPromptText (caught live
+ * 2026-06-12 after the elder image refresh bundled Claude Code 2.1.175).
+ */
+function isEmptyPrompt(text: string | null): boolean {
+  if (text === null) return false;
+  return text === "" || /^Try ".+"$/.test(text);
 }
 
 /**
@@ -59,7 +73,7 @@ function isInputSubmitted(pane: string): boolean {
     .map(inputPromptText)
     .filter((text): text is string => text !== null);
   if (promptLines.length === 0) return false;
-  return promptLines.every((text) => text.length === 0);
+  return promptLines.every((text) => isEmptyPrompt(text));
 }
 
 function inputRegion(pane: string): string[] {

--- a/packages/runner/test/pasteVerification.test.ts
+++ b/packages/runner/test/pasteVerification.test.ts
@@ -61,6 +61,16 @@ describe("paste verification", () => {
     expect(tmux.sendKeys).not.toHaveBeenCalled();
   });
 
+  it("post-paste does NOT treat unquoted Try-prefixed stuck input as submitted", async () => {
+    vi.useFakeTimers();
+    const tmux = mockTmux([pane("Submitted?", "│ ❯ Try the eastern pass")]);
+    const promise = postPasteSubmitted(tmux);
+    await vi.advanceTimersByTimeAsync(
+      POST_PASTE_INITIAL_SETTLE_MS + STUCK_INPUT_RETRY_DELAY_MS * STUCK_INPUT_MAX_RETRIES,
+    );
+    await expect(promise).resolves.toBe(false);
+  });
+
   it("pre-paste does NOT treat a non-empty ❯ input (busy) as ready", async () => {
     vi.useFakeTimers();
     const tmux = mockTmux([pane("Claude is thinking", "│ ❯ draft the orders")]);

--- a/packages/runner/test/pasteVerification.test.ts
+++ b/packages/runner/test/pasteVerification.test.ts
@@ -36,6 +36,31 @@ describe("paste verification", () => {
     }
   });
 
+  it("pre-paste treats the Claude Code >=2.1.x placeholder hint as an empty prompt", async () => {
+    // CC 2.1.x renders a hint INSIDE the empty input box (`❯ Try "..."`); it
+    // vanishes on first real keystroke. Without isEmptyPrompt accepting it,
+    // every tick paste died with ready_probe_timeout (live 2026-06-12 outage).
+    // Mutation-tested 2026-06-12: reverting the isEmptyPrompt fix fails this.
+    const tmux = mockTmux([pane("Claude is ready", '│ ❯ Try "fix typecheck errors"')]);
+    await expect(prePasteReady(tmux)).resolves.toBe(true);
+  });
+
+  it("pre-paste does NOT treat unquoted Try-prefixed REAL input as ready", async () => {
+    // Guards the hint matcher's precision: a user/runner message that merely
+    // starts with `Try` (no quoted suffix) is genuine typed input, not a hint.
+    vi.useFakeTimers();
+    const tmux = mockTmux([pane("Claude is thinking", "│ ❯ Try the eastern pass")]);
+    const promise = prePasteReady(tmux);
+    await vi.advanceTimersByTimeAsync(READY_PROBE_TIMEOUT_MS);
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it("post-paste treats the placeholder hint as submitted (input returned to empty)", async () => {
+    const tmux = mockTmux([pane("Submitted", '│ ❯ Try "how does foo work?"')]);
+    await expect(postPasteSubmitted(tmux)).resolves.toBe(true);
+    expect(tmux.sendKeys).not.toHaveBeenCalled();
+  });
+
   it("pre-paste does NOT treat a non-empty ❯ input (busy) as ready", async () => {
     vi.useFakeTimers();
     const tmux = mockTmux([pane("Claude is thinking", "│ ❯ draft the orders")]);


### PR DESCRIPTION
Closes #649
Closes #650

Two production-validated fixes from the 2026-06-12 live stack revival (both root-caused and verified on the running dev stack before this PR).

## #649 — heartbeat over-sleeps on offset anvil forks
The scheduler computed delay as `nextHeartbeatAtTs*1000 - Date.now()`, but `nextHeartbeatAtTs` is **chain** time and the long-lived anvil fork's internal clock sits ~25 min ahead of wall time (persistent for the node's lifetime). Result: 1 tick per ~26 wall-minutes instead of 60s. Fix: env-gated (`HEARTBEAT_SCHEDULE_FROM_CHAIN=1`) chain-anchored clock — `resolveSchedulerNowMs()` measures the offset from the latest block timestamp at boot and anchors the scheduler clock. Anchor failure degrades loudly to wall-clock scheduling (no crash-loop). Flag unset = behavior unchanged (prod/Base Sepolia unaffected).

## #650 — CC ≥2.1.x placeholder hint silently killed every tick paste
Claude Code 2.1.175 renders a hint **inside** the empty input box (`❯ Try "fix typecheck errors"`). The readiness probe required an empty prompt line, read the hint as typed text, and every per-tick paste died with `ready_probe_timeout` — while all container healthchecks stayed green. Third instance of the TUI-change-breaks-probe class (see inline comment history). Fix: `isEmptyPrompt()` treats `^Try ".+"$` as empty (the hint vanishes on first real keystroke). Precision boundary documented in-code: ttyd is read-only and runner paste shapes never produce a lone quoted Try-line, so a real-input false-match is unreachable.

## Tests
- 4 new unit tests for `resolveSchedulerNowMs` (flag off / non-`'1'` / anchored clock / anchor-failure fallback)
- 3 new + 1 symmetric precision test for the ready-probe (mutation-tested 2026-06-12: reverting the fix fails the 2 hint-acceptance tests)
- `main()` entrypoint-guarded so test imports can't `process.exit(1)` the runner (caught by swarm round 2 — suite exit code, not assertion count, now verified)
- Gates: `pnpm --filter @clan-world/heartbeat test` exit 0 (160 passed/1 skipped), `pnpm --filter @clan-world/runner test` exit 0 (67/67)

## Local swarm evidence (pre-push, 3 rounds)
- R1: codex 1 MED (regex precision → triaged document-over-tighten, boundary unreachable) + tier-1 2 MED (unguarded boot RPC; missing #649 tests) — all addressed
- R2: codex CLEAN, gemini CLEAN (1 LOW = the documented boundary), tier-1 1 HIGH (test-import exit-code theater) — fixed
- R3: tier-1 CLEAN (guard empirically verified under tsx argv semantics)

## Deployment note
The running dev stack already carries these fixes via images built mid-revival (`clanworld/agents:dev`, `clan-world-heartbeat`); the deployed heartbeat image predates the `resolveSchedulerNowMs` refactor but is functionally equivalent. Rebuild both images on next deploy to converge on this code. `HEARTBEAT_SCHEDULE_FROM_CHAIN=1` is set via the local gitignored `docker-compose.override.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)