### PR TITLE
feat(walrus): cockpit Agent panel — show per-Elder encrypted Walrus memories (PR3)

### DIFF
--- a/apps/web/scripts/shot-agent-tab.mjs
+++ b/apps/web/scripts/shot-agent-tab.mjs
@@ -1,0 +1,35 @@
+// One-off screenshot of the cockpit Agent (0g) tab for PR3 review.
+// Renders against the dev server (stub-fallback data — no live Convex needed).
+// Usage: BASE=http://127.0.0.1:58743 node scripts/shot-agent-tab.mjs /tmp/pr3-agent-tab.png
+import { chromium } from '@playwright/test';
+
+const BASE = process.env.BASE || 'http://127.0.0.1:58743';
+const OUT = process.argv[2] || '/tmp/pr3-agent-tab.png';
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1600, height: 1100 }, deviceScaleFactor: 2 });
+page.on('console', (m) => { if (m.type() === 'error') console.log('[console.error]', m.text()); });
+
+await page.goto(BASE, { waitUntil: 'networkidle' });
+
+// Open the Agent (0g) tab on every mini-cockpit so all four panels show it.
+const tabs = page.locator('[data-testid$="-tab-0g"]');
+const n = await tabs.count();
+console.log('agent tabs found:', n);
+for (let i = 0; i < n; i++) await tabs.nth(i).click();
+
+// Wait for at least one Walrus KV section to mount.
+await page.locator('[data-testid$="-0g-kv"]').first().waitFor({ timeout: 10_000 });
+await page.waitForTimeout(400);
+
+await page.screenshot({ path: OUT, fullPage: true });
+console.log('saved', OUT);
+
+// Also capture a tight shot of clan-1's Agent panel for a focused review image.
+const panel = page.locator('[data-testid="mini-cockpit-1-content-0g"]').first();
+if (await panel.count()) {
+  await panel.screenshot({ path: OUT.replace(/\.png$/, '-panel.png') });
+  console.log('saved panel', OUT.replace(/\.png$/, '-panel.png'));
+}
+
+await browser.close();

--- a/apps/web/scripts/shot-agent-tab.mjs
+++ b/apps/web/scripts/shot-agent-tab.mjs
@@ -10,10 +10,13 @@ const browser = await chromium.launch();
 const page = await browser.newPage({ viewport: { width: 1600, height: 1100 }, deviceScaleFactor: 2 });
 page.on('console', (m) => { if (m.type() === 'error') console.log('[console.error]', m.text()); });
 
-await page.goto(BASE, { waitUntil: 'networkidle' });
+// `networkidle` hangs against Vite's HMR websocket (never idles). Wait for the
+// DOM instead, then explicitly wait for the Agent-tab control to be visible.
+await page.goto(BASE, { waitUntil: 'domcontentloaded' });
 
 // Open the Agent (0g) tab on every mini-cockpit so all four panels show it.
 const tabs = page.locator('[data-testid$="-tab-0g"]');
+await tabs.first().waitFor({ state: 'visible', timeout: 15_000 });
 const n = await tabs.count();
 console.log('agent tabs found:', n);
 for (let i = 0; i < n; i++) await tabs.nth(i).click();

--- a/apps/web/src/components/cockpit/tabs/ZeroGTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/ZeroGTab.tsx
@@ -8,9 +8,32 @@ interface Props {
   testIdPrefix: string;
 }
 
