### PR TITLE
[codex] Add GOLD campaign retention prototype

### DIFF
--- a/.world/ports.yml
+++ b/.world/ports.yml
@@ -24,10 +24,20 @@ purposes:
     env: dev
     canonical: 58741   # Vite dev server for apps/landing
 
+  - name: clan-world-retention-dev
+    type: frontend
+    env: dev
+    canonical: 58742   # Vite dev server for apps/retention
+
   - name: clan-world-backend-dev
     type: backend
     env: dev
     canonical: 38740   # Hono dev server for apps/server (Convex local emulator port too)
+
+  - name: clan-world-retention-api-dev
+    type: backend
+    env: dev
+    canonical: 38742   # Local API server for apps/retention
 
   - name: clan-world-frontend-test
     type: frontend

--- a/apps/retention/PLAN.md
+++ b/apps/retention/PLAN.md
@@ -1,0 +1,151 @@
+# ClanWorld Retention Prototype Plan
+
+Living tracking document for the retention and gamification dapp prototype.
+
+This app is intentionally experimental inside the ClanWorld monorepo worktree. The code should stay portable so it can be moved into a private repo once the product shape hardens.
+
+## Current Status
+
+- **Active worktree:** `.claude/worktrees/retention-gamification-prototype`
+- **App root:** `apps/retention`
+- **Frontend:** Vite + React prototype
+- **Backend:** small local API for wallet verification, profile persistence, social capture, and spin rewards
+- **Persistence:** app-local file-backed DB at `apps/retention/runtime/retention-prototype-db.json`, real DB later
+- **Rule of record:** a campaign user only counts after at least one verified EVM or Solana wallet signature
+- **Private preview:** `https://gold.clan-world.com` behind Cloudflare Access
+
+## Product Shape
+
+ClanWorld campaign onboarding should become a daily retention loop, not a one-time form.
+
+Users can optionally register or verify:
+
+- EVM wallet
+- Solana wallet
+- X follow
+- Telegram group join
+- TikTok follow
+
+Each completed source grants **one daily spin credit**, up to **5 spins per day**. Credits reset at **midnight Pacific Time**.
+
+The wheel is a horizontal CS:GO-style loot reel using ClanWorld sprites. Spins grant XP and collectible sprite rewards. Users build streaks, collections, and leaderboard rank over time.
+
+## Completed
+
+- Created experimental worktree branch: `exp/retention-gamification-prototype`
+- Added initial `apps/retention` Vite React app
+- Added first-pass onboarding UI:
+  - EVM wallet input
+  - Solana wallet input
+  - X handle/follow flow
+  - Telegram handle/join flow
+  - TikTok handle/follow flow
+- Added first-pass local profile persistence
+- Added first-pass horizontal reel concept using ClanWorld game assets
+- Added first-pass streak, XP, collection, and leaderboard UI concepts
+- Added backend API for:
+  - nonce issuance
+  - EVM signature verification
+  - Solana signature verification
+  - file-backed profile DB
+  - social handle persistence
+  - server-side spin reward generation
+  - simple rate limiting
+- Wired frontend to backend-owned profile, social, spin, XP, streak, and collection state
+- Added request states:
+  - wallet signing/loading/success/error
+  - social verification/loading/success/error
+  - alias debounce save
+  - spin loading/success/error
+- Added demo EVM and Solana signing paths for local automation while keeping injected wallet signing paths in place
+- Ran desktop and mobile Playwright flows and screenshot review
+- Verified backend rejects social-before-wallet and malformed wallet signatures
+
+## Actively In Progress
+
+- None. Current prototype pass is complete and running locally.
+
+## Immediately Planned
+
+1. Tune the XP economy.
+   - XP range: 3 to 99 per spin.
+   - Target EV: about 25 XP per spin.
+   - Re-check median target, because a median around 35 with mean 25 is mathematically unusual unless the distribution has many tiny rewards and a chunky mid-band.
+
+2. Improve the leaderboard backend.
+   - Current leaderboard mixes the active user with static seeded rows.
+   - Next version should rank all DB users and expose `GET /api/leaderboard`.
+   - Later refresh hourly from DB/cache.
+
+3. Replace demo signing with production wallet adapters.
+   - EVM injected wallet path exists but wants a real wallet extension to test.
+   - Solana injected wallet path exists but wants a real wallet extension to test.
+   - Demo signing should be hidden behind dev mode before any public release.
+
+4. Decide real social verification strategy.
+   - Current version records handles and grants provisional credit after the fake verification delay.
+   - Later: batch follower/group checks near campaign end, or wire X/TG/TikTok APIs/bots.
+
+## Dependencies
+
+- `viem` for EVM message verification.
+- `tweetnacl` and `bs58` for Solana signature verification.
+- A real wallet adapter later:
+  - EVM: injected wallet / wagmi / RainbowKit / simple `window.ethereum`.
+  - Solana: wallet adapter or direct `window.solana`.
+- Real DB later:
+  - Convex, Postgres, SQLite, or Supabase are all viable.
+  - For this prototype, a file-backed JSON DB is enough.
+
+## Gotchas
+
+- Social verification is intentionally fake for now. The UI must avoid implying instant final verification.
+- Social spin credit should be **provisional** after the fake verify click.
+- The backend must own XP, streaks, daily credits, and reward selection to prevent trivial local tampering.
+- Midnight reset is Pacific Time, not the host time zone.
+- The host machine runs in Europe/Moscow. User-facing campaign timing should be shown in PT for resets unless we decide otherwise.
+- Existing port registry is crowded in this repo. The prototype currently reuses the landing dev port allocation for Vite.
+- This code is still in a monorepo experiment and should stay easy to extract into a private repo.
+- `pnpm --filter @clan-world/retention api` runs with the package as cwd, so DB paths must be app-root-relative, not shell-cwd-relative.
+- Vite config should avoid `port-for` lookups during production build to keep build logs clean while dev servers are running.
+- The reel animation must reconcile server-owned reward results with the visual marker; the current version settles the returned reward near the marker after the animation completes.
+
+## Open Product Decisions
+
+- Should each social source grant provisional credit immediately, or only after the 24h pending window?
+  - Current recommendation: immediate provisional credit.
+- Should both wallets count independently if the same person verifies both?
+  - Current recommendation: yes, one EVM credit and one Solana credit.
+- Should a user be able to change social handles after verification?
+  - Current recommendation: allow edits during prototype, add cooldown later.
+- Should spin credits accrue if unused?
+  - Current recommendation: no, reset daily to drive return behavior.
+- Should streak advance on any spin or only if all available spins are used?
+  - Current recommendation: any spin advances streak.
+
+## Work Log
+
+### 2026-05-27
+
+- Created this living plan document.
+- Clarified core loop:
+  - wallet-verified user profile
+  - optional sources
+  - daily spin credits
+  - sprite reel
+  - XP, streaks, collection, leaderboard
+- Captured implementation principle: real wallet verification and server-owned rewards, fake/provisional social verification for speed.
+- Added a local API for nonce issuance, wallet signature verification, profile persistence, social handle persistence, server-owned spin rewards, and simple rate limiting.
+- Reworked the frontend so wallet/profile/social/spin state comes from API responses instead of local-only optimistic state.
+- Added demo signing paths for automated testing and local prototype usage without browser wallet extensions; injected EVM/Solana signing remains the intended real wallet path.
+- Validation completed:
+  - `pnpm --filter @clan-world/retention typecheck`
+  - `pnpm --filter @clan-world/retention build`
+  - Playwright full flow: empty state -> EVM demo-sign -> X/TG/TikTok provisional verification -> spin -> collection/leaderboard update
+  - Playwright mobile screenshot review
+  - API edge checks for social-before-wallet and malformed EVM signatures
+- Exposed private preview at `gold.clan-world.com` through Cloudflare Tunnel + Caddy:
+  - `/api/*` routes to local API port `38042`
+  - web/HMR routes to Vite port `58443`
+  - user systemd services keep both processes running
+  - Cloudflare Access protects external traffic

--- a/apps/retention/PLAN.md
+++ b/apps/retention/PLAN.md
@@ -104,7 +104,7 @@ The wheel is a horizontal CS:GO-style loot reel using ClanWorld sprites. Spins g
 - The backend must own XP, streaks, daily credits, and reward selection to prevent trivial local tampering.
 - Midnight reset is Pacific Time, not the host time zone.
 - The host machine runs in Europe/Moscow. User-facing campaign timing should be shown in PT for resets unless we decide otherwise.
-- Existing port registry is crowded in this repo. The prototype currently reuses the landing dev port allocation for Vite.
+- Existing port registry is crowded in this repo. The prototype now has dedicated `port-for` purposes for web and API dev servers.
 - This code is still in a monorepo experiment and should stay easy to extract into a private repo.
 - `pnpm --filter @clan-world/retention api` runs with the package as cwd, so DB paths must be app-root-relative, not shell-cwd-relative.
 - Vite config should avoid `port-for` lookups during production build to keep build logs clean while dev servers are running.
@@ -149,3 +149,22 @@ The wheel is a horizontal CS:GO-style loot reel using ClanWorld sprites. Spins g
   - web/HMR routes to Vite port `58443`
   - user systemd services keep both processes running
   - Cloudflare Access protects external traffic
+
+### 2026-06-13
+
+- Addressed cloud review feedback on PR #653:
+  - Wallet verification now accepts the current profile id so an EVM wallet and a Solana wallet attach to one campaign profile.
+  - Wallet collisions now return a conflict instead of silently merging accounts.
+  - File-backed DB writes now run through a serialized read-modify-write queue with unique temp files.
+  - Solana wallet matching preserves base58 case sensitivity.
+  - Streaks now increment across consecutive Pacific Time days and hold steady for multiple same-day spins.
+  - API rate limiting now keys by pathname instead of full URL/query.
+  - Oversized JSON bodies stop reading immediately.
+  - Wildcard API CORS headers were removed because the app uses the same-origin Vite proxy behind Cloudflare Access.
+  - Retention Vite/API servers now use dedicated `port-for` purposes.
+  - Demo signing is hidden outside dev unless explicitly enabled with `VITE_RETENTION_ENABLE_DEMO_SIGNING=true`.
+- Validation completed:
+  - `pnpm --filter @clan-world/retention typecheck`
+  - `pnpm --filter @clan-world/retention build`
+  - API smoke with fresh EVM and Solana signatures: wallet attach, wallet conflict, social saves, spin reward/streak.
+  - Playwright visual smoke against `http://127.0.0.1:58443` with screenshot and console-error check.

--- a/apps/retention/index.html
+++ b/apps/retention/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#101820" />
+    <title>ClanWorld Campaign Access</title>
+    <meta name="description" content="ClanWorld wallet and social campaign access funnel." />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/retention/package.json
+++ b/apps/retention/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@clan-world/retention",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "api": "tsx src/api.ts",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo 'lint stub'",
+    "clean": "rm -rf dist .turbo node_modules/.vite"
+  },
+  "dependencies": {
+    "bs58": "^6.0.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "tweetnacl": "^1.0.3",
+    "viem": "^2.48.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "tsx": "4.19.2",
+    "typescript": "~5.9.3",
+    "vite": "^8.0.10"
+  }
+}

