### PR TITLE
ci: skip forge + regen steps when unrelated paths change (keep required checks green)

### DIFF
--- a/.github/workflows/chainclient-abi.yml
+++ b/.github/workflows/chainclient-abi.yml
@@ -15,16 +15,33 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      # The job ALWAYS runs and ALWAYS reports the `chainclient-abi` required
+      # check. Only the forge install + ABI-drift verification are gated: ABI
+      # drift can only happen when contract sources or the committed ABI change.
+      - name: Detect contract / ABI changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            abi:
+              - 'packages/contracts/**'
+              - '**/*.sol'
+              - 'packages/contracts/abi/**'
+              - 'pnpm-lock.yaml'
       - uses: pnpm/action-setup@v4
+        if: steps.changes.outputs.abi == 'true'
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.abi == 'true'
         with:
           node-version: 24
           cache: pnpm
       - name: Install Foundry
+        if: steps.changes.outputs.abi == 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
       - name: Verify Foundry
+        if: steps.changes.outputs.abi == 'true'
         run: |
           command -v forge >/dev/null 2>&1 || {
             echo "::error::forge is not installed after foundry-toolchain action — CI cannot validate contract ABI drift. Check the foundry-toolchain action output above."
@@ -32,4 +49,9 @@ jobs:
           }
           forge --version
       - run: pnpm install --frozen-lockfile
+        if: steps.changes.outputs.abi == 'true'
       - run: pnpm test:chainclient-abi
+        if: steps.changes.outputs.abi == 'true'
+      - name: Skipped — no contract / ABI changes
+        if: steps.changes.outputs.abi != 'true'
+        run: echo "No contract or ABI files changed; skipping ABI drift verification. The 'chainclient-abi' required check passes."

--- a/.github/workflows/chainclient-abi.yml
+++ b/.github/workflows/chainclient-abi.yml
@@ -31,6 +31,9 @@ jobs:
               - 'packages/shared/src/adapters/IChainClient.ts'
               - 'scripts/gen-chainclient-abi.mjs'
               - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
               # self-reference: edits to this workflow must re-run ABI validation
               - '.github/workflows/chainclient-abi.yml'
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/chainclient-abi.yml
+++ b/.github/workflows/chainclient-abi.yml
@@ -27,7 +27,12 @@ jobs:
               - 'packages/contracts/**'
               - '**/*.sol'
               - 'packages/contracts/abi/**'
+              # gen output + generator: editing either must re-validate ABI drift
+              - 'packages/shared/src/adapters/IChainClient.ts'
+              - 'scripts/gen-chainclient-abi.mjs'
               - 'pnpm-lock.yaml'
+              # self-reference: edits to this workflow must re-run ABI validation
+              - '.github/workflows/chainclient-abi.yml'
       - uses: pnpm/action-setup@v4
         if: steps.changes.outputs.abi == 'true'
       - uses: actions/setup-node@v4

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -32,6 +32,8 @@ jobs:
               - 'packages/contracts/foundry.toml'
               - 'packages/contracts/foundry.lock'
               - 'pnpm-lock.yaml'
+              # self-reference: edits to this workflow must re-run forge validation
+              - '.github/workflows/contracts.yml'
       - uses: pnpm/action-setup@v4
         if: steps.changes.outputs.contracts == 'true'
       - uses: actions/setup-node@v4

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -32,6 +32,9 @@ jobs:
               - 'packages/contracts/foundry.toml'
               - 'packages/contracts/foundry.lock'
               - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
               # self-reference: edits to this workflow must re-run forge validation
               - '.github/workflows/contracts.yml'
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -15,23 +15,47 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      # Detect whether any Solidity / forge-relevant files changed. On
+      # pull_request the base ref is auto-detected (compared against the PR
+      # base); on push it compares against the previous commit. The job itself
+      # ALWAYS runs and ALWAYS reports the `contracts` required check — only the
+      # expensive forge steps below are gated, so a docs/web/agents PR finishes
+      # this job green in seconds instead of ~5 minutes.
+      - name: Detect contract changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            contracts:
+              - 'packages/contracts/**'
+              - '**/*.sol'
+              - 'packages/contracts/foundry.toml'
+              - 'packages/contracts/foundry.lock'
+              - 'pnpm-lock.yaml'
       - uses: pnpm/action-setup@v4
