### PR TITLE
fix(heartbeat): #652 — clean 30s cadence on anvil fork (r1–r5 + runner funding)

### DIFF
--- a/packages/heartbeat/.env.example
+++ b/packages/heartbeat/.env.example
@@ -32,6 +32,11 @@ RUNNER_ID=clanworld-runner
 # Optional heartbeat success marker path override; defaults to /tmp/last-heartbeat-success.
 # HEARTBEAT_SUCCESS_FILE_OVERRIDE=
 
+# DEV/FORK ONLY — never set these against a real chain.
+# CHAIN_NETWORK=dev
+# HEARTBEAT_ADVANCE_FORK_TIME=1
+# HEARTBEAT_SCHEDULE_FROM_CHAIN=1
+
 # Optional Telegram alerting for heartbeat retry exhaustion. If the bot token is
 # missing or Telegram fails, the runner logs locally and keeps running.
 TELEGRAM_BOT_TOKEN=

--- a/packages/heartbeat/README.md
+++ b/packages/heartbeat/README.md
@@ -37,7 +37,7 @@ Heartbeat cadence comes from the diamond's owner-configured
 2. Restart the runner or `scripts/start-heartbeat-loop.sh`.
 
 The scheduler reads `heartbeatIntervalSeconds()` once at boot, then schedules
-each fire from `getWorldState().nextHeartbeatAtTs` with a 500 ms jitter buffer.
+each fire from `getWorldState().nextHeartbeatAtTs` with a 1,500 ms safety margin.
 
 ## Alerts and status
 

--- a/packages/heartbeat/src/heartbeatScheduler.ts
+++ b/packages/heartbeat/src/heartbeatScheduler.ts
@@ -69,6 +69,14 @@ export function computeHeartbeatDelayMs(
   return Math.max(0, nextHeartbeatAtTs * 1000 + safetyMarginMs - nowMs);
 }
 