--- a/apps/retention/src/api.ts
+++ b/apps/retention/src/api.ts
@@ -1,0 +1,348 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { randomBytes, randomUUID } from 'node:crypto';
+import bs58 from 'bs58';
+import nacl from 'tweetnacl';
+import { verifyMessage } from 'viem';
+
+type WalletKind = 'evm' | 'solana';
+type SocialKind = 'x' | 'telegram' | 'tiktok';
+type Rarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
+
+type WalletProfile = {
+  address: string;
+  verifiedAt: number;
+};
+
+type SocialProfile = {
+  handle: string;
+  status: 'idle' | 'verifying' | 'pending' | 'granted';
+  openedAt?: number;
+  verifiedAt?: number;
+};
+
+type SpinReward = {
+  id: string;
+  key: string;
+  name: string;
+  rarity: Rarity;
+  xp: number;
+  wonAt: number;
+};
+
+type UserProfile = {
+  id: string;
+  alias: string;
+  createdAt: number;
+  totalXp: number;
+  currentStreak: number;
+  longestStreak: number;
+  lastSpinDay?: string;
+  dailySpins: Record<string, number>;
+  collection: SpinReward[];
+  evm?: WalletProfile;
+  solana?: WalletProfile;
+  x: SocialProfile;
+  telegram: SocialProfile;
+  tiktok: SocialProfile;
+};
+
+type NonceRecord = {
+  nonce: string;
+  walletKind: WalletKind;
+  address: string;
+  message: string;
+  expiresAt: number;
+};
+
+type Db = {
+  users: Record<string, UserProfile>;
+  nonces: Record<string, NonceRecord>;
+};
+
+type RewardDefinition = {
+  key: string;
+  name: string;
+  rarity: Rarity;
+};
+
+const PORT = Number(process.env.PORT || 38740);
+const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DB_PATH = resolve(APP_ROOT, 'runtime/retention-prototype-db.json');
+const MAX_BODY_BYTES = 16 * 1024;
+const NONCE_TTL_MS = 5 * 60 * 1000;
+const RATE_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT = 90;
+
+const REWARDS: RewardDefinition[] = [
+  { key: 'dawnWatch', name: 'Dawn Watch Keep', rarity: 'common' },
+  { key: 'ironGuard', name: 'Iron Guard Bastion', rarity: 'common' },
+  { key: 'tideWardens', name: 'Tide Wardens Dock', rarity: 'common' },
+  { key: 'boneStandard', name: 'Bone Standard Camp', rarity: 'uncommon' },
+  { key: 'cobaltKeep', name: 'Cobalt Keep', rarity: 'uncommon' },
+  { key: 'verdantGrove', name: 'Verdant Grove', rarity: 'uncommon' },
+  { key: 'blackForge', name: 'Black Forge', rarity: 'rare' },
+  { key: 'amethystSpire', name: 'Amethyst Spire', rarity: 'rare' },
+  { key: 'paleCathedral', name: 'Pale Cathedral', rarity: 'epic' },
+  { key: 'gildedHold', name: 'Gilded Hold', rarity: 'epic' },
+  { key: 'stormRiders', name: 'Storm Riders Citadel', rarity: 'legendary' },
+  { key: 'emberHand', name: 'Ember Hand Furnace', rarity: 'legendary' },
+];
+
+const rateBuckets = new Map<string, { count: number; resetAt: number }>();
+
+const emptySocial = (): SocialProfile => ({ handle: '', status: 'idle' });
+
+const emptyDb = (): Db => ({ users: {}, nonces: {} });
+
+const readDb = async (): Promise<Db> => {
+  try {
+    return JSON.parse(await readFile(DB_PATH, 'utf8')) as Db;
+  } catch {
+    return emptyDb();
+  }
+};
+
+const writeDb = async (db: Db) => {
+  await mkdir(dirname(DB_PATH), { recursive: true });
+  const tmp = `${DB_PATH}.${process.pid}.tmp`;
+  await writeFile(tmp, JSON.stringify(db, null, 2));
+  await rename(tmp, DB_PATH);
+};
+
+const json = (res: ServerResponse, status: number, body: unknown) => {
+  res.writeHead(status, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'GET,POST,OPTIONS',
+    'access-control-allow-headers': 'content-type',
+    'content-type': 'application/json',
+  });
+  res.end(JSON.stringify(body));
+};
+
+const readJson = async (req: IncomingMessage) =>
+  new Promise<Record<string, unknown>>((resolveBody, reject) => {
+    let body = '';
+    req.on('data', (chunk: Buffer) => {
+      body += chunk.toString('utf8');
+      if (body.length > MAX_BODY_BYTES) reject(new Error('Request too large'));
+    });
+    req.on('end', () => {
+      try {
+        resolveBody(body ? JSON.parse(body) : {});
+      } catch {
+        reject(new Error('Invalid JSON'));
+      }
+    });
+  });
+
+const clientKey = (req: IncomingMessage) => `${req.socket.remoteAddress ?? 'local'}:${req.url ?? '/'}`;
+
+const isRateLimited = (req: IncomingMessage) => {
+  const key = clientKey(req);
+  const now = Date.now();
+  const bucket = rateBuckets.get(key);
+  if (!bucket || bucket.resetAt <= now) {
+    rateBuckets.set(key, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    return false;
+  }
+  bucket.count += 1;
+  return bucket.count > RATE_LIMIT;
+};
+
+const str = (value: unknown) => (typeof value === 'string' ? value.trim() : '');
+
+const walletKind = (value: unknown): WalletKind | undefined => (value === 'evm' || value === 'solana' ? value : undefined);
+
+const socialKind = (value: unknown): SocialKind | undefined =>
+  value === 'x' || value === 'telegram' || value === 'tiktok' ? value : undefined;
+
+const buildMessage = (kind: WalletKind, address: string, nonce: string) =>
+  [
+    'ClanWorld Campaign Access',
+    '',
+    `Wallet: ${address}`,
+    `Chain: ${kind}`,
+    `Nonce: ${nonce}`,
+    '',
+    'Sign this message to register your wallet and create a campaign profile.',
+  ].join('\n');
+
+const verifySolana = (address: string, message: string, signature: unknown) => {
+  if (!Array.isArray(signature)) return false;
+  const signatureBytes = Uint8Array.from(signature.map((value) => Number(value)));
+  const publicKeyBytes = bs58.decode(address);
+  return nacl.sign.detached.verify(new TextEncoder().encode(message), signatureBytes, publicKeyBytes);
+};
+
+const findUserByWallet = (db: Db, kind: WalletKind, address: string) =>
+  Object.values(db.users).find((user) => user[kind]?.address.toLowerCase() === address.toLowerCase());
+
+const defaultUser = (id: string): UserProfile => ({
+  id,
+  alias: '',
+  createdAt: Date.now(),
+  totalXp: 0,
+  currentStreak: 0,
+  longestStreak: 0,
+  dailySpins: {},
+  collection: [],
+  x: emptySocial(),
+  telegram: emptySocial(),
+  tiktok: emptySocial(),
+});
+
+const getPacificDay = (date = new Date()) =>
+  new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+
+const completedTasks = (user: UserProfile) =>
+  [user.evm, user.solana, user.x.status !== 'idle', user.telegram.status !== 'idle', user.tiktok.status !== 'idle'].filter(Boolean)
+    .length;
+
+const pickXp = () => {
+  const roll = Math.random();
+  if (roll < 0.45) return randomInt(3, 12);
+  if (roll < 0.8) return randomInt(30, 39);
+  if (roll < 0.93) return randomInt(40, 64);
+  if (roll < 0.99) return randomInt(13, 24);
+  return randomInt(65, 99);
+};
+
+const pickReward = () => {
+  const roll = Math.random();
+  const rarity: Rarity = roll < 0.5 ? 'common' : roll < 0.78 ? 'uncommon' : roll < 0.92 ? 'rare' : roll < 0.985 ? 'epic' : 'legendary';
+  const choices = REWARDS.filter((reward) => reward.rarity === rarity);
+  return choices[randomInt(0, choices.length - 1)] ?? REWARDS[0]!;
+};
+
+const randomInt = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
+
+const verifyWalletSignature = async (kind: WalletKind, address: string, message: string, signature: unknown) => {
+  try {
+    return kind === 'evm'
+      ? await verifyMessage({ address: address as `0x${string}`, message, signature: str(signature) as `0x${string}` })
+      : verifySolana(address, message, signature);
+  } catch {
+    return false;
+  }
+};
+
+const server = createServer(async (req, res) => {
+  if (req.method === 'OPTIONS') return json(res, 204, {});
+  if (isRateLimited(req)) return json(res, 429, { error: 'Slow down for a moment.' });
+
+  try {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+    const db = await readDb();
+
+    if (req.method === 'GET' && url.pathname === '/api/profile') {
+      const user = db.users[url.searchParams.get('userId') ?? ''];
+      return user ? json(res, 200, { profile: user }) : json(res, 404, { error: 'Profile not found.' });
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/nonce') {
+      const body = await readJson(req);
+      const kind = walletKind(body.walletKind);
+      const address = str(body.address);
+      if (!kind || !address) return json(res, 400, { error: 'Wallet kind and address are required.' });
+
+      const nonce = randomBytes(16).toString('hex');
+      const message = buildMessage(kind, address, nonce);
+      db.nonces[nonce] = { nonce, walletKind: kind, address, message, expiresAt: Date.now() + NONCE_TTL_MS };
+      await writeDb(db);
+      return json(res, 200, { nonce, message });
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/wallet/verify') {
+      const body = await readJson(req);
+      const kind = walletKind(body.walletKind);
+      const address = str(body.address);
+      const nonce = str(body.nonce);
+      const message = str(body.message);
+      const alias = str(body.alias).slice(0, 32);
+      const record = db.nonces[nonce];
+      if (!kind || !address || !record || record.expiresAt < Date.now()) return json(res, 400, { error: 'Signature request expired.' });
+      if (record.walletKind !== kind || record.address !== address || record.message !== message) {
+        return json(res, 400, { error: 'Signature request does not match this wallet.' });
+      }
+
+      const ok = await verifyWalletSignature(kind, address, message, body.signature);
+      if (!ok) return json(res, 401, { error: 'Signature verification failed.' });
+
+      const existing = findUserByWallet(db, kind, address);
+      const user = existing ?? defaultUser(randomUUID());
+      user.alias = alias || user.alias;
+      user[kind] = { address, verifiedAt: Date.now() };
+      db.users[user.id] = user;
+      delete db.nonces[nonce];
+      await writeDb(db);
+      return json(res, 200, { profile: user });
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/social') {
+      const body = await readJson(req);
+      const user = db.users[str(body.userId)];
+      const kind = socialKind(body.kind);
+      const handle = str(body.handle).replace(/^@/, '').slice(0, 40);
+      if (!user?.evm && !user?.solana) return json(res, 401, { error: 'Register a wallet first.' });
+      if (!kind || !handle) return json(res, 400, { error: 'Social handle is required.' });
+
+      user[kind] = { handle, status: 'pending', openedAt: Date.now(), verifiedAt: Date.now() };
+      await writeDb(db);
+      return json(res, 200, { profile: user });
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/profile') {
+      const body = await readJson(req);
+      const user = db.users[str(body.userId)];
+      if (!user?.evm && !user?.solana) return json(res, 401, { error: 'Register a wallet first.' });
+
+      user.alias = str(body.alias).slice(0, 32);
+      await writeDb(db);
+      return json(res, 200, { profile: user });
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/spin') {
+      const body = await readJson(req);
+      const user = db.users[str(body.userId)];
+      if (!user?.evm && !user?.solana) return json(res, 401, { error: 'Register a wallet first.' });
+
+      const today = getPacificDay();
+      const credits = completedTasks(user) - (user.dailySpins[today] ?? 0);
+      if (credits <= 0) return json(res, 409, { error: 'No spin credits left until midnight PT.' });
+
+      const rewardDef = pickReward();
+      const reward: SpinReward = {
+        ...rewardDef,
+        id: randomUUID(),
+        xp: pickXp(),
+        wonAt: Date.now(),
+      };
+
+      const currentStreak = user.lastSpinDay === today || !user.lastSpinDay ? Math.max(1, user.currentStreak || 1) : 1;
+      user.totalXp += reward.xp;
+      user.currentStreak = currentStreak;
+      user.longestStreak = Math.max(user.longestStreak, currentStreak);
+      user.lastSpinDay = today;
+      user.dailySpins[today] = (user.dailySpins[today] ?? 0) + 1;
+      user.collection = [reward, ...user.collection].slice(0, 24);
+      await writeDb(db);
+      return json(res, 200, { profile: user, reward });
+    }
+
+    return json(res, 404, { error: 'Not found.' });
+  } catch (error) {
+    return json(res, 500, { error: error instanceof Error ? error.message : 'Unexpected server error.' });
+  }
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`Retention API listening on http://127.0.0.1:${PORT}`);
+});

