### PR TITLE
feat(mint): host mint app at clanworld.wal.app/mint (#660)

### DIFF
--- a/apps/mint/vite.config.ts
+++ b/apps/mint/vite.config.ts
@@ -20,8 +20,9 @@ const DEFAULT_PORT = (() => {
 
 export default defineConfig({
   plugins: [react()],
-  // Relative asset paths so the build works when served from a Walrus portal.
-  base: './',
+  // Served as a subpath of the main ClanWorld Walrus Site at /mint/ — absolute
+  // base so SPA deep-links resolve assets correctly at any depth under /mint/.
+  base: '/mint/',
   server: {
     port: DEFAULT_PORT,
     host: '127.0.0.1',

--- a/scripts/deploy-walrus-sites.sh
+++ b/scripts/deploy-walrus-sites.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Deploy the ClanWorld site to Walrus, with the free-mint app nested at /mint.
+#
+# The game (apps/web) is served at the site root; the mint app (apps/mint, built
+# with base=/mint/) is nested under /mint. Both are SPAs, so ws-resources.json
+# routes /mint/* -> /mint/index.html (more specific, matched first) and /* ->
+# /index.html. Everything lands in ONE Walrus Site object so it's reachable at
+# clanworld.wal.app and clanworld.wal.app/mint — no second SuiNS name needed.
+#
+# Required env:
+#   VITE_CONVEX_URL, VITE_CLANWORLD_DEMO_MODE, VITE_CLAN_WORLD_CONTRACT_ADDRESS
+#     -> for apps/web (pull from Vercel prod: `vercel env pull --environment=production`)
+#   VITE_DYNAMIC_ENVIRONMENT_ID
+#     -> for apps/mint (Dynamic dashboard)
+# Requires: pnpm, site-builder (mainnet config at ~/.config/walrus/sites-config.yaml).
+set -euo pipefail
+
+SITE_OBJECT="${SITE_OBJECT:-0x407f079c2f235a588546008550ce1f479fce8a0ad10525ab17802cc63adce125}"
+EPOCHS="${EPOCHS:-5}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMBINED="$(mktemp -d)/clanworld-site"
+
+echo "[1/5] build game (apps/web)…"
+pnpm --filter @clan-world/web build
+
+echo "[2/5] build mint app (apps/mint, base=/mint/)…"
+pnpm --filter @clan-world/mint build
+
+echo "[3/5] assemble combined dist at $COMBINED…"
+mkdir -p "$COMBINED"
+cp -r "$ROOT/apps/web/dist/." "$COMBINED/"
+rm -rf "$COMBINED/mint"
+cp -r "$ROOT/apps/mint/dist" "$COMBINED/mint"
+
+echo "[4/5] write combined ws-resources.json (/mint/* before /*)…"
+cat > "$COMBINED/ws-resources.json" <<'JSON'
+{
+  "routes": {
+    "/mint": "/mint/index.html",
+    "/mint/*": "/mint/index.html",
+    "/*": "/index.html"
+  }
+}
+JSON
+
+echo "[5/5] deploy to Walrus Site $SITE_OBJECT (--epochs $EPOCHS)…"
+site-builder --config "$HOME/.config/walrus/sites-config.yaml" --context mainnet \
+  deploy "$COMBINED" --object-id "$SITE_OBJECT" --epochs "$EPOCHS"
+
+echo "Done. Game: https://clanworld.wal.app/   Mint: https://clanworld.wal.app/mint"


### PR DESCRIPTION
## Summary
Hosts the free-mint app as a **subpath of the main ClanWorld Walrus Site** — `clanworld.wal.app/mint` — instead of a separate site/subname.

**Why the pivot:** the original plan (subname `nft.clanworld.sui` → `nft.clanworld.wal.app`) is blocked at the TLS layer — the wal.app cert is `*.wal.app` (single label), so a two-label host fails HTTPS before the portal runs. Verified via cert SANs + portal-source research. The subpath approach needs no second SuiNS name and no subname.

## Changes
- `apps/mint/vite.config.ts`: `base: '/mint/'` (absolute base so SPA deep-links resolve under /mint/).
- `scripts/deploy-walrus-sites.sh`: builds game + mint, assembles a combined `dist` (mint nested at `/mint`), writes `ws-resources.json` routes (`/mint`, `/mint/*` before the `/*` SPA catch-all), and updates the **same** clanworld Site object `0x407f…ce125`.

## Verified live
- `https://clanworld.wal.app/` → game (HTTP 200, intact) ✓
- `https://clanworld.wal.app/mint/` → mint app (HTTP 200, JS+CSS assets 200) ✓

Base = `feat/issue-660-mint-app` (stacked on the mint-app PR #661). Related: #660