+        if: steps.changes.outputs.contracts == 'true'
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.contracts == 'true'
         with:
           node-version: 24
           cache: pnpm
       - name: Install Foundry
+        if: steps.changes.outputs.contracts == 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
       - run: pnpm install --frozen-lockfile
+        if: steps.changes.outputs.contracts == 'true'
       - name: Build contracts
+        if: steps.changes.outputs.contracts == 'true'
         working-directory: packages/contracts
         run: pnpm run build
       - name: Check deployable bytecode sizes
+        if: steps.changes.outputs.contracts == 'true'
         working-directory: packages/contracts
         run: pnpm run check:sizes
       - name: Run targeted contract gates
+        if: steps.changes.outputs.contracts == 'true'
         working-directory: packages/contracts
         run: |
           bash scripts/forge.sh test --match-path test/diamond/DiamondSkeleton.t.sol
@@ -42,7 +66,11 @@ jobs:
           bash scripts/forge.sh test --match-path test/BanditAttackResolution.t.sol
           bash scripts/forge.sh test --match-path test/ReservationConsistency.t.sol
       - name: Dry-run diamond deploy script
+        if: steps.changes.outputs.contracts == 'true'
         working-directory: packages/contracts
         env:
           DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
         run: bash scripts/forge.sh script script/DeployDiamond.s.sol:DeployDiamond
+      - name: Skipped — no contract changes
+        if: steps.changes.outputs.contracts != 'true'
+        run: echo "No Solidity / forge-relevant files changed; skipping forge build/test/deploy. The 'contracts' required check passes."

--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -32,7 +32,12 @@ jobs:
               - 'packages/sdk/**'
               - 'scripts/gen-constants.mjs'
               - 'scripts/gen-enums.mjs'
+              - 'scripts/abi-targets.mjs'
+              # gen output lives in packages/shared (not covered by the globs above)
+              - 'packages/shared/src/generated/**'
               - 'pnpm-lock.yaml'
+              # self-reference: edits to this workflow must re-run type freshness
+              - '.github/workflows/typechain-ci.yml'
       - uses: pnpm/action-setup@v4
         if: steps.changes.outputs.types == 'true'
       - uses: actions/setup-node@v4
@@ -90,7 +95,11 @@ jobs:
             convex:
               - 'packages/sdk/convex/**'
               - 'apps/server/convex/**'
+              # convex.json (sibling of convex/) sets the codegen functions dir
+              - 'packages/sdk/convex.json'
+              - 'apps/server/convex.json'
               - 'pnpm-lock.yaml'
+              - '.github/workflows/typechain-ci.yml'
       - uses: pnpm/action-setup@v4
         if: steps.changes.outputs.convex == 'true'
       - uses: actions/setup-node@v4

--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -36,6 +36,9 @@ jobs:
               # gen output lives in packages/shared (not covered by the globs above)
               - 'packages/shared/src/generated/**'
               - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
               # self-reference: edits to this workflow must re-run type freshness
               - '.github/workflows/typechain-ci.yml'
       - uses: pnpm/action-setup@v4
@@ -99,6 +102,9 @@ jobs:
               - 'packages/sdk/convex.json'
               - 'apps/server/convex.json'
               - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
               - '.github/workflows/typechain-ci.yml'
       - uses: pnpm/action-setup@v4
         if: steps.changes.outputs.convex == 'true'

