### PR TITLE
fix(anvil-fork): chown /data so --state writes one file, not 240GB of dumps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,7 +185,25 @@ services:
   # ---------------------------------------------------------------------------
   anvil-fork:
     image: ghcr.io/foundry-rs/foundry:v1.2.0
-    entrypoint: anvil
+    # The anvil_data named volume is created empty + root-owned, but the foundry
+    # image runs anvil as non-root uid 1000 (foundry). Without the chown below,
+    # anvil cannot write /data/anvil-state.json — it silently spams ~71MB
+    # timestamped state-dump snapshots into the container writable layer
+    # (~240GB observed) AND the fork never persists (re-forks on restart).
+    # Fix: start as root, chown /data to the foundry uid, then drop back to
+    # foundry via setpriv before exec'ing anvil. Result: a single overwriting
+    # /data/anvil-state.json, zero tmp dump accumulation, state survives restart.
+    # Same volume-ownership pattern as the Coolify ssh-dir chown-to-app-uid fix.
+    user: root
+    entrypoint:
+      - /bin/sh
+      # -e so a failed chown/setpriv fails the container loudly instead of
+      # silently exec'ing anvil into the original broken (root-owned) state.
+      - -ec
+      - |
+        chown foundry:foundry /data
+        exec setpriv --reuid foundry --regid foundry --init-groups anvil "$@"
+      - anvil
     command:
       - --host=0.0.0.0
       - --fork-url=${RPC_URL_PRIMARY:?RPC_URL_PRIMARY required for fork seed}


### PR DESCRIPTION
Closes #654

## The bug
The `anvil-fork` dev-profile service runs anvil with `--state=/data/anvil-state.json --state-interval=60`. The `anvil_data` named volume mounts **empty + root-owned** at `/data`, but the `ghcr.io/foundry-rs/foundry:v1.2.0` image runs anvil as non-root user `foundry` (uid 1000).

Result: anvil (uid 1000) **cannot write** root-owned `/data`. Instead of maintaining one overwriting `/data/anvil-state.json`, it accumulates ~71MB timestamped state-dump snapshots in the container writable layer — **3,599 files / ~240GB** observed live, filling the host disk to 88%. Same root cause means fork state **never persists** → the service re-forks (loses progress) on every restart.

Reproduced directly:
```
$ docker run --rm -v scratch:/data ghcr.io/foundry-rs/foundry:v1.2.0 sh -c 'id; touch /data/x'
uid=1000(foundry) ...
touch: cannot touch '/data/x': Permission denied
```

## The fix
Start the service as `root`, override the entrypoint to a shell that **chowns `/data` to the foundry uid**, then **drops privileges via `setpriv`** before `exec`-ing anvil with the original flags. anvil ends up running as uid 1000 (unprivileged, unchanged) but `/data` is now writable, so `--state` maintains a single overwriting `/data/anvil-state.json`.

- `-ec` makes a failed `chown`/`setpriv` exit non-zero (crash-loud, no silent fallback to the broken state).
- Mirrors the existing volume-ownership pattern used for the Coolify ssh dir (chown the root-owned volume to the app uid).
- No new image, no init/sidecar service, no compose machinery — one-file change.

**Why not alternatives:** `user: "1000:1000"` alone does NOT fix an already-root-owned named volume (Docker won't re-chown it). A one-shot init/sidecar container is architecturally cleaner but adds compose machinery for a single dir; rejected for a dev-profile fork helper.

## Test evidence (throwaway `docker run` / compose — live `clan-world-anvil-fork-1` NOT touched)
Ran the exact compose-rendered entrypoint against a scratch volume:

| Check | Before (broken) | After (this fix) |
|---|---|---|
| anvil process owner | foundry uid 1000 | foundry uid 1000 (PID 1, via `exec setpriv`) |
| `/data` write as foundry | **Permission denied** | writable (chowned) |
| state file | none persisted | one `anvil-state.json`, overwritten in place (21517 → 32735 B after a tx + interval) |
| `anvil-state-*` dump count | grows unbounded (3599 / 240GB live) | **0** |
| container writable layer | 240GB | **8.19kB** |
| healthcheck | n/a | **healthy** |
| restart persistence | re-forks, state lost | state file survives + reloads |
| chown-failure (read-only /data) | silent broken run | **exit code 1** (fail-loud) |

## Operational note (Task A)
The live `clan-world-anvil-fork-1` was already `--force-recreate`d earlier (which reset its writable layer); at time of this PR it has 0 dump files and an 8.19kB layer — no regrowth yet, nothing to clean. This PR prevents recurrence. The live container is NOT recreated here; deploying this fix (recreate on the dev stack) is left to the operator.

Related: VPS changelog 2026-06-13 entry on the 240GB leak.