+/** Claude/Walrus coral — signals decentralized, encrypted, on-chain storage. */
+const WALRUS_CORAL = '#d97757';
+
 interface KvRow {
   key: string;
   value: string;
+  /**
+   * Storage backend the row lives on. `"walrus"` (added by PR4's schema work)
+   * means the value is encrypted on Walrus + owned per-Elder on Sui; anything
+   * else is local/demo scratch. Read as a widened string so this UI compiles
+   * before the schema literal lands and renders correctly once it does.
+   */
+  source: string;
+  /** Walrus blob id (on-chain proof), present once a row is published. */
+  blobId?: string;
+  /** Sui object / account id owning the encrypted memory. */
+  accountId?: string;
+}
+
+/** Free-text episodic reflection (memwal_remember), distinct from KV state. */
+interface ReflectionRow {
+  tick?: number;
+  text: string;
+  source: string;
+  blobId?: string;
+  accountId?: string;
 }
 
 interface CrudRow {
@@ -26,10 +49,20 @@ interface BulletinRow {
 }
 
 const STUB_KV: KvRow[] = [
-  { key: 'last_grudge',     value: 'clan-3'             },
-  { key: 'wood_threshold',  value: '80'                 },
-  { key: 'pref_target',     value: 'forest'             },
-  { key: 'mood',            value: 'cautious'           },
+  { key: 'last_grudge',     value: 'clan-3',    source: 'local' },
+  { key: 'wood_threshold',  value: '80',        source: 'local' },
+  { key: 'pref_target',     value: 'forest',    source: 'local' },
+  { key: 'mood',            value: 'cautious',  source: 'local' },
+];
+
+/**
+ * Reflections are intentionally stub-only until PR4 wires the live
+ * `memwal_remember` free-text feed. We do NOT fabricate on-chain ids here —
+ * the section renders an explicit "awaiting live data" affordance instead.
+ */
+const STUB_REFLECTIONS: ReflectionRow[] = [
+  { tick: 5, text: 'Crimson feinted at the river then pulled back — likely baiting a wall commitment. Hold the millers.', source: 'demo' },
+  { tick: 3, text: 'Winter is two ticks out and the granary is thin. Prioritise wheat over wood until the threshold clears.', source: 'demo' },
 ];
 
 const STUB_CRUD: CrudRow[] = [
@@ -50,6 +83,64 @@ function bulletinAge(slot: number, currentSlot: number): string {
   return `${diff}t`;
 }
 
+/**
+ * Read a string field off a Convex memory doc without depending on the schema
+ * literal. PR4 adds the `"walrus"` source value plus `blobId`/`accountId`
+ * on-chain proof fields; until its generated types land, those keys aren't on
+ * the inferred row type, so we widen through `unknown` and validate at runtime.
+ */
+function readStr(row: unknown, ...keys: string[]): string | undefined {
+  if (!row || typeof row !== 'object') return undefined;
+  const rec = row as Record<string, unknown>;
+  for (const k of keys) {
+    const v = rec[k];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return undefined;
+}
+
+/** Read a finite number field off a Convex doc without depending on its type. */
+function readNum(row: unknown, ...keys: string[]): number | undefined {
+  if (!row || typeof row !== 'object') return undefined;
+  const rec = row as Record<string, unknown>;
+  for (const k of keys) {
+    const v = rec[k];
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+  }
+  return undefined;
+}
+
+/** True when a memory row lives on decentralized Walrus storage. */
+function isWalrus(source: string): boolean {
+  return source === 'walrus';
+}
+
+// Explorer roots. Single source of truth so a future testnet/devnet toggle is
+// a one-line change. ClanWorld targets Sui + Walrus mainnet.
+const SUISCAN_ROOT = 'https://suiscan.xyz/mainnet';
+const WALRUSCAN_ROOT = 'https://walruscan.com/mainnet';
+
+/**
+ * Explorer link for an on-chain proof id. A Walrus blob id is a content digest
+ * resolved on Walruscan; a Sui object id resolves on Suiscan. They are
+ * different namespaces, so route by which field carried the id.
+ *
+ * NOTE (PR4): we currently treat the non-blob id as a Sui *object* (`/object/`).
+ * If PR4 surfaces an owner *address* in `accountId` rather than an object id,
+ * switch that branch to `/account/` — confirm the id semantics when the live
+ * field lands.
+ */
+function proofUrl(kind: 'blob' | 'object', id: string): string {
+  return kind === 'blob'
+    ? `${WALRUSCAN_ROOT}/blob/${id}`
+    : `${SUISCAN_ROOT}/object/${id}`;
+}
+
+/** Shorten a long hex/base64 id to `head…tail` for chip display. */
+function shortId(id: string): string {
+  return id.length > 14 ? `${id.slice(0, 6)}…${id.slice(-4)}` : id;
+}
+
 export function ZeroGTab({ elder, testIdPrefix }: Props) {
   // ─── Live Convex queries with stub fallback ────────────────────────────
   // Every section follows the same discipline as CommsTab:
@@ -61,15 +152,46 @@ export function ZeroGTab({ elder, testIdPrefix }: Props) {
   const liveEvents = useQuery(api.memory.getEventsByClan, { clanId: elder.clanId });
   const liveBulletins = useQuery(api.bulletins.getByClan, { clanId: elder.clanId });
 
-  // KV state: prefer live memoryEntries, else stub.
-  const memorySource: 'live' | 'stub' =
-    liveMemory && liveMemory.length > 0
-        ? 'live'
-        : 'stub';
+  // KV state: prefer live memoryEntries, else stub. Reflection-kind rows (if
+  // PR4 ever returns them from this same query) are excluded here so they only
+  // appear in the Reflections section below — the two sections stay mutually
+  // exclusive regardless of how PR4 routes free-text memories.
+  const liveKv = (liveMemory ?? []).filter(
+    (m) => readStr(m, 'kind', 'memType') !== 'reflection',
+  );
+  const memorySource: 'live' | 'stub' = liveKv.length > 0 ? 'live' : 'stub';
   const kvRows: KvRow[] =
-    (liveMemory && liveMemory.length > 0
-      ? liveMemory.map((m) => ({ key: m.key, value: m.value }))
-      : STUB_KV);
+    liveKv.length > 0
+      ? liveKv.map((m) => ({
+          key: m.key,
+          value: m.value,
+          source: readStr(m, 'source') ?? 'local',
+          blobId: readStr(m, 'blobId', 'blob_id'),
+          accountId: readStr(m, 'accountId', 'account_id'),
+        }))
+      : STUB_KV;
+
+  // ─── Walrus Reflections (free-text episodic, memwal_remember) ───────────
+  // No live free-text feed exists yet (PR4 owns the dedicated query + the row
+  // discriminator). We deliberately do NOT scrape KV rows by value length —
+  // that would double-render a long KV value in both the KV table and here.
+  // Instead we only surface rows EXPLICITLY tagged as reflections via a `kind`
+  // discriminator (`kind === "reflection"`, which PR4 will set). Until such
+  // rows exist, fall back to the stub with an explicit "awaiting live data"
+  // affordance. We never fabricate on-chain ids.
+  const liveReflections: ReflectionRow[] = (liveMemory ?? [])
+    .filter((m) => readStr(m, 'kind', 'memType') === 'reflection')
+    .map((m) => ({
+      tick: readNum(m, 'tick'),
+      text: m.value,
+      source: readStr(m, 'source') ?? 'local',
+      blobId: readStr(m, 'blobId', 'blob_id'),
+      accountId: readStr(m, 'accountId', 'account_id'),
+    }));
+  const reflectionsSource: 'live' | 'stub' =
+    liveReflections.length > 0 ? 'live' : 'stub';
+  const reflectionRows: ReflectionRow[] =
+    liveReflections.length > 0 ? liveReflections : STUB_REFLECTIONS;
 
   const eventsSource: 'live' | 'stub' =
     liveEvents && liveEvents.length > 0 ? 'live' : 'stub';
@@ -147,20 +269,56 @@ export function ZeroGTab({ elder, testIdPrefix }: Props) {
               gap: '2px',
             }}
           >
-            {kvRows.map((kv) => (
-              <div
-                key={kv.key}
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  padding: '3px 6px',
-                  background: 'rgba(255,255,255,0.18)',
-                }}
-              >
-                <span style={{ color: tokens.text.onParchmentDim }}>{kv.key}</span>
-                <span style={{ color: elder.accent, fontWeight: 600 }}>{kv.value}</span>
-              </div>
-            ))}
+            {kvRows.map((kv) => {
+              const onWalrus = isWalrus(kv.source);
+              const hasProof = Boolean(kv.blobId ?? kv.accountId);
+              return (
+                <div
+                  key={kv.key}
+                  data-testid={`${testIdPrefix}-0g-kv-row`}
+                  data-source={kv.source}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: tokens.space.sm,
+                    padding: '3px 6px',
+                    background: 'rgba(255,255,255,0.18)',
+                  }}
+                >
+                  <span
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                      minWidth: 0,
+                    }}
+                  >
+                    <SourceBadge source={kv.source} testId={`${testIdPrefix}-0g-kv-badge`} />
+                    <span
+                      style={{
+                        color: tokens.text.onParchmentDim,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {kv.key}
+                    </span>
+                  </span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '6px', flexShrink: 0 }}>
+                    {onWalrus && hasProof && (
+                      <ProofChip
+                        blobId={kv.blobId}
+                        accountId={kv.accountId}
+                        testId={`${testIdPrefix}-0g-kv-proof`}
+                      />
+                    )}
+                    <span style={{ color: elder.accent, fontWeight: 600 }}>{kv.value}</span>
+                  </span>
+                </div>
+              );
+            })}
           </div>
         </div>
 