--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -15,54 +15,108 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      # The job ALWAYS runs and ALWAYS reports the `Contract types are current`
+      # required check. Generated constants/enums/ABI + the contract-types & sdk
+      # packages can only go stale when contracts, the committed ABI, or the
+      # generator/package sources change — gate the heavy steps on those paths.
+      - name: Detect contract-type-relevant changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            types:
+              - 'packages/contracts/**'
+              - '**/*.sol'
+              - 'packages/contracts/abi/**'
+              - 'packages/contract-types/**'
+              - 'packages/sdk/**'
+              - 'scripts/gen-constants.mjs'
+              - 'scripts/gen-enums.mjs'
+              - 'pnpm-lock.yaml'
       - uses: pnpm/action-setup@v4
+        if: steps.changes.outputs.types == 'true'
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.types == 'true'
         with:
           node-version: 24
           cache: pnpm
       - name: Install Foundry
+        if: steps.changes.outputs.types == 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
       - run: pnpm install --frozen-lockfile
+        if: steps.changes.outputs.types == 'true'
       - name: Check generated constants are current
+        if: steps.changes.outputs.types == 'true'
         run: pnpm gen:constants -- --check
       - name: Check generated enums are current
+        if: steps.changes.outputs.types == 'true'
         run: pnpm gen:enums -- --check
       - name: Verify committed ABI JSON matches forge artifacts
+        if: steps.changes.outputs.types == 'true'
         run: pnpm --filter @clan-world/contracts run check:abi
       # codegen:check reads the ABI JSON and exits non-zero if the committed
       # output in packages/contract-types/src/ is stale — no files are written.
       - name: Check @clan-world/contract-types output is current
+        if: steps.changes.outputs.types == 'true'
         run: pnpm --filter @clan-world/contract-types run codegen:check
       - name: Build smoke — @clan-world/contract-types compiles cleanly
+        if: steps.changes.outputs.types == 'true'
         run: pnpm --filter @clan-world/contract-types run build
       - name: Check SDK generated constants/enums are current
+        if: steps.changes.outputs.types == 'true'
         run: node scripts/gen-constants.mjs --check && node scripts/gen-enums.mjs --check
       - name: Build smoke — @clan-world/sdk compiles cleanly
+        if: steps.changes.outputs.types == 'true'
         run: pnpm --filter @clan-world/sdk run build
+      - name: Skipped — no contract-type-relevant changes
+        if: steps.changes.outputs.types != 'true'
+        run: echo "No contract / ABI / contract-types / sdk sources changed; generated types cannot have drifted. The 'Contract types are current' required check passes."
 
   convex-types-freshness:
     name: Convex generated types are current
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # The job ALWAYS runs and ALWAYS reports the `Convex generated types are
+      # current` required check. Convex _generated output can only drift when a
+      # Convex schema/function in packages/sdk or apps/server changes.
+      - name: Detect Convex source changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            convex:
+              - 'packages/sdk/convex/**'
+              - 'apps/server/convex/**'
+              - 'pnpm-lock.yaml'
       - uses: pnpm/action-setup@v4
+        if: steps.changes.outputs.convex == 'true'
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.convex == 'true'
         with:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+        if: steps.changes.outputs.convex == 'true'
       - name: Regenerate SDK Convex types
+        if: steps.changes.outputs.convex == 'true'
         working-directory: packages/sdk
         run: pnpm run codegen
       - name: Regenerate Convex types
+        if: steps.changes.outputs.convex == 'true'
         working-directory: apps/server
         run: pnpm run codegen
       - name: Verify no working-tree changes in SDK _generated
+        if: steps.changes.outputs.convex == 'true'
         run: git diff --exit-code packages/sdk/convex/_generated/
       - name: Verify no working-tree changes in _generated
+        if: steps.changes.outputs.convex == 'true'
         run: git diff --exit-code apps/server/convex/_generated/
+      - name: Skipped — no Convex source changes
+        if: steps.changes.outputs.convex != 'true'
+        run: echo "No Convex schema/function sources changed; generated types cannot have drifted. The 'Convex generated types are current' required check passes."
 
   no-as-abi-casts:
     name: No raw as-Abi casts in source