+export function computeWallIntervalDelayMs(
+  intervalMs: number,
+  lastBeatWallMs: number,
+  wallNowMs: number,
+): number {
+  return Math.max(0, intervalMs - (wallNowMs - lastBeatWallMs));
+}
+
 export function classifyHeartbeatError(err: unknown): HeartbeatFireResult {
   if (err instanceof HeartbeatRateLimitedError) return 'rate-limited';
   if (err instanceof Error) {
@@ -88,6 +96,7 @@ async function runHeartbeatScheduler(
   const alert = deps.alert ?? sendTelegramAlert;
   let heartbeatIntervalSeconds: number | undefined;
   let consecutiveReadFailures = 0;
+  let lastBeatWallMs: number | undefined;
   const lastAlertAtMs = new Map<string, number>();
 
   try {
@@ -127,8 +136,15 @@ async function runHeartbeatScheduler(
     // whether the on-chain nextHeartbeatAtTs (chain time) and the local wall
     // clock diverge (e.g. on an anvil-fork whose block.timestamp drifts ahead),
     // which would skew computedDelayMs. Cheap (no extra RPC); read from logs.
+    const forkTimeAdvanceEnabled = isForkTimeAdvanceEnabled(deps);
     const schedulerNowMs = await readSchedulerNowMs(deps, nowMs);
-    const delayMs = computeHeartbeatDelayMs(nextHeartbeatAtTs, schedulerNowMs);
+    const delayMs = forkTimeAdvanceEnabled
+      ? computeForkWallDelayMs({
+        heartbeatIntervalSeconds,
+        lastBeatWallMs,
+        wallNowMs: schedulerNowMs,
+      })
+      : computeHeartbeatDelayMs(nextHeartbeatAtTs, schedulerNowMs);
     deps.log.info(
       `heartbeat schedule: nextHeartbeatAtTs=${nextHeartbeatAtTs}s schedulerNowMs=${schedulerNowMs} computedDelayMs=${delayMs}`,
     );
@@ -150,6 +166,7 @@ async function runHeartbeatScheduler(
     });
     if (result.success) {
       lastAlertAtMs.clear();
+      lastBeatWallMs = nowMs();
     }
     if (result.success) {
       const nextAfterSuccess = await deps.heartbeatCaller
@@ -309,9 +326,7 @@ async function prepareHeartbeatWindow(args: {
   let schedulerNowMs = await readChainNowMs(args.deps, args.fallbackNowMs);
   if (args.nextHeartbeatAtTs === undefined) return schedulerNowMs;
 
-  const targetUnixTs = Math.ceil(
-    (args.nextHeartbeatAtTs * 1000 + HEARTBEAT_SAFETY_MARGIN_MS) / 1000,
-  );
+  const targetUnixTs = args.nextHeartbeatAtTs;
   if (schedulerNowMs >= targetUnixTs * 1000) return schedulerNowMs;
 
   const advanced = await args.deps.heartbeatCaller
@@ -324,6 +339,16 @@ async function prepareHeartbeatWindow(args: {
 
   schedulerNowMs = await readChainNowMs(args.deps, args.fallbackNowMs);
   return schedulerNowMs;
+}
+
+function computeForkWallDelayMs(args: {
+  heartbeatIntervalSeconds: number | undefined;
+  lastBeatWallMs: number | undefined;
+  wallNowMs: number;
+}): number {
+  const intervalMs = (args.heartbeatIntervalSeconds ?? 30) * 1000;
+  const lastBeatWallMs = args.lastBeatWallMs ?? args.wallNowMs - intervalMs;
+  return computeWallIntervalDelayMs(intervalMs, lastBeatWallMs, args.wallNowMs);
 }
 
 async function readSchedulerNowMs(

--- a/packages/heartbeat/src/heartbeatScheduler.ts
+++ b/packages/heartbeat/src/heartbeatScheduler.ts
@@ -5,8 +5,13 @@ import { sendTelegramAlert } from './telegramAlert';
 
 export type HeartbeatFireResult = RunnerStatusUpdate['lastFireResult'];
 
+export type ForkTimeAdvancer = {
+  readChainNowMs?: () => Promise<number>;
+  advanceForkTimeTo?: (targetUnixTs: number) => Promise<boolean>;
+};
+
 export interface HeartbeatSchedulerDeps {
-  heartbeatCaller: IHeartbeatCaller;
+  heartbeatCaller: IHeartbeatCaller & ForkTimeAdvancer;
   /** AbortSignal for clean shutdown. */
   signal: AbortSignal;
   /** Logger — defaults to console. Tests pass a recorder. */
@@ -27,6 +32,7 @@ export interface HeartbeatSchedulerDeps {
 
 export const HEARTBEAT_SAFETY_MARGIN_MS = 1_500;
 export const HEARTBEAT_JITTER_MS = HEARTBEAT_SAFETY_MARGIN_MS;
+export const HEARTBEAT_RATE_LIMIT_RETRY_FLOOR_MS = 2_000;
 export const HEARTBEAT_RETRY_BACKOFF_MS = [1_000, 2_000, 5_000, 10_000] as const;
 const HOT_LOOP_GUARD_MS = 1_000;
 const ALERT_DEDUP_WINDOW_MS = 5 * 60 * 1_000;
@@ -120,10 +126,14 @@ async function runHeartbeatScheduler(
     // whether the on-chain nextHeartbeatAtTs (chain time) and the local wall
     // clock diverge (e.g. on an anvil-fork whose block.timestamp drifts ahead),
     // which would skew computedDelayMs. Cheap (no extra RPC); read from logs.
-    const wallNowMs = nowMs();
-    const delayMs = computeHeartbeatDelayMs(nextHeartbeatAtTs, wallNowMs);
+    const schedulerNowMs = await prepareHeartbeatWindow({
+      deps,
+      nextHeartbeatAtTs,
+      fallbackNowMs: nowMs,
+    });
+    const delayMs = computeHeartbeatDelayMs(nextHeartbeatAtTs, schedulerNowMs);
     deps.log.info(
-      `heartbeat schedule: nextHeartbeatAtTs=${nextHeartbeatAtTs}s wallNowMs=${wallNowMs} computedDelayMs=${delayMs}`,
+      `heartbeat schedule: nextHeartbeatAtTs=${nextHeartbeatAtTs}s schedulerNowMs=${schedulerNowMs} computedDelayMs=${delayMs}`,
     );
     await sleepWithSignal(delayMs, deps.signal);
     if (deps.signal.aborted) break;
@@ -141,7 +151,8 @@ async function runHeartbeatScheduler(
       const nextAfterSuccess = await deps.heartbeatCaller
         .readNextHeartbeatAtTs()
         .catch(() => undefined);
-      if (nextAfterSuccess !== undefined && nextAfterSuccess * 1000 <= nowMs()) {
+      const schedulerNowAfterSuccessMs = await readSchedulerNowMs(deps, nowMs);
+      if (nextAfterSuccess !== undefined && nextAfterSuccess * 1000 <= schedulerNowAfterSuccessMs) {
         deps.log.warn(
           `heartbeat succeeded but nextHeartbeatAtTs (${nextAfterSuccess}) is still in the past; sleeping ${HOT_LOOP_GUARD_MS}ms before retry`,
         );
@@ -166,6 +177,8 @@ async function runHeartbeatScheduler(
     const alertResult = await alert(alertMessage);
     if (alertResult.ok) {
       lastAlertAtMs.set(alertClass, currentMs);
+    } else if (alertResult.error === 'TELEGRAM_BOT_TOKEN is not set') {
+      deps.log.info('[heartbeatScheduler] Telegram alert skipped: TELEGRAM_BOT_TOKEN is not set');
     } else {
       deps.log.error('[heartbeatScheduler] Telegram alert failed:', alertResult.error);
     }
@@ -220,9 +233,17 @@ async function attemptHeartbeatWithBackoff(
           heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
           nextHeartbeatAtTs,
         });
+        const schedulerNowMs = await prepareHeartbeatWindow({
+          deps,
+          nextHeartbeatAtTs,
+          fallbackNowMs: nowMs,
+        });
         const waitMs = nextHeartbeatAtTs === undefined
-          ? HEARTBEAT_SAFETY_MARGIN_MS
-          : computeHeartbeatDelayMs(nextHeartbeatAtTs, nowMs());
+          ? HEARTBEAT_RATE_LIMIT_RETRY_FLOOR_MS
+          : Math.max(
+            HEARTBEAT_RATE_LIMIT_RETRY_FLOOR_MS,
+            computeHeartbeatDelayMs(nextHeartbeatAtTs, schedulerNowMs),
+          );
         deps.log.info(
           `heartbeat rate-limited; retrying after ${waitMs}ms (nextHeartbeatAtTs=${nextHeartbeatAtTs ?? 'unknown'})`,
         );
@@ -272,6 +293,49 @@ async function attemptHeartbeatWithBackoff(
     }
   }
   return { success: false, aborted: false, message: 'retry loop exhausted', lastFireResult: 'error' };
+}
+
+async function prepareHeartbeatWindow(args: {
+  deps: HeartbeatSchedulerDeps & {
+    log: NonNullable<HeartbeatSchedulerDeps['log']>;
+  };
+  nextHeartbeatAtTs: number | undefined;
+  fallbackNowMs: () => number;
+}): Promise<number> {
+  let schedulerNowMs = await readSchedulerNowMs(args.deps, args.fallbackNowMs);
+  if (args.nextHeartbeatAtTs === undefined) return schedulerNowMs;
+
+  const targetUnixTs = Math.ceil(
+    (args.nextHeartbeatAtTs * 1000 + HEARTBEAT_SAFETY_MARGIN_MS) / 1000,
+  );
+  if (schedulerNowMs >= targetUnixTs * 1000) return schedulerNowMs;
+
+  const advanced = await args.deps.heartbeatCaller
+    .advanceForkTimeTo?.(targetUnixTs)
+    .catch(err => {
+      args.deps.log.warn('fork time advance failed; falling back to sleep:', err);
+      return false;
+    });
+  if (!advanced) return schedulerNowMs;
+
+  schedulerNowMs = await readSchedulerNowMs(args.deps, args.fallbackNowMs);
+  return schedulerNowMs;
+}
+
+async function readSchedulerNowMs(
+  deps: HeartbeatSchedulerDeps & {
+    log: NonNullable<HeartbeatSchedulerDeps['log']>;
+  },
+  fallbackNowMs: () => number,
+): Promise<number> {
+  const readChainNowMs = deps.heartbeatCaller.readChainNowMs;
+  if (typeof readChainNowMs !== 'function') return fallbackNowMs();
+  try {
+    return await readChainNowMs.call(deps.heartbeatCaller);
+  } catch (err) {
+    deps.log.warn('failed to read chain clock; falling back to local scheduler clock:', err);
+    return fallbackNowMs();
+  }
 }
 
 async function postRunnerStatus(

--- a/packages/heartbeat/src/heartbeatScheduler.ts
+++ b/packages/heartbeat/src/heartbeatScheduler.ts
@@ -25,7 +25,8 @@ export interface HeartbeatSchedulerDeps {
   nowMs?: () => number;
 }
 
-export const HEARTBEAT_JITTER_MS = 500;
+export const HEARTBEAT_SAFETY_MARGIN_MS = 1_500;
+export const HEARTBEAT_JITTER_MS = HEARTBEAT_SAFETY_MARGIN_MS;
 export const HEARTBEAT_RETRY_BACKOFF_MS = [1_000, 2_000, 5_000, 10_000] as const;
 const HOT_LOOP_GUARD_MS = 1_000;
 const ALERT_DEDUP_WINDOW_MS = 5 * 60 * 1_000;
@@ -56,9 +57,9 @@ export function startHeartbeatScheduler(deps: HeartbeatSchedulerDeps): void {
 export function computeHeartbeatDelayMs(
   nextHeartbeatAtTs: number,
   nowMs: number,
-  jitterMs = HEARTBEAT_JITTER_MS,
+  safetyMarginMs = HEARTBEAT_SAFETY_MARGIN_MS,
 ): number {
-  return Math.max(0, nextHeartbeatAtTs * 1000 - nowMs) + jitterMs;
+  return Math.max(0, nextHeartbeatAtTs * 1000 + safetyMarginMs - nowMs);
 }
 
 export function classifyHeartbeatError(err: unknown): HeartbeatFireResult {
@@ -133,7 +134,7 @@ async function runHeartbeatScheduler(
       heartbeatIntervalSeconds,
       nextHeartbeatAtTs,
     });
-    if (result.success && !result.rateLimited) {
+    if (result.success) {
       lastAlertAtMs.clear();
     }
     if (result.success) {
@@ -179,14 +180,14 @@ async function attemptHeartbeatWithBackoff(
     nextHeartbeatAtTs?: number;
   },
 ): Promise<
-  | { success: true; rateLimited?: false }
-  | { success: true; rateLimited: true }
+  | { success: true }
   | { success: false; aborted: true; message: string; lastFireResult?: HeartbeatFireResult }
   | { success: false; aborted: false; message: string; lastFireResult: HeartbeatFireResult }
 > {
   const nowMs = deps.nowMs ?? (() => Date.now());
 
-  for (let attempt = 0; attempt <= HEARTBEAT_RETRY_BACKOFF_MS.length; attempt++) {
+  let attempt = 0;
+  while (attempt <= HEARTBEAT_RETRY_BACKOFF_MS.length) {
     try {
       const { txHash } = await deps.heartbeatCaller.callHeartbeat();
       deps.log.info(`heartbeat tx confirmed: ${txHash}`);
@@ -208,15 +209,26 @@ async function attemptHeartbeatWithBackoff(
     } catch (err) {
       if (err instanceof HeartbeatRateLimitedError) {
         const lastFailureMessage = messageFrom(err);
+        const nextHeartbeatAtTs = await deps.heartbeatCaller
+          .readNextHeartbeatAtTs()
+          .catch(() => err.nextAllowedAt || deps.nextHeartbeatAtTs);
         deps.log.warn(`heartbeat rate-limited: ${lastFailureMessage}`);
         await postRunnerStatus(deps, {
           runnerId: deps.runnerId,
           lastFireResult: 'rate-limited',
           lastFailureMessage,
           heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
-          nextHeartbeatAtTs: deps.nextHeartbeatAtTs,
+          nextHeartbeatAtTs,
         });
-        return { success: true, rateLimited: true };
+        const waitMs = nextHeartbeatAtTs === undefined
+          ? HEARTBEAT_SAFETY_MARGIN_MS
+          : computeHeartbeatDelayMs(nextHeartbeatAtTs, nowMs());
+        deps.log.info(
+          `heartbeat rate-limited; retrying after ${waitMs}ms (nextHeartbeatAtTs=${nextHeartbeatAtTs ?? 'unknown'})`,
+        );
+        await sleepWithSignal(waitMs, deps.signal);
+        if (deps.signal.aborted) return { success: false, aborted: true, message: 'aborted' };
+        continue;
       }
       if (deps.signal.aborted) return { success: false, aborted: true, message: 'aborted' };
       if (isHeartbeatTimeoutError(err) && deps.nextHeartbeatAtTs !== undefined) {
@@ -254,6 +266,7 @@ async function attemptHeartbeatWithBackoff(
         return { success: false, aborted: false, message: lastFailureMessage, lastFireResult };
       }
       const backoffMs = HEARTBEAT_RETRY_BACKOFF_MS[attempt] ?? HEARTBEAT_RETRY_BACKOFF_MS[0];
+      attempt++;
       await sleepWithSignal(backoffMs, deps.signal);
       if (deps.signal.aborted) return { success: false, aborted: true, message: 'aborted' };
     }

--- a/packages/heartbeat/src/heartbeatScheduler.ts
+++ b/packages/heartbeat/src/heartbeatScheduler.ts
@@ -8,6 +8,7 @@ export type HeartbeatFireResult = RunnerStatusUpdate['lastFireResult'];
 export type ForkTimeAdvancer = {
   readChainNowMs?: () => Promise<number>;
   advanceForkTimeTo?: (targetUnixTs: number) => Promise<boolean>;
+  isForkTimeAdvanceEnabled?: () => boolean;
 };
 
 export interface HeartbeatSchedulerDeps {
@@ -126,16 +127,19 @@ async function runHeartbeatScheduler(
     // whether the on-chain nextHeartbeatAtTs (chain time) and the local wall
     // clock diverge (e.g. on an anvil-fork whose block.timestamp drifts ahead),
     // which would skew computedDelayMs. Cheap (no extra RPC); read from logs.
-    const schedulerNowMs = await prepareHeartbeatWindow({
-      deps,
-      nextHeartbeatAtTs,
-      fallbackNowMs: nowMs,
-    });
+    const schedulerNowMs = await readSchedulerNowMs(deps, nowMs);
     const delayMs = computeHeartbeatDelayMs(nextHeartbeatAtTs, schedulerNowMs);
     deps.log.info(
       `heartbeat schedule: nextHeartbeatAtTs=${nextHeartbeatAtTs}s schedulerNowMs=${schedulerNowMs} computedDelayMs=${delayMs}`,
     );
     await sleepWithSignal(delayMs, deps.signal);
+    if (deps.signal.aborted) break;
+
+    await prepareHeartbeatWindow({
+      deps,
+      nextHeartbeatAtTs,
+      fallbackNowMs: nowMs,
+    });
     if (deps.signal.aborted) break;
 
     const result = await attemptHeartbeatWithBackoff({
@@ -302,7 +306,7 @@ async function prepareHeartbeatWindow(args: {
   nextHeartbeatAtTs: number | undefined;
   fallbackNowMs: () => number;
 }): Promise<number> {
-  let schedulerNowMs = await readSchedulerNowMs(args.deps, args.fallbackNowMs);
+  let schedulerNowMs = await readChainNowMs(args.deps, args.fallbackNowMs);
   if (args.nextHeartbeatAtTs === undefined) return schedulerNowMs;
 
   const targetUnixTs = Math.ceil(
@@ -318,11 +322,21 @@ async function prepareHeartbeatWindow(args: {
     });
   if (!advanced) return schedulerNowMs;
 
-  schedulerNowMs = await readSchedulerNowMs(args.deps, args.fallbackNowMs);
+  schedulerNowMs = await readChainNowMs(args.deps, args.fallbackNowMs);
   return schedulerNowMs;
 }
 
 async function readSchedulerNowMs(
+  deps: HeartbeatSchedulerDeps & {
+    log: NonNullable<HeartbeatSchedulerDeps['log']>;
+  },
+  fallbackNowMs: () => number,
+): Promise<number> {
+  if (isForkTimeAdvanceEnabled(deps)) return fallbackNowMs();
+  return readChainNowMs(deps, fallbackNowMs);
+}
+
+async function readChainNowMs(
   deps: HeartbeatSchedulerDeps & {
     log: NonNullable<HeartbeatSchedulerDeps['log']>;
   },
@@ -336,6 +350,10 @@ async function readSchedulerNowMs(
     deps.log.warn('failed to read chain clock; falling back to local scheduler clock:', err);
     return fallbackNowMs();
   }
+}
+
+function isForkTimeAdvanceEnabled(deps: HeartbeatSchedulerDeps): boolean {
+  return deps.heartbeatCaller.isForkTimeAdvanceEnabled?.() === true;
 }
 
 async function postRunnerStatus(

--- a/packages/heartbeat/src/heartbeatScheduler.ts
+++ b/packages/heartbeat/src/heartbeatScheduler.ts
@@ -34,6 +34,7 @@ export interface HeartbeatSchedulerDeps {
 export const HEARTBEAT_SAFETY_MARGIN_MS = 1_500;
 export const HEARTBEAT_JITTER_MS = HEARTBEAT_SAFETY_MARGIN_MS;
 export const HEARTBEAT_RATE_LIMIT_RETRY_FLOOR_MS = 2_000;
+export const HEARTBEAT_RATE_LIMIT_RETRY_MAX = 5;
 export const HEARTBEAT_RETRY_BACKOFF_MS = [1_000, 2_000, 5_000, 10_000] as const;
 const HOT_LOOP_GUARD_MS = 1_000;
 const ALERT_DEDUP_WINDOW_MS = 5 * 60 * 1_000;
@@ -163,6 +164,7 @@ async function runHeartbeatScheduler(
       runnerId,
       heartbeatIntervalSeconds,
       nextHeartbeatAtTs,
+      lastBeatWallMs,
     });
     if (result.success) {
       lastAlertAtMs.clear();
@@ -182,7 +184,7 @@ async function runHeartbeatScheduler(
       continue;
     }
 
-    if (result.aborted || result.lastFireResult === 'rate-limited') continue;
+    if (result.aborted) continue;
     const currentMs = nowMs();
     const alertClass = result.lastFireResult;
     const lastAlertForClassAtMs = lastAlertAtMs.get(alertClass);
@@ -212,6 +214,7 @@ async function attemptHeartbeatWithBackoff(
     runnerId: string;
     heartbeatIntervalSeconds?: number;
     nextHeartbeatAtTs?: number;
+    lastBeatWallMs?: number;
   },
 ): Promise<
   | { success: true }
@@ -221,6 +224,8 @@ async function attemptHeartbeatWithBackoff(
   const nowMs = deps.nowMs ?? (() => Date.now());
 
   let attempt = 0;
+  let rateLimitedWaits = 0;
+  let lastRateLimitedWallMs: number | undefined;
   while (attempt <= HEARTBEAT_RETRY_BACKOFF_MS.length) {
     try {
       const { txHash } = await deps.heartbeatCaller.callHeartbeat();
@@ -254,17 +259,30 @@ async function attemptHeartbeatWithBackoff(
           heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
           nextHeartbeatAtTs,
         });
+        if (rateLimitedWaits >= HEARTBEAT_RATE_LIMIT_RETRY_MAX) {
+          return {
+            success: false,
+            aborted: false,
+            message: `${lastFailureMessage}; rate-limit retry cap exceeded`,
+            lastFireResult: 'rate-limited',
+          };
+        }
+        rateLimitedWaits++;
         const schedulerNowMs = await prepareHeartbeatWindow({
           deps,
           nextHeartbeatAtTs,
           fallbackNowMs: nowMs,
         });
-        const waitMs = nextHeartbeatAtTs === undefined
-          ? HEARTBEAT_RATE_LIMIT_RETRY_FLOOR_MS
-          : Math.max(
-            HEARTBEAT_RATE_LIMIT_RETRY_FLOOR_MS,
-            computeHeartbeatDelayMs(nextHeartbeatAtTs, schedulerNowMs),
-          );
+        const waitMs = computeRateLimitWaitMs({
+          deps,
+          heartbeatIntervalSeconds: deps.heartbeatIntervalSeconds,
+          lastBeatWallMs: deps.lastBeatWallMs,
+          lastRateLimitedWallMs,
+          nextHeartbeatAtTs,
+          schedulerNowMs,
+          wallNowMs: nowMs(),
+        });
+        lastRateLimitedWallMs = nowMs();
         deps.log.info(
           `heartbeat rate-limited; retrying after ${waitMs}ms (nextHeartbeatAtTs=${nextHeartbeatAtTs ?? 'unknown'})`,
         );
@@ -349,6 +367,35 @@ function computeForkWallDelayMs(args: {
   const intervalMs = (args.heartbeatIntervalSeconds ?? 30) * 1000;
   const lastBeatWallMs = args.lastBeatWallMs ?? args.wallNowMs - intervalMs;
   return computeWallIntervalDelayMs(intervalMs, lastBeatWallMs, args.wallNowMs);
+}
+
+function computeRateLimitWaitMs(args: {
+  deps: HeartbeatSchedulerDeps;
+  heartbeatIntervalSeconds: number | undefined;
+  lastBeatWallMs: number | undefined;
+  lastRateLimitedWallMs: number | undefined;
+  nextHeartbeatAtTs: number | undefined;
+  schedulerNowMs: number;
+  wallNowMs: number;
+}): number {
+  if (isForkTimeAdvanceEnabled(args.deps)) {
+    const cadenceAnchorWallMs = args.lastRateLimitedWallMs ?? args.wallNowMs;
+    return Math.max(
+      HEARTBEAT_RATE_LIMIT_RETRY_FLOOR_MS,
+      computeForkWallDelayMs({
+        heartbeatIntervalSeconds: args.heartbeatIntervalSeconds,
+        lastBeatWallMs: cadenceAnchorWallMs,
+        wallNowMs: args.wallNowMs,
+      }),
+    );
+  }
+
+  return args.nextHeartbeatAtTs === undefined
+    ? HEARTBEAT_RATE_LIMIT_RETRY_FLOOR_MS
+    : Math.max(
+      HEARTBEAT_RATE_LIMIT_RETRY_FLOOR_MS,
+      computeHeartbeatDelayMs(args.nextHeartbeatAtTs, args.schedulerNowMs),
+    );
 }
 
 async function readSchedulerNowMs(

--- a/packages/heartbeat/src/runnerCastHeartbeat.ts
+++ b/packages/heartbeat/src/runnerCastHeartbeat.ts
@@ -30,6 +30,8 @@ export interface RunnerHeartbeatConfig {
   convexWebhookUrl?: string;
   /** Shared webhook auth secret. */
   webhookSharedSecret?: string;
+  /** Dev-only affordance: advance a local anvil fork clock before heartbeats. */
+  advanceForkTime?: boolean;
 }
 
 /**
@@ -76,6 +78,7 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): RunnerHeart
     contractAddress: contractAddress as `0x${string}`,
     convexWebhookUrl,
     webhookSharedSecret: env['WEBHOOK_SHARED_SECRET'],
+    advanceForkTime: shouldAdvanceForkTime(env, env['RPC_URL_PRIMARY'] || env['RPC_URL_FALLBACK']),
   };
 }
 
@@ -96,6 +99,8 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
   private readonly receiptTimeoutMs: number;
   private readonly convexWebhookUrl?: string;
   private readonly webhookSharedSecret?: string;
+  private readonly rpcUrl?: string;
+  private readonly advanceForkTime: boolean;
 
   constructor(cfg: RunnerHeartbeatConfig) {
     const pk = normalizePk(cfg.privateKey);
@@ -111,6 +116,8 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     this.receiptTimeoutMs = cfg.receiptTimeoutMs ?? 15_000;
     this.convexWebhookUrl = cfg.convexWebhookUrl;
     this.webhookSharedSecret = cfg.webhookSharedSecret;
+    this.rpcUrl = cfg.rpcUrl;
+    this.advanceForkTime = cfg.advanceForkTime ?? false;
   }
 
   async callHeartbeat(): Promise<{ txHash: string }> {
@@ -212,6 +219,22 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     return this.readBlockTimestampMs();
   }
 
+  async advanceForkTimeTo(targetUnixTs: number): Promise<boolean> {
+    if (!this.advanceForkTime) return false;
+    if (!this.rpcUrl) throw new Error('advanceForkTime requires an explicit RPC URL');
+
+    const latestUnixTs = Math.floor(await this.readChainNowMs() / 1000);
+    if (latestUnixTs >= targetUnixTs) return false;
+
+    try {
+      await this.sendForkRpc('evm_setNextBlockTimestamp', [toQuantityHex(targetUnixTs)]);
+    } catch {
+      await this.sendForkRpc('evm_increaseTime', [toQuantityHex(targetUnixTs - latestUnixTs)]);
+    }
+    await this.sendForkRpc('evm_mine', []);
+    return true;
+  }
+
   async readNextHeartbeatAtTs(): Promise<number> {
     const state = await this.publicClient.readContract({
       address: this.contractAddress,
@@ -236,6 +259,24 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
       ? await this.publicClient.getBlock({ blockTag: 'latest' })
       : await this.publicClient.getBlock({ blockNumber: BigInt(blockNumber) });
     return Number(block.timestamp) * 1000;
+  }
+
+  private async sendForkRpc(method: string, params: unknown[]): Promise<unknown> {
+    if (!this.rpcUrl) throw new Error(`${method} requires an explicit RPC URL`);
+    const response = await fetch(this.rpcUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method,
+        params,
+      }),
+    });
+    if (!response.ok) throw new Error(`${method} failed: HTTP ${response.status}`);
+    const payload = await response.json() as { result?: unknown; error?: { message?: string } };
+    if (payload.error) throw new Error(`${method} failed: ${payload.error.message ?? 'RPC error'}`);
+    return payload.result;
   }
 
   private async postHeartbeatWebhook(args: {
@@ -353,4 +394,37 @@ function deriveConvexWebhookUrl(convexDeployUrl?: string): string | undefined {
   url.hostname = url.hostname.replace(/\.convex\.cloud$/, '.convex.site');
   // Preserve protocol/port; strip trailing slash if URL had no explicit path.
   return url.toString().replace(/\/$/, '');
+}
+
+function shouldAdvanceForkTime(
+  env: NodeJS.ProcessEnv,
+  rpcUrl: string | undefined,
+): boolean {
+  if (env['HEARTBEAT_ADVANCE_FORK_TIME'] === '1') return true;
+  if (env['HEARTBEAT_ADVANCE_FORK_TIME'] === '0') return false;
+  return env['CHAIN_NETWORK'] === 'dev' && isLocalForkRpcUrl(rpcUrl);
+}
+
+function isLocalForkRpcUrl(rpcUrl: string | undefined): boolean {
+  if (!rpcUrl) return false;
+  let url: URL;
+  try {
+    url = new URL(rpcUrl);
+  } catch {
+    return false;
+  }
+  const hostname = url.hostname.toLowerCase();
+  return hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '0.0.0.0' ||
+    hostname === '::1' ||
+    hostname === 'host.docker.internal' ||
+    hostname === 'anvil-fork';
+}
+
+function toQuantityHex(value: number): `0x${string}` {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`invalid JSON-RPC quantity: ${value}`);
+  }
+  return `0x${value.toString(16)}`;
 }

--- a/packages/heartbeat/src/runnerCastHeartbeat.ts
+++ b/packages/heartbeat/src/runnerCastHeartbeat.ts
@@ -241,6 +241,10 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     return true;
   }
 
+  isForkTimeAdvanceEnabled(): boolean {
+    return this.advanceForkTime;
+  }
+
   async readNextHeartbeatAtTs(): Promise<number> {
     const state = await this.publicClient.readContract({
       address: this.contractAddress,

--- a/packages/heartbeat/src/runnerCastHeartbeat.ts
+++ b/packages/heartbeat/src/runnerCastHeartbeat.ts
@@ -228,6 +228,9 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
   async advanceForkTimeTo(targetUnixTs: number): Promise<boolean> {
     if (!this.advanceForkTime) return false;
     if (!this.rpcUrl) throw new Error('advanceForkTime requires an explicit RPC URL');
+    if (!isLocalForkRpcUrl(this.rpcUrl)) {
+      throw new Error(`advanceForkTime refused for non-local RPC URL: ${this.rpcUrl}`);
+    }
 
     const latestUnixTs = Math.floor(await this.readChainNowMs() / 1000);
     if (latestUnixTs >= targetUnixTs) return false;
@@ -235,7 +238,9 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     try {
       await this.sendForkRpc('evm_setNextBlockTimestamp', [toQuantityHex(targetUnixTs)]);
     } catch {
-      await this.sendForkRpc('evm_increaseTime', [toQuantityHex(targetUnixTs - latestUnixTs)]);
+      const refreshedUnixTs = Math.floor(await this.readChainNowMs() / 1000);
+      if (refreshedUnixTs >= targetUnixTs) return false;
+      await this.sendForkRpc('evm_increaseTime', [toQuantityHex(targetUnixTs - refreshedUnixTs)]);
     }
     await this.sendForkRpc('evm_mine', []);
     return true;
@@ -429,7 +434,7 @@ function shouldAdvanceForkTime(
   env: NodeJS.ProcessEnv,
   rpcUrl: string | undefined,
 ): boolean {
-  if (env['HEARTBEAT_ADVANCE_FORK_TIME'] === '1') return true;
+  if (env['HEARTBEAT_ADVANCE_FORK_TIME'] === '1') return isLocalForkRpcUrl(rpcUrl);
   if (env['HEARTBEAT_ADVANCE_FORK_TIME'] === '0') return false;
   return env['CHAIN_NETWORK'] === 'dev' && isLocalForkRpcUrl(rpcUrl);
 }

--- a/packages/heartbeat/src/runnerCastHeartbeat.ts
+++ b/packages/heartbeat/src/runnerCastHeartbeat.ts
@@ -139,7 +139,10 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
         // instrumentation diagnoses this), revisit with decodeErrorResult on the
         // receipt revert data.
         const next = await this.readNextHeartbeatAtTs().catch(() => undefined);
-        if (next !== undefined && next > Math.floor(Date.now() / 1000)) {
+        if (
+          next !== undefined &&
+          await this.isNextHeartbeatStillFuture(next, receipt.blockNumber)
+        ) {
           throw new HeartbeatRateLimitedError(next);
         }
         throw new Error(`heartbeat tx ${hash} reverted on-chain`);
@@ -181,7 +184,7 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
       // No decoded reason (e.g. a custom error with no ABI match) — only here do
       // we fall back to the timestamp heuristic for the rate-limit case.
       const next = await this.readNextHeartbeatAtTs().catch(() => undefined);
-      if (next !== undefined && next > Math.floor(Date.now() / 1000)) {
+      if (next !== undefined && await this.isNextHeartbeatStillFuture(next)) {
         throw new HeartbeatRateLimitedError(next);
       }
       throw err;
@@ -206,8 +209,7 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     // cycle. Measured from the latest block, so it under-estimates by the age
     // of that block — which only delays the next fire, never causes a
     // rate-limited revert.
-    const block = await this.publicClient.getBlock({ blockTag: 'latest' });
-    return Number(block.timestamp) * 1000;
+    return this.readBlockTimestampMs();
   }
 
   async readNextHeartbeatAtTs(): Promise<number> {
@@ -219,6 +221,21 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     });
     // viem decodes the named tuple into an object with the same field names.
     return Number((state as { nextHeartbeatAtTs: bigint }).nextHeartbeatAtTs);
+  }
+
+  private async isNextHeartbeatStillFuture(
+    nextHeartbeatAtTs: number,
+    blockNumber?: bigint | number | null,
+  ): Promise<boolean> {
+    const chainNowMs = await this.readBlockTimestampMs(blockNumber).catch(() => Date.now());
+    return nextHeartbeatAtTs * 1000 > chainNowMs;
+  }
+
+  private async readBlockTimestampMs(blockNumber?: bigint | number | null): Promise<number> {
+    const block = blockNumber === undefined || blockNumber === null
+      ? await this.publicClient.getBlock({ blockTag: 'latest' })
+      : await this.publicClient.getBlock({ blockNumber: BigInt(blockNumber) });
+    return Number(block.timestamp) * 1000;
   }
 
   private async postHeartbeatWebhook(args: {

--- a/packages/heartbeat/src/runnerCastHeartbeat.ts
+++ b/packages/heartbeat/src/runnerCastHeartbeat.ts
@@ -32,6 +32,8 @@ export interface RunnerHeartbeatConfig {
   webhookSharedSecret?: string;
   /** Dev-only affordance: advance a local anvil fork clock before heartbeats. */
   advanceForkTime?: boolean;
+  /** Optional tx gas limit. Dev fork defaults high to avoid estimate/call mismatch. */
+  gasLimit?: bigint;
 }
 
 /**
@@ -79,6 +81,7 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): RunnerHeart
     convexWebhookUrl,
     webhookSharedSecret: env['WEBHOOK_SHARED_SECRET'],
     advanceForkTime: shouldAdvanceForkTime(env, env['RPC_URL_PRIMARY'] || env['RPC_URL_FALLBACK']),
+    gasLimit: resolveHeartbeatGasLimit(env),
   };
 }
 
@@ -101,6 +104,7 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
   private readonly webhookSharedSecret?: string;
   private readonly rpcUrl?: string;
   private readonly advanceForkTime: boolean;
+  private readonly gasLimit?: bigint;
 
   constructor(cfg: RunnerHeartbeatConfig) {
     const pk = normalizePk(cfg.privateKey);
@@ -118,6 +122,7 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     this.webhookSharedSecret = cfg.webhookSharedSecret;
     this.rpcUrl = cfg.rpcUrl;
     this.advanceForkTime = cfg.advanceForkTime ?? false;
+    this.gasLimit = cfg.gasLimit;
   }
 
   async callHeartbeat(): Promise<{ txHash: string }> {
@@ -129,6 +134,7 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
         abi: CLAN_WORLD_ABI,
         functionName: 'heartbeat',
         args: [],
+        ...(this.gasLimit === undefined ? {} : { gas: this.gasLimit }),
       });
       // Wait for confirmation per the seam contract ("not fire-and-forget").
       const receipt = await this.publicClient.waitForTransactionReceipt({
@@ -152,7 +158,7 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
         ) {
           throw new HeartbeatRateLimitedError(next);
         }
-        throw new Error(`heartbeat tx ${hash} reverted on-chain`);
+        throw new Error(`heartbeat tx ${hash} reverted on-chain; ${await this.heartbeatDiagnostics(receipt.blockNumber)}`);
       }
       await this.postHeartbeatWebhook({
         txHash: hash,
@@ -194,7 +200,7 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
       if (next !== undefined && await this.isNextHeartbeatStillFuture(next)) {
         throw new HeartbeatRateLimitedError(next);
       }
-      throw err;
+      throw await this.withHeartbeatDiagnostics(err);
     }
   }
 
@@ -277,6 +283,25 @@ export class RunnerCastHeartbeat implements IHeartbeatCaller {
     const payload = await response.json() as { result?: unknown; error?: { message?: string } };
     if (payload.error) throw new Error(`${method} failed: ${payload.error.message ?? 'RPC error'}`);
     return payload.result;
+  }
+
+  private async withHeartbeatDiagnostics(err: unknown): Promise<Error> {
+    const diagnostics = await this.heartbeatDiagnostics().catch(diagErr =>
+      `diagnostics failed: ${messageFrom(diagErr)}`);
+    const error = new Error(`${messageFrom(err)}; ${diagnostics}`);
+    (error as Error & { cause?: unknown }).cause = err;
+    return error;
+  }
+
+  private async heartbeatDiagnostics(blockNumber?: bigint | number | null): Promise<string> {
+    const [chainNowMs, nextHeartbeatAtTs] = await Promise.all([
+      this.readBlockTimestampMs(blockNumber).catch(() => undefined),
+      this.readNextHeartbeatAtTs().catch(() => undefined),
+    ]);
+    const chainNowTs = chainNowMs === undefined ? 'unknown' : String(Math.floor(chainNowMs / 1000));
+    const nextTs = nextHeartbeatAtTs === undefined ? 'unknown' : String(nextHeartbeatAtTs);
+    const gasLimit = this.gasLimit === undefined ? 'auto' : this.gasLimit.toString();
+    return `heartbeat diagnostics: chainBlockTs=${chainNowTs} nextHeartbeatAtTs=${nextTs} wallTs=${Math.floor(Date.now() / 1000)} gasLimit=${gasLimit}`;
   }
 
   private async postHeartbeatWebhook(args: {
@@ -405,6 +430,12 @@ function shouldAdvanceForkTime(
   return env['CHAIN_NETWORK'] === 'dev' && isLocalForkRpcUrl(rpcUrl);
 }
 
+function resolveHeartbeatGasLimit(env: NodeJS.ProcessEnv): bigint | undefined {
+  const raw = env['HEARTBEAT_GAS_LIMIT'];
+  if (raw !== undefined && raw !== '') return parsePositiveBigIntEnv('HEARTBEAT_GAS_LIMIT', raw);
+  return env['CHAIN_NETWORK'] === 'dev' ? 25_000_000n : undefined;
+}
+
 function isLocalForkRpcUrl(rpcUrl: string | undefined): boolean {
   if (!rpcUrl) return false;
   let url: URL;
@@ -427,4 +458,15 @@ function toQuantityHex(value: number): `0x${string}` {
     throw new Error(`invalid JSON-RPC quantity: ${value}`);
   }
   return `0x${value.toString(16)}`;
+}
+
+function parsePositiveBigIntEnv(name: string, raw: string): bigint {
+  if (!/^[1-9][0-9]*$/.test(raw)) {
+    throw new Error(`${name} must be a positive integer, got ${raw}`);
+  }
+  return BigInt(raw);
+}
+
+function messageFrom(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/packages/heartbeat/test/heartbeatScheduler.test.ts
+++ b/packages/heartbeat/test/heartbeatScheduler.test.ts
@@ -195,6 +195,7 @@ describe('heartbeatScheduler', () => {
       callHeartbeat,
       async readChainNowMs() { return chainNowMs; },
       advanceForkTimeTo,
+      isForkTimeAdvanceEnabled: () => true,
       readNextHeartbeatAtTs: vi.fn()
         .mockResolvedValueOnce(10)
         .mockResolvedValue(40),
@@ -231,6 +232,7 @@ describe('heartbeatScheduler', () => {
       callHeartbeat,
       async readChainNowMs() { return 13_000; },
       advanceForkTimeTo,
+      isForkTimeAdvanceEnabled: () => true,
       readNextHeartbeatAtTs: vi.fn()
         .mockResolvedValueOnce(10)
         .mockResolvedValue(40),
@@ -250,6 +252,48 @@ describe('heartbeatScheduler', () => {
     expect(postRunnerStatus).toHaveBeenCalledWith(
       expect.objectContaining({ lastFireResult: 'success' }),
     );
+  });
+
+  it('paces fork-advance heartbeats by wall time instead of advanced chain time', async () => {
+    vi.setSystemTime(0);
+    let chainNowMs = 0;
+    let nextHeartbeatAtTs = 30;
+    const abort = new AbortController();
+    const postRunnerStatus = vi.fn().mockResolvedValue(undefined);
+    const advanceForkTimeTo = vi.fn(async (targetUnixTs: number) => {
+      chainNowMs = targetUnixTs * 1000;
+      return true;
+    });
+    const callHeartbeat = vi.fn(async () => {
+      nextHeartbeatAtTs = 62;
+      return { txHash: '0x1' };
+    });
+    const caller = makeHeartbeatCaller({
+      callHeartbeat,
+      async readChainNowMs() { return chainNowMs; },
+      advanceForkTimeTo,
+      isForkTimeAdvanceEnabled: () => true,
+      async readNextHeartbeatAtTs() { return nextHeartbeatAtTs; },
+    });
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      convex: { postRunnerStatus },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(31_499);
+    expect(callHeartbeat).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(advanceForkTimeTo).toHaveBeenCalledWith(32);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+
+    abort.abort();
   });
 
   it('exits silently when aborted during retry sleep', async () => {

--- a/packages/heartbeat/test/heartbeatScheduler.test.ts
+++ b/packages/heartbeat/test/heartbeatScheduler.test.ts
@@ -185,7 +185,7 @@ describe('heartbeatScheduler', () => {
       return true;
     });
     const callHeartbeat = vi.fn(async () => {
-      if (chainNowMs < 10_000 + HEARTBEAT_SAFETY_MARGIN_MS) {
+      if (chainNowMs < 10_000) {
         throw new HeartbeatRateLimitedError(10);
       }
       abort.abort();
@@ -210,7 +210,7 @@ describe('heartbeatScheduler', () => {
 
     await vi.advanceTimersByTimeAsync(1);
 
-    expect(advanceForkTimeTo).toHaveBeenCalledWith(12);
+    expect(advanceForkTimeTo).toHaveBeenCalledWith(10);
     expect(callHeartbeat).toHaveBeenCalledTimes(1);
     expect(postRunnerStatus).toHaveBeenCalledWith(
       expect.objectContaining({ lastFireResult: 'success' }),
@@ -254,10 +254,10 @@ describe('heartbeatScheduler', () => {
     );
   });
 
-  it('paces fork-advance heartbeats by wall time instead of advanced chain time', async () => {
-    vi.setSystemTime(0);
-    let chainNowMs = 0;
-    let nextHeartbeatAtTs = 30;
+  it('paces fork-advance heartbeats by wall interval when chain time is far ahead of wall', async () => {
+    vi.setSystemTime(1_000_000);
+    let chainNowMs = 4_770_000;
+    let nextHeartbeatAtTs = 4_800;
     const abort = new AbortController();
     const postRunnerStatus = vi.fn().mockResolvedValue(undefined);
     const advanceForkTimeTo = vi.fn(async (targetUnixTs: number) => {
@@ -265,11 +265,16 @@ describe('heartbeatScheduler', () => {
       return true;
     });
     const callHeartbeat = vi.fn(async () => {
-      nextHeartbeatAtTs = 62;
+      if (callHeartbeat.mock.calls.length === 1) {
+        nextHeartbeatAtTs = 4_832;
+      } else {
+        abort.abort();
+      }
       return { txHash: '0x1' };
     });
     const caller = makeHeartbeatCaller({
       callHeartbeat,
+      async readHeartbeatIntervalSeconds() { return 30; },
       async readChainNowMs() { return chainNowMs; },
       advanceForkTimeTo,
       isForkTimeAdvanceEnabled: () => true,
@@ -283,17 +288,15 @@ describe('heartbeatScheduler', () => {
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     });
 
-    await vi.advanceTimersByTimeAsync(31_499);
-    expect(callHeartbeat).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+    expect(advanceForkTimeTo).toHaveBeenCalledWith(4_800);
+
+    await vi.advanceTimersByTimeAsync(29_998);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(1);
-    expect(advanceForkTimeTo).toHaveBeenCalledWith(32);
-    expect(callHeartbeat).toHaveBeenCalledTimes(1);
-
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(callHeartbeat).toHaveBeenCalledTimes(1);
-
-    abort.abort();
+    expect(callHeartbeat).toHaveBeenCalledTimes(2);
   });
 
   it('exits silently when aborted during retry sleep', async () => {

--- a/packages/heartbeat/test/heartbeatScheduler.test.ts
+++ b/packages/heartbeat/test/heartbeatScheduler.test.ts
@@ -216,6 +216,42 @@ describe('heartbeatScheduler', () => {
     );
   });
 
+  it('does not advance fork time when chain time is already past nextHeartbeatAtTs', async () => {
+    vi.setSystemTime(20_000);
+    const abort = new AbortController();
+    const postRunnerStatus = vi.fn().mockResolvedValue(undefined);
+    const advanceForkTimeTo = vi.fn(async () => {
+      throw new Error('must not move fork time backward');
+    });
+    const callHeartbeat = vi.fn(async () => {
+      abort.abort();
+      return { txHash: '0x1' };
+    });
+    const caller = makeHeartbeatCaller({
+      callHeartbeat,
+      async readChainNowMs() { return 13_000; },
+      advanceForkTimeTo,
+      readNextHeartbeatAtTs: vi.fn()
+        .mockResolvedValueOnce(10)
+        .mockResolvedValue(40),
+    });
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      convex: { postRunnerStatus },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(advanceForkTimeTo).not.toHaveBeenCalled();
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+    expect(postRunnerStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ lastFireResult: 'success' }),
+    );
+  });
+
   it('exits silently when aborted during retry sleep', async () => {
     const callHeartbeat = vi.fn().mockRejectedValue(new Error('rpc down'));
     const alert = vi.fn().mockResolvedValue({ ok: true });

--- a/packages/heartbeat/test/heartbeatScheduler.test.ts
+++ b/packages/heartbeat/test/heartbeatScheduler.test.ts
@@ -7,6 +7,7 @@ import {
   HEARTBEAT_RETRY_BACKOFF_MS,
   HEARTBEAT_SAFETY_MARGIN_MS,
   startHeartbeatScheduler,
+  type ForkTimeAdvancer,
 } from '../src/heartbeatScheduler';
 import { HeartbeatRateLimitedError, type IHeartbeatCaller } from '@clan-world/agents/seams';
 
@@ -23,7 +24,9 @@ function cleanupHeartbeatSuccessFile(): void {
   rmSync(`${heartbeatSuccessFile}.${process.pid}.tmp`, { force: true });
 }
 
-function makeHeartbeatCaller(overrides: Partial<IHeartbeatCaller> = {}): IHeartbeatCaller {
+function makeHeartbeatCaller(
+  overrides: Partial<IHeartbeatCaller & ForkTimeAdvancer> = {},
+): IHeartbeatCaller & ForkTimeAdvancer {
   return {
     async callHeartbeat() { return { txHash: '0xabc' }; },
     async readHeartbeatIntervalSeconds() { return 60; },
@@ -172,6 +175,47 @@ describe('heartbeatScheduler', () => {
     abort.abort();
   });
 
+  it('advances fork time before firing when wall time is past due but chain time is behind', async () => {
+    vi.setSystemTime(20_000);
+    let chainNowMs = 9_000;
+    const abort = new AbortController();
+    const postRunnerStatus = vi.fn().mockResolvedValue(undefined);
+    const advanceForkTimeTo = vi.fn(async (targetUnixTs: number) => {
+      chainNowMs = targetUnixTs * 1000;
+      return true;
+    });
+    const callHeartbeat = vi.fn(async () => {
+      if (chainNowMs < 10_000 + HEARTBEAT_SAFETY_MARGIN_MS) {
+        throw new HeartbeatRateLimitedError(10);
+      }
+      abort.abort();
+      return { txHash: '0x1' };
+    });
+    const caller = makeHeartbeatCaller({
+      callHeartbeat,
+      async readChainNowMs() { return chainNowMs; },
+      advanceForkTimeTo,
+      readNextHeartbeatAtTs: vi.fn()
+        .mockResolvedValueOnce(10)
+        .mockResolvedValue(40),
+    });
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      convex: { postRunnerStatus },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(advanceForkTimeTo).toHaveBeenCalledWith(12);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+    expect(postRunnerStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ lastFireResult: 'success' }),
+    );
+  });
+
   it('exits silently when aborted during retry sleep', async () => {
     const callHeartbeat = vi.fn().mockRejectedValue(new Error('rpc down'));
     const alert = vi.fn().mockResolvedValue({ ok: true });
@@ -281,6 +325,38 @@ describe('heartbeatScheduler', () => {
       expect.objectContaining({
         lastFailureMessage: 'Telegram alert failed: telegram down',
       }),
+    );
+
+    abort.abort();
+  });
+
+  it('skips Telegram alert errors when the bot token is intentionally absent', async () => {
+    const callHeartbeat = vi.fn().mockRejectedValue(new Error('rpc down'));
+    const alert = vi.fn().mockResolvedValue({ ok: false, error: 'TELEGRAM_BOT_TOKEN is not set' });
+    const info = vi.fn();
+    const error = vi.fn();
+    const caller = makeHeartbeatCaller({ callHeartbeat });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 0,
+      alert,
+      log: { info, warn: vi.fn(), error },
+    });
+
+    await vi.advanceTimersByTimeAsync(
+      HEARTBEAT_SAFETY_MARGIN_MS + 1 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0),
+    );
+
+    expect(alert).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenCalledWith(
+      '[heartbeatScheduler] Telegram alert skipped: TELEGRAM_BOT_TOKEN is not set',
+    );
+    expect(error).not.toHaveBeenCalledWith(
+      '[heartbeatScheduler] Telegram alert failed:',
+      'TELEGRAM_BOT_TOKEN is not set',
     );
 
     abort.abort();

--- a/packages/heartbeat/test/heartbeatScheduler.test.ts
+++ b/packages/heartbeat/test/heartbeatScheduler.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   computeHeartbeatDelayMs,
+  HEARTBEAT_RATE_LIMIT_RETRY_MAX,
   HEARTBEAT_RETRY_BACKOFF_MS,
   HEARTBEAT_SAFETY_MARGIN_MS,
   startHeartbeatScheduler,
@@ -171,6 +172,66 @@ describe('heartbeatScheduler', () => {
     expect(postRunnerStatus).toHaveBeenCalledWith(
       expect.objectContaining({ lastFireResult: 'success', nextHeartbeatAtTs: 33 }),
     );
+
+    abort.abort();
+  });
+
+  it('surfaces persistent rate limits after a bounded number of waits', async () => {
+    vi.setSystemTime(0);
+    const callHeartbeat = vi.fn().mockRejectedValue(new HeartbeatRateLimitedError(0));
+    const abort = new AbortController();
+    const alert = vi.fn().mockImplementation(async () => {
+      abort.abort();
+      return { ok: true };
+    });
+    const caller = makeHeartbeatCaller({
+      callHeartbeat,
+      async readNextHeartbeatAtTs() { return 0; },
+    });
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      alert,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(
+      HEARTBEAT_SAFETY_MARGIN_MS + 1 +
+      HEARTBEAT_RATE_LIMIT_RETRY_MAX * 2_000,
+    );
+
+    expect(callHeartbeat).toHaveBeenCalledTimes(HEARTBEAT_RATE_LIMIT_RETRY_MAX + 1);
+    expect(alert).toHaveBeenCalledTimes(1);
+    expect(alert.mock.calls[0]?.[0]).toContain('rate-limit retry cap exceeded');
+
+    abort.abort();
+  });
+
+  it('paces rate-limit retries by wall interval in fork-advance mode', async () => {
+    vi.setSystemTime(0);
+    const callHeartbeat = vi.fn().mockRejectedValue(new HeartbeatRateLimitedError(0));
+    const caller = makeHeartbeatCaller({
+      callHeartbeat,
+      async readHeartbeatIntervalSeconds() { return 30; },
+      async readChainNowMs() { return 0; },
+      async advanceForkTimeTo() { return false; },
+      isForkTimeAdvanceEnabled: () => true,
+      async readNextHeartbeatAtTs() { return 0; },
+    });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
 
     abort.abort();
   });

--- a/packages/heartbeat/test/heartbeatScheduler.test.ts
+++ b/packages/heartbeat/test/heartbeatScheduler.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   computeHeartbeatDelayMs,
   HEARTBEAT_RETRY_BACKOFF_MS,
+  HEARTBEAT_SAFETY_MARGIN_MS,
   startHeartbeatScheduler,
 } from '../src/heartbeatScheduler';
 import { HeartbeatRateLimitedError, type IHeartbeatCaller } from '@clan-world/agents/seams';
@@ -48,9 +49,34 @@ afterEach(() => {
 });
 
 describe('heartbeatScheduler', () => {
-  it('computes delay from nextHeartbeatAtTs with 500ms jitter', () => {
-    expect(computeHeartbeatDelayMs(10, 9_250)).toBe(1_250);
+  it('computes delay from nextHeartbeatAtTs with a safety margin', () => {
+    expect(computeHeartbeatDelayMs(10, 9_250)).toBe(2_250);
     expect(computeHeartbeatDelayMs(10, 11_000)).toBe(500);
+    expect(computeHeartbeatDelayMs(10, 12_000)).toBe(0);
+  });
+
+  it('does not fire before nextHeartbeatAtTs plus the safety margin', async () => {
+    const callHeartbeat = vi.fn().mockResolvedValue({ txHash: '0x1' });
+    const caller = makeHeartbeatCaller({
+      callHeartbeat,
+      async readNextHeartbeatAtTs() { return 10; },
+    });
+    const abort = new AbortController();
+
+    startHeartbeatScheduler({
+      heartbeatCaller: caller,
+      signal: abort.signal,
+      nowMs: () => 9_250,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await vi.advanceTimersByTimeAsync(2_249);
+    expect(callHeartbeat).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+
+    abort.abort();
   });
 
   it('fires heartbeat when on-chain nextHeartbeatAtTs is due', async () => {
@@ -71,7 +97,7 @@ describe('heartbeatScheduler', () => {
       nowMs: () => 0,
     });
 
-    await vi.advanceTimersByTimeAsync(501);
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_SAFETY_MARGIN_MS + 1);
     expect(callHeartbeat).toHaveBeenCalledTimes(1);
 
     abort.abort();
@@ -92,7 +118,7 @@ describe('heartbeatScheduler', () => {
     });
 
     await vi.advanceTimersByTimeAsync(
-      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0),
+      HEARTBEAT_SAFETY_MARGIN_MS + 1 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0),
     );
 
     expect(callHeartbeat).toHaveBeenCalledTimes(HEARTBEAT_RETRY_BACKOFF_MS.length + 1);
@@ -101,35 +127,46 @@ describe('heartbeatScheduler', () => {
     abort.abort();
   });
 
-  it('treats rate-limited heartbeats as terminal without retrying or alerting', async () => {
-    const callHeartbeat = vi.fn().mockRejectedValue(new HeartbeatRateLimitedError(60));
+  it('waits until nextHeartbeatAtTs plus safety margin after a rate limit without consuming backoff budget', async () => {
+    vi.setSystemTime(0);
+    const callHeartbeat = vi.fn()
+      .mockRejectedValueOnce(new HeartbeatRateLimitedError(3))
+      .mockResolvedValueOnce({ txHash: '0x1' });
     const alert = vi.fn().mockResolvedValue({ ok: true });
     const postRunnerStatus = vi.fn().mockResolvedValue(undefined);
-    let readNextCount = 0;
     const caller = makeHeartbeatCaller({
       callHeartbeat,
-      async readNextHeartbeatAtTs() {
-        readNextCount++;
-        return readNextCount === 2 ? 60 : 0;
-      },
+      readNextHeartbeatAtTs: vi.fn()
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(3)
+        .mockResolvedValue(33),
     });
     const abort = new AbortController();
 
     startHeartbeatScheduler({
       heartbeatCaller: caller,
       signal: abort.signal,
-      nowMs: () => 0,
       alert,
       convex: { postRunnerStatus },
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     });
 
-    await vi.advanceTimersByTimeAsync(501);
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_SAFETY_MARGIN_MS + 1);
 
     expect(callHeartbeat).toHaveBeenCalledTimes(1);
     expect(alert).not.toHaveBeenCalled();
     expect(postRunnerStatus).toHaveBeenCalledWith(
-      expect.objectContaining({ lastFireResult: 'rate-limited' }),
+      expect.objectContaining({ lastFireResult: 'rate-limited', nextHeartbeatAtTs: 3 }),
+    );
+
+    await vi.advanceTimersByTimeAsync(2_998);
+    expect(callHeartbeat).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(callHeartbeat).toHaveBeenCalledTimes(2);
+    expect(alert).not.toHaveBeenCalled();
+    expect(postRunnerStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ lastFireResult: 'success', nextHeartbeatAtTs: 33 }),
     );
 
     abort.abort();
@@ -149,7 +186,7 @@ describe('heartbeatScheduler', () => {
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     });
 
-    await vi.advanceTimersByTimeAsync(501);
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_SAFETY_MARGIN_MS + 1);
     abort.abort();
     await vi.advanceTimersByTimeAsync(1_000);
 
@@ -172,7 +209,7 @@ describe('heartbeatScheduler', () => {
     });
 
     const failureCycleMs =
-      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
+      HEARTBEAT_SAFETY_MARGIN_MS + 1 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
     await vi.advanceTimersByTimeAsync(failureCycleMs);
     await vi.advanceTimersByTimeAsync(failureCycleMs);
 
@@ -202,7 +239,7 @@ describe('heartbeatScheduler', () => {
     });
 
     const failureCycleMs =
-      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
+      HEARTBEAT_SAFETY_MARGIN_MS + 1 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
     await vi.advanceTimersByTimeAsync(failureCycleMs);
     await vi.advanceTimersByTimeAsync(120_000 - failureCycleMs);
     await vi.advanceTimersByTimeAsync(failureCycleMs);
@@ -229,7 +266,7 @@ describe('heartbeatScheduler', () => {
     });
 
     await vi.advanceTimersByTimeAsync(
-      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0),
+      HEARTBEAT_SAFETY_MARGIN_MS + 1 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0),
     );
 
     expect(alert).toHaveBeenCalledTimes(1);
@@ -277,7 +314,7 @@ describe('heartbeatScheduler', () => {
     });
 
     const failureCycleMs =
-      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
+      HEARTBEAT_SAFETY_MARGIN_MS + 1 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
     await vi.advanceTimersByTimeAsync(failureCycleMs);
     await vi.advanceTimersByTimeAsync(120_000 - failureCycleMs);
     await vi.advanceTimersByTimeAsync(failureCycleMs);
@@ -307,7 +344,7 @@ describe('heartbeatScheduler', () => {
     });
 
     const failureCycleMs =
-      501 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
+      HEARTBEAT_SAFETY_MARGIN_MS + 1 + HEARTBEAT_RETRY_BACKOFF_MS.reduce((sum, ms) => sum + ms, 0);
     await vi.advanceTimersByTimeAsync(failureCycleMs);
     await vi.advanceTimersByTimeAsync(120_000 - failureCycleMs);
     await vi.advanceTimersByTimeAsync(failureCycleMs);
@@ -369,7 +406,7 @@ describe('heartbeatScheduler', () => {
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     });
 
-    await vi.advanceTimersByTimeAsync(501);
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_SAFETY_MARGIN_MS + 1);
 
     expect(callHeartbeat).toHaveBeenCalledTimes(1);
     expect(alert).not.toHaveBeenCalled();
@@ -377,7 +414,7 @@ describe('heartbeatScheduler', () => {
       expect.objectContaining({ lastFireResult: 'success', nextHeartbeatAtTs: 160 }),
     );
     expect(existsSync(heartbeatSuccessFile)).toBe(true);
-    expect(readFileSync(heartbeatSuccessFile, 'utf8')).toBe('100');
+    expect(readFileSync(heartbeatSuccessFile, 'utf8')).toBe('101');
 
     abort.abort();
   });
@@ -399,7 +436,7 @@ describe('heartbeatScheduler', () => {
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     });
 
-    await vi.advanceTimersByTimeAsync(2_002);
+    await vi.advanceTimersByTimeAsync(4_002);
 
     expect(postRunnerStatus).toHaveBeenCalled();
     expect(callHeartbeat).toHaveBeenCalledTimes(2);
@@ -428,7 +465,7 @@ describe('heartbeatScheduler', () => {
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     });
 
-    await vi.advanceTimersByTimeAsync(501);
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_SAFETY_MARGIN_MS + 1);
 
     expect(postRunnerStatus).toHaveBeenCalledWith(
       expect.objectContaining({ lastFireAt: 123_456, lastFireResult: 'success' }),
@@ -452,10 +489,10 @@ describe('heartbeatScheduler', () => {
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     });
 
-    await vi.advanceTimersByTimeAsync(501);
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_SAFETY_MARGIN_MS + 1);
     expect(callHeartbeat).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(1_501);
+    await vi.advanceTimersByTimeAsync(2_501);
     expect(callHeartbeat).toHaveBeenCalledTimes(2);
 
     abort.abort();
@@ -480,7 +517,7 @@ describe('heartbeatScheduler', () => {
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     });
 
-    await vi.advanceTimersByTimeAsync(501);
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_SAFETY_MARGIN_MS + 1);
     expect(callHeartbeat).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(999);

--- a/packages/heartbeat/test/runnerCastHeartbeat.test.ts
+++ b/packages/heartbeat/test/runnerCastHeartbeat.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const viemMocks = vi.hoisted(() => ({
+  getBlock: vi.fn(),
   readContract: vi.fn(),
   waitForTransactionReceipt: vi.fn(),
   writeContract: vi.fn(),
@@ -14,6 +15,7 @@ vi.mock('viem', async () => {
   return {
     ...actual,
     createPublicClient: vi.fn(() => ({
+      getBlock: viemMocks.getBlock,
       readContract: viemMocks.readContract,
       waitForTransactionReceipt: viemMocks.waitForTransactionReceipt,
     })),
@@ -62,6 +64,7 @@ beforeEach(() => {
   heartbeatSuccessFile = join(heartbeatSuccessDir, 'last-heartbeat-success');
   vi.stubEnv('HEARTBEAT_SUCCESS_FILE_OVERRIDE', heartbeatSuccessFile);
   cleanupHeartbeatSuccessFile();
+  viemMocks.getBlock.mockReset();
   viemMocks.readContract.mockReset();
   viemMocks.waitForTransactionReceipt.mockReset();
   viemMocks.writeContract.mockReset();
@@ -87,6 +90,22 @@ describe('configFromEnv', () => {
     });
 
     expect(cfg.rpcUrl).toBe('https://fallback.example');
+  });
+
+  it('enables fork time advance only for dev local fork RPCs by default', () => {
+    expect(configFromEnv({
+      RUNNER_PRIVATE_KEY: '1'.repeat(64),
+      CLAN_WORLD_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000001',
+      CHAIN_NETWORK: 'dev',
+      RPC_URL_PRIMARY: 'http://anvil-fork:8545',
+    }).advanceForkTime).toBe(true);
+
+    expect(configFromEnv({
+      RUNNER_PRIVATE_KEY: '1'.repeat(64),
+      CLAN_WORLD_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000001',
+      CHAIN_NETWORK: 'prod',
+      RPC_URL_PRIMARY: 'https://base-sepolia.example',
+    }).advanceForkTime).toBe(false);
   });
 
   it('derives CONVEX_WEBHOOK_URL from CONVEX_DEPLOY_URL when explicit URL is unset', () => {
@@ -335,6 +354,61 @@ describe('RunnerCastHeartbeat', () => {
     );
     warn.mockRestore();
   }, 7_000);
+
+  it('detects a mined rate-limit revert using the reverted block timestamp, not wall clock', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(135_000);
+    const hash = `0x${'a'.repeat(64)}` as const;
+    viemMocks.writeContract.mockResolvedValue(hash);
+    viemMocks.waitForTransactionReceipt.mockResolvedValue({
+      status: 'reverted',
+      blockNumber: 7n,
+    });
+    viemMocks.readContract.mockResolvedValue({ nextHeartbeatAtTs: 130n });
+    viemMocks.getBlock.mockResolvedValue({ timestamp: 127n });
+
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'https://rpc.example',
+    });
+
+    const err = await heartbeat.callHeartbeat().then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(HeartbeatRateLimitedError);
+    expect(viemMocks.getBlock).toHaveBeenCalledWith({ blockNumber: 7n });
+  });
+
+  it('advances a dev fork to the requested heartbeat timestamp and mines a block', async () => {
+    viemMocks.getBlock.mockResolvedValue({ timestamp: 10n });
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ result: '0x1' }),
+    } satisfies Partial<Response>);
+    vi.stubGlobal('fetch', fetch);
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'http://anvil-fork:8545',
+      advanceForkTime: true,
+    });
+
+    await expect(heartbeat.advanceForkTimeTo(12)).resolves.toBe(true);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://anvil-fork:8545',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"method":"evm_setNextBlockTimestamp"'),
+      }),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      'http://anvil-fork:8545',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"method":"evm_mine"'),
+      }),
+    );
+  });
 
   it('detects a viem-wrapped rate-limit revert by reason ALONE (no timestamp help)', async () => {
     // viem wraps the on-chain revert in a BaseError (e.g. ContractFunctionExecutionError)

--- a/packages/heartbeat/test/runnerCastHeartbeat.test.ts
+++ b/packages/heartbeat/test/runnerCastHeartbeat.test.ts
@@ -93,19 +93,33 @@ describe('configFromEnv', () => {
   });
 
   it('enables fork time advance only for dev local fork RPCs by default', () => {
-    expect(configFromEnv({
+    const devCfg = configFromEnv({
       RUNNER_PRIVATE_KEY: '1'.repeat(64),
       CLAN_WORLD_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000001',
       CHAIN_NETWORK: 'dev',
       RPC_URL_PRIMARY: 'http://anvil-fork:8545',
-    }).advanceForkTime).toBe(true);
+    });
+    expect(devCfg.advanceForkTime).toBe(true);
+    expect(devCfg.gasLimit).toBe(25_000_000n);
 
+    const prodCfg = configFromEnv({
+      RUNNER_PRIVATE_KEY: '1'.repeat(64),
+      CLAN_WORLD_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000001',
+      CHAIN_NETWORK: 'prod',
+      RPC_URL_PRIMARY: 'https://base-sepolia.example',
+    });
+    expect(prodCfg.advanceForkTime).toBe(false);
+    expect(prodCfg.gasLimit).toBeUndefined();
+  });
+
+  it('honors explicit HEARTBEAT_GAS_LIMIT', () => {
     expect(configFromEnv({
       RUNNER_PRIVATE_KEY: '1'.repeat(64),
       CLAN_WORLD_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000001',
       CHAIN_NETWORK: 'prod',
       RPC_URL_PRIMARY: 'https://base-sepolia.example',
-    }).advanceForkTime).toBe(false);
+      HEARTBEAT_GAS_LIMIT: '1234567',
+    }).gasLimit).toBe(1_234_567n);
   });
 
   it('derives CONVEX_WEBHOOK_URL from CONVEX_DEPLOY_URL when explicit URL is unset', () => {
@@ -221,8 +235,30 @@ describe('RunnerCastHeartbeat', () => {
 
     await expect(heartbeat.callHeartbeat()).resolves.toEqual({ txHash: hash });
 
+    expect(viemMocks.writeContract.mock.calls[0]?.[0]).not.toHaveProperty('gas');
     expect(existsSync(heartbeatSuccessFile)).toBe(true);
     expect(readFileSync(heartbeatSuccessFile, 'utf8')).toBe('123');
+  });
+
+  it('sends heartbeat with an explicit gas limit when configured', async () => {
+    const hash = `0x${'a'.repeat(64)}` as const;
+    viemMocks.writeContract.mockResolvedValue(hash);
+    viemMocks.waitForTransactionReceipt.mockResolvedValue({
+      status: 'success',
+      blockNumber: 123n,
+    });
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'https://rpc.example',
+      gasLimit: 25_000_000n,
+    });
+
+    await expect(heartbeat.callHeartbeat()).resolves.toEqual({ txHash: hash });
+
+    expect(viemMocks.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({ gas: 25_000_000n }),
+    );
   });
 
   it('swallows EACCES when heartbeat success file cannot be written', () => {
@@ -408,6 +444,22 @@ describe('RunnerCastHeartbeat', () => {
         body: expect.stringContaining('"method":"evm_mine"'),
       }),
     );
+  });
+
+  it('does not move fork time backward when the chain timestamp is already ahead', async () => {
+    viemMocks.getBlock.mockResolvedValue({ timestamp: 130n });
+    const fetch = vi.fn();
+    vi.stubGlobal('fetch', fetch);
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'http://anvil-fork:8545',
+      advanceForkTime: true,
+    });
+
+    await expect(heartbeat.advanceForkTimeTo(120)).resolves.toBe(false);
+
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('detects a viem-wrapped rate-limit revert by reason ALONE (no timestamp help)', async () => {

--- a/packages/heartbeat/test/runnerCastHeartbeat.test.ts
+++ b/packages/heartbeat/test/runnerCastHeartbeat.test.ts
@@ -122,6 +122,18 @@ describe('configFromEnv', () => {
     }).gasLimit).toBe(1_234_567n);
   });
 
+  it('does not let HEARTBEAT_ADVANCE_FORK_TIME enable a non-local RPC', () => {
+    const cfg = configFromEnv({
+      RUNNER_PRIVATE_KEY: '1'.repeat(64),
+      CLAN_WORLD_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000001',
+      CHAIN_NETWORK: 'dev',
+      RPC_URL_PRIMARY: 'https://base-sepolia.example',
+      HEARTBEAT_ADVANCE_FORK_TIME: '1',
+    });
+
+    expect(cfg.advanceForkTime).toBe(false);
+  });
+
   it('derives CONVEX_WEBHOOK_URL from CONVEX_DEPLOY_URL when explicit URL is unset', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -460,6 +472,57 @@ describe('RunnerCastHeartbeat', () => {
     await expect(heartbeat.advanceForkTimeTo(120)).resolves.toBe(false);
 
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses fork time RPCs against a non-local URL even if constructed enabled', async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal('fetch', fetch);
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'https://base-sepolia.example',
+      advanceForkTime: true,
+    });
+
+    await expect(heartbeat.advanceForkTimeTo(120)).rejects.toThrow(/non-local RPC URL/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('refreshes chain time before evm_increaseTime fallback delta', async () => {
+    viemMocks.getBlock
+      .mockResolvedValueOnce({ timestamp: 10n })
+      .mockResolvedValueOnce({ timestamp: 11n });
+    const fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ error: { message: 'set timestamp unsupported' } }),
+      } satisfies Partial<Response>)
+      .mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ result: '0x1' }),
+      } satisfies Partial<Response>);
+    vi.stubGlobal('fetch', fetch);
+    const heartbeat = new RunnerCastHeartbeat({
+      privateKey: '1'.repeat(64),
+      contractAddress: '0x0000000000000000000000000000000000000001',
+      rpcUrl: 'http://anvil-fork:8545',
+      advanceForkTime: true,
+    });
+
+    await expect(heartbeat.advanceForkTimeTo(12)).resolves.toBe(true);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://anvil-fork:8545',
+      expect.objectContaining({
+        body: expect.stringContaining('"method":"evm_increaseTime"'),
+      }),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      'http://anvil-fork:8545',
+      expect.objectContaining({
+        body: expect.stringContaining('"params":["0x1"]'),
+      }),
+    );
   });
 
   it('detects a viem-wrapped rate-limit revert by reason ALONE (no timestamp help)', async () => {


### PR DESCRIPTION
## Summary
Resolves the long-deferred #652 heartbeat flapping/freeze. Verified LIVE on a fresh anvil fork: **clean 30s cadence, container healthy, zero rate-limited reverts.**

## The real root cause (after 3 wrong theories)
The deepest cause of the frozen game was **the heartbeat runner wallet being out of ETH on the fork** (drained to 0.000234 ETH by an earlier revert flood — every reverted tx still burns gas). Diagnostic signature: `cast call heartbeat()` from the runner SUCCEEDS (eth_call needs no gas) while the runner's real tx reverts with **empty data** (`0x`) = insufficient funds. Fixed live via `anvil_setBalance` (1000 ETH) — and this must become a permanent fork-bootstrap step.

## The fix stack (commits)
- **r1** `c98602b` — safety margin (no early fire) + treat rate-limited revert as wait-in-window, not a back-off-and-miss.
- **r2** `0c7a88f` — fork-time advance (`evm_setNextBlockTimestamp`/`evm_increaseTime` + `evm_mine`), **double-gated to dev-fork only** (`CHAIN_NETWORK=dev` AND local-fork RPC, or explicit `HEARTBEAT_ADVANCE_FORK_TIME=1`) — never runs against Base Sepolia. Retry floor (no 0ms hot-loop). Telegram-token-absent → no-op.
- **r3** `fba8a85` — send-path diagnostics (chainBlockTs/nextHeartbeatAtTs/wallTs/gasLimit) so empty reverts are legible; dev gas default.
- **r4** `e423d97` — wall-pace cadence in fork-advance mode (chain-clock scheduling was making every cycle "due").
- **r5** `d6a984d` — pace by **wall interval since last beat** (not absolute chain-time target), fixing a 63-min sleep when the fork clock had diverged ahead of wall.

## Tests + live verification
- 76/76 heartbeat package tests pass; typecheck clean. New tests model the fork case (chain clock diverged from wall) — the gap that let earlier green tests ship a broken live game.
- Live: fresh fork → 3 confirms in 95s, `computedDelayMs ≈ 28990` (waiting ~29s between beats), healthy.

## Follow-ups (tracked separately)
- Make runner-funding a permanent fork-bootstrap step (fund `0xBC34…6cc7` on every fresh fork).
- Consider lowering the r3 25M dev-gas default now that the wallet is funded.

Closes #652