@@ -209,6 +367,100 @@ export function ZeroGTab({ elder, testIdPrefix }: Props) {
                 </span>
               </li>
             ))}
+          </ul>
+        </div>
+
+        <div
+          data-testid={`${testIdPrefix}-0g-reflections`}
+          data-source={reflectionsSource}
+        >
+          <SectionHeader>Walrus Reflections</SectionHeader>
+          {reflectionsSource === 'stub' && (
+            <div
+              data-testid={`${testIdPrefix}-0g-reflections-awaiting`}
+              style={{
+                marginTop: tokens.space.sm,
+                padding: '4px 8px',
+                fontFamily: tokens.font.mono,
+                fontSize: '9px',
+                letterSpacing: '0.04em',
+                color: tokens.text.muted,
+                background: 'rgba(0,0,0,0.06)',
+                border: `1px dashed ${tokens.border.parchmentEdge}`,
+                display: 'flex',
+                alignItems: 'center',
+                gap: '6px',
+              }}
+            >
+              <span style={{ color: tokens.text.accent }}>◌</span>
+              awaiting live data — sample reflections shown
+            </div>
+          )}
+          <ul
+            style={{
+              listStyle: 'none',
+              margin: `${tokens.space.sm} 0 0`,
+              padding: 0,
+              fontFamily: tokens.font.body,
+              fontSize: '11px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '6px',
+            }}
+          >
+            {reflectionRows.map((r, i) => {
+              const onWalrus = isWalrus(r.source);
+              const hasProof = Boolean(r.blobId ?? r.accountId);
+              return (
+                <li
+                  key={r.blobId ?? r.accountId ?? `${r.tick ?? 'x'}-${r.text.slice(0, 24)}-${i}`}
+                  data-testid={`${testIdPrefix}-0g-reflection-row`}
+                  data-source={r.source}
+                  style={{
+                    padding: '6px 8px',
+                    background: onWalrus
+                      ? 'rgba(217,119,87,0.10)'
+                      : 'rgba(255,255,255,0.18)',
+                    borderLeft: `2px solid ${onWalrus ? WALRUS_CORAL : tokens.border.parchmentEdge}`,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '4px',
+                  }}
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                      flexWrap: 'wrap',
+                    }}
+                  >
+                    <SourceBadge source={r.source} testId={`${testIdPrefix}-0g-reflection-badge`} />
+                    {typeof r.tick === 'number' && (
+                      <span
+                        style={{
+                          fontFamily: tokens.font.mono,
+                          fontSize: '9px',
+                          color: tokens.text.muted,
+                        }}
+                      >
+                        T{r.tick}
+                      </span>
+                    )}
+                    {onWalrus && hasProof && (
+                      <ProofChip
+                        blobId={r.blobId}
+                        accountId={r.accountId}
+                        testId={`${testIdPrefix}-0g-reflection-proof`}
+                      />
+                    )}
+                  </div>
+                  <span style={{ color: tokens.text.onParchment, lineHeight: 1.4 }}>
+                    {r.text}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         </div>
 
@@ -266,6 +518,91 @@ function Field({ k, v }: { k: string; v: string }) {
       <span style={{ color: tokens.text.onParchmentDim }}>{k}</span>
       <span style={{ color: tokens.text.onParchment, fontWeight: 600 }}>{v}</span>
     </>
+  );
+}
+
+/**
+ * Storage-source badge. `"walrus"` rows get a coral "● Walrus" pill signalling
+ * encrypted, per-Elder-owned decentralized storage; everything else gets a
+ * muted "local" pill.
+ */
+function SourceBadge({ source, testId }: { source: string; testId?: string }) {
+  const onWalrus = isWalrus(source);
+  return (
+    <span
+      data-testid={testId}
+      data-source={source}
+      title={
+        onWalrus
+          ? 'Encrypted on Walrus — owned per-Elder on Sui'
+          : 'Local scratch memory (not on decentralized storage)'
+      }
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '3px',
+        flexShrink: 0,
+        padding: '1px 6px',
+        borderRadius: '999px',
+        fontFamily: tokens.font.mono,
+        fontSize: '8px',
+        fontWeight: 700,
+        letterSpacing: '0.06em',
+        textTransform: 'uppercase',
+        color: onWalrus ? WALRUS_CORAL : tokens.text.muted,
+        background: onWalrus ? 'rgba(217,119,87,0.14)' : 'rgba(0,0,0,0.06)',
+        border: `1px solid ${onWalrus ? 'rgba(217,119,87,0.5)' : tokens.border.parchmentEdge}`,
+      }}
+    >
+      <span aria-hidden style={{ fontSize: '7px', lineHeight: 1 }}>●</span>
+      {onWalrus ? 'Walrus' : 'local'}
+    </span>
+  );
+}
+
+/**
+ * On-chain-proof chip — renders a short monospace id linking to the right
+ * explorer: a Walrus blob id → Walruscan, else a Sui object/account id →
+ * Suiscan. Only rendered when a real id is present (never fabricated).
+ */
+function ProofChip({
+  blobId,
+  accountId,
+  testId,
+}: {
+  blobId?: string;
+  accountId?: string;
+  testId?: string;
+}) {
+  // Prefer the Walrus blob id (the strongest "encrypted on Walrus" proof);
+  // fall back to the Sui object/account id.
+  const kind: 'blob' | 'object' = blobId ? 'blob' : 'object';
+  const id = blobId ?? accountId;
+  if (!id) return null;
+  return (
+    <a
+      data-testid={testId}
+      data-proof-kind={kind}
+      href={proofUrl(kind, id)}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={`On-chain proof (${kind === 'blob' ? 'Walrus blob' : 'Sui object'}) — ${id}`}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        flexShrink: 0,
+        padding: '1px 5px',
+        borderRadius: tokens.radius.sm,
+        fontFamily: tokens.font.mono,
+        fontSize: '8px',
+        textDecoration: 'none',
+        color: WALRUS_CORAL,
+        background: 'rgba(217,119,87,0.08)',
+        border: `1px solid rgba(217,119,87,0.35)`,
+      }}
+    >
+      {shortId(id)}
+    </a>
   );
 }
 