--- a/.github/workflows/typechain-ci.yml
+++ b/.github/workflows/typechain-ci.yml
@@ -101,6 +101,9 @@ jobs:
               # convex.json (sibling of convex/) sets the codegen functions dir
               - 'packages/sdk/convex.json'
               - 'apps/server/convex.json'
+              # the codegen steps run `pnpm run codegen` in these package dirs
+              - 'packages/sdk/package.json'
+              - 'apps/server/package.json'
               - 'pnpm-lock.yaml'
               - 'package.json'
               - 'pnpm-workspace.yaml'


### PR DESCRIPTION
Closes #578.

## What this does

Most PRs (docs, web, agents, scripts) don't touch Solidity, yet the `contracts` job runs a full `forge build` + targeted tests + deploy dry-run (~5 min) on every one. The ABI-drift and codegen-freshness checks have the same waste. This PR makes the expensive work **skip when the relevant code didn't change**, while keeping every required status check reporting.

## The safe required-check pattern (read this before worrying it'll block your PR)

GitHub branch protection requires certain checks by **name**. If a workflow that produces a required check simply *doesn't run* (e.g. a workflow-level `on.pull_request.paths:` filter excludes it), GitHub leaves that check **pending forever → blocks merge for ALL PRs**, including other teams' in-flight work.

So this PR does **NOT** add any workflow-level `paths:` filters. Instead:

1. **Every job still runs on every PR** and keeps its exact name, so the required check always reports.
2. A `dorny/paths-filter@v3` step at the top of each job detects whether relevant files changed (on `pull_request` the base ref is auto-detected and compared against the PR base).
3. The **heavy steps** (forge install/build/test, codegen, ABI verify) carry `if: steps.changes.outputs.<filter> == 'true'`. When nothing relevant changed they skip, the job ends successfully in seconds, and the required check reports ✅.
4. A trailing "Skipped — no … changes" step logs why, so a green-in-seconds run is self-explanatory.

### Worked reasoning

- **Docs-only PR** → `contracts` filter is `false` → forge install/build/test/deploy all skip → `contracts` required check reports ✅ **green in seconds** (no foundry, no ~5 min). Same for `chainclient-abi`, `Contract types are current`, `Convex generated types are current`.
- **Contracts PR** (touches `packages/contracts/**` or any `*.sol`) → filter is `true` → forge runs the **full** suite exactly as before.

## Required checks — all preserved, none can go pending

| Required check (name) | Workflow | Gated on |
|---|---|---|
| `contracts` | contracts.yml | `packages/contracts/**`, `**/*.sol`, `foundry.toml`, `foundry.lock`, `pnpm-lock.yaml` |
| `chainclient-abi` | chainclient-abi.yml | `packages/contracts/**`, `**/*.sol`, `packages/contracts/abi/**`, `pnpm-lock.yaml` |
| `Contract types are current` | typechain-ci.yml | above **+** `packages/contract-types/**`, `packages/sdk/**`, `scripts/gen-constants.mjs`, `scripts/gen-enums.mjs` |
| `Convex generated types are current` | typechain-ci.yml | `packages/sdk/convex/**`, `apps/server/convex/**`, `pnpm-lock.yaml` |
| `No raw as-Abi casts in source` | typechain-ci.yml | **unchanged** — it's a fast grep with no foundry, left always-on |

`pnpm-lock.yaml` is included in each filter so a dependency bump still triggers the full check (and a docs-only PR won't touch it).

## Not touched

`android-release.yml` and `deploy-prod.yml` — tag/release/deploy logic left entirely alone.

## Verification

- All five workflow files YAML-parse cleanly (`yaml.safe_load`).
- Confirmed no workflow-level `on.pull_request.paths` filters were introduced (every workflow still triggers on every PR).
- Confirmed all required-check job **names** are byte-for-byte preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)