### PR TITLE
feat(walrus): per-Elder MemWal encrypted memory — provisioning + MCP wiring (PR1)

### DIFF
--- a/agents/shared/APPENDED_SYSTEM_PROMPT.md
+++ b/agents/shared/APPENDED_SYSTEM_PROMPT.md
@@ -29,9 +29,12 @@ You interact with ClanWorld exclusively through the `elder` MCP server tools (th
 - `world_snapshot` — current world state (cheap, call freely)
 - `clan_view` — your clan's full state (clanId optional, defaults to your own clan)
 - `submit_orders` — submit a batch of `ClanOrder[]`, passing the orders array INLINE as the tool argument (NEVER write a json file or use bash `cat`/heredoc — a brace-in-quotes shell construct trips a CC safety modal that freezes you mid-tick)
-- `memory_recall` / `memory_save` (key + value) — durable memory
+- `memory_recall` / `memory_save` (key + value) — durable **key→value facts** (exact, structured: counts, addresses, named plans)
+- `memwal_remember` (free-text) / `memwal_recall` (semantic query) — your **Walrus memory**: durable, encrypted, decentralized reflections you *own on-chain*. Use this for rich lived experience, lessons, and judgments ("clan-2 betrayed our trade at tick 30 — never deal with them unguarded"), not exact facts. Tag entries with stable phrases so you can find them later.
 - `peer_whisper` (clanId + message) / `peer_inbox` — peer-to-peer comms
 - `ack_clear` — signal ready-for-context-reset (only when prompted)
+
+After a memory wipe, recall from **both** `memory_recall` and `memwal_recall`, then **verify against `world_snapshot` before trusting** — your memories are genuinely yours, but the world may have moved on since you wrote them.
 
 ## Convex command bus (Phase 1.8+)
 

--- a/agents/shared/elder-mcp.json
+++ b/agents/shared/elder-mcp.json
@@ -3,6 +3,10 @@
     "elder": {
       "type": "stdio",
       "command": "/usr/local/bin/elder-mcp"
+    },
+    "memwal": {
+      "type": "stdio",
+      "command": "/usr/local/bin/memwal-mcp"
     }
   }
 }

--- a/docs/walrus-memory-docker-handoff.md
+++ b/docs/walrus-memory-docker-handoff.md
@@ -1,0 +1,49 @@
+# Walrus Memory — Docker-build hand-off (PR1)
+
+PR1 stands up per-Elder **Walrus Memory (MemWal)** identities + the runner-side wiring. Two container-image
+changes remain, which live in the **docker-build session's lane** (`Dockerfile` + `docker-compose.yml`) — listed
+here so they can land there without me touching those hot files.
+
+## What PR1 already shipped (this PR)
+- `scripts/walrus/provision-elders.mjs` — idempotent provisioning. Already RUN on **mainnet**: 4 Elder owner
+  accounts (fresh Ed25519 Sui keys) + Ed25519 delegates created; per-Elder `credentials.json` written. Isolation
+  proven (Elder 2 cannot read Elder 1's memory).
+- `agents/shared/elder-mcp.json` — added the `memwal` stdio MCP server entry (`/usr/local/bin/memwal-mcp`).
+- `agents/shared/APPENDED_SYSTEM_PROMPT.md` — Elders are told about `memwal_remember`/`memwal_recall` + the
+  KV-vs-reflection split + the post-wipe "recall both, verify vs world_snapshot" behavior.
+
+## What the docker-build session needs to add (2 changes)
+
+### 1. Install the `memwal-mcp` binary in the Elder image
+The `elder-mcp.json` entry points at `/usr/local/bin/memwal-mcp`. The Elder Dockerfile must provide it, e.g.:
+```dockerfile
+RUN npm install -g @mysten-incubation/memwal-mcp \
+ && ln -sf "$(npm root -g)/@mysten-incubation/memwal-mcp/dist/cli.js" /usr/local/bin/memwal-mcp \
+ || true   # confirm the actual bin path from the package's "bin" field
+```
+(Verify the package's `bin` name; the global install should drop a `memwal-mcp` on PATH — symlink into
+`/usr/local/bin` to match the `elder-mcp` convention.)
+
+### 2. Mount each Elder's credentials into its container
+The MemWal MCP reads `~/.memwal/credentials.json` (→ `/home/elder/.memwal/credentials.json`). Each Elder needs
+**its own** file. Source files on the host:
+```
+~/.secrets/clanworld-elder-walrus/elder-1/credentials.json   → elder-1 container :/home/elder/.memwal/credentials.json
+~/.secrets/clanworld-elder-walrus/elder-2/credentials.json   → elder-2 container :…
+~/.secrets/clanworld-elder-walrus/elder-3/credentials.json   → elder-3 …
+~/.secrets/clanworld-elder-walrus/elder-4/credentials.json   → elder-4 …
+```
+Wire as a per-Elder docker secret / bind mount, mirroring the existing `ELDER_WALLET_KEY_PATH` pattern
+(`elder-wallet-N` secret → `/run/secrets/elder-wallet-N`). Mount read-only is fine — creds are pre-provisioned.
+**Do NOT** copy `owner.key` into containers (provisioning/rotation only; keep it host-side).
+
+## Verify (per Elder container)
+1. `memwal-mcp` resolves on PATH; `/home/elder/.memwal/credentials.json` present + matches that Elder's `accountId`.
+2. In the Elder Claude session, `mcp__memwal__*` tools appear.
+3. `memwal_remember("smoke test")` → `memwal_recall("smoke")` returns it.
+
+## Notes
+- The `@mysten/sui` version compat wrapper (`SuiJsonRpcClient` vs old `waitForTransaction`) only affects the
+  **host-side provisioning script**, not the MCP runtime in the container.
+- Relayer: `https://relayer.memory.walrus.xyz`. Mainnet pkg `0xcee7a6fd…a24c6`, registry `0x0da982ce…7edd`.
+- Per-Elder account/delegate addresses are in the provisioning run output (host `~/.secrets/clanworld-elder-walrus/`).

--- a/docs/walrus-memory-docker-handoff.md
+++ b/docs/walrus-memory-docker-handoff.md
@@ -12,7 +12,18 @@ here so they can land there without me touching those hot files.
 - `agents/shared/APPENDED_SYSTEM_PROMPT.md` — Elders are told about `memwal_remember`/`memwal_recall` + the
   KV-vs-reflection split + the post-wipe "recall both, verify vs world_snapshot" behavior.
 
-## What the docker-build session needs to add (2 changes)
+## What the docker-build session needs to add (3 changes — do #0 FIRST)
+
+### 0. 🚨 Egress allow-list — the #1 demo-day risk (de-risk this BEFORE anything else)
+Elders run **network-sandboxed** (per `APPENDED_SYSTEM_PROMPT.md`: `api.anthropic.com`, `claude.ai`, DNS, internal
+docker net only). The MemWal MCP must reach the **public** relayer **`relayer.memory.walrus.xyz`** over HTTPS.
+If it's not in the egress allow-list, `remember`/`recall` **fail silently inside the container** even though they
+work perfectly on the host (where provisioning was proven). Add `relayer.memory.walrus.xyz` (+ its DNS/TLS path) to
+the Elder egress allow-list. **Verify with the dumbest possible check from inside an Elder container first:**
+```bash
+docker compose exec elder-1 curl -s -o /dev/null -w '%{http_code}\n' --max-time 8 https://relayer.memory.walrus.xyz/health
+# non-000 = reachable. 000 = egress blocked → fix the allow-list before proceeding.
+```
 
 ### 1. Install the `memwal-mcp` binary in the Elder image
 The `elder-mcp.json` entry points at `/usr/local/bin/memwal-mcp`. The Elder Dockerfile must provide it, e.g.:
@@ -38,9 +49,23 @@ Wire as a per-Elder docker secret / bind mount, mirroring the existing `ELDER_WA
 **Do NOT** copy `owner.key` into containers (provisioning/rotation only; keep it host-side).
 
 ## Verify (per Elder container)
-1. `memwal-mcp` resolves on PATH; `/home/elder/.memwal/credentials.json` present + matches that Elder's `accountId`.
-2. In the Elder Claude session, `mcp__memwal__*` tools appear.
-3. `memwal_remember("smoke test")` → `memwal_recall("smoke")` returns it.
+Run the bundled smoke script inside each Elder container — it checks binary-on-PATH, per-Elder creds + accountId,
+and (critically) egress to the relayer:
+```bash
+docker compose exec elder-1 /opt/clan-world/shared/scripts/walrus/smoke-elder-memwal.sh
+```
+Then the manual check: in the Elder Claude session, `mcp__memwal__*` tools appear and
+`memwal_remember("smoke")` → `memwal_recall("smoke")` round-trips.
+
+⚠️ **Confirm `accountId` is DISTINCT per container.** Identical creds across the 4 Elders collapses them into one
+MemWal identity (the 2nd-biggest risk after egress). The smoke script prints each container's accountId — eyeball
+that elder-1..4 differ.
+
+## Observability for demo day (recommended)
+Before recording, stand up a tiny visible proof trail per Elder — `accountId`, last remembered tag, last recall
+result + timestamp — so a failed recall at 5:40am is debuggable at a glance rather than guesswork. The cockpit
+Agent panel (PR3) is the natural home; until it lands, the smoke script + `~/.secrets/clanworld-elder-walrus/`
+addresses suffice.
 
 ## Notes
 - The `@mysten/sui` version compat wrapper (`SuiJsonRpcClient` vs old `waitForTransaction`) only affects the

--- a/scripts/walrus/provision-elders.mjs
+++ b/scripts/walrus/provision-elders.mjs
@@ -1,0 +1,550 @@
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+function moduleFile(...parts) {
+  const roots = (process.env.NODE_PATH ?? "").split(":").filter(Boolean);
+  const root = roots.find((candidate) => existsSync(join(candidate, parts[0])));
+  if (!root) {
+    throw new Error(`Could not resolve ${parts.join("/")} from NODE_PATH`);
+  }
+  return pathToFileURL(join(root, ...parts)).href;
+}
+
+const { Ed25519Keypair } = await import(
+  moduleFile("@mysten", "sui", "dist", "keypairs", "ed25519", "index.mjs")
+);
+const { SuiJsonRpcClient, getJsonRpcFullnodeUrl } = await import(
+  moduleFile("@mysten", "sui", "dist", "jsonRpc", "index.mjs")
+);
+const { addDelegateKey, createAccount, generateDelegateKey } = await import(
+  moduleFile("@mysten-incubation", "memwal", "dist", "account-entry.js")
+);
+const { delegateKeyToPublicKey, MemWal } = await import(
+  moduleFile("@mysten-incubation", "memwal", "dist", "index.js")
+);
+
+const DEPLOYER =
+  "0xa607735e95142e8540b17f055cbf55f48e24c99f847949b13989985ebcdf2b96";
+const PACKAGE_ID =
+  "0xcee7a6fd8de52ce645c38332bde23d4a30fd9426bc4681409733dd50958a24c6";
+const REGISTRY_ID =
+  "0x0da982cefa26864ae834a8a0504b904233d49e20fcc17c373c8bed99c75a7edd";
+const RELAYER = "https://relayer.memory.walrus.xyz";
+const SECRETS_ROOT = join(homedir(), ".secrets", "clanworld-elder-walrus");
+const FINDINGS_PATH =
+  "/home/claude/claudes-world/tmp/codex-walmem-ownerkey/FINDINGS-provisioning.md";
+const MIN_BALANCE_MIST = 50_000_000n;
+const FUND_AMOUNT_MIST = 100_000_000n;
+const PROBE_TEXT = "elder_1_isolation_probe | secret-ridge-cache";
+const PROBE_QUERY = "elder_1_isolation_probe secret-ridge-cache";
+
+class MemWalSuiClientCompat {
+  constructor(inner) {
+    this.inner = inner;
+  }
+
+  async signAndExecuteTransaction(input) {
+    return this.inner.signAndExecuteTransaction(input);
+  }
+
+  async waitForTransaction(input) {
+    const include = {};
+    if (input.options?.showEffects) include.effects = true;
+    if (input.options?.showObjectChanges) include.objectChanges = true;
+    return this.inner.waitForTransaction({ digest: input.digest, include });
+  }
+}
+
+const rpc = new SuiJsonRpcClient({
+  network: "mainnet",
+  url: getJsonRpcFullnodeUrl("mainnet"),
+});
+const suiClient = new MemWalSuiClientCompat(rpc);
+
+function logPublic(value) {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function sui(mist) {
+  return (Number(mist) / 1_000_000_000).toFixed(6);
+}
+
+function bytesToHex(bytes) {
+  return Buffer.from(bytes).toString("hex");
+}
+
+function normalizeAddress(address) {
+  return address.toLowerCase();
+}
+
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function ensureSecretDir(path) {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+  chmodSync(path, 0o700);
+}
+
+function writeSecretFile(path, contents, mode) {
+  writeFileSync(path, contents, { mode });
+  chmodSync(path, mode);
+}
+
+function loadOrCreateOwner(elderNumber) {
+  const dir = join(SECRETS_ROOT, `elder-${elderNumber}`);
+  const keyPath = join(dir, "owner.key");
+  const credentialsPath = join(dir, "credentials.json");
+  ensureSecretDir(dir);
+
+  let ownerKey;
+  let generated = false;
+  if (existsSync(keyPath)) {
+    ownerKey = readFileSync(keyPath, "utf8").trim();
+  } else {
+    ownerKey = Ed25519Keypair.generate().getSecretKey();
+    writeSecretFile(keyPath, `${ownerKey}\n`, 0o600);
+    generated = true;
+  }
+  chmodSync(keyPath, 0o600);
+
+  const keypair = Ed25519Keypair.fromSecretKey(ownerKey);
+  return {
+    dir,
+    keyPath,
+    credentialsPath,
+    ownerKey,
+    ownerAddress: keypair.getPublicKey().toSuiAddress(),
+    generated,
+  };
+}
+
+async function getSuiBalance(address) {
+  const balance = await rpc.getBalance({ owner: address });
+  return BigInt(balance.totalBalance);
+}
+
+function getTransferGasCoinId() {
+  const raw = execFileSync("sui", ["client", "gas", "--json"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const coins = JSON.parse(raw);
+  const coin = coins
+    .map((candidate) => ({
+      id: candidate.gasCoinId,
+      mist: BigInt(candidate.mistBalance),
+    }))
+    .filter((candidate) => candidate.mist > FUND_AMOUNT_MIST + 20_000_000n)
+    .sort((a, b) => (a.mist < b.mist ? 1 : -1))[0];
+  if (!coin) {
+    throw new Error("No deployer SUI gas coin has enough balance to fund an Elder");
+  }
+  return coin.id;
+}
+
+async function fundIfNeeded(elderNumber, ownerAddress) {
+  const before = await getSuiBalance(ownerAddress);
+  const result = {
+    beforeMist: before.toString(),
+    afterMist: before.toString(),
+    beforeSui: sui(before),
+    afterSui: sui(before),
+    funded: false,
+    fundAmountSui: "0.000000",
+    digest: null,
+  };
+
+  if (before >= MIN_BALANCE_MIST) {
+    logPublic({
+      elder: elderNumber,
+      step: "funding",
+      status: "skip",
+      ownerAddress,
+      balanceSui: result.beforeSui,
+    });
+    return result;
+  }
+
+  const activeAddress = execFileSync("sui", ["client", "active-address"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  const activeEnv = execFileSync("sui", ["client", "active-env"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  if (normalizeAddress(activeAddress) !== normalizeAddress(DEPLOYER)) {
+    throw new Error(`Sui CLI active address is ${activeAddress}, expected ${DEPLOYER}`);
+  }
+  if (activeEnv !== "mainnet") {
+    throw new Error(`Sui CLI active env is ${activeEnv}, expected mainnet`);
+  }
+
+  const gasCoinId = getTransferGasCoinId();
+  logPublic({
+    elder: elderNumber,
+    step: "funding",
+    status: "transfer",
+    ownerAddress,
+    beforeSui: result.beforeSui,
+    amountSui: sui(FUND_AMOUNT_MIST),
+  });
+
+  const raw = execFileSync(
+    "sui",
+    [
+      "client",
+      "transfer-sui",
+      "--to",
+      ownerAddress,
+      "--sui-coin-object-id",
+      gasCoinId,
+      "--amount",
+      FUND_AMOUNT_MIST.toString(),
+      "--gas-budget",
+      "10000000",
+      "--json",
+    ],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const parsed = JSON.parse(raw);
+  const after = await getSuiBalance(ownerAddress);
+
+  return {
+    beforeMist: before.toString(),
+    afterMist: after.toString(),
+    beforeSui: sui(before),
+    afterSui: sui(after),
+    funded: true,
+    fundAmountSui: sui(FUND_AMOUNT_MIST),
+    digest: parsed.digest ?? parsed.effects?.transactionDigest ?? null,
+  };
+}
+
+async function findExistingAccount(ownerAddress) {
+  const eventType = `${PACKAGE_ID}::account::AccountCreated`;
+  let cursor = null;
+  for (let page = 0; page < 20; page += 1) {
+    const events = await rpc.queryEvents({
+      query: { MoveEventType: eventType },
+      cursor,
+      limit: 50,
+      order: "descending",
+    });
+    const event = events.data.find(
+      (ev) => normalizeAddress(ev.parsedJson?.owner ?? "") === normalizeAddress(ownerAddress),
+    );
+    if (event?.parsedJson?.account_id) {
+      return {
+        accountId: event.parsedJson.account_id,
+        owner: ownerAddress,
+        digest: event.id.txDigest,
+        reusedExisting: true,
+      };
+    }
+    if (!events.hasNextPage || !events.nextCursor) break;
+    cursor = events.nextCursor;
+  }
+  throw new Error(`MemWal account already exists for ${ownerAddress}, but no AccountCreated event was found`);
+}
+
+async function createOrRecoverAccount(ownerAddress, ownerKey) {
+  try {
+    const account = await createAccount({
+      packageId: PACKAGE_ID,
+      registryId: REGISTRY_ID,
+      suiPrivateKey: ownerKey,
+      suiClient,
+      suiNetwork: "mainnet",
+    });
+    if (!account.accountId) {
+      const recovered = await findExistingAccount(ownerAddress);
+      return {
+        ...recovered,
+        createDigest: account.digest,
+        recoveredFromEmptyCreateResult: true,
+      };
+    }
+    return account;
+  } catch (err) {
+    if (String(err?.message ?? err).includes("abort code: 3")) {
+      return findExistingAccount(ownerAddress);
+    }
+    throw err;
+  }
+}
+
+async function readAccountDelegateKeys(accountId) {
+  const object = await rpc.getObject({
+    id: accountId,
+    options: { showContent: true },
+  });
+  const fields = object.data?.content?.fields ?? {};
+  const delegateKeys =
+    fields.delegate_keys?.fields?.contents ??
+    fields.delegate_keys?.contents ??
+    fields.delegateKeys?.fields?.contents ??
+    [];
+  return Array.isArray(delegateKeys) ? delegateKeys : [];
+}
+
+function publicKeyHexFromDelegateEntry(entry) {
+  const value = entry.fields?.key ?? entry.fields?.name ?? entry.key ?? entry.name;
+  if (Array.isArray(value)) return bytesToHex(value);
+  if (typeof value === "string") return value.startsWith("0x") ? value.slice(2) : value;
+  if (value?.fields?.bytes && Array.isArray(value.fields.bytes)) return bytesToHex(value.fields.bytes);
+  return null;
+}
+
+async function isDelegateValid(accountId, publicKeyHex) {
+  const delegates = await readAccountDelegateKeys(accountId);
+  const wanted = publicKeyHex.toLowerCase();
+  return delegates.some((entry) => publicKeyHexFromDelegateEntry(entry)?.toLowerCase() === wanted);
+}
+
+async function prepareDelegate(elderNumber, ownerKey, ownerAddress, account, credentialsPath) {
+  const existing = readJson(credentialsPath);
+  if (
+    existing?.delegatePrivateKey &&
+    existing?.delegatePublicKeyHex &&
+    existing?.accountId === account.accountId &&
+    existing?.packageId === PACKAGE_ID &&
+    (await isDelegateValid(account.accountId, existing.delegatePublicKeyHex))
+  ) {
+    logPublic({
+      elder: elderNumber,
+      step: "delegate",
+      status: "skip-valid-existing",
+      delegateAddress: existing.delegateAddress,
+      accountId: account.accountId,
+    });
+    return {
+      credentials: existing,
+      addDelegate: null,
+      reusedExisting: true,
+    };
+  }
+
+  const delegate = await generateDelegateKey();
+  const delegatePublicKeyHex = bytesToHex(delegate.publicKey);
+  const addDelegate = await addDelegateKey({
+    packageId: PACKAGE_ID,
+    accountId: account.accountId,
+    publicKey: delegate.publicKey,
+    label: `elder-${elderNumber}`,
+    suiPrivateKey: ownerKey,
+    suiClient,
+    suiNetwork: "mainnet",
+  });
+  const credentials = {
+    delegatePrivateKey: delegate.privateKey,
+    delegatePublicKeyHex,
+    delegateAddress: delegate.suiAddress,
+    walletAddress: ownerAddress,
+    accountId: account.accountId,
+    packageId: PACKAGE_ID,
+    relayerUrl: RELAYER,
+    label: `elder-${elderNumber}`,
+    createdAt: new Date().toISOString(),
+    version: 1,
+  };
+  writeSecretFile(credentialsPath, `${JSON.stringify(credentials, null, 2)}\n`, 0o600);
+  return {
+    credentials,
+    addDelegate,
+    reusedExisting: false,
+  };
+}
+
+async function healCredentialsPublicKey(credentials) {
+  if (credentials.delegatePublicKeyHex) return credentials;
+  const publicKey = await delegateKeyToPublicKey(credentials.delegatePrivateKey);
+  return { ...credentials, delegatePublicKeyHex: bytesToHex(publicKey) };
+}
+
+async function provisionElder(elderNumber) {
+  const owner = loadOrCreateOwner(elderNumber);
+  logPublic({
+    elder: elderNumber,
+    step: "owner",
+    status: owner.generated ? "generated" : "loaded",
+    ownerAddress: owner.ownerAddress,
+    ownerKeyPath: owner.keyPath,
+  });
+
+  const funding = await fundIfNeeded(elderNumber, owner.ownerAddress);
+  const account = await createOrRecoverAccount(owner.ownerAddress, owner.ownerKey);
+  logPublic({
+    elder: elderNumber,
+    step: "account",
+    ownerAddress: owner.ownerAddress,
+    accountId: account.accountId,
+    digest: account.digest,
+    reusedExisting: Boolean(account.reusedExisting),
+  });
+
+  const delegate = await prepareDelegate(
+    elderNumber,
+    owner.ownerKey,
+    owner.ownerAddress,
+    account,
+    owner.credentialsPath,
+  );
+  const credentials = await healCredentialsPublicKey(delegate.credentials);
+  if (credentials !== delegate.credentials) {
+    writeSecretFile(owner.credentialsPath, `${JSON.stringify(credentials, null, 2)}\n`, 0o600);
+  }
+  logPublic({
+    elder: elderNumber,
+    step: "credentials",
+    credentialsPath: owner.credentialsPath,
+    delegateAddress: credentials.delegateAddress,
+    delegatePublicKeyHex: credentials.delegatePublicKeyHex,
+    delegateReused: delegate.reusedExisting,
+    addDelegateDigest: delegate.addDelegate?.digest ?? null,
+  });
+
+  return {
+    elderNumber,
+    ownerAddress: owner.ownerAddress,
+    accountId: account.accountId,
+    delegateAddress: credentials.delegateAddress,
+    delegatePublicKeyHex: credentials.delegatePublicKeyHex,
+    credentialsPath: owner.credentialsPath,
+    ownerKeyPath: owner.keyPath,
+    funding,
+    accountDigest: account.digest,
+    delegateAddDigest: delegate.addDelegate?.digest ?? null,
+    delegateReused: delegate.reusedExisting,
+    credentials,
+  };
+}
+
+function makeClient(provisioned, namespace) {
+  return MemWal.create({
+    key: provisioned.credentials.delegatePrivateKey,
+    accountId: provisioned.accountId,
+    serverUrl: RELAYER,
+    namespace,
+  });
+}
+
+function recallContainsProbe(recall) {
+  return (recall.results ?? []).some((result) => result.text?.includes(PROBE_TEXT));
+}
+
+async function proveIsolation(elder1, elder2) {
+  const client1 = makeClient(elder1, "elder-1");
+  const client2 = makeClient(elder2, "elder-2");
+  const remembered = await client1.rememberAndWait(PROBE_TEXT, undefined, {
+    timeoutMs: 120_000,
+    pollIntervalMs: 2_000,
+  });
+  const elder2Recall = await client2.recall({ query: PROBE_QUERY, limit: 5 });
+  const elder1Recall = await client1.recall({ query: PROBE_QUERY, limit: 5 });
+  const elder2DoesNotSee = !recallContainsProbe(elder2Recall);
+  const elder1Sees = recallContainsProbe(elder1Recall);
+  const pass = elder2DoesNotSee && elder1Sees;
+  logPublic({
+    step: "isolation",
+    verdict: pass ? "PASS" : "FAIL",
+    elder1Remembered: {
+      id: remembered.id,
+      jobId: remembered.job_id,
+      blobId: remembered.blob_id,
+      namespace: remembered.namespace,
+    },
+    elder2DoesNotSee,
+    elder1Sees,
+    elder2RecallTotal: elder2Recall.total,
+    elder1RecallTotal: elder1Recall.total,
+  });
+  return {
+    pass,
+    remembered,
+    elder2DoesNotSee,
+    elder1Sees,
+    elder2RecallTotal: elder2Recall.total,
+    elder1RecallTotal: elder1Recall.total,
+    elder2RecallMatches: (elder2Recall.results ?? [])
+      .filter((result) => result.text?.includes(PROBE_TEXT))
+      .map((result) => ({ blobId: result.blob_id, distance: result.distance })),
+    elder1RecallMatches: (elder1Recall.results ?? [])
+      .filter((result) => result.text?.includes(PROBE_TEXT))
+      .map((result) => ({ blobId: result.blob_id, distance: result.distance })),
+  };
+}
+
+function writeFindings(provisioned, isolation) {
+  const totalFunded = provisioned.reduce(
+    (sum, elder) => sum + (elder.funding.funded ? FUND_AMOUNT_MIST : 0n),
+    0n,
+  );
+  const lines = [
+    "# Walrus Elder provisioning findings",
+    "",
+    `Run date: ${new Date().toISOString()}`,
+    "",
+    "## VERDICT",
+    "",
+    `All 4 Elders provisioned: **YES**.`,
+    `Isolation proof: **${isolation.pass ? "PASS" : "FAIL"}**.`,
+    "",
+    "## Per-Elder artifacts",
+    "",
+    "| Elder | Owner address | Account ID | Delegate address | Funded this run SUI | Owner balance after SUI | Credentials path |",
+    "|---|---|---|---|---:|---:|---|",
+    ...provisioned.map(
+      (elder) =>
+        `| ${elder.elderNumber} | \`${elder.ownerAddress}\` | \`${elder.accountId}\` | \`${elder.delegateAddress}\` | ${elder.funding.funded ? elder.funding.fundAmountSui : "0.000000"} | ${elder.funding.afterSui} | \`${elder.credentialsPath}\` |`,
+    ),
+    "",
+    "## Isolation assertions",
+    "",
+    `- Elder 1 remembered \`${PROBE_TEXT}\` in namespace \`elder-1\`.`,
+    `- Elder 2 recall for \`${PROBE_QUERY}\` returned Elder 1 probe: **${isolation.elder2DoesNotSee ? "NO" : "YES"}**.`,
+    `- Elder 1 recall for \`${PROBE_QUERY}\` returned Elder 1 probe: **${isolation.elder1Sees ? "YES" : "NO"}**.`,
+    `- Elder 1 blob ID: \`${isolation.remembered.blob_id}\`.`,
+    `- Elder 1 recall total: ${isolation.elder1RecallTotal}. Elder 2 recall total: ${isolation.elder2RecallTotal}.`,
+    "",
+    "## Spend",
+    "",
+    `- Deployer funding sent: approximately ${sui(totalFunded)} SUI.`,
+    "- Additional SUI gas was spent by the deployer for funding transfers and by each Elder owner for MemWal account/delegate transactions.",
+    "- WAL spent: not separately reported by the script; MemWal relayer/Walrus storage costs are represented by the successful remember blob write.",
+    "",
+    "## Runner wiring notes",
+    "",
+    "- Run each Elder with an isolated HOME or explicit credential path so `~/.memwal/credentials.json` maps to that Elder only.",
+    "- For per-Elder HOME isolation, copy/symlink the relevant `credentials.json` into `<elder-home>/.memwal/credentials.json` and keep `owner.key` outside runtime containers unless rotation/provisioning is needed.",
+    `- Credentials root: \`${SECRETS_ROOT}/elder-N/credentials.json\`. Owner keys are stored alongside credentials with mode 0600 and should not be logged.`,
+    "",
+  ];
+  mkdirSync(dirname(FINDINGS_PATH), { recursive: true });
+  writeFileSync(FINDINGS_PATH, `${lines.join("\n")}\n`, { mode: 0o600 });
+}
+
+const provisioned = [];
+provisioned.push(await provisionElder(1));
+provisioned.push(await provisionElder(2));
+const isolation = await proveIsolation(provisioned[0], provisioned[1]);
+provisioned.push(await provisionElder(3));
+provisioned.push(await provisionElder(4));
+writeFindings(provisioned, isolation);
+logPublic({
+  step: "complete",
+  allProvisioned: provisioned.length === 4,
+  isolation: isolation.pass ? "PASS" : "FAIL",
+  findingsPath: FINDINGS_PATH,
+});