--- a/apps/retention/src/api.ts
+++ b/apps/retention/src/api.ts
@@ -62,13 +62,18 @@ type Db = {
   nonces: Record<string, NonceRecord>;
 };
 
+type ApiResult = {
+  status: number;
+  body: unknown;
+};
+
 type RewardDefinition = {
   key: string;
   name: string;
   rarity: Rarity;
 };
 
-const PORT = Number(process.env.PORT || 38740);
+const PORT = Number(process.env.RETENTION_API_PORT || process.env.PORT || 38742);
 const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const DB_PATH = resolve(APP_ROOT, 'runtime/retention-prototype-db.json');
 const MAX_BODY_BYTES = 16 * 1024;
@@ -92,6 +97,7 @@ const REWARDS: RewardDefinition[] = [
 ];
 
 const rateBuckets = new Map<string, { count: number; resetAt: number }>();
+let dbWriteQueue = Promise.resolve();
 
 const emptySocial = (): SocialProfile => ({ handle: '', status: 'idle' });
 
@@ -107,16 +113,27 @@ const readDb = async (): Promise<Db> => {
 
 const writeDb = async (db: Db) => {
   await mkdir(dirname(DB_PATH), { recursive: true });
-  const tmp = `${DB_PATH}.${process.pid}.tmp`;
+  const tmp = `${DB_PATH}.${process.pid}.${randomUUID()}.tmp`;
   await writeFile(tmp, JSON.stringify(db, null, 2));
   await rename(tmp, DB_PATH);
 };
 
+const updateDb = async <T,>(mutate: (db: Db) => Promise<T> | T) => {
+  const task = dbWriteQueue.then(async () => {
+    const db = await readDb();
+    const result = await mutate(db);
+    await writeDb(db);
+    return result;
+  });
+  dbWriteQueue = task.then(
+    () => undefined,
+    () => undefined,
+  );
+  return task;
+};
+
 const json = (res: ServerResponse, status: number, body: unknown) => {
   res.writeHead(status, {
-    'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,POST,OPTIONS',
-    'access-control-allow-headers': 'content-type',
     'content-type': 'application/json',
   });
   res.end(JSON.stringify(body));
@@ -125,20 +142,36 @@ const json = (res: ServerResponse, status: number, body: unknown) => {
 const readJson = async (req: IncomingMessage) =>
   new Promise<Record<string, unknown>>((resolveBody, reject) => {
     let body = '';
+    let settled = false;
     req.on('data', (chunk: Buffer) => {
+      if (settled) return;
       body += chunk.toString('utf8');
-      if (body.length > MAX_BODY_BYTES) reject(new Error('Request too large'));
+      if (body.length > MAX_BODY_BYTES) {
+        settled = true;
+        req.destroy();
+        reject(new Error('Request too large'));
+      }
     });
     req.on('end', () => {
+      if (settled) return;
+      settled = true;
       try {
         resolveBody(body ? JSON.parse(body) : {});
       } catch {
         reject(new Error('Invalid JSON'));
       }
     });
+    req.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    });
   });
 
-const clientKey = (req: IncomingMessage) => `${req.socket.remoteAddress ?? 'local'}:${req.url ?? '/'}`;
+const clientKey = (req: IncomingMessage) => {
+  const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+  return `${req.socket.remoteAddress ?? 'local'}:${url.pathname}`;
+};
 
 const isRateLimited = (req: IncomingMessage) => {
   const key = clientKey(req);
@@ -178,7 +211,11 @@ const verifySolana = (address: string, message: string, signature: unknown) => {
 };
 
 const findUserByWallet = (db: Db, kind: WalletKind, address: string) =>
-  Object.values(db.users).find((user) => user[kind]?.address.toLowerCase() === address.toLowerCase());
+  Object.values(db.users).find((user) => {
+    const registered = user[kind]?.address;
+    if (!registered) return false;
+    return kind === 'evm' ? registered.toLowerCase() === address.toLowerCase() : registered === address;
+  });
 
 const defaultUser = (id: string): UserProfile => ({
   id,
@@ -201,6 +238,12 @@ const getPacificDay = (date = new Date()) =>
     month: '2-digit',
     day: '2-digit',
   }).format(date);
+
+const getPreviousPacificDay = () => {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - 1);
+  return getPacificDay(date);
+};
 
 const completedTasks = (user: UserProfile) =>
   [user.evm, user.solana, user.x.status !== 'idle', user.telegram.status !== 'idle', user.tiktok.status !== 'idle'].filter(Boolean)
@@ -240,9 +283,9 @@ const server = createServer(async (req, res) => {
 
   try {
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
-    const db = await readDb();
 
     if (req.method === 'GET' && url.pathname === '/api/profile') {
+      const db = await readDb();
       const user = db.users[url.searchParams.get('userId') ?? ''];
       return user ? json(res, 200, { profile: user }) : json(res, 404, { error: 'Profile not found.' });
     }
@@ -255,9 +298,11 @@ const server = createServer(async (req, res) => {
 
       const nonce = randomBytes(16).toString('hex');
       const message = buildMessage(kind, address, nonce);
-      db.nonces[nonce] = { nonce, walletKind: kind, address, message, expiresAt: Date.now() + NONCE_TTL_MS };
-      await writeDb(db);
-      return json(res, 200, { nonce, message });
+      const result = await updateDb<ApiResult>((db) => {
+        db.nonces[nonce] = { nonce, walletKind: kind, address, message, expiresAt: Date.now() + NONCE_TTL_MS };
+        return { status: 200, body: { nonce, message } };
+      });
+      return json(res, result.status, result.body);
     }
 
     if (req.method === 'POST' && url.pathname === '/api/wallet/verify') {
@@ -267,7 +312,9 @@ const server = createServer(async (req, res) => {
       const nonce = str(body.nonce);
       const message = str(body.message);
       const alias = str(body.alias).slice(0, 32);
-      const record = db.nonces[nonce];
+      const requestedUserId = str(body.userId);
+      const dbBeforeVerify = await readDb();
+      const record = dbBeforeVerify.nonces[nonce];
       if (!kind || !address || !record || record.expiresAt < Date.now()) return json(res, 400, { error: 'Signature request expired.' });
       if (record.walletKind !== kind || record.address !== address || record.message !== message) {
         return json(res, 400, { error: 'Signature request does not match this wallet.' });
@@ -276,65 +323,97 @@ const server = createServer(async (req, res) => {
       const ok = await verifyWalletSignature(kind, address, message, body.signature);
       if (!ok) return json(res, 401, { error: 'Signature verification failed.' });
 
-      const existing = findUserByWallet(db, kind, address);
-      const user = existing ?? defaultUser(randomUUID());
-      user.alias = alias || user.alias;
-      user[kind] = { address, verifiedAt: Date.now() };
-      db.users[user.id] = user;
-      delete db.nonces[nonce];
-      await writeDb(db);
-      return json(res, 200, { profile: user });
+      const result = await updateDb<ApiResult>((db) => {
+        const freshRecord = db.nonces[nonce];
+        if (!freshRecord || freshRecord.expiresAt < Date.now()) {
+          return { status: 400, body: { error: 'Signature request expired.' } };
+        }
+        if (freshRecord.walletKind !== kind || freshRecord.address !== address || freshRecord.message !== message) {
+          return { status: 400, body: { error: 'Signature request does not match this wallet.' } };
+        }
+
+        const existingByWallet = findUserByWallet(db, kind, address);
+        const requestedUser = requestedUserId ? db.users[requestedUserId] : undefined;
+        if (requestedUserId && !requestedUser) {
+          return { status: 404, body: { error: 'Profile not found. Reset local session and sign again.' } };
+        }
+        if (existingByWallet && requestedUser && existingByWallet.id !== requestedUser.id) {
+          return { status: 409, body: { error: 'Wallet is already registered to another profile.' } };
+        }
+
+        const user = requestedUser ?? existingByWallet ?? defaultUser(randomUUID());
+        user.alias = alias || user.alias;
+        user[kind] = { address, verifiedAt: Date.now() };
+        db.users[user.id] = user;
+        delete db.nonces[nonce];
+        return { status: 200, body: { profile: user } };
+      });
+      return json(res, result.status, result.body);
     }
 
     if (req.method === 'POST' && url.pathname === '/api/social') {
       const body = await readJson(req);
-      const user = db.users[str(body.userId)];
       const kind = socialKind(body.kind);
       const handle = str(body.handle).replace(/^@/, '').slice(0, 40);
-      if (!user?.evm && !user?.solana) return json(res, 401, { error: 'Register a wallet first.' });
       if (!kind || !handle) return json(res, 400, { error: 'Social handle is required.' });
 
-      user[kind] = { handle, status: 'pending', openedAt: Date.now(), verifiedAt: Date.now() };
-      await writeDb(db);
-      return json(res, 200, { profile: user });
+      const result = await updateDb<ApiResult>((db) => {
+        const user = db.users[str(body.userId)];
+        if (!user?.evm && !user?.solana) return { status: 401, body: { error: 'Register a wallet first.' } };
+
+        user[kind] = { handle, status: 'pending', openedAt: Date.now(), verifiedAt: Date.now() };
+        return { status: 200, body: { profile: user } };
+      });
+      return json(res, result.status, result.body);
     }
 
     if (req.method === 'POST' && url.pathname === '/api/profile') {
       const body = await readJson(req);
-      const user = db.users[str(body.userId)];
-      if (!user?.evm && !user?.solana) return json(res, 401, { error: 'Register a wallet first.' });
+      const alias = str(body.alias).slice(0, 32);
+      const result = await updateDb<ApiResult>((db) => {
+        const user = db.users[str(body.userId)];
+        if (!user?.evm && !user?.solana) return { status: 401, body: { error: 'Register a wallet first.' } };
 
-      user.alias = str(body.alias).slice(0, 32);
-      await writeDb(db);
-      return json(res, 200, { profile: user });
+        user.alias = alias;
+        return { status: 200, body: { profile: user } };
+      });
+      return json(res, result.status, result.body);
     }
 
     if (req.method === 'POST' && url.pathname === '/api/spin') {
       const body = await readJson(req);
-      const user = db.users[str(body.userId)];
-      if (!user?.evm && !user?.solana) return json(res, 401, { error: 'Register a wallet first.' });
+      const result = await updateDb<ApiResult>((db) => {
+        const user = db.users[str(body.userId)];
+        if (!user?.evm && !user?.solana) return { status: 401, body: { error: 'Register a wallet first.' } };
 
-      const today = getPacificDay();
-      const credits = completedTasks(user) - (user.dailySpins[today] ?? 0);
-      if (credits <= 0) return json(res, 409, { error: 'No spin credits left until midnight PT.' });
+        const today = getPacificDay();
+        const credits = completedTasks(user) - (user.dailySpins[today] ?? 0);
+        if (credits <= 0) return { status: 409, body: { error: 'No spin credits left until midnight PT.' } };
 
-      const rewardDef = pickReward();
-      const reward: SpinReward = {
-        ...rewardDef,
-        id: randomUUID(),
-        xp: pickXp(),
-        wonAt: Date.now(),
-      };
+        const rewardDef = pickReward();
+        const reward: SpinReward = {
+          ...rewardDef,
+          id: randomUUID(),
+          xp: pickXp(),
+          wonAt: Date.now(),
+        };
 
-      const currentStreak = user.lastSpinDay === today || !user.lastSpinDay ? Math.max(1, user.currentStreak || 1) : 1;
-      user.totalXp += reward.xp;
-      user.currentStreak = currentStreak;
-      user.longestStreak = Math.max(user.longestStreak, currentStreak);
-      user.lastSpinDay = today;
-      user.dailySpins[today] = (user.dailySpins[today] ?? 0) + 1;
-      user.collection = [reward, ...user.collection].slice(0, 24);
-      await writeDb(db);
-      return json(res, 200, { profile: user, reward });
+        const yesterday = getPreviousPacificDay();
+        const currentStreak =
+          user.lastSpinDay === today
+            ? Math.max(1, user.currentStreak || 1)
+            : user.lastSpinDay === yesterday
+              ? Math.max(1, user.currentStreak || 0) + 1
+              : 1;
+        user.totalXp += reward.xp;
+        user.currentStreak = currentStreak;
+        user.longestStreak = Math.max(user.longestStreak, currentStreak);
+        user.lastSpinDay = today;
+        user.dailySpins[today] = (user.dailySpins[today] ?? 0) + 1;
+        user.collection = [reward, ...user.collection].slice(0, 24);
+        return { status: 200, body: { profile: user, reward } };
+      });
+      return json(res, result.status, result.body);
     }
 
     return json(res, 404, { error: 'Not found.' });

--- a/apps/retention/src/main.tsx
+++ b/apps/retention/src/main.tsx
@@ -1,0 +1,931 @@
+import { StrictMode, useEffect, useMemo, useRef, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import bs58 from 'bs58';
+import nacl from 'tweetnacl';
+import { createWalletClient, custom, http } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { mainnet } from 'viem/chains';
+import amethystSpire from '../../web/public/bases/amethyst-spire-lv3.png';
+import blackForge from '../../web/public/bases/black-forge-lv4.png';
+import boneStandard from '../../web/public/bases/bone-standard-lv3.png';
+import cobaltKeep from '../../web/public/bases/cobalt-keep-lv3.png';
+import dawnWatch from '../../web/public/bases/dawn-watch-lv4.png';
+import emberHand from '../../web/public/bases/ember-hand-lv5.png';
+import gildedHold from '../../web/public/bases/gilded-hold-lv4.png';
+import ironGuard from '../../web/public/bases/iron-guard-lv3.png';
+import paleCathedral from '../../web/public/bases/pale-cathedral-lv4.png';
+import stormRiders from '../../web/public/bases/storm-riders-lv5.png';
+import tideWardens from '../../web/public/bases/tide-wardens-lv3.png';
+import verdantGrove from '../../web/public/bases/verdant-grove-lv4.png';
+import './styles.css';
+
+declare global {
+  interface Window {
+    ethereum?: {
+      request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
+    };
+    solana?: {
+      publicKey?: { toString: () => string };
+      connect?: () => Promise<{ publicKey: { toString: () => string } }>;
+      signMessage?: (message: Uint8Array, encoding?: string) => Promise<{ signature: Uint8Array }>;
+    };
+  }
+}
+
+type VerificationStatus = 'idle' | 'verifying' | 'pending' | 'granted';
+type WalletKind = 'evm' | 'solana';
+type SocialKind = 'x' | 'telegram' | 'tiktok';
+type Rarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
+type RequestState = 'idle' | 'loading' | 'success' | 'error';
+
+type WalletProfile = {
+  address: string;
+  verifiedAt: number;
+};
+
+type SocialProfile = {
+  handle: string;
+  status: VerificationStatus;
+  openedAt?: number;
+  verifiedAt?: number;
+};
+
+type SpinReward = {
+  id: string;
+  key: string;
+  name: string;
+  rarity: Rarity;
+  xp: number;
+  wonAt: number;
+};
+
+type CampaignProfile = {
+  id: string;
+  alias: string;
+  createdAt: number;
+  totalXp: number;
+  currentStreak: number;
+  longestStreak: number;
+  lastSpinDay?: string;
+  dailySpins: Record<string, number>;
+  collection: SpinReward[];
+  evm?: WalletProfile;
+  solana?: WalletProfile;
+  x: SocialProfile;
+  telegram: SocialProfile;
+  tiktok: SocialProfile;
+};
+
+type RewardDefinition = {
+  key: string;
+  name: string;
+  rarity: Rarity;
+  image: string;
+};
+
+type ApiResponse<T> = T | { error: string };
+
+const USER_ID_KEY = 'clanworld.retention.prototype.userId';
+const TWENTY_HOURS_MS = 20 * 60 * 60 * 1000;
+const STREAK_BONUSES = [3, 7, 15, 21, 25, 30];
+const DEMO_EVM_PRIVATE_KEY = '0x59c6995e998f97a5a0044966f094538e9b7f1ecb4f26dcb5f9969de231120439';
+
+const REWARD_IMAGES: Record<string, string> = {
+  dawnWatch,
+  ironGuard,
+  tideWardens,
+  boneStandard,
+  cobaltKeep,
+  verdantGrove,
+  blackForge,
+  amethystSpire,
+  paleCathedral,
+  gildedHold,
+  stormRiders,
+  emberHand,
+};
+
+const REWARDS: RewardDefinition[] = [
+  { key: 'dawnWatch', name: 'Dawn Watch Keep', rarity: 'common', image: dawnWatch },
+  { key: 'ironGuard', name: 'Iron Guard Bastion', rarity: 'common', image: ironGuard },
+  { key: 'tideWardens', name: 'Tide Wardens Dock', rarity: 'common', image: tideWardens },
+  { key: 'boneStandard', name: 'Bone Standard Camp', rarity: 'uncommon', image: boneStandard },
+  { key: 'cobaltKeep', name: 'Cobalt Keep', rarity: 'uncommon', image: cobaltKeep },
+  { key: 'verdantGrove', name: 'Verdant Grove', rarity: 'uncommon', image: verdantGrove },
+  { key: 'blackForge', name: 'Black Forge', rarity: 'rare', image: blackForge },
+  { key: 'amethystSpire', name: 'Amethyst Spire', rarity: 'rare', image: amethystSpire },
+  { key: 'paleCathedral', name: 'Pale Cathedral', rarity: 'epic', image: paleCathedral },
+  { key: 'gildedHold', name: 'Gilded Hold', rarity: 'epic', image: gildedHold },
+  { key: 'stormRiders', name: 'Storm Riders Citadel', rarity: 'legendary', image: stormRiders },
+  { key: 'emberHand', name: 'Ember Hand Furnace', rarity: 'legendary', image: emberHand },
+];
+
+const LEADERBOARD_BASE = [
+  { alias: 'mira.sol', xp: 1840, streak: 19 },
+  { alias: 'ironbren.eth', xp: 1725, streak: 15 },
+  { alias: 'sora.base', xp: 1550, streak: 12 },
+  { alias: 'anon-7f4c', xp: 1320, streak: 9 },
+  { alias: 'dawncaster', xp: 1185, streak: 7 },
+];
+
+const emptySocial = (): SocialProfile => ({ handle: '', status: 'idle' });
+
+const emptyProfile = (): CampaignProfile => ({
+  id: '',
+  alias: '',
+  createdAt: Date.now(),
+  totalXp: 0,
+  currentStreak: 0,
+  longestStreak: 0,
+  dailySpins: {},
+  collection: [],
+  x: emptySocial(),
+  telegram: emptySocial(),
+  tiktok: emptySocial(),
+});
+
+const normalizeHandle = (value: string) => value.trim().replace(/^@/, '');
+
+const api = async <T,>(path: string, options?: RequestInit): Promise<T> => {
+  const response = await fetch(path, {
+    ...options,
+    headers: {
+      'content-type': 'application/json',
+      ...options?.headers,
+    },
+  });
+  const data = (await response.json()) as ApiResponse<T>;
+  if (!response.ok || isApiError(data)) {
+    throw new Error(isApiError(data) ? data.error : 'Request failed.');
+  }
+  return data;
+};
+
+const isApiError = (value: unknown): value is { error: string } =>
+  typeof value === 'object' && value !== null && 'error' in value && typeof (value as { error?: unknown }).error === 'string';
+
+const post = <T,>(path: string, body: unknown) =>
+  api<T>(path, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+
+const getPacificDay = (date = new Date()) =>
+  new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+
+const getNextPacificMidnight = (from = new Date()) => {
+  const pacificParts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  }).formatToParts(from);
+  const year = Number(pacificParts.find((part) => part.type === 'year')?.value);
+  const month = Number(pacificParts.find((part) => part.type === 'month')?.value);
+  const day = Number(pacificParts.find((part) => part.type === 'day')?.value);
+  const noonUtcTomorrow = new Date(Date.UTC(year, month - 1, day + 1, 12, 0, 0));
+  const offsetMinutes = getTimeZoneOffsetMinutes(noonUtcTomorrow, 'America/Los_Angeles');
+  return new Date(Date.UTC(year, month - 1, day + 1, 0, 0, 0) - offsetMinutes * 60000);
+};
+
+const getTimeZoneOffsetMinutes = (date: Date, timeZone: string) => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).formatToParts(date);
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  const asUtc = Date.UTC(
+    Number(values.year),
+    Number(values.month) - 1,
+    Number(values.day),
+    Number(values.hour),
+    Number(values.minute),
+    Number(values.second),
+  );
+  return (asUtc - date.getTime()) / 60000;
+};
+
+const formatCountdown = (ms: number) => {
+  if (ms <= 0) return 'Ready';
+  const totalMinutes = Math.ceil(ms / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m`;
+};
+
+const randomInt = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
+
+const settledReel = (reward: RewardDefinition, frame: HTMLDivElement | null) => {
+  const frameWidth = frame?.clientWidth ?? 1080;
+  const compact = frameWidth < 520;
+  const slotWidth = compact ? 112 : 132;
+  const slotPitch = compact ? 122 : 142;
+  const rewardIndex = compact ? 1 : Math.max(1, Math.floor((frameWidth / 2 - slotWidth / 2) / slotPitch));
+
+  return [
+    ...Array.from({ length: rewardIndex }, () => REWARDS[randomInt(0, REWARDS.length - 1)]!),
+    reward,
+    ...Array.from({ length: 8 }, () => REWARDS[randomInt(0, REWARDS.length - 1)]!),
+  ];
+};
+
+const taskCount = (profile: CampaignProfile) =>
+  [profile.evm, profile.solana, profile.x.status !== 'idle', profile.telegram.status !== 'idle', profile.tiktok.status !== 'idle'].filter(
+    Boolean,
+  ).length;
+
+const displayAlias = (profile: CampaignProfile) => {
+  if (profile.alias.trim()) return profile.alias.trim();
+  if (profile.solana?.address.endsWith('.sol')) return profile.solana.address;
+  if (profile.evm?.address.endsWith('.eth')) return profile.evm.address;
+  return profile.id ? `anon-${profile.id.slice(0, 4)}` : 'anon-cw';
+};
+
+const rewardImage = (reward: SpinReward) => REWARD_IMAGES[reward.key] ?? dawnWatch;
+
+function App() {
+  const [profile, setProfile] = useState<CampaignProfile>(() => emptyProfile());
+  const [aliasInput, setAliasInput] = useState('');
+  const [evmInput, setEvmInput] = useState('');
+  const [solanaInput, setSolanaInput] = useState('');
+  const [socialInputs, setSocialInputs] = useState<Record<SocialKind, string>>({ x: '', telegram: '', tiktok: '' });
+  const [now, setNow] = useState(Date.now());
+  const [walletStates, setWalletStates] = useState<Record<WalletKind, RequestState>>({ evm: 'idle', solana: 'idle' });
+  const [walletErrors, setWalletErrors] = useState<Record<WalletKind, string>>({ evm: '', solana: '' });
+  const [socialStates, setSocialStates] = useState<Record<SocialKind, RequestState>>({ x: 'idle', telegram: 'idle', tiktok: 'idle' });
+  const [socialErrors, setSocialErrors] = useState<Record<SocialKind, string>>({ x: '', telegram: '', tiktok: '' });
+  const [aliasState, setAliasState] = useState<RequestState>('idle');
+  const [spinState, setSpinState] = useState<RequestState>('idle');
+  const [spinError, setSpinError] = useState('');
+  const [lastReward, setLastReward] = useState<SpinReward | undefined>();
+  const reelFrameRef = useRef<HTMLDivElement | null>(null);
+  const [reelItems, setReelItems] = useState<RewardDefinition[]>(() =>
+    Array.from({ length: 18 }, () => REWARDS[randomInt(0, REWARDS.length - 1)]!),
+  );
+
+  useEffect(() => {
+    const userId = window.localStorage.getItem(USER_ID_KEY);
+    if (!userId) return;
+
+    api<{ profile: CampaignProfile }>(`/api/profile?userId=${encodeURIComponent(userId)}`)
+      .then(({ profile: nextProfile }) => {
+        hydrateProfile(nextProfile);
+      })
+      .catch(() => {
+        window.localStorage.removeItem(USER_ID_KEY);
+      });
+  }, []);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(Date.now()), 30000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (!profile.id || aliasInput === profile.alias) return;
+
+    setAliasState('loading');
+    const timeout = window.setTimeout(() => {
+      post<{ profile: CampaignProfile }>('/api/profile', { userId: profile.id, alias: aliasInput })
+        .then(({ profile: nextProfile }) => {
+          hydrateProfile(nextProfile);
+          setAliasState('success');
+        })
+        .catch(() => setAliasState('error'));
+    }, 650);
+
+    return () => window.clearTimeout(timeout);
+  }, [aliasInput, profile.alias, profile.id]);
+
+  const hydrateProfile = (nextProfile: CampaignProfile) => {
+    setProfile(nextProfile);
+    setAliasInput(nextProfile.alias);
+    setEvmInput(nextProfile.evm?.address ?? '');
+    setSolanaInput(nextProfile.solana?.address ?? '');
+    setSocialInputs({
+      x: nextProfile.x.handle,
+      telegram: nextProfile.telegram.handle,
+      tiktok: nextProfile.tiktok.handle,
+    });
+    window.localStorage.setItem(USER_ID_KEY, nextProfile.id);
+  };
+
+  const today = getPacificDay(new Date(now));
+  const completedTasks = taskCount(profile);
+  const usedToday = profile.dailySpins[today] ?? 0;
+  const creditsToday = Math.max(0, completedTasks - usedToday);
+  const nextReset = getNextPacificMidnight(new Date(now));
+  const hasWallet = Boolean(profile.evm || profile.solana);
+  const unlockAt = profile.createdAt + TWENTY_HOURS_MS;
+  const rewardReady = hasWallet && now >= unlockAt;
+  const leaderboard = useMemo(
+    () =>
+      [
+        ...(profile.id ? [{ alias: displayAlias(profile), xp: profile.totalXp, streak: profile.currentStreak }] : []),
+        ...LEADERBOARD_BASE,
+      ]
+        .sort((a, b) => b.xp - a.xp || b.streak - a.streak)
+        .slice(0, 6),
+    [profile],
+  );
+
+  const verifyWallet = async (kind: WalletKind, mode: 'wallet' | 'demo') => {
+    const requestedAddress = kind === 'evm' ? evmInput.trim() : solanaInput.trim();
+    setWalletStates((current) => ({ ...current, [kind]: 'loading' }));
+    setWalletErrors((current) => ({ ...current, [kind]: '' }));
+
+    try {
+      const signed = await signWallet(kind, mode, requestedAddress);
+      const response = await post<{ profile: CampaignProfile }>('/api/wallet/verify', {
+        walletKind: kind,
+        address: signed.address,
+        nonce: signed.nonce,
+        message: signed.message,
+        signature: signed.signature,
+        alias: aliasInput,
+      });
+      hydrateProfile(response.profile);
+      setWalletStates((current) => ({ ...current, [kind]: 'success' }));
+    } catch (error) {
+      setWalletErrors((current) => ({
+        ...current,
+        [kind]: error instanceof Error ? error.message : 'Could not verify wallet.',
+      }));
+      setWalletStates((current) => ({ ...current, [kind]: 'error' }));
+    }
+  };
+
+  const signWallet = async (kind: WalletKind, mode: 'wallet' | 'demo', requestedAddress: string) => {
+    if (kind === 'evm') {
+      const address = mode === 'demo' ? privateKeyToAccount(DEMO_EVM_PRIVATE_KEY).address : await requestEvmAddress();
+      const nonce = await post<{ nonce: string; message: string }>('/api/nonce', { walletKind: kind, address });
+      const signature =
+        mode === 'demo'
+          ? await privateKeyToAccount(DEMO_EVM_PRIVATE_KEY).signMessage({ message: nonce.message })
+          : await signInjectedEvm(address, nonce.message);
+      return { address, ...nonce, signature };
+    }
+
+    if (mode === 'demo') {
+      const keypair = nacl.sign.keyPair.fromSeed(new TextEncoder().encode('clanworld-retention-demo-solana!').slice(0, 32));
+      const address = bs58.encode(keypair.publicKey);
+      const nonce = await post<{ nonce: string; message: string }>('/api/nonce', { walletKind: kind, address });
+      return { address, ...nonce, signature: Array.from(nacl.sign.detached(new TextEncoder().encode(nonce.message), keypair.secretKey)) };
+    }
+
+    const address = requestedAddress || (await requestSolanaAddress());
+    const nonce = await post<{ nonce: string; message: string }>('/api/nonce', { walletKind: kind, address });
+    const signature = await signInjectedSolana(nonce.message);
+    return { address, ...nonce, signature };
+  };
+
+  const requestEvmAddress = async () => {
+    if (!window.ethereum) throw new Error('No EVM wallet detected. Use demo sign or install a wallet.');
+    const accounts = (await window.ethereum.request({ method: 'eth_requestAccounts' })) as string[];
+    const address = accounts[0];
+    if (!address) throw new Error('No EVM account selected.');
+    return address;
+  };
+
+  const signInjectedEvm = async (address: string, message: string) => {
+    if (!window.ethereum) throw new Error('No EVM wallet detected.');
+    const client = createWalletClient({ chain: mainnet, transport: custom(window.ethereum) });
+    return client.signMessage({ account: address as `0x${string}`, message });
+  };
+
+  const requestSolanaAddress = async () => {
+    if (!window.solana?.connect) throw new Error('No Solana wallet detected. Use demo sign or install a wallet.');
+    const account = await window.solana.connect();
+    return account.publicKey.toString();
+  };
+
+  const signInjectedSolana = async (message: string) => {
+    if (!window.solana?.signMessage) throw new Error('No Solana wallet message signer detected.');
+    const result = await window.solana.signMessage(new TextEncoder().encode(message), 'utf8');
+    return Array.from(result.signature);
+  };
+
+  const setSocialHandle = (key: SocialKind, value: string) => {
+    setSocialInputs((current) => ({ ...current, [key]: normalizeHandle(value) }));
+  };
+
+  const openSocialLink = (key: SocialKind) => {
+    const href = {
+      x: 'https://x.com/intent/follow?screen_name=ClanWorldGame',
+      telegram: 'https://t.me/ClanWorldGame',
+      tiktok: 'https://www.tiktok.com/@clanworldgame',
+    }[key];
+    window.open(href, '_blank', 'noopener,noreferrer');
+  };
+
+  const verifySocial = (key: SocialKind) => {
+    if (!profile.id) return;
+
+    setSocialStates((current) => ({ ...current, [key]: 'loading' }));
+    setSocialErrors((current) => ({ ...current, [key]: '' }));
+
+    window.setTimeout(() => {
+      post<{ profile: CampaignProfile }>('/api/social', {
+        userId: profile.id,
+        kind: key,
+        handle: socialInputs[key],
+      })
+        .then(({ profile: nextProfile }) => {
+          hydrateProfile(nextProfile);
+          setSocialStates((current) => ({ ...current, [key]: 'success' }));
+        })
+        .catch((error) => {
+          setSocialErrors((current) => ({
+            ...current,
+            [key]: error instanceof Error ? error.message : 'Could not save social handle.',
+          }));
+          setSocialStates((current) => ({ ...current, [key]: 'error' }));
+        });
+    }, 5000);
+  };
+
+  const spin = () => {
+    if (creditsToday <= 0 || spinState === 'loading' || !profile.id) return;
+
+    setSpinState('loading');
+    setSpinError('');
+    const teaserItems = Array.from({ length: 32 }, () => REWARDS[randomInt(0, REWARDS.length - 1)]!);
+    setReelItems(teaserItems);
+
+    post<{ profile: CampaignProfile; reward: SpinReward }>('/api/spin', { userId: profile.id })
+      .then(({ profile: nextProfile, reward }) => {
+        const rewardDef = REWARDS.find((item) => item.key === reward.key) ?? REWARDS[0]!;
+        setReelItems([
+          ...Array.from({ length: 24 }, () => REWARDS[randomInt(0, REWARDS.length - 1)]!),
+          rewardDef,
+          ...Array.from({ length: 6 }, () => REWARDS[randomInt(0, REWARDS.length - 1)]!),
+        ]);
+        window.setTimeout(() => {
+          setReelItems(settledReel(rewardDef, reelFrameRef.current));
+          hydrateProfile(nextProfile);
+          setLastReward(reward);
+          setSpinState('success');
+        }, 2300);
+      })
+      .catch((error) => {
+        setSpinError(error instanceof Error ? error.message : 'Spin failed.');
+        setSpinState('error');
+      });
+  };
+
+  const resetLocal = () => {
+    window.localStorage.removeItem(USER_ID_KEY);
+    setProfile(emptyProfile());
+    setAliasInput('');
+    setEvmInput('');
+    setSolanaInput('');
+    setSocialInputs({ x: '', telegram: '', tiktok: '' });
+    setLastReward(undefined);
+    setSpinError('');
+    setWalletErrors({ evm: '', solana: '' });
+    setSocialErrors({ x: '', telegram: '', tiktok: '' });
+  };
+
+  return (
+    <main className="shell">
+      <section className="workspace" aria-labelledby="page-title">
+        <div className="masthead">
+          <div>
+            <p className="eyebrow">ClanWorld Campaign Access</p>
+            <h1 id="page-title">Register optional accounts. Earn daily spins. Build a collectible streak.</h1>
+          </div>
+          <div className="progressDial" aria-label={`${completedTasks} of 5 optional spin sources active`}>
+            <span>{completedTasks}/5</span>
+          </div>
+        </div>
+
+        <section className="panel spinPanel" aria-labelledby="spin-title">
+          <div className="spinHeader">
+            <div>
+              <p className="step">Daily Wheel</p>
+              <h2 id="spin-title">Loot Reel</h2>
+            </div>
+            <div className="spinStats">
+              <Stat label="Credits" value={`${creditsToday}/${completedTasks}`} />
+              <Stat label="XP" value={String(profile.totalXp)} />
+              <Stat label="Streak" value={`${profile.currentStreak}d`} />
+              <Stat label="Reset" value={formatCountdown(nextReset.getTime() - now)} />
+            </div>
+          </div>
+
+          <div className="reelFrame" ref={reelFrameRef}>
+            <div className="reelMarker" />
+            <div className={`reelTrack ${spinState === 'loading' ? 'spinning' : ''}`}>
+              {reelItems.map((item, index) => (
+                <div className={`reelSlot ${item.rarity}`} key={`${item.name}-${index}`}>
+                  <img src={item.image} alt="" />
+                  <span>{item.name}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="spinFooter">
+            <button
+              className="primaryButton spinButton"
+              type="button"
+              onClick={spin}
+              disabled={!hasWallet || creditsToday <= 0 || spinState === 'loading'}
+            >
+              {spinState === 'loading' ? (
+                <>
+                  <span className="spinner" aria-hidden="true" />
+                  Spinning...
+                </>
+              ) : (
+                'Spin Wheel'
+              )}
+            </button>
+            <p className={spinError ? 'errorText' : 'statusCopy'}>
+              {spinError ||
+                (lastReward
+                  ? `Last pull: ${lastReward.name}, ${lastReward.xp} XP.`
+                  : hasWallet
+                    ? 'Each active wallet/social source grants one spin per PT day.'
+                    : 'Verify at least one wallet to activate the campaign profile.')}
+            </p>
+          </div>
+        </section>
+
+        <div className="layout">
+          <section className="panel walletPanel" aria-labelledby="wallet-title">
+            <div className="panelHeader">
+              <p className="step">Spin Sources</p>
+              <h2 id="wallet-title">Wallets</h2>
+            </div>
+
+            <AliasRow alias={aliasInput} state={aliasState} onChange={setAliasInput} />
+            <WalletRow
+              label="EVM"
+              placeholder="Wallet fills after signing"
+              value={evmInput}
+              wallet={profile.evm}
+              state={walletStates.evm}
+              error={walletErrors.evm}
+              onChange={setEvmInput}
+              onVerify={() => verifyWallet('evm', 'wallet')}
+              onDemo={() => verifyWallet('evm', 'demo')}
+            />
+            <WalletRow
+              label="Solana"
+              placeholder="Wallet fills after signing"
+              value={solanaInput}
+              wallet={profile.solana}
+              state={walletStates.solana}
+              error={walletErrors.solana}
+              onChange={setSolanaInput}
+              onVerify={() => verifyWallet('solana', 'wallet')}
+              onDemo={() => verifyWallet('solana', 'demo')}
+            />
+          </section>
+
+          <section className={`panel ${hasWallet ? '' : 'locked'}`} aria-labelledby="social-title">
+            <div className="panelHeader">
+              <p className="step">Optional</p>
+              <h2 id="social-title">Social Sources</h2>
+            </div>
+
+            <SocialQuest
+              label="X"
+              handleLabel="X handle"
+              placeholder="ClanWorldGame"
+              profile={profile.x}
+              value={socialInputs.x}
+              state={socialStates.x}
+              error={socialErrors.x}
+              disabled={!hasWallet}
+              linkLabel="Follow @ClanWorldGame"
+              onHandle={(value) => setSocialHandle('x', value)}
+              onOpen={() => openSocialLink('x')}
+              onVerify={() => verifySocial('x')}
+            />
+            <SocialQuest
+              label="Telegram"
+              handleLabel="Telegram handle"
+              placeholder="your_handle"
+              profile={profile.telegram}
+              value={socialInputs.telegram}
+              state={socialStates.telegram}
+              error={socialErrors.telegram}
+              disabled={!hasWallet}
+              linkLabel="Join ClanWorldGame"
+              onHandle={(value) => setSocialHandle('telegram', value)}
+              onOpen={() => openSocialLink('telegram')}
+              onVerify={() => verifySocial('telegram')}
+            />
+            <SocialQuest
+              label="TikTok"
+              handleLabel="TikTok handle"
+              placeholder="clanworldgame"
+              profile={profile.tiktok}
+              value={socialInputs.tiktok}
+              state={socialStates.tiktok}
+              error={socialErrors.tiktok}
+              disabled={!hasWallet}
+              linkLabel="Follow @clanworldgame"
+              onHandle={(value) => setSocialHandle('tiktok', value)}
+              onOpen={() => openSocialLink('tiktok')}
+              onVerify={() => verifySocial('tiktok')}
+            />
+          </section>
+
+          <aside className="panel statusPanel" aria-labelledby="status-title">
+            <div className="panelHeader">
+              <p className="step">Campaign</p>
+              <h2 id="status-title">Profile</h2>
+            </div>
+
+            <div className="rewardMeter">
+              <div className={`rewardOrb ${rewardReady ? 'ready' : ''}`} />
+              <div>
+                <p className="statusLabel">{rewardReady ? 'Campaign access granted' : 'Campaign access pending'}</p>
+                <p className="statusCopy">
+                  {hasWallet
+                    ? `Automatic grant window: ${formatCountdown(unlockAt - now)}`
+                    : 'Register at least one wallet to start the access timer.'}
+                </p>
+              </div>
+            </div>
+
+            <BonusTrack streak={profile.currentStreak} />
+
+            <dl className="profileList">
+              <ProfileItem label="Alias" value={displayAlias(profile)} />
+              <ProfileItem label="EVM" value={profile.evm?.address ?? 'Not registered'} />
+              <ProfileItem label="Solana" value={profile.solana?.address ?? 'Not registered'} />
+              <ProfileItem label="X" value={profile.x.handle ? `@${profile.x.handle}` : 'Not linked'} />
+              <ProfileItem label="Telegram" value={profile.telegram.handle ? `@${profile.telegram.handle}` : 'Not linked'} />
+              <ProfileItem label="TikTok" value={profile.tiktok.handle ? `@${profile.tiktok.handle}` : 'Not linked'} />
+            </dl>
+
+            <button className="secondaryButton" type="button" onClick={resetLocal}>
+              Reset Local Session
+            </button>
+          </aside>
+        </div>
+
+        <div className="lowerGrid">
+          <section className="panel" aria-labelledby="collection-title">
+            <div className="panelHeader">
+              <p className="step">Collection</p>
+              <h2 id="collection-title">Recent Sprites</h2>
+            </div>
+            <div className="collectionGrid">
+              {profile.collection.length ? (
+                profile.collection.map((reward) => (
+                  <div className={`collectionItem ${reward.rarity}`} key={reward.id}>
+                    <img src={rewardImage(reward)} alt="" />
+                    <span>{reward.xp} XP</span>
+                  </div>
+                ))
+              ) : (
+                <p className="emptyState">Spin to start collecting ClanWorld sprites.</p>
+              )}
+            </div>
+          </section>
+
+          <section className="panel" aria-labelledby="leaderboard-title">
+            <div className="panelHeader">
+              <p className="step">Hourly</p>
+              <h2 id="leaderboard-title">Leaderboard</h2>
+            </div>
+            <ol className="leaderboard">
+              {leaderboard.map((entry, index) => (
+                <li key={`${entry.alias}-${index}`}>
+                  <span className="rank">#{index + 1}</span>
+                  <span>{entry.alias}</span>
+                  <strong>{entry.xp} XP</strong>
+                  <small>{entry.streak}d streak</small>
+                </li>
+              ))}
+            </ol>
+          </section>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="stat">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function AliasRow({
+  alias,
+  state,
+  onChange,
+}: {
+  alias: string;
+  state: RequestState;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="aliasRow">
+      <div className="fieldGroup">
+        <label>Leaderboard alias</label>
+        <div className="inputStatusWrap">
+          <input
+            aria-label="Leaderboard alias"
+            value={alias}
+            onChange={(event) => onChange(event.target.value)}
+            placeholder="Optional username"
+          />
+          <InlineState state={state} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type WalletRowProps = {
+  label: string;
+  placeholder: string;
+  value: string;
+  wallet?: WalletProfile;
+  state: RequestState;
+  error: string;
+  onChange: (value: string) => void;
+  onVerify: () => void;
+  onDemo: () => void;
+};
+
+function WalletRow({ label, placeholder, value, wallet, state, error, onChange, onVerify, onDemo }: WalletRowProps) {
+  const loading = state === 'loading';
+
+  return (
+    <div className="walletRow expanded">
+      <div className="fieldGroup">
+        <label>{label} Wallet</label>
+        <div className="inputStatusWrap">
+          <input
+            aria-label={`${label} Wallet`}
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            placeholder={placeholder}
+            disabled={Boolean(wallet)}
+          />
+          <InlineState state={state} />
+        </div>
+        {error ? <p className="errorText">{error}</p> : <p className="hintText">Cryptographic signature is verified before profile save.</p>}
+      </div>
+      <div className="walletActions">
+        <button className={wallet ? 'verifiedButton' : 'primaryButton'} type="button" onClick={onVerify} disabled={loading || Boolean(wallet)}>
+          {loading ? (
+            <>
+              <span className="spinner" aria-hidden="true" />
+              Signing...
+            </>
+          ) : wallet ? (
+            '+1 Spin'
+          ) : (
+            'Connect'
+          )}
+        </button>
+        <button className="secondaryButton" type="button" onClick={onDemo} disabled={loading || Boolean(wallet)}>
+          Demo Sign
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type SocialQuestProps = {
+  label: string;
+  handleLabel: string;
+  placeholder: string;
+  profile: SocialProfile;
+  value: string;
+  state: RequestState;
+  error: string;
+  disabled: boolean;
+  linkLabel: string;
+  onHandle: (value: string) => void;
+  onOpen: () => void;
+  onVerify: () => void;
+};
+
+function SocialQuest({
+  label,
+  handleLabel,
+  placeholder,
+  profile,
+  value,
+  state,
+  error,
+  disabled,
+  linkLabel,
+  onHandle,
+  onOpen,
+  onVerify,
+}: SocialQuestProps) {
+  const loading = state === 'loading';
+  const active = profile.status !== 'idle';
+
+  return (
+    <div className="questRow" aria-disabled={disabled}>
+      <div className="questTitle">
+        <span className="questBadge">{label}</span>
+        <StatusPill status={profile.status} />
+      </div>
+      <div className="fieldGroup">
+        <label>{handleLabel}</label>
+        <div className="inputStatusWrap">
+          <input
+            aria-label={handleLabel}
+            value={value}
+            onChange={(event) => onHandle(event.target.value)}
+            placeholder={placeholder}
+            disabled={disabled || active}
+          />
+          <InlineState state={state} />
+        </div>
+      </div>
+      <div className="buttonLine">
+        <button className="secondaryButton" type="button" onClick={onOpen} disabled={disabled || !value || loading}>
+          {linkLabel}
+        </button>
+        <button className={active ? 'verifiedButton' : 'primaryButton'} type="button" onClick={onVerify} disabled={disabled || !value || loading || active}>
+          {loading ? (
+            <>
+              <span className="spinner" aria-hidden="true" />
+              Verifying...
+            </>
+          ) : active ? (
+            '+1 Spin'
+          ) : (
+            'Click to verify'
+          )}
+        </button>
+      </div>
+      {error ? <p className="errorText">{error}</p> : null}
+      {profile.verifiedAt ? <p className="notice">Verification can take up to 24h. Spin credit is provisionally active.</p> : null}
+    </div>
+  );
+}
+
+function InlineState({ state }: { state: RequestState }) {
+  if (state === 'loading') return <span className="inlineState loading">Saving</span>;
+  if (state === 'success') return <span className="inlineState success">Saved</span>;
+  if (state === 'error') return <span className="inlineState error">Retry</span>;
+  return null;
+}
+
+function StatusPill({ status }: { status: VerificationStatus }) {
+  const label = {
+    idle: 'Optional',
+    verifying: 'Checking',
+    pending: 'Active',
+    granted: 'Granted',
+  }[status];
+
+  return <span className={`statusPill ${status}`}>{label}</span>;
+}
+
+function BonusTrack({ streak }: { streak: number }) {
+  return (
+    <div className="bonusTrack">
+      {STREAK_BONUSES.map((day) => (
+        <div className={streak >= day ? 'bonusNode earned' : 'bonusNode'} key={day}>
+          <strong>{day}</strong>
+          <span>days</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ProfileItem({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/retention/src/main.tsx
+++ b/apps/retention/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode, useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import bs58 from 'bs58';
 import nacl from 'tweetnacl';
-import { createWalletClient, custom, http } from 'viem';
+import { createWalletClient, custom } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { mainnet } from 'viem/chains';
 import amethystSpire from '../../web/public/bases/amethyst-spire-lv3.png';
@@ -89,6 +89,7 @@ const USER_ID_KEY = 'clanworld.retention.prototype.userId';
 const TWENTY_HOURS_MS = 20 * 60 * 60 * 1000;
 const STREAK_BONUSES = [3, 7, 15, 21, 25, 30];
 const DEMO_EVM_PRIVATE_KEY = '0x59c6995e998f97a5a0044966f094538e9b7f1ecb4f26dcb5f9969de231120439';
+const DEMO_SIGNING_ENABLED = import.meta.env.DEV || import.meta.env.VITE_RETENTION_ENABLE_DEMO_SIGNING === 'true';
 
 const REWARD_IMAGES: Record<string, string> = {
   dawnWatch,
@@ -346,8 +347,10 @@ function App() {
     setWalletErrors((current) => ({ ...current, [kind]: '' }));
 
     try {
+      if (mode === 'demo' && !DEMO_SIGNING_ENABLED) throw new Error('Demo signing is disabled for this build.');
       const signed = await signWallet(kind, mode, requestedAddress);
       const response = await post<{ profile: CampaignProfile }>('/api/wallet/verify', {
+        userId: profile.id || undefined,
         walletKind: kind,
         address: signed.address,
         nonce: signed.nonce,
@@ -391,7 +394,9 @@ function App() {
   };
 
   const requestEvmAddress = async () => {
-    if (!window.ethereum) throw new Error('No EVM wallet detected. Use demo sign or install a wallet.');
+    if (!window.ethereum) {
+      throw new Error(DEMO_SIGNING_ENABLED ? 'No EVM wallet detected. Use demo sign or install a wallet.' : 'No EVM wallet detected.');
+    }
     const accounts = (await window.ethereum.request({ method: 'eth_requestAccounts' })) as string[];
     const address = accounts[0];
     if (!address) throw new Error('No EVM account selected.');
@@ -405,7 +410,9 @@ function App() {
   };
 
   const requestSolanaAddress = async () => {
-    if (!window.solana?.connect) throw new Error('No Solana wallet detected. Use demo sign or install a wallet.');
+    if (!window.solana?.connect) {
+      throw new Error(DEMO_SIGNING_ENABLED ? 'No Solana wallet detected. Use demo sign or install a wallet.' : 'No Solana wallet detected.');
+    }
     const account = await window.solana.connect();
     return account.publicKey.toString();
   };
@@ -581,6 +588,7 @@ function App() {
               onChange={setEvmInput}
               onVerify={() => verifyWallet('evm', 'wallet')}
               onDemo={() => verifyWallet('evm', 'demo')}
+              demoEnabled={DEMO_SIGNING_ENABLED}
             />
             <WalletRow
               label="Solana"
@@ -592,6 +600,7 @@ function App() {
               onChange={setSolanaInput}
               onVerify={() => verifyWallet('solana', 'wallet')}
               onDemo={() => verifyWallet('solana', 'demo')}
+              demoEnabled={DEMO_SIGNING_ENABLED}
             />
           </section>
 
@@ -765,12 +774,13 @@ type WalletRowProps = {
   wallet?: WalletProfile;
   state: RequestState;
   error: string;
+  demoEnabled: boolean;
   onChange: (value: string) => void;
   onVerify: () => void;
   onDemo: () => void;
 };
 
-function WalletRow({ label, placeholder, value, wallet, state, error, onChange, onVerify, onDemo }: WalletRowProps) {
+function WalletRow({ label, placeholder, value, wallet, state, error, demoEnabled, onChange, onVerify, onDemo }: WalletRowProps) {
   const loading = state === 'loading';
 
   return (
@@ -802,9 +812,11 @@ function WalletRow({ label, placeholder, value, wallet, state, error, onChange, 
             'Connect'
           )}
         </button>
-        <button className="secondaryButton" type="button" onClick={onDemo} disabled={loading || Boolean(wallet)}>
-          Demo Sign
-        </button>
+        {demoEnabled ? (
+          <button className="secondaryButton" type="button" onClick={onDemo} disabled={loading || Boolean(wallet)}>
+            Demo Sign
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/retention/src/styles.css
+++ b/apps/retention/src/styles.css
@@ -1,0 +1,764 @@
+:root {
+  color: #162021;
+  background: #eef1ed;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled,
+input:disabled {
+  cursor: not-allowed;
+}
+
+.shell {
+  min-height: 100vh;
+  padding: 32px;
+  background:
+    radial-gradient(circle at 18% 14%, rgba(72, 128, 115, 0.18), transparent 28%),
+    linear-gradient(135deg, #f4f0e8 0%, #eef1ed 44%, #e8eef4 100%);
+}
+
+.workspace {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+}
+
+.masthead {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 22px;
+}
+
+.eyebrow,
+.step {
+  margin: 0 0 8px;
+  color: #53696b;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 0;
+  color: #101820;
+  font-size: 2.45rem;
+  line-height: 1.05;
+}
+
+h2 {
+  margin-bottom: 0;
+  color: #162021;
+  font-size: 1.15rem;
+}
+
+.progressDial {
+  display: grid;
+  flex: 0 0 auto;
+  width: 72px;
+  height: 72px;
+  place-items: center;
+  border: 1px solid rgba(16, 24, 32, 0.14);
+  border-radius: 50%;
+  background: conic-gradient(#257a6b 0deg, #257a6b 120deg, #d7d5c9 120deg);
+  color: #101820;
+  font-weight: 900;
+}
+
+.progressDial span {
+  display: grid;
+  width: 52px;
+  height: 52px;
+  place-items: center;
+  border-radius: 50%;
+  background: #fbfaf6;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.08fr) 340px;
+  gap: 16px;
+  align-items: start;
+  margin-top: 16px;
+}
+
+.panel {
+  border: 1px solid rgba(16, 24, 32, 0.14);
+  border-radius: 8px;
+  background: rgba(251, 250, 246, 0.92);
+  box-shadow: 0 18px 50px rgba(16, 24, 32, 0.08);
+  padding: 18px;
+}
+
+.panel.locked {
+  opacity: 0.62;
+}
+
+.panelHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+  border-bottom: 1px solid rgba(16, 24, 32, 0.11);
+  padding-bottom: 14px;
+}
+
+.walletRow,
+.questRow {
+  display: grid;
+  gap: 12px;
+  padding: 14px 0;
+}
+
+.walletRow {
+  grid-template-columns: minmax(0, 1fr) 104px;
+  align-items: end;
+}
+
+.walletRow.expanded {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.walletRow + .walletRow,
+.questRow + .questRow {
+  border-top: 1px solid rgba(16, 24, 32, 0.09);
+}
+
+.aliasRow {
+  padding-bottom: 14px;
+}
+
+.fieldGroup {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+label {
+  color: #334749;
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+input {
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid rgba(16, 24, 32, 0.18);
+  border-radius: 8px;
+  background: #ffffff;
+  color: #101820;
+  padding: 0 12px;
+  outline: none;
+}
+
+input:focus {
+  border-color: #257a6b;
+  box-shadow: 0 0 0 3px rgba(37, 122, 107, 0.16);
+}
+
+.inputStatusWrap {
+  position: relative;
+}
+
+.inputStatusWrap input {
+  padding-right: 74px;
+}
+
+.inlineState {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  translate: 0 -50%;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 0.7rem;
+  font-weight: 900;
+  pointer-events: none;
+}
+
+.inlineState.loading {
+  background: #dfeeff;
+  color: #1d4e7a;
+}
+
+.inlineState.success {
+  background: #dff0e4;
+  color: #155b4f;
+}
+
+.inlineState.error {
+  background: #ffe0df;
+  color: #8f2b24;
+}
+
+.primaryButton,
+.secondaryButton,
+.verifiedButton {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 8px;
+  padding: 0 14px;
+  font-weight: 850;
+  white-space: nowrap;
+}
+
+.primaryButton {
+  border: 1px solid #101820;
+  background: #101820;
+  color: #ffffff;
+}
+
+.secondaryButton {
+  border: 1px solid rgba(16, 24, 32, 0.18);
+  background: #ffffff;
+  color: #162021;
+}
+
+.verifiedButton {
+  border: 1px solid rgba(37, 122, 107, 0.3);
+  background: #dff0e4;
+  color: #155b4f;
+}
+
+.primaryButton:disabled,
+.secondaryButton:disabled,
+.verifiedButton:disabled {
+  opacity: 0.48;
+}
+
+.questTitle,
+.buttonLine {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.questTitle {
+  justify-content: space-between;
+}
+
+.walletActions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.questBadge {
+  display: inline-grid;
+  min-width: 88px;
+  min-height: 34px;
+  place-items: center;
+  border-radius: 8px;
+  background: #ead7bd;
+  color: #4b3420;
+  font-weight: 900;
+}
+
+.statusPill {
+  display: inline-grid;
+  min-height: 28px;
+  place-items: center;
+  border-radius: 999px;
+  padding: 0 10px;
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.statusPill.idle {
+  background: #e5e8eb;
+  color: #53606b;
+}
+
+.statusPill.verifying {
+  background: #dfeeff;
+  color: #1d4e7a;
+}
+
+.statusPill.pending {
+  background: #fff1c7;
+  color: #76520c;
+}
+
+.statusPill.granted {
+  background: #dff0e4;
+  color: #155b4f;
+}
+
+.notice {
+  margin: -2px 0 0;
+  color: #6d521d;
+  font-size: 0.88rem;
+  font-weight: 750;
+}
+
+.hintText,
+.errorText {
+  margin: -2px 0 0;
+  font-size: 0.84rem;
+  font-weight: 750;
+}
+
+.hintText {
+  color: #53606b;
+}
+
+.errorText {
+  color: #9a3128;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.45);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.rewardMeter {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.spinPanel {
+  overflow: hidden;
+}
+
+.spinHeader,
+.spinFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.spinHeader {
+  margin-bottom: 16px;
+}
+
+.spinStats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(80px, 1fr));
+  gap: 8px;
+}
+
+.stat {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  border: 1px solid rgba(16, 24, 32, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 10px;
+}
+
+.stat span {
+  color: #53606b;
+  font-size: 0.72rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.stat strong {
+  overflow: hidden;
+  color: #101820;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reelFrame {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(16, 24, 32, 0.14);
+  border-radius: 8px;
+  background:
+    linear-gradient(90deg, rgba(16, 24, 32, 0.18), transparent 14%, transparent 86%, rgba(16, 24, 32, 0.18)),
+    #182223;
+  padding: 14px 0;
+}
+
+.reelMarker {
+  position: absolute;
+  z-index: 2;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 3px;
+  border-radius: 999px;
+  background: #ffd166;
+  box-shadow: 0 0 0 1px rgba(16, 24, 32, 0.22), 0 0 22px rgba(255, 209, 102, 0.65);
+}
+
+.reelTrack {
+  display: flex;
+  gap: 10px;
+  width: max-content;
+  padding-inline: 16px;
+  transform: translateX(0);
+}
+
+.reelTrack.spinning {
+  animation: reelSlide 2.35s cubic-bezier(0.12, 0.76, 0.12, 1) forwards;
+}
+
+.reelSlot {
+  display: grid;
+  width: 132px;
+  height: 148px;
+  flex: 0 0 auto;
+  grid-template-rows: minmax(0, 1fr) 34px;
+  align-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  background: #f8f5ec;
+  padding: 8px;
+}
+
+.reelSlot img,
+.collectionItem img {
+  width: 100%;
+  min-width: 0;
+  object-fit: contain;
+}
+
+.reelSlot img {
+  height: 88px;
+}
+
+.reelSlot span {
+  overflow: hidden;
+  color: #162021;
+  font-size: 0.76rem;
+  font-weight: 900;
+  line-height: 1.05;
+  text-align: center;
+}
+
+.reelSlot.common,
+.collectionItem.common {
+  border-color: #a9b8b3;
+}
+
+.reelSlot.uncommon,
+.collectionItem.uncommon {
+  border-color: #3b8f7e;
+}
+
+.reelSlot.rare,
+.collectionItem.rare {
+  border-color: #3d6ee4;
+}
+
+.reelSlot.epic,
+.collectionItem.epic {
+  border-color: #8b5bd6;
+}
+
+.reelSlot.legendary,
+.collectionItem.legendary {
+  border-color: #d99626;
+  box-shadow: inset 0 0 0 2px rgba(255, 209, 102, 0.22);
+}
+
+.spinFooter {
+  margin-top: 14px;
+}
+
+.spinButton {
+  min-width: 160px;
+}
+
+.rewardOrb {
+  width: 56px;
+  height: 56px;
+  border: 1px solid rgba(16, 24, 32, 0.12);
+  border-radius: 50%;
+  background: linear-gradient(135deg, #ead7bd, #d7d5c9);
+}
+
+.rewardOrb.ready {
+  background: linear-gradient(135deg, #3b8f7e, #ffd166);
+}
+
+.statusLabel {
+  margin-bottom: 4px;
+  font-weight: 900;
+}
+
+.statusCopy {
+  margin-bottom: 0;
+  color: #53606b;
+  font-size: 0.92rem;
+}
+
+.profileList {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 10px 12px;
+  margin: 0 0 18px;
+  border-top: 1px solid rgba(16, 24, 32, 0.09);
+  padding-top: 16px;
+}
+
+.bonusTrack {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.bonusNode {
+  display: grid;
+  min-height: 52px;
+  place-items: center;
+  border: 1px solid rgba(16, 24, 32, 0.12);
+  border-radius: 8px;
+  background: #ffffff;
+  color: #53606b;
+}
+
+.bonusNode.earned {
+  border-color: rgba(37, 122, 107, 0.35);
+  background: #dff0e4;
+  color: #155b4f;
+}
+
+.bonusNode strong,
+.bonusNode span {
+  line-height: 1;
+}
+
+.bonusNode strong {
+  font-size: 1rem;
+}
+
+.bonusNode span {
+  font-size: 0.7rem;
+  font-weight: 850;
+}
+
+.lowerGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 420px;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.collectionGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(92px, 1fr));
+  gap: 10px;
+}
+
+.collectionItem {
+  display: grid;
+  min-height: 118px;
+  grid-template-rows: minmax(0, 1fr) 24px;
+  align-items: center;
+  border: 1px solid rgba(16, 24, 32, 0.12);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 8px;
+}
+
+.collectionItem img {
+  height: 74px;
+}
+
+.collectionItem span {
+  color: #162021;
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-align: center;
+}
+
+.emptyState {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: #53606b;
+  font-weight: 750;
+}
+
+.leaderboard {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.leaderboard li {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  border: 1px solid rgba(16, 24, 32, 0.1);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 10px;
+}
+
+.leaderboard span:not(.rank) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.leaderboard small {
+  grid-column: 2 / 4;
+  color: #53606b;
+  font-weight: 750;
+}
+
+.rank {
+  color: #257a6b;
+  font-weight: 900;
+}
+
+dt {
+  color: #53606b;
+  font-weight: 850;
+}
+
+dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: #162021;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes reelSlide {
+  0% {
+    transform: translateX(0);
+  }
+
+  100% {
+    transform: translateX(-2820px);
+  }
+}
+
+@media (max-width: 980px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .statusPanel {
+    order: -1;
+  }
+
+  .lowerGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .spinHeader,
+  .spinFooter {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .spinStats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .shell {
+    padding: 18px;
+  }
+
+  .masthead {
+    align-items: flex-start;
+  }
+
+  h1 {
+    font-size: 1.75rem;
+  }
+
+  .progressDial {
+    width: 60px;
+    height: 60px;
+  }
+
+  .progressDial span {
+    width: 44px;
+    height: 44px;
+  }
+
+  .walletRow {
+    grid-template-columns: 1fr;
+  }
+
+  .buttonLine > button,
+  .walletRow > button,
+  .walletActions {
+    width: 100%;
+  }
+
+  .walletActions {
+    grid-template-columns: 1fr;
+  }
+
+  .spinStats {
+    grid-template-columns: 1fr;
+  }
+
+  .reelSlot {
+    width: 112px;
+    height: 134px;
+  }
+
+  @keyframes reelSlide {
+    0% {
+      transform: translateX(0);
+    }
+
+    100% {
+      transform: translateX(-2440px);
+    }
+  }
+}

--- a/apps/retention/tsconfig.json
+++ b/apps/retention/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "noEmit": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/retention/vite.config.ts
+++ b/apps/retention/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 const FALLBACK_PORT = 58742;
+const FALLBACK_API_PORT = 38742;
 const IS_BUILD = process.env.npm_lifecycle_event === 'build';
 
 const DEFAULT_PORT = (() => {
@@ -14,7 +15,7 @@ const DEFAULT_PORT = (() => {
   }
 
   try {
-    const port = parseInt(execSync('port-for clan-world-landing-dev', { encoding: 'utf8' }).trim(), 10);
+    const port = parseInt(execSync('port-for clan-world-retention-dev', { encoding: 'utf8' }).trim(), 10);
     return Number.isNaN(port) ? FALLBACK_PORT : port;
   } catch {
     return FALLBACK_PORT;
@@ -22,18 +23,18 @@ const DEFAULT_PORT = (() => {
 })();
 
 const API_PORT = (() => {
-  if (IS_BUILD) return 38740;
+  if (IS_BUILD) return FALLBACK_API_PORT;
 
   if (process.env.RETENTION_API_PORT) {
     const parsed = parseInt(process.env.RETENTION_API_PORT, 10);
-    return Number.isNaN(parsed) ? 38740 : parsed;
+    return Number.isNaN(parsed) ? FALLBACK_API_PORT : parsed;
   }
 
   try {
-    const port = parseInt(execSync('port-for clan-world-backend-dev', { encoding: 'utf8' }).trim(), 10);
-    return Number.isNaN(port) ? 38740 : port;
+    const port = parseInt(execSync('port-for clan-world-retention-api-dev', { encoding: 'utf8' }).trim(), 10);
+    return Number.isNaN(port) ? FALLBACK_API_PORT : port;
   } catch {
-    return 38740;
+    return FALLBACK_API_PORT;
   }
 })();
 

--- a/apps/retention/vite.config.ts
+++ b/apps/retention/vite.config.ts
@@ -1,0 +1,50 @@
+import { execSync } from 'node:child_process';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+const FALLBACK_PORT = 58742;
+const IS_BUILD = process.env.npm_lifecycle_event === 'build';
+
+const DEFAULT_PORT = (() => {
+  if (IS_BUILD) return FALLBACK_PORT;
+
+  if (process.env.PORT) {
+    const parsed = parseInt(process.env.PORT, 10);
+    return Number.isNaN(parsed) ? FALLBACK_PORT : parsed;
+  }
+
+  try {
+    const port = parseInt(execSync('port-for clan-world-landing-dev', { encoding: 'utf8' }).trim(), 10);
+    return Number.isNaN(port) ? FALLBACK_PORT : port;
+  } catch {
+    return FALLBACK_PORT;
+  }
+})();
+
+const API_PORT = (() => {
+  if (IS_BUILD) return 38740;
+
+  if (process.env.RETENTION_API_PORT) {
+    const parsed = parseInt(process.env.RETENTION_API_PORT, 10);
+    return Number.isNaN(parsed) ? 38740 : parsed;
+  }
+
+  try {
+    const port = parseInt(execSync('port-for clan-world-backend-dev', { encoding: 'utf8' }).trim(), 10);
+    return Number.isNaN(port) ? 38740 : port;
+  } catch {
+    return 38740;
+  }
+})();
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '127.0.0.1',
+    port: DEFAULT_PORT,
+    allowedHosts: ['gold.clan-world.com'],
+    proxy: {
+      '/api': `http://127.0.0.1:${API_PORT}`,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,43 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  apps/retention:
+    dependencies:
+      bs58:
+        specifier: ^6.0.0
+        version: 6.0.0
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      tweetnacl:
+        specifier: ^1.0.3
+        version: 1.0.3
+      viem:
+        specifier: ^2.48.7
+        version: 2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.2)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.0)(terser@5.46.2)(tsx@4.19.2)(yaml@2.8.3))
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.0)(terser@5.46.2)(tsx@4.19.2)(yaml@2.8.3)
+
   apps/server:
     dependencies:
       '@clan-world/contract-types':
@@ -6266,6 +6303,9 @@ packages:
   turbo@2.9.6:
     resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
     hasBin: true
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -14161,6 +14201,8 @@ snapshots:
       '@turbo/windows-64': 2.9.6
       '@turbo/windows-arm64': 2.9.6
 
+  tweetnacl@1.0.3: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -14337,6 +14379,23 @@ snapshots:
       - utf-8-validate
       - zod
     optional: true
+
+  viem@2.48.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.2):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.2)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      ox: 0.14.20(typescript@5.9.3)(zod@4.4.2)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
 
   viem@2.48.11(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.22.4):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `apps/retention`, a Vite + React GOLD campaign retention prototype.
- Adds a local Node API for wallet nonce issuance, EVM/Solana signature verification, profile persistence, provisional social capture, server-owned spin rewards, XP, streaks, and collection state.
- Adds a living implementation tracker at `apps/retention/PLAN.md`.

## Preview

Private preview is running behind Cloudflare Access at:

https://gold.clan-world.com

## Notes

The prototype includes demo EVM/Solana signing paths for local automation and preview testing without browser wallet extensions. Injected wallet signing paths are also present, but should be hardened with production wallet adapters before public launch.

Social verification is intentionally provisional for now: handles are recorded after the fake verification delay, and the UI tells users verification can take up to 24h.

## Validation

- `pnpm --filter @clan-world/retention typecheck`
- `pnpm --filter @clan-world/retention build`
- Playwright smoke flow during implementation: empty state -> demo wallet sign -> X/TG/TikTok provisional verification -> spin -> collection/leaderboard update
- API edge checks during implementation: social-before-wallet rejected; malformed EVM signature rejected
