### PR TITLE
feat(walrus): Track A — KV memory via MemWal SDK in Elder MCP + Convex mirror (PR4)

### DIFF
--- a/apps/server/convex/inft.ts
+++ b/apps/server/convex/inft.ts
@@ -26,7 +26,13 @@ export const mirrorMemoryEntry = mutation({
     value: v.string(),
     dataHash: v.optional(v.string()),
     // "0g" retained for historical rows (deploy-safety); see schema.ts.
-    source: v.union(v.literal("local"), v.literal("0g"), v.literal("demo")),
+    // "walrus" = mirrored after a successful Walrus Memory KV save.
+    source: v.union(
+      v.literal("local"),
+      v.literal("0g"),
+      v.literal("demo"),
+      v.literal("walrus"),
+    ),
     txHash: v.optional(v.string()),
   },
   handler: async (ctx, args) => {

--- a/apps/server/convex/memory.ts
+++ b/apps/server/convex/memory.ts
@@ -41,7 +41,14 @@ export const seedEntry = internalMutation({
     clanId: v.number(),
     key: v.string(),
     value: v.string(),
-    source: v.optional(v.union(v.literal("local"), v.literal("0g"), v.literal("demo"))),
+    source: v.optional(
+      v.union(
+        v.literal("local"),
+        v.literal("0g"),
+        v.literal("demo"),
+        v.literal("walrus"),
+      ),
+    ),
     dataHash: v.optional(v.string()),
     txHash: v.optional(v.string()),
   },

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -20,6 +20,8 @@
   },
   "dependencies": {
     "@clan-world/shared": "workspace:*",
+    "@mysten-incubation/memwal": "0.0.7",
+    "@mysten/sui": "2.17.0",
     "tsx": "4.19.2"
   },
   "devDependencies": {

--- a/packages/agents/src/mcp.ts
+++ b/packages/agents/src/mcp.ts
@@ -9,6 +9,7 @@ import {
   validateSubmitOrderPayload,
 } from '@clan-world/shared/adapters';
 import { getElderN, memoryFile, inboxFile, ackFile, UsageError, runCommand } from './cli.js';
+import { createWalrusKvStore, type WalrusKvStore } from './walrusKvStore.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
@@ -27,7 +28,29 @@ export type ElderToolDeps = {
   chain: IChainClient;
   env?: Record<string, string | undefined>;
   homeBase?: string;
+  /**
+   * Walrus KV store (MemWal). Optional + lazily created per Elder. When absent
+   * (or when its credentials/relayer are unavailable) the MCP transparently
+   * falls back to the local file store — a tick is never blocked by Walrus.
+   */
+  walrusKv?: WalrusKvStore;
 };
+
+/**
+ * Resolve (and memoise on `deps`) the Walrus KV store for this Elder. Returns
+ * `undefined` if `ELDER_N` is not resolvable — callers then use the file path.
+ */
+function resolveWalrusKv(deps: ElderToolDeps, env: Record<string, string | undefined>): WalrusKvStore | undefined {
+  if (deps.walrusKv) return deps.walrusKv;
+  let elder: number;
+  try {
+    elder = getElderN(env);
+  } catch {
+    return undefined;
+  }
+  deps.walrusKv = createWalrusKvStore(elder);
+  return deps.walrusKv;
+}
 
 const text = (value: string): ToolResult => ({ content: [{ type: 'text', text: value }] });
 const jsonText = (value: unknown): ToolResult => text(JSON.stringify(value, null, 2));
@@ -134,6 +157,12 @@ export async function callElderTool(name: string, args: unknown, deps: ElderTool
 
   if (name === 'memory_recall') {
     const key = requireBody(parsed, 'key');
+    // Read prefers Walrus (durable, cross-host), falls back to the local file.
+    const walrusKv = resolveWalrusKv(deps, env);
+    if (walrusKv) {
+      const fromWalrus = await walrusKv.recall(key).catch(() => undefined);
+      if (fromWalrus !== undefined) return text(fromWalrus);
+    }
     const mem = await readMemoryAsync(getElderN(env), deps.homeBase);
     return text(mem[key] ?? `no memory for ${key}`);
   }
@@ -142,9 +171,27 @@ export async function callElderTool(name: string, args: unknown, deps: ElderTool
     const key = requireBody(parsed, 'key');
     const value = requireBody(parsed, 'value');
     const elder = getElderN(env);
+    // File first (fast, always-available cache/fallback)…
     const mem = await readMemoryAsync(elder, deps.homeBase);
     mem[key] = value;
     await writeMemoryAsync(elder, mem, deps.homeBase);
+    // …then Walrus (best-effort, durable). Never let a Walrus/relayer outage
+    // fail the tool call — the file write above already succeeded.
+    const walrusKv = resolveWalrusKv(deps, env);
+    if (walrusKv) {
+      const saved = await walrusKv.save(key, value).catch(() => ({ ok: false as const }));
+      if (saved.ok) {
+        // Mirror to Convex so the cockpit's memoryEntries shows source:"walrus".
+        // Best-effort: IConvexClient swallows + warns when INDEXER_SECRET is
+        // unset (no indexer secret reaches the MCP today — see PR notes).
+        // Optional-chain guards older IConvexClient impls without this method.
+        try {
+          await deps.convex.mirrorMemoryEntry?.({ clanId: elder, key, value, source: 'walrus' });
+        } catch {
+          // non-fatal: cockpit mirror is decoupled from the durable Walrus save
+        }
+      }
+    }
     return text(`saved ${key}`);
   }
 

--- a/packages/agents/src/walrusKvStore.ts
+++ b/packages/agents/src/walrusKvStore.ts
@@ -1,0 +1,377 @@
+/**
+ * walrusKvStore — a key→value store emulated on top of the MemWal SDK
+ * (Walrus Memory).
+ *
+ * MemWal is a semantic memory store, not a literal KV store: you `remember`
+ * free text and `recall` by semantic query. We emulate exact-key KV on top of
+ * it with a deterministic tagged-text encoding:
+ *
+ *     kv:<key> = <value>
+ *
+ * On `save` we `rememberAndWait` that line. On `recall(key)` we issue a
+ * semantic `recall({ query: "kv:<key>" })`, then scan the returned results for
+ * the FIRST one whose decoded text carries the exact `kv:<key>` tag and return
+ * its value. Because semantic search can return near-miss neighbours, we never
+ * trust the top hit blindly — we re-parse the tag and require an exact key
+ * match before returning a value.
+ *
+ * Design constraints (the Elder MCP must never hard-fail a tick):
+ *   - Credentials (`~/.memwal/credentials.json`) or the relayer being absent /
+ *     unreachable degrades gracefully: `save` returns `{ ok: false }` and
+ *     `recall` returns `undefined`. The caller keeps using the local file
+ *     store as the source of truth.
+ *   - The MemWal client is constructed lazily and memoised per process. A
+ *     failed construction is cached as "disabled" so we do not re-read a
+ *     missing/broken credential file on every tick.
+ *   - All network calls are time-boxed so a hung relayer cannot stall a tick.
+ *
+ * One Elder == one credential file == one MemWal account/delegate identity.
+ * The namespace further isolates this Elder's KV namespace under that account.
+ */
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { MemWal } from '@mysten-incubation/memwal';
+
+/** Shape of `~/.memwal/credentials.json` (only the fields we consume). */
+export type MemWalCredentials = {
+  delegatePrivateKey: string;
+  accountId: string;
+  relayerUrl: string;
+  // packageId / registryId / label etc. are present in the file but are not
+  // needed to construct a runtime MemWal client (they are provisioning-time
+  // values), so we do not require them here.
+  packageId?: string;
+  namespace?: string;
+};
+
+export type WalrusSaveResult = {
+  ok: boolean;
+  /** Walrus blob id when the write succeeded; undefined on degrade/failure. */
+  blobId?: string;
+  /** Populated when degraded so the caller can log/observe (best-effort). */
+  reason?: string;
+};
+
+/** Default credential path. HOME is /home/elder inside the elder container. */
+function defaultCredentialsPath(home: string = os.homedir()): string {
+  return path.join(home, '.memwal', 'credentials.json');
+}
+
+/**
+ * Deterministic tag prefix for a key. Kept stable so a value written in one
+ * process can be recalled in another.
+ *
+ * Keys MUST NOT contain newlines: the encoding is a single line, and a key
+ * like `a\nb` would otherwise collide with the literal key `"a b"`. We reject
+ * such keys (the caller catches and degrades to the file store) rather than
+ * silently normalising them into a different key. KV keys in practice are
+ * short identifiers like `active-strategy`.
+ */
+function kvTag(key: string): string {
+  if (/[\r\n]/.test(key)) {
+    throw new Error('walrus-kv: key must not contain newline characters');
+  }
+  return `kv:${key}`;
+}
+
+/**
+ * Encode a key/value pair into a single tagged line. The value is
+ * JSON-encoded so embedded newlines / control characters / `=` survive the
+ * round-trip losslessly. A monotonic `v=<version>` field lets recall pick the
+ * latest write among multiple stored entries for the same key (MemWal append
+ * semantics mean an overwrite leaves the older entry in the index).
+ */
+function encodeKv(key: string, value: string, version: number): string {
+  return `${kvTag(key)} v=${version} = ${JSON.stringify(value)}`;
+}
+
+/** Parsed KV memory line: the value plus its write version (0 if absent). */
+export type ParsedKv = { value: string; version: number };
+
+/**
+ * Parse a value (and its version) back out of a tagged line, requiring an
+ * EXACT key match. Returns `undefined` when the text is not a
+ * `kv:<key> v=<n> = <json>` line for this exact key — guarding against
+ * semantic near-miss neighbours returned by the relayer.
+ *
+ * The whole memory text is treated as ONE line: encode never emits a newline
+ * (the value is JSON-encoded), so a stored KV memory is always single-line.
+ */
+export function parseKvValue(text: string, key: string): ParsedKv | undefined {
+  const tag = kvTag(key);
+  // ^kv:<key> v=<digits> = <json-rest>$  — anchored, exact key, rest is the
+  // JSON-encoded value (may legitimately contain spaces, `=`, escaped \n).
+  const prefix = `${tag} v=`;
+  if (!text.startsWith(prefix)) return undefined;
+  const afterPrefix = text.slice(prefix.length);
+  const sep = afterPrefix.indexOf(' = ');
+  if (sep < 0) return undefined;
+  const versionStr = afterPrefix.slice(0, sep);
+  if (!/^\d+$/.test(versionStr)) return undefined;
+  const jsonValue = afterPrefix.slice(sep + 3);
+  let value: unknown;
+  try {
+    value = JSON.parse(jsonValue);
+  } catch {
+    return undefined;
+  }
+  if (typeof value !== 'string') return undefined;
+  return { value, version: Number(versionStr) };
+}
+
+export type WalrusKvStoreOptions = {
+  /** Override credential path (tests). Defaults to ~/.memwal/credentials.json. */
+  credentialsPath?: string;
+  /**
+   * Namespace isolating this Elder's KV under its MemWal account. Strongly
+   * recommended to be per-Elder (e.g. `elder-3-kv`).
+   */
+  namespace: string;
+  /** Per-call timeout for remember (ms). */
+  rememberTimeoutMs?: number;
+  /** Per-call timeout for recall (ms). */
+  recallTimeoutMs?: number;
+  /** recall() top-K. We scan results for an exact tag match. */
+  recallLimit?: number;
+  /** Timeout (ms) for lazy client construction (credential read + create). */
+  initTimeoutMs?: number;
+  /** Injectable MemWal factory for tests. */
+  memwalFactory?: typeof MemWal.create;
+};
+
+// Kept well under typical agentic tool-call ceilings (~30-60s). The local file
+// write in memory_save already succeeded by the time we await this, so a slow
+// relayer just degrades that one save to file-only rather than stalling the
+// Elder's tool call. The blob still lands in the local cache and the next save
+// re-attempts Walrus.
+const DEFAULT_REMEMBER_TIMEOUT_MS = 15_000;
+const DEFAULT_RECALL_TIMEOUT_MS = 12_000;
+const DEFAULT_INIT_TIMEOUT_MS = 8_000;
+const DEFAULT_RECALL_LIMIT = 5;
+
+/**
+ * A lazily-initialised KV-over-MemWal store. Construct once per Elder process;
+ * the underlying MemWal client + credentials are loaded on first use and then
+ * memoised. All public methods are degrade-safe and never throw.
+ */
+export class WalrusKvStore {
+  private readonly options: Required<Omit<WalrusKvStoreOptions, 'credentialsPath' | 'memwalFactory'>> &
+    Pick<WalrusKvStoreOptions, 'credentialsPath' | 'memwalFactory'>;
+  /**
+   * Tri-state init cache:
+   *   - undefined  → not yet attempted
+   *   - null       → attempted and disabled (no creds / construction failed)
+   *   - MemWal     → ready
+   */
+  private client: MemWal | null | undefined = undefined;
+  private initPromise: Promise<MemWal | null> | undefined;
+  /**
+   * Monotonic write-version source. Each save() stamps the encoded line with a
+   * strictly-increasing version so recall() can pick the latest among the
+   * (append-only) MemWal entries for a key. Seeded from wall-clock ms so
+   * versions stay ordered across process restarts; the in-process counter then
+   * guarantees strict monotonicity even for sub-millisecond consecutive saves.
+   */
+  private versionCounter = Date.now();
+
+  constructor(options: WalrusKvStoreOptions) {
+    this.options = {
+      namespace: options.namespace,
+      rememberTimeoutMs: options.rememberTimeoutMs ?? DEFAULT_REMEMBER_TIMEOUT_MS,
+      recallTimeoutMs: options.recallTimeoutMs ?? DEFAULT_RECALL_TIMEOUT_MS,
+      recallLimit: options.recallLimit ?? DEFAULT_RECALL_LIMIT,
+      initTimeoutMs: options.initTimeoutMs ?? DEFAULT_INIT_TIMEOUT_MS,
+      credentialsPath: options.credentialsPath,
+      memwalFactory: options.memwalFactory,
+    };
+  }
+
+  private nextVersion(): number {
+    this.versionCounter = Math.max(this.versionCounter + 1, Date.now());
+    return this.versionCounter;
+  }
+
+  /** True if a MemWal client could be constructed (creds present + valid). */
+  async isAvailable(): Promise<boolean> {
+    return (await this.ensureClient()) !== null;
+  }
+
+  /**
+   * Save a key/value to Walrus. Best-effort: returns `{ ok: false, reason }`
+   * if the store is unavailable or the write fails — never throws.
+   */
+  async save(key: string, value: string): Promise<WalrusSaveResult> {
+    let encoded: string;
+    try {
+      // kvTag (via encodeKv) throws on newline-bearing keys — treat as a
+      // degrade, not a crash, so the local file write (already done) stands.
+      encoded = encodeKv(key, value, this.nextVersion());
+    } catch (err) {
+      return { ok: false, reason: errMessage(err) };
+    }
+    const client = await this.ensureClient();
+    if (!client) return { ok: false, reason: 'walrus-kv unavailable' };
+    try {
+      // Outer backstop deadline is the SDK timeout + a margin so the SDK's own
+      // timeout fires first in the normal case; the outer guard only trips if
+      // the SDK call hangs past its own deadline.
+      const remembered = await this.withTimeout(
+        client.rememberAndWait(encoded, this.options.namespace, {
+          timeoutMs: this.options.rememberTimeoutMs,
+          pollIntervalMs: 2_000,
+        }),
+        this.options.rememberTimeoutMs + 5_000,
+        'walrus-kv save',
+      );
+      return { ok: true, blobId: remembered.blob_id };
+    } catch (err) {
+      return { ok: false, reason: errMessage(err) };
+    }
+  }
+
+  /**
+   * Recall a value for an exact key. Returns `undefined` when unavailable, on
+   * error, or when no stored memory carries the exact `kv:<key>` tag — never
+   * throws.
+   *
+   * MemWal is append-only, so several entries may exist for the same key after
+   * repeated saves. We scan ALL exact-tag matches and return the one with the
+   * highest write version (latest write wins) rather than trusting the
+   * similarity-ranked top hit, which would otherwise serve stale state.
+   */
+  async recall(key: string): Promise<string | undefined> {
+    let query: string;
+    try {
+      query = kvTag(key);
+    } catch {
+      return undefined;
+    }
+    const client = await this.ensureClient();
+    if (!client) return undefined;
+    try {
+      const result = await this.withTimeout(
+        client.recall({ query, limit: this.options.recallLimit }),
+        this.options.recallTimeoutMs,
+        'walrus-kv recall',
+      );
+      let best: ParsedKv | undefined;
+      for (const memory of result.results ?? []) {
+        const parsed = parseKvValue(memory.text, key);
+        if (parsed && (!best || parsed.version > best.version)) best = parsed;
+      }
+      return best?.value;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // ── internals ───────────────────────────────────────────────────────────
+
+  private async ensureClient(): Promise<MemWal | null> {
+    if (this.client !== undefined) return this.client;
+    if (!this.initPromise) {
+      this.initPromise = this.buildClient()
+        .then(client => {
+          this.client = client;
+          return client;
+        })
+        .catch(() => {
+          this.client = null;
+          return null;
+        })
+        .finally(() => {
+          this.initPromise = undefined;
+        });
+    }
+    return this.initPromise;
+  }
+
+  private async buildClient(): Promise<MemWal | null> {
+    // Time-box construction (credential read + MemWal.create). A hung relayer
+    // probe during create() must not stall the first memory tool call; on
+    // timeout we degrade to the file store (returns null → disabled).
+    return this.withTimeout(this.buildClientInner(), this.options.initTimeoutMs, 'walrus-kv init');
+  }
+
+  private async buildClientInner(): Promise<MemWal | null> {
+    const creds = await this.loadCredentials();
+    if (!creds) return null;
+    const create = this.options.memwalFactory ?? MemWal.create;
+    return create({
+      key: creds.delegatePrivateKey,
+      accountId: creds.accountId,
+      serverUrl: creds.relayerUrl,
+      namespace: this.options.namespace,
+    });
+  }
+
+  private async loadCredentials(): Promise<MemWalCredentials | null> {
+    const file = this.options.credentialsPath ?? defaultCredentialsPath();
+    let raw: string;
+    try {
+      raw = await fs.readFile(file, 'utf8');
+    } catch {
+      // Missing / unreadable credentials → degrade silently.
+      return null;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+    if (!isCredentials(parsed)) return null;
+    return parsed;
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    });
+    try {
+      return await Promise.race([promise, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}
+
+function isCredentials(value: unknown): value is MemWalCredentials {
+  if (value === null || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.delegatePrivateKey === 'string' &&
+    v.delegatePrivateKey.length > 0 &&
+    typeof v.accountId === 'string' &&
+    v.accountId.length > 0 &&
+    typeof v.relayerUrl === 'string' &&
+    v.relayerUrl.length > 0
+  );
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Stable per-Elder KV namespace, e.g. elder 3 → `elder-3-kv`. */
+export function elderKvNamespace(elderN: number): string {
+  return `elder-${elderN}-kv`;
+}
+
+/**
+ * Build a WalrusKvStore for an Elder. `credentialsPath` is optional (tests).
+ * Construction is cheap; the client is lazy-initialised on first save/recall.
+ */
+export function createWalrusKvStore(elderN: number, opts?: Partial<WalrusKvStoreOptions>): WalrusKvStore {
+  return new WalrusKvStore({
+    namespace: opts?.namespace ?? elderKvNamespace(elderN),
+    credentialsPath: opts?.credentialsPath,
+    rememberTimeoutMs: opts?.rememberTimeoutMs,
+    recallTimeoutMs: opts?.recallTimeoutMs,
+    recallLimit: opts?.recallLimit,
+    initTimeoutMs: opts?.initTimeoutMs,
+    memwalFactory: opts?.memwalFactory,
+  });
+}

--- a/packages/agents/test/cli.test.ts
+++ b/packages/agents/test/cli.test.ts
@@ -38,6 +38,7 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
     async postOrchEvent() {},
     async postHumanSteering() {},
     async postBulletin() {},
+    async mirrorMemoryEntry() {},
     ...overrides,
   };
 }

--- a/packages/agents/test/mcp.test.ts
+++ b/packages/agents/test/mcp.test.ts
@@ -5,7 +5,27 @@ import path from 'node:path';
 import type { IChainClient, IConvexClient } from '@clan-world/shared/adapters';
 import type { ClanFullView, Tick, WorldSnapshot } from '@clan-world/shared';
 import { callElderTool } from '../src/mcp.js';
-import { ackFile, inboxFile } from '../src/cli.js';
+import { ackFile, inboxFile, memoryFile } from '../src/cli.js';
+import type { WalrusKvStore } from '../src/walrusKvStore.js';
+
+/** Minimal in-memory fake WalrusKvStore for wiring tests. */
+function makeWalrusKv(opts: {
+  available?: boolean;
+  saveOk?: boolean;
+  recallValue?: string | undefined;
+  onSave?: (key: string, value: string) => void;
+} = {}): WalrusKvStore {
+  return {
+    async isAvailable() { return opts.available ?? true; },
+    async save(key: string, value: string) {
+      opts.onSave?.(key, value);
+      return opts.saveOk === false
+        ? { ok: false as const, reason: 'fake-unavailable' }
+        : { ok: true as const, blobId: 'fakeblob' };
+    },
+    async recall(_key: string) { return opts.recallValue; },
+  } as unknown as WalrusKvStore;
+}
 
 const STUB_SNAPSHOT: WorldSnapshot = {
   tick: 9,
@@ -31,6 +51,7 @@ function makeConvex(overrides: Partial<IConvexClient> = {}): IConvexClient {
     async postOrchEvent() {},
     async postHumanSteering() {},
     async postBulletin() {},
+    async mirrorMemoryEntry() {},
     ...overrides,
   };
 }
@@ -181,5 +202,88 @@ describe('elder MCP tools', () => {
 
     expect(out.content[0]?.text).toBe('ack cleared');
     expect(fs.existsSync(ackFile(4, tmpDir))).toBe(true);
+  });
+
+  it('memory_save writes the local file AND mirrors a successful Walrus save to Convex (source: walrus)', async () => {
+    const mirrors: Array<{ clanId: number; key: string; value: string; source: string }> = [];
+    let savedToWalrus: { key: string; value: string } | undefined;
+    const out = await callElderTool(
+      'memory_save',
+      { key: 'active-strategy', value: 'hold the ridge' },
+      {
+        convex: makeConvex({
+          async mirrorMemoryEntry(args) { mirrors.push(args); },
+        }),
+        chain: makeChain(),
+        env: { ELDER_N: '3' },
+        homeBase: tmpDir,
+        walrusKv: makeWalrusKv({ onSave: (key, value) => { savedToWalrus = { key, value }; } }),
+      },
+    );
+
+    expect(out.content[0]?.text).toBe('saved active-strategy');
+    // Local file path preserved.
+    const file = JSON.parse(fs.readFileSync(memoryFile(3, tmpDir), 'utf8'));
+    expect(file['active-strategy']).toBe('hold the ridge');
+    // Walrus write happened.
+    expect(savedToWalrus).toEqual({ key: 'active-strategy', value: 'hold the ridge' });
+    // Convex mirror happened with source "walrus" + the elder's clanId.
+    expect(mirrors).toEqual([
+      { clanId: 3, key: 'active-strategy', value: 'hold the ridge', source: 'walrus' },
+    ]);
+  });
+
+  it('memory_save still succeeds + writes the file when Walrus is unavailable (no mirror)', async () => {
+    const mirrors: unknown[] = [];
+    const out = await callElderTool(
+      'memory_save',
+      { key: 'k', value: 'v' },
+      {
+        convex: makeConvex({ async mirrorMemoryEntry(args) { mirrors.push(args); } }),
+        chain: makeChain(),
+        env: { ELDER_N: '1' },
+        homeBase: tmpDir,
+        walrusKv: makeWalrusKv({ saveOk: false }),
+      },
+    );
+
+    expect(out.content[0]?.text).toBe('saved k');
+    const file = JSON.parse(fs.readFileSync(memoryFile(1, tmpDir), 'utf8'));
+    expect(file['k']).toBe('v');
+    expect(mirrors).toEqual([]); // no mirror when Walrus save failed
+  });
+
+  it('memory_recall prefers a Walrus hit over the local file', async () => {
+    fs.mkdirSync(path.dirname(memoryFile(2, tmpDir)), { recursive: true });
+    fs.writeFileSync(memoryFile(2, tmpDir), JSON.stringify({ k: 'file-value' }));
+    const out = await callElderTool(
+      'memory_recall',
+      { key: 'k' },
+      {
+        convex: makeConvex(),
+        chain: makeChain(),
+        env: { ELDER_N: '2' },
+        homeBase: tmpDir,
+        walrusKv: makeWalrusKv({ recallValue: 'walrus-value' }),
+      },
+    );
+    expect(out.content[0]?.text).toBe('walrus-value');
+  });
+
+  it('memory_recall falls back to the local file when Walrus has no hit', async () => {
+    fs.mkdirSync(path.dirname(memoryFile(2, tmpDir)), { recursive: true });
+    fs.writeFileSync(memoryFile(2, tmpDir), JSON.stringify({ k: 'file-value' }));
+    const out = await callElderTool(
+      'memory_recall',
+      { key: 'k' },
+      {
+        convex: makeConvex(),
+        chain: makeChain(),
+        env: { ELDER_N: '2' },
+        homeBase: tmpDir,
+        walrusKv: makeWalrusKv({ recallValue: undefined }),
+      },
+    );
+    expect(out.content[0]?.text).toBe('file-value');
   });
 });

--- a/packages/agents/test/walrusKvStore.test.ts
+++ b/packages/agents/test/walrusKvStore.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import {
+  WalrusKvStore,
+  parseKvValue,
+  elderKvNamespace,
+  createWalrusKvStore,
+} from '../src/walrusKvStore.js';
+
+describe('parseKvValue', () => {
+  it('extracts the value + version for an exact tagged line', () => {
+    expect(parseKvValue('kv:active-strategy v=5 = "hold the ridge"', 'active-strategy')).toEqual({
+      value: 'hold the ridge',
+      version: 5,
+    });
+  });
+
+  it('returns undefined when the key tag does not match (semantic near-miss guard)', () => {
+    expect(parseKvValue('kv:other-key v=1 = "something"', 'active-strategy')).toBeUndefined();
+  });
+
+  it('supports an empty value', () => {
+    expect(parseKvValue('kv:k v=1 = ""', 'k')).toEqual({ value: '', version: 1 });
+  });
+
+  it('preserves " = " inside the value', () => {
+    expect(parseKvValue('kv:eq v=2 = "x = y = z"', 'eq')).toEqual({ value: 'x = y = z', version: 2 });
+  });
+
+  it('round-trips a value containing newlines (no truncation)', () => {
+    // JSON-encoded value keeps the line single-line; the literal stored text is
+    // `kv:k v=3 = "line1\nline2"` (with the \n escaped inside the JSON string).
+    const encoded = `kv:k v=3 = ${JSON.stringify('line1\nline2')}`;
+    expect(parseKvValue(encoded, 'k')).toEqual({ value: 'line1\nline2', version: 3 });
+  });
+
+  it('rejects a malformed (non-numeric version) line', () => {
+    expect(parseKvValue('kv:k v=x = "y"', 'k')).toBeUndefined();
+  });
+
+  it('rejects a line missing the version field (legacy/unknown shape)', () => {
+    expect(parseKvValue('kv:k = y', 'k')).toBeUndefined();
+  });
+});
+
+describe('elderKvNamespace', () => {
+  it('builds a stable per-elder namespace', () => {
+    expect(elderKvNamespace(3)).toBe('elder-3-kv');
+  });
+});
+
+describe('WalrusKvStore degrade behaviour (no credentials)', () => {
+  it('isAvailable() is false when the credential file is missing', async () => {
+    const store = new WalrusKvStore({
+      namespace: 'elder-1-kv',
+      credentialsPath: path.join(os.tmpdir(), `nope-${Date.now()}.json`),
+    });
+    expect(await store.isAvailable()).toBe(false);
+  });
+
+  it('save() degrades gracefully (ok:false) and recall() returns undefined', async () => {
+    const store = new WalrusKvStore({
+      namespace: 'elder-1-kv',
+      credentialsPath: path.join(os.tmpdir(), `nope-${Date.now()}.json`),
+    });
+    const saved = await store.save('active-strategy', 'hold the ridge');
+    expect(saved.ok).toBe(false);
+    expect(saved.reason).toBeTruthy();
+    expect(await store.recall('active-strategy')).toBeUndefined();
+  });
+
+  it('degrades when credential JSON is malformed', async () => {
+    const file = path.join(os.tmpdir(), `bad-creds-${Date.now()}.json`);
+    await fs.writeFile(file, '{ not valid json', 'utf8');
+    const store = new WalrusKvStore({ namespace: 'elder-1-kv', credentialsPath: file });
+    expect(await store.isAvailable()).toBe(false);
+    await fs.unlink(file).catch(() => {});
+  });
+
+  it('degrades when required credential fields are absent', async () => {
+    const file = path.join(os.tmpdir(), `partial-creds-${Date.now()}.json`);
+    await fs.writeFile(file, JSON.stringify({ accountId: '0xabc' }), 'utf8');
+    const store = new WalrusKvStore({ namespace: 'elder-1-kv', credentialsPath: file });
+    expect(await store.isAvailable()).toBe(false);
+    await fs.unlink(file).catch(() => {});
+  });
+});
+
+describe('WalrusKvStore with injected MemWal client', () => {
+  function fakeMemwalFactory(remembered: unknown[], onRemember?: (t: string) => void) {
+    return (() => ({
+      async rememberAndWait(text: string) {
+        onRemember?.(text);
+        return { id: 'job', blob_id: 'blob123', owner: '0xowner', namespace: 'ns' };
+      },
+      async recall() {
+        return { results: remembered, total: remembered.length };
+      },
+    })) as never;
+  }
+
+  const credsFile = async () => {
+    const file = path.join(os.tmpdir(), `good-creds-${Date.now()}-${Math.random()}.json`);
+    await fs.writeFile(
+      file,
+      JSON.stringify({
+        delegatePrivateKey: 'deadbeef',
+        accountId: '0xacct',
+        relayerUrl: 'https://relayer.example',
+      }),
+      'utf8',
+    );
+    return file;
+  };
+
+  it('round-trips a save → recall, encoding value as versioned JSON', async () => {
+    const file = await credsFile();
+    let rememberedText = '';
+    const store = createWalrusKvStore(2, {
+      credentialsPath: file,
+      memwalFactory: fakeMemwalFactory(
+        [{ blob_id: 'b', text: 'kv:active-strategy v=5 = "hold the ridge"', distance: 0.1 }],
+        t => {
+          rememberedText = t;
+        },
+      ),
+    });
+
+    const saved = await store.save('active-strategy', 'hold the ridge');
+    expect(saved.ok).toBe(true);
+    expect(saved.blobId).toBe('blob123');
+    // Encoded as kv:<key> v=<version> = <json-value>.
+    expect(rememberedText).toMatch(/^kv:active-strategy v=\d+ = "hold the ridge"$/);
+
+    const recalled = await store.recall('active-strategy');
+    expect(recalled).toBe('hold the ridge');
+    await fs.unlink(file).catch(() => {});
+  });
+
+  it('save → recall round-trips a value containing newlines without truncation', async () => {
+    const file = await credsFile();
+    let rememberedText = '';
+    const store = createWalrusKvStore(2, {
+      credentialsPath: file,
+      memwalFactory: fakeMemwalFactory([], t => {
+        rememberedText = t;
+      }),
+    });
+    const multiline = 'hold the ridge\nfall back at dawn';
+    await store.save('plan', multiline);
+    // Stored text is a single line (newline escaped inside the JSON string).
+    expect(rememberedText.includes('\n')).toBe(false);
+    expect(parseKvValue(rememberedText, 'plan')?.value).toBe(multiline);
+    await fs.unlink(file).catch(() => {});
+  });
+
+  it('recall ignores semantic near-miss neighbours that lack the exact tag', async () => {
+    const file = await credsFile();
+    const store = createWalrusKvStore(2, {
+      credentialsPath: file,
+      memwalFactory: fakeMemwalFactory([
+        { blob_id: 'b1', text: 'kv:some-other-key v=1 = "noise"', distance: 0.05 },
+        { blob_id: 'b2', text: 'kv:active-strategy v=1 = "the real one"', distance: 0.4 },
+      ]),
+    });
+    expect(await store.recall('active-strategy')).toBe('the real one');
+    await fs.unlink(file).catch(() => {});
+  });
+
+  it('recall picks the highest-version entry among exact-tag matches (latest write wins)', async () => {
+    const file = await credsFile();
+    const store = createWalrusKvStore(2, {
+      credentialsPath: file,
+      memwalFactory: fakeMemwalFactory([
+        // Older write ranks higher on similarity, but newer version must win.
+        { blob_id: 'b1', text: 'kv:active-strategy v=10 = "old"', distance: 0.01 },
+        { blob_id: 'b2', text: 'kv:active-strategy v=42 = "new"', distance: 0.9 },
+      ]),
+    });
+    expect(await store.recall('active-strategy')).toBe('new');
+    await fs.unlink(file).catch(() => {});
+  });
+
+  it('recall returns undefined when no result carries the exact tag', async () => {
+    const file = await credsFile();
+    const store = createWalrusKvStore(2, {
+      credentialsPath: file,
+      memwalFactory: fakeMemwalFactory([
+        { blob_id: 'b1', text: 'kv:unrelated v=1 = "x"', distance: 0.05 },
+      ]),
+    });
+    expect(await store.recall('active-strategy')).toBeUndefined();
+    await fs.unlink(file).catch(() => {});
+  });
+
+  it('save degrades (ok:false) for a key containing a newline rather than colliding', async () => {
+    const file = await credsFile();
+    const store = createWalrusKvStore(2, {
+      credentialsPath: file,
+      memwalFactory: fakeMemwalFactory([]),
+    });
+    const saved = await store.save('bad\nkey', 'v');
+    expect(saved.ok).toBe(false);
+    expect(saved.reason).toMatch(/newline/);
+    await fs.unlink(file).catch(() => {});
+  });
+});

--- a/packages/heartbeat/test/tickLoop.test.ts
+++ b/packages/heartbeat/test/tickLoop.test.ts
@@ -34,6 +34,7 @@ function fakeConvex(tick: number): IConvexClient {
     async postOrchEvent() {},
     async postHumanSteering() {},
     async postBulletin() {},
+    async mirrorMemoryEntry() {},
   };
 }
 

--- a/packages/sdk/convex/schema.ts
+++ b/packages/sdk/convex/schema.ts
@@ -347,8 +347,14 @@ export default defineSchema({
     value: v.string(),
     dataHash: v.optional(v.string()),
     // "0g" retained for historical rows so `convex deploy` validates existing
-    // data; new writes use local/demo (Walrus source lands with that work).
-    source: v.union(v.literal("local"), v.literal("0g"), v.literal("demo")),
+    // data; new writes use local/demo. "walrus" = rows mirrored after a
+    // successful Walrus Memory (MemWal) KV save from the Elder MCP.
+    source: v.union(
+      v.literal("local"),
+      v.literal("0g"),
+      v.literal("demo"),
+      v.literal("walrus"),
+    ),
     updatedAt: v.number(),
     txHash: v.optional(v.string()),
   })

--- a/packages/shared/src/adapters/IConvexClient.ts
+++ b/packages/shared/src/adapters/IConvexClient.ts
@@ -57,6 +57,18 @@ export interface IConvexClient {
     dataHash?: string;
     txHash?: string;
   }): Promise<void>;
+  // Cockpit memory mirror — best-effort. Called after a successful Walrus
+  // Memory KV save so the cockpit's memoryEntries surfaces `source: "walrus"`.
+  // Optional so callers (Elder MCP) can guard with `?.` and stay compatible
+  // with any historical IConvexClient implementation that predates it.
+  mirrorMemoryEntry?(args: {
+    clanId: number;
+    key: string;
+    value: string;
+    source: 'local' | '0g' | 'demo' | 'walrus';
+    dataHash?: string;
+    txHash?: string;
+  }): Promise<void>;
 }
 
 export type RunnerStatusUpdate = {
@@ -101,6 +113,7 @@ class StubConvexClient implements IConvexClient {
   async postOrchEvent(_args: { tick: number; kind: 'world_event' | 'directive' | 'narration'; body: string; targetClanId?: number }): Promise<void> {}
   async postHumanSteering(_args: { tick: number; targetClanId: number; body: string; sentBy?: string }): Promise<void> {}
   async postBulletin(_args: { clanId: number; slot: number; body: string; dataHash?: string; txHash?: string }): Promise<void> {}
+  async mirrorMemoryEntry(_args: { clanId: number; key: string; value: string; source: 'local' | '0g' | 'demo' | 'walrus'; dataHash?: string; txHash?: string }): Promise<void> {}
 }
 
 const getSnapshotRef = convexApiRefs.getSnapshot.getSnapshot;
@@ -108,6 +121,7 @@ const sendWhisperRef = convexApiRefs.comms.sendWhisper;
 const seedOrchEventRef = convexApiRefs.comms.seedOrchEvent;
 const seedHumanSteeringRef = convexApiRefs.comms.seedHumanSteering;
 const seedBulletinRef = convexApiRefs.bulletins.seedBulletin;
+const mirrorMemoryEntryRef = convexApiRefs.inft.mirrorMemoryEntry;
 const updateRunnerStatusRef = convexApiRefs.runnerStatus.updateRunnerStatus;
 
 class RealConvexClient implements IConvexClient {
@@ -242,6 +256,19 @@ class RealConvexClient implements IConvexClient {
       await this.http.mutation(seedBulletinRef, { secret, ...args });
     } catch (err) {
       console.warn('[ConvexClient] postBulletin failed (non-fatal):', err);
+    }
+  }
+
+  async mirrorMemoryEntry(args: { clanId: number; key: string; value: string; source: 'local' | '0g' | 'demo' | 'walrus'; dataHash?: string; txHash?: string }): Promise<void> {
+    const secret = this.indexerSecret();
+    if (!secret) {
+      console.warn('[ConvexClient] mirrorMemoryEntry skipped: INDEXER_SECRET not set');
+      return;
+    }
+    try {
+      await this.http.mutation(mirrorMemoryEntryRef, { secret, ...args });
+    } catch (err) {
+      console.warn('[ConvexClient] mirrorMemoryEntry failed (non-fatal):', err);
     }
   }
 }

--- a/packages/shared/src/adapters/convexApiRefs.ts
+++ b/packages/shared/src/adapters/convexApiRefs.ts
@@ -39,6 +39,16 @@ type SeedBulletinArgs = {
   txHash?: string;
 };
 
+type MirrorMemoryEntryArgs = {
+  secret: string;
+  clanId: number;
+  key: string;
+  value: string;
+  dataHash?: string;
+  source: 'local' | '0g' | 'demo' | 'walrus';
+  txHash?: string;
+};
+
 type UpdateRunnerStatusArgs = {
   secret: string;
   runnerId: string;
@@ -60,6 +70,9 @@ type ClanWorldConvexApi = {
   };
   bulletins: {
     seedBulletin: PublicMutation<SeedBulletinArgs>;
+  };
+  inft: {
+    mirrorMemoryEntry: PublicMutation<MirrorMemoryEntryArgs, string>;
   };
   runnerStatus: {
     updateRunnerStatus: PublicMutation<UpdateRunnerStatusArgs, string>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,6 +396,12 @@ importers:
       '@clan-world/shared':
         specifier: workspace:*
         version: link:../shared
+      '@mysten-incubation/memwal':
+        specifier: 0.0.7
+        version: 0.0.7(@mysten/seal@1.1.3(@mysten/sui@2.17.0(typescript@5.9.3)))(@mysten/sui@2.17.0(typescript@5.9.3))(zod@4.4.2)
+      '@mysten/sui':
+        specifier: 2.17.0
+        version: 2.17.0(typescript@5.9.3)
       tsx:
         specifier: 4.19.2
         version: 4.19.2
@@ -2381,15 +2387,46 @@ packages:
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
 
+  '@mysten-incubation/memwal@0.0.7':
+    resolution: {integrity: sha512-jZycnsstVX/aP33OyJM3bTciwFiiOEcZV4XfhHGbqh8e9pMV/pbOAfD5m9gxrD3V8en29QGAISBsiMIdP3CIyg==}
+    peerDependencies:
+      '@mysten/seal': '>=1.1.0'
+      '@mysten/sui': '>=2.5.0'
+      '@mysten/walrus': '>=1.0.3'
+      ai: '>=4.0.0'
+      zod: ^3.23.0
+    peerDependenciesMeta:
+      '@mysten/walrus':
+        optional: true
+      ai:
+        optional: true
+      zod:
+        optional: true
+
   '@mysten/bcs@1.9.2':
     resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
+
+  '@mysten/bcs@2.0.5':
+    resolution: {integrity: sha512-Dop9Xq36DPLlsmIDQZvUg4uJeBBxIGirgp2OXGaEff+mtLKFBoW2HnE3aSTSSpiMQH9XRhjwtiM16zFJhFqz0Q==}
+
+  '@mysten/seal@1.1.3':
+    resolution: {integrity: sha512-HS54mkWEkd6ENl4U94jorwYzahTSSxWiFiDKbYFw+SFEIc4HoqSg2dULKI1WUi6nw8eWYcw/XobeNOlm3Ss5CQ==}
+    peerDependencies:
+      '@mysten/sui': ^2.16.2
 
   '@mysten/sui@1.45.2':
     resolution: {integrity: sha512-gftf7fNpFSiXyfXpbtP2afVEnhc7p2m/MEYc/SO5pov92dacGKOpQIF7etZsGDI1Wvhv+dpph+ulRNpnYSs7Bg==}
     engines: {node: '>=18'}
 
+  '@mysten/sui@2.17.0':
+    resolution: {integrity: sha512-TrS1BCPm4V6rC69MBejmcqnKIyJ5t1iksax4XA9jWarZxAAp9LMmdxEBebejyDT/yAJxYIf3fNm5WBkHE2qnIw==}
+    engines: {node: '>=22'}
+
   '@mysten/utils@0.2.0':
     resolution: {integrity: sha512-CM6kJcJHX365cK6aXfFRLBiuyXc5WSBHQ43t94jqlCAIRw8umgNcTb5EnEA9n31wPAQgLDGgbG/rCUISCTJ66w==}
+
+  '@mysten/utils@0.3.3':
+    resolution: {integrity: sha512-gVHn5toh24eXXLEyBknwwM2F/tbDgqPX0yj77KtHjuoYUallcQ9vSwGfGsAy39IcTB259Yprt/ZOEwdup+zrpA==}
 
   '@mysten/wallet-standard@0.19.9':
     resolution: {integrity: sha512-jHFt+62os7x7y+4ZVMLck8WSanEO9b8deCD+VApUQkdAHA99TuxbREaujQTjnGQN5DaGEz8wQgeBPqxRY/vKQA==}
@@ -2434,6 +2471,13 @@ packages:
   '@noble/curves@2.0.1':
     resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
     engines: {node: '>= 20.19.0'}
+
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/ed25519@2.3.0':
+    resolution: {integrity: sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -2853,17 +2897,26 @@ packages:
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
+
   '@scure/bip32@1.6.2':
     resolution: {integrity: sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==}
 
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
 
+  '@scure/bip32@2.2.0':
+    resolution: {integrity: sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==}
+
   '@scure/bip39@1.5.4':
     resolution: {integrity: sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==}
 
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  '@scure/bip39@2.2.0':
+    resolution: {integrity: sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==}
 
   '@segment/loosely-validate-event@2.0.0':
     resolution: {integrity: sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==}
@@ -9970,10 +10023,31 @@ snapshots:
       '@lit-labs/ssr-dom-shim': 1.5.1
     optional: true
 
+  '@mysten-incubation/memwal@0.0.7(@mysten/seal@1.1.3(@mysten/sui@2.17.0(typescript@5.9.3)))(@mysten/sui@2.17.0(typescript@5.9.3))(zod@4.4.2)':
+    dependencies:
+      '@mysten/seal': 1.1.3(@mysten/sui@2.17.0(typescript@5.9.3))
+      '@mysten/sui': 2.17.0(typescript@5.9.3)
+      '@noble/ed25519': 2.3.0
+      '@noble/hashes': 2.2.0
+    optionalDependencies:
+      zod: 4.4.2
+
   '@mysten/bcs@1.9.2':
     dependencies:
       '@mysten/utils': 0.2.0
       '@scure/base': 1.2.6
+
+  '@mysten/bcs@2.0.5':
+    dependencies:
+      '@mysten/utils': 0.3.3
+      '@scure/base': 2.2.0
+
+  '@mysten/seal@1.1.3(@mysten/sui@2.17.0(typescript@5.9.3))':
+    dependencies:
+      '@mysten/bcs': 2.0.5
+      '@mysten/sui': 2.17.0(typescript@5.9.3)
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.2.0
 
   '@mysten/sui@1.45.2(typescript@5.9.3)':
     dependencies:
@@ -9997,9 +10071,35 @@ snapshots:
       - '@gql.tada/vue-support'
       - typescript
 
+  '@mysten/sui@2.17.0(typescript@5.9.3)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
+      '@mysten/bcs': 2.0.5
+      '@mysten/utils': 0.3.3
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.2.0
+      '@protobuf-ts/grpcweb-transport': 2.11.1
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      '@scure/base': 2.2.0
+      '@scure/bip32': 2.2.0
+      '@scure/bip39': 2.2.0
+      gql.tada: 1.10.2(graphql@16.13.2)(typescript@5.9.3)
+      graphql: 16.13.2
+      poseidon-lite: 0.2.1
+      valibot: 1.4.1(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - typescript
+
   '@mysten/utils@0.2.0':
     dependencies:
       '@scure/base': 1.2.6
+
+  '@mysten/utils@0.3.3':
+    dependencies:
+      '@scure/base': 2.2.0
 
   '@mysten/wallet-standard@0.19.9(typescript@5.9.3)':
     dependencies:
@@ -10049,6 +10149,12 @@ snapshots:
   '@noble/curves@2.0.1':
     dependencies:
       '@noble/hashes': 2.0.1
+
+  '@noble/curves@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@noble/ed25519@2.3.0': {}
 
   '@noble/hashes@1.4.0':
     optional: true
@@ -10677,6 +10783,8 @@ snapshots:
 
   '@scure/base@1.2.6': {}
 
+  '@scure/base@2.2.0': {}
+
   '@scure/bip32@1.6.2':
     dependencies:
       '@noble/curves': 1.8.1
@@ -10690,6 +10798,12 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@scure/bip32@2.2.0':
+    dependencies:
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
+
   '@scure/bip39@1.5.4':
     dependencies:
       '@noble/hashes': 1.7.1
@@ -10700,6 +10814,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
+
+  '@scure/bip39@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
 
   '@segment/loosely-validate-event@2.0.0':
     dependencies:


### PR DESCRIPTION
## What

Track A of the ClanWorld Walrus Memory migration. Makes the **Elder MCP**'s key→value memory tools (`memory_save` / `memory_recall`) ALSO persist to **Walrus** via the MemWal SDK and mirror writes to **Convex** so the cockpit can show them — while keeping the local JSON file as a fast cache/fallback.

**Hard invariant:** the MCP must never hard-fail a tick. Every Walrus/credential/relayer failure degrades silently to the local file path.

## Changes

- **`packages/agents/src/walrusKvStore.ts` (new)** — KV store emulated over MemWal:
  - `save(key, value)` → `rememberAndWait` with a deterministic, version-stamped, JSON-encoded line: `kv:<key> v=<version> = <json-value>`.
  - `recall(key)` → `recall({ query: "kv:<key>" })`, scans **all** exact-tag matches, returns the **highest version** (latest-write-wins — guards against MemWal's append-only semantics + similarity-ranked recall serving stale state).
  - JSON-encoded value is newline- and `=`-safe (no truncation). Newline-bearing keys are rejected (degrade, not collide).
  - Degrade-safe everywhere: missing/invalid creds, malformed JSON, relayer outages → `save` returns `{ok:false}`, `recall` returns `undefined`. Lazy client init is memoised + time-boxed; remember/recall/init timeouts kept under typical tool-call ceilings.
- **`packages/agents/src/mcp.ts`** — `memory_save` writes file-first (fast) then best-effort Walrus + Convex mirror; `memory_recall` prefers Walrus, falls back to file.
- **Convex `"walrus"` source** — added to the `memoryEntries.source` union in `packages/sdk/convex/schema.ts`, `apps/server/convex/inft.ts` (`mirrorMemoryEntry`), and `apps/server/convex/memory.ts` (`seedEntry`). Added a best-effort `mirrorMemoryEntry` method to `IConvexClient` (gated by `INDEXER_SECRET` like the other cockpit mirrors).
- **Deps** — `@mysten-incubation/memwal` + `@mysten/sui` added to `packages/agents`.

## Ownership / coordination

- **This PR OWNS the `"walrus"` Convex `memoryEntries.source` literal** — PR3 will NOT add it.
- May need a rebase if PR1 / #666 lands first.

## Indexer secret caveat

The Convex mirror needs `INDEXER_SECRET`. In the current MCP runtime the `RealConvexClient` reads `INDEXER_SECRET` from env (same path as `postBulletin`/`postWhisper`); if it is unset the mirror is skipped with a single warn (best-effort, non-fatal). No new secret-plumbing was added — the mirror rides the existing `IConvexClient` secret path.

## Verification

- `pnpm --filter @clan-world/agents typecheck` ✅ + `test` ✅ (80 tests, incl. 18 new walrusKvStore + 4 new MCP wiring tests)
- `pnpm --filter @clan-world/{shared,sdk,server} typecheck` ✅
- `pnpm --filter @clan-world/heartbeat test` ✅ (65)
- `pnpm --filter @clan-world/shared test` ✅ (28)
- `convex codegen` ✅ offline, no `_generated` drift
- Local 3-tier swarm review (codex + gemini + claude): **CLEAN** after one fix round (stale-recall, multiline-truncation, init-timeout, newline-key, optional-mirror, timeout-margin).

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)