--- a/scripts/walrus/provision-elders.mjs
+++ b/scripts/walrus/provision-elders.mjs
@@ -7,7 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, fileURLToPath, join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 function moduleFile(...parts) {
@@ -40,12 +40,20 @@ const REGISTRY_ID =
   "0x0da982cefa26864ae834a8a0504b904233d49e20fcc17c373c8bed99c75a7edd";
 const RELAYER = "https://relayer.memory.walrus.xyz";
 const SECRETS_ROOT = join(homedir(), ".secrets", "clanworld-elder-walrus");
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const FINDINGS_PATH =
-  "/home/claude/claudes-world/tmp/codex-walmem-ownerkey/FINDINGS-provisioning.md";
+  process.env.WALRUS_PROVISION_FINDINGS ??
+  join(SCRIPT_DIR, "tmp", "FINDINGS-provisioning.md");
 const MIN_BALANCE_MIST = 50_000_000n;
 const FUND_AMOUNT_MIST = 100_000_000n;
+// Hard cap: at most 4 Elders × FUND_AMOUNT_MIST per run.  Any rerun that would
+// exceed this aborts early rather than silently double-spending.
+const MAX_TOTAL_FUND_MIST = FUND_AMOUNT_MIST * 4n;
 const PROBE_TEXT = "elder_1_isolation_probe | secret-ridge-cache";
 const PROBE_QUERY = "elder_1_isolation_probe secret-ridge-cache";
+// Throwaway namespace for the isolation probe — prevents the probe memory from
+// being recalled by a live Elder 1 session running against the real "elder-1" namespace.
+const PROBE_NAMESPACE = "__isolation_probe__";
 
 class MemWalSuiClientCompat {
   constructor(inner) {
@@ -57,10 +65,10 @@ class MemWalSuiClientCompat {
   }
 
   async waitForTransaction(input) {
-    const include = {};
-    if (input.options?.showEffects) include.effects = true;
-    if (input.options?.showObjectChanges) include.objectChanges = true;
-    return this.inner.waitForTransaction({ digest: input.digest, include });
+    // SuiJsonRpcClient.waitForTransaction spreads ...input into getTransactionBlock,
+    // which passes input.options directly to the RPC — pass options through as-is.
+    // (The prior include:{} mapping silently dropped showEffects/showObjectChanges.)
+    return this.inner.waitForTransaction({ digest: input.digest, options: input.options });
   }
 }
 
@@ -153,7 +161,7 @@ function getTransferGasCoinId() {
   return coin.id;
 }
 
-async function fundIfNeeded(elderNumber, ownerAddress) {
+async function fundIfNeeded(elderNumber, ownerAddress, runFundingTotal) {
   const before = await getSuiBalance(ownerAddress);
   const result = {
     beforeMist: before.toString(),
@@ -191,6 +199,13 @@ async function fundIfNeeded(elderNumber, ownerAddress) {
     throw new Error(`Sui CLI active env is ${activeEnv}, expected mainnet`);
   }
 
+  if (runFundingTotal.value + FUND_AMOUNT_MIST > MAX_TOTAL_FUND_MIST) {
+    throw new Error(
+      `Per-run funding cap would be exceeded (already sent ${sui(runFundingTotal.value)} SUI this run). ` +
+        `Aborting to prevent double-spend on Elder ${elderNumber}. Investigate before rerunning.`,
+    );
+  }
+
   const gasCoinId = getTransferGasCoinId();
   logPublic({
     elder: elderNumber,
@@ -219,7 +234,20 @@ async function fundIfNeeded(elderNumber, ownerAddress) {
     { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
   );
   const parsed = JSON.parse(raw);
+  const txStatus = parsed.effects?.status?.status ?? parsed.status?.status;
+  if (txStatus && txStatus !== "success") {
+    throw new Error(
+      `transfer-sui failed for Elder ${elderNumber}: status=${txStatus}, error=${parsed.effects?.status?.error ?? "unknown"}`,
+    );
+  }
   const after = await getSuiBalance(ownerAddress);
+  if (after <= before) {
+    throw new Error(
+      `transfer-sui reported success for Elder ${elderNumber} but balance did not increase (before=${before}, after=${after})`,
+    );
+  }
+
+  runFundingTotal.value += FUND_AMOUNT_MIST;
 
   return {
     beforeMist: before.toString(),
@@ -338,15 +366,9 @@ async function prepareDelegate(elderNumber, ownerKey, ownerAddress, account, cre
 
   const delegate = await generateDelegateKey();
   const delegatePublicKeyHex = bytesToHex(delegate.publicKey);
-  const addDelegate = await addDelegateKey({
-    packageId: PACKAGE_ID,
-    accountId: account.accountId,
-    publicKey: delegate.publicKey,
-    label: `elder-${elderNumber}`,
-    suiPrivateKey: ownerKey,
-    suiClient,
-    suiNetwork: "mainnet",
-  });
+  // Write credentials BEFORE the on-chain addDelegateKey so that if addDelegateKey
+  // succeeds but a subsequent step throws, the credentials are already persisted.
+  // A rerun will detect the existing valid on-chain delegate and skip re-registration.
   const credentials = {
     delegatePrivateKey: delegate.privateKey,
     delegatePublicKeyHex,
@@ -360,6 +382,15 @@ async function prepareDelegate(elderNumber, ownerKey, ownerAddress, account, cre
     version: 1,
   };
   writeSecretFile(credentialsPath, `${JSON.stringify(credentials, null, 2)}\n`, 0o600);
+  const addDelegate = await addDelegateKey({
+    packageId: PACKAGE_ID,
+    accountId: account.accountId,
+    publicKey: delegate.publicKey,
+    label: `elder-${elderNumber}`,
+    suiPrivateKey: ownerKey,
+    suiClient,
+    suiNetwork: "mainnet",
+  });
   return {
     credentials,
     addDelegate,
@@ -373,7 +404,7 @@ async function healCredentialsPublicKey(credentials) {
   return { ...credentials, delegatePublicKeyHex: bytesToHex(publicKey) };
 }
 
-async function provisionElder(elderNumber) {
+async function provisionElder(elderNumber, runFundingTotal) {
   const owner = loadOrCreateOwner(elderNumber);
   logPublic({
     elder: elderNumber,
@@ -383,7 +414,52 @@ async function provisionElder(elderNumber) {
     ownerKeyPath: owner.keyPath,
   });
 
-  const funding = await fundIfNeeded(elderNumber, owner.ownerAddress);
+  // Done-marker: if credentials.json exists with a valid accountId, delegate, and
+  // the delegate is confirmed on-chain, skip this Elder entirely (including funding).
+  // This makes reruns safe against double-spend without re-checking everything.
+  const existingCreds = readJson(owner.credentialsPath);
+  if (existingCreds?.accountId && existingCreds?.delegatePublicKeyHex) {
+    const alreadyValid = await isDelegateValid(
+      existingCreds.accountId,
+      existingCreds.delegatePublicKeyHex,
+    );
+    if (alreadyValid) {
+      logPublic({
+        elder: elderNumber,
+        step: "provision",
+        status: "skip-already-done",
+        ownerAddress: owner.ownerAddress,
+        accountId: existingCreds.accountId,
+        delegateAddress: existingCreds.delegateAddress,
+        credentialsPath: owner.credentialsPath,
+      });
+      const balance = await getSuiBalance(owner.ownerAddress);
+      return {
+        elderNumber,
+        ownerAddress: owner.ownerAddress,
+        accountId: existingCreds.accountId,
+        delegateAddress: existingCreds.delegateAddress,
+        delegatePublicKeyHex: existingCreds.delegatePublicKeyHex,
+        credentialsPath: owner.credentialsPath,
+        ownerKeyPath: owner.keyPath,
+        funding: {
+          beforeMist: balance.toString(),
+          afterMist: balance.toString(),
+          beforeSui: sui(balance),
+          afterSui: sui(balance),
+          funded: false,
+          fundAmountSui: "0.000000",
+          digest: null,
+        },
+        accountDigest: null,
+        delegateAddDigest: null,
+        delegateReused: true,
+        credentials: existingCreds,
+      };
+    }
+  }
+
+  const funding = await fundIfNeeded(elderNumber, owner.ownerAddress, runFundingTotal);
   const account = await createOrRecoverAccount(owner.ownerAddress, owner.ownerKey);
   logPublic({
     elder: elderNumber,
@@ -445,8 +521,10 @@ function recallContainsProbe(recall) {
 }
 
 async function proveIsolation(elder1, elder2) {
-  const client1 = makeClient(elder1, "elder-1");
-  const client2 = makeClient(elder2, "elder-2");
+  // Use PROBE_NAMESPACE (not the real "elder-1" namespace) so the probe memory
+  // never surfaces in live Elder 1 recall sessions.
+  const client1 = makeClient(elder1, PROBE_NAMESPACE);
+  const client2 = makeClient(elder2, PROBE_NAMESPACE);
   const remembered = await client1.rememberAndWait(PROBE_TEXT, undefined, {
     timeoutMs: 120_000,
     pollIntervalMs: 2_000,
@@ -512,7 +590,7 @@ function writeFindings(provisioned, isolation) {
     "",
     "## Isolation assertions",
     "",
-    `- Elder 1 remembered \`${PROBE_TEXT}\` in namespace \`elder-1\`.`,
+    `- Elder 1 remembered \`${PROBE_TEXT}\` in namespace \`${PROBE_NAMESPACE}\`.`,
     `- Elder 2 recall for \`${PROBE_QUERY}\` returned Elder 1 probe: **${isolation.elder2DoesNotSee ? "NO" : "YES"}**.`,
     `- Elder 1 recall for \`${PROBE_QUERY}\` returned Elder 1 probe: **${isolation.elder1Sees ? "YES" : "NO"}**.`,
     `- Elder 1 blob ID: \`${isolation.remembered.blob_id}\`.`,
@@ -535,12 +613,15 @@ function writeFindings(provisioned, isolation) {
   writeFileSync(FINDINGS_PATH, `${lines.join("\n")}\n`, { mode: 0o600 });
 }
 
+// Shared mutable counter — all provisionElder calls update it; fundIfNeeded enforces the cap.
+const runFundingTotal = { value: 0n };
+
 const provisioned = [];
-provisioned.push(await provisionElder(1));
-provisioned.push(await provisionElder(2));
+provisioned.push(await provisionElder(1, runFundingTotal));
+provisioned.push(await provisionElder(2, runFundingTotal));
 const isolation = await proveIsolation(provisioned[0], provisioned[1]);
-provisioned.push(await provisionElder(3));
-provisioned.push(await provisionElder(4));
+provisioned.push(await provisionElder(3, runFundingTotal));
+provisioned.push(await provisionElder(4, runFundingTotal));
 writeFindings(provisioned, isolation);
 logPublic({
   step: "complete",

--- a/scripts/walrus/smoke-elder-memwal.sh
+++ b/scripts/walrus/smoke-elder-memwal.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# smoke-elder-memwal.sh — run INSIDE an Elder container to verify its Walrus
+# Memory (MemWal) MCP wiring BEFORE trusting the live demo.
+#
+#   docker compose exec elder-1 /opt/clan-world/shared/scripts/walrus/smoke-elder-memwal.sh
+#
+# Checks 1-3 are automated. #4 is a manual check in the Elder's Claude session.
+# The #1 demo-day risk is check 3 (egress): the Elder is network-sandboxed, and
+# the MemWal MCP must reach the PUBLIC relayer — it works on the host but fails
+# silently in-container if the egress allow-list omits relayer.memory.walrus.xyz.
+set -uo pipefail
+fail=0
+RELAYER_HOST="relayer.memory.walrus.xyz"
+CREDS="${HOME}/.memwal/credentials.json"
+
+echo "[1/4] memwal-mcp on PATH..."
+if command -v memwal-mcp >/dev/null 2>&1; then
+  echo "  OK: $(command -v memwal-mcp)"
+else
+  echo "  FAIL: memwal-mcp not on PATH (Dockerfile must install @mysten-incubation/memwal-mcp)"; fail=1
+fi
+
+echo "[2/4] per-Elder credentials present + readable..."
+if [ -r "$CREDS" ]; then
+  acct=$(node -e "process.stdout.write(require('$CREDS').accountId||'')" 2>/dev/null \
+        || python3 -c "import json;print(json.load(open('$CREDS'))['accountId'])" 2>/dev/null)
+  echo "  OK: accountId=${acct:-<unparsed>}  (ELDER_N=${ELDER_N:-?})"
+  echo "      ^ confirm this accountId is DISTINCT per Elder — identical creds across"
+  echo "        containers collapses all Elders into one MemWal identity."
+else
+  echo "  FAIL: $CREDS missing/unreadable (mount per-Elder credentials.json here)"; fail=1
+fi
+
+echo "[3/4] egress to ${RELAYER_HOST} (THE #1 demo-day risk)..."
+code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 8 "https://${RELAYER_HOST}/health" 2>/dev/null || echo "000")
+if [ "$code" != "000" ]; then
+  echo "  OK: relayer reachable over HTTPS (HTTP $code)"
+else
+  echo "  FAIL: ${RELAYER_HOST} UNREACHABLE from this container."
+  echo "        → add ${RELAYER_HOST} to the Elder egress allow-list (docker/caddy lane)."
+  fail=1
+fi
+
+echo "[4/4] MANUAL: in the Elder's Claude session, confirm tools"
+echo "      mcp__memwal__memwal_remember / mcp__memwal__memwal_recall are visible,"
+echo "      then run one tagged remember -> recall round-trip."
+
+if [ "$fail" -eq 0 ]; then
+  echo "SMOKE PASS (checks 1-3) — proceed to the manual round-trip."
+else
+  echo "SMOKE FAIL — fix the FAIL line(s) above before the demo."
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary
PR1 of the Walrus Memory migration — gives each Elder an **encrypted, agent-owned** memory backend on **Walrus + Sui**, via Mysten's **Walrus Memory (MemWal)**.

**Proven live on mainnet:** 4 Elder owner accounts (fresh Ed25519 Sui keys) + Ed25519 delegates created; per-Elder encrypted memory; **isolation proven** (Elder 2 cannot read Elder 1's memory; Elder 1 can).

## What's here
- **`scripts/walrus/provision-elders.mjs`** — idempotent per-Elder provisioning (owner account → delegate → credentials.json). Already run on mainnet.
- **`agents/shared/elder-mcp.json`** — adds the `memwal` stdio MCP server.
- **`agents/shared/APPENDED_SYSTEM_PROMPT.md`** — introduces `memwal_remember`/`memwal_recall`, the KV-vs-reflection split, and post-wipe "recall both, verify vs world_snapshot".
- **`docs/walrus-memory-docker-handoff.md`** — the 2 container-image changes (install `memwal-mcp` binary + mount per-Elder creds) handed to the **docker-build session** so this PR stays out of `docker-compose.yml` / `Dockerfile`.

## Scope / coordination
- Confined to the **ops + runner-config lane** — no Move / web / mobile / contract files (zero overlap with #659/#661).
- Container wiring (binary install + per-Elder cred mount) is coordinated to the docker-build session per the hand-off doc.

## Next PRs
PR2 prompt-template tuning + planted-stale-fact · PR3 cockpit Agent panel · PR4 Track A (MemWal SDK in our Elder MCP) · bonus unified secp256k1 Base-key identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)