--- a/apps/web/src/components/cockpit/tabs/ZeroGTab.tsx
+++ b/apps/web/src/components/cockpit/tabs/ZeroGTab.tsx
@@ -131,9 +131,12 @@ const WALRUSCAN_ROOT = 'https://walruscan.com/mainnet';
  * field lands.
  */
 function proofUrl(kind: 'blob' | 'object', id: string): string {
+  // Walrus blob ids / Sui object ids are opaque and may contain characters that
+  // aren't path-safe — encode before interpolating into the explorer URL path.
+  const safeId = encodeURIComponent(id);
   return kind === 'blob'
-    ? `${WALRUSCAN_ROOT}/blob/${id}`
-    : `${SUISCAN_ROOT}/object/${id}`;
+    ? `${WALRUSCAN_ROOT}/blob/${safeId}`
+    : `${SUISCAN_ROOT}/object/${safeId}`;
 }
 
 /** Shorten a long hex/base64 id to `head…tail` for chip display. */
@@ -270,7 +273,9 @@ export function ZeroGTab({ elder, testIdPrefix }: Props) {
             }}
           >
             {kvRows.map((kv) => {
-              const onWalrus = isWalrus(kv.source);
+              // The on-chain-proof chip renders whenever a real id is present,
+              // independent of `source` — a blobId/accountId IS the proof. The
+              // coral "● Walrus" source badge stays keyed off source below.
               const hasProof = Boolean(kv.blobId ?? kv.accountId);
               return (
                 <div
@@ -307,7 +312,7 @@ export function ZeroGTab({ elder, testIdPrefix }: Props) {
                     </span>
                   </span>
                   <span style={{ display: 'flex', alignItems: 'center', gap: '6px', flexShrink: 0 }}>
-                    {onWalrus && hasProof && (
+                    {hasProof && (
                       <ProofChip
                         blobId={kv.blobId}
                         accountId={kv.accountId}
@@ -409,6 +414,9 @@ export function ZeroGTab({ elder, testIdPrefix }: Props) {
             }}
           >
             {reflectionRows.map((r, i) => {
+              // `onWalrus` drives the coral row accent + source badge (correct —
+              // that's the source signal). The proof chip below keys off id
+              // presence instead: a blobId/accountId IS the on-chain proof.
               const onWalrus = isWalrus(r.source);
               const hasProof = Boolean(r.blobId ?? r.accountId);
               return (
@@ -447,7 +455,7 @@ export function ZeroGTab({ elder, testIdPrefix }: Props) {
                         T{r.tick}
                       </span>
                     )}
-                    {onWalrus && hasProof && (
+                    {hasProof && (
                       <ProofChip
                         blobId={r.blobId}
                         accountId={r.accountId}


### PR DESCRIPTION
## Walrus Memory PR3 — cockpit Agent panel

Make the cockpit **Agent tab** (`ZeroGTab.tsx`) visibly show that Elders' memories live **encrypted on Walrus**, owned per-Elder on Sui — the sponsor-visible payoff.

### What changed (apps/web only)
- **Walrus KV State** — each row now carries a storage-source badge: coral **"● Walrus"** for `source === "walrus"` (encrypted, on-chain), muted **"local"** otherwise. Makes it obvious which memories are on decentralized storage.
- **New "Walrus Reflections" section** — free-text episodic memories (`memwal_remember`), distinct from KV. Renders the stub-fallback **"awaiting live data"** affordance when no live feed exists. Never fabricates on-chain ids.
- **On-chain-proof chips** — when a `blobId`/`accountId` is present on a row, a short monospace chip links to the explorer (Walrus blob → Walruscan, Sui object → Suiscan). Only rendered when a real id is present.
- Existing `data-testid` selectors preserved; new ones added for new elements.
- Adds `apps/web/scripts/shot-agent-tab.mjs` — Playwright helper used to capture the review screenshot.

### Depends on / rebase note
This reads the **`"walrus"` source literal** plus `blobId`/`accountId` fields that **PR4 (#668)** adds to the Convex schema. This PR touches **no** Convex schema/functions — it reads those fields defensively via `readStr`/`readNum` unknown-widening helpers, so it typechecks **before** PR4 lands and renders the coral Walrus state automatically **once** PR4 writes such rows. **May need a trivial rebase after #668 merges.**

### Verification
- `pnpm --filter @clan-world/web typecheck` — clean.
- Rendered the Agent tab on a local dev server; screenshots (honest stub = all "local"; and a demo capture forcing the `walrus` path to show the coral badges + proof chips) saved to `~/shared/public/tmp/pr3-agent-tab*.png`. The shipped stubs remain honest (no fabricated ids).
- Local 3-tier swarm review (Gemini + Codex + Claude) run; must/should-fixes applied (reflection/KV mutual exclusion via `kind` discriminator, `rel="noopener noreferrer"`, per-id-type explorer routing, content-based list keys).

Related: #668
Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)