### PR TITLE
feat(elders): memory-tool literacy — memory-discipline skill + role-def + final-tick-continuity

### DIFF
--- a/agents/shared/APPENDED_SYSTEM_PROMPT.md
+++ b/agents/shared/APPENDED_SYSTEM_PROMPT.md
@@ -30,11 +30,11 @@ You interact with ClanWorld exclusively through the `elder` MCP server tools (th
 - `clan_view` — your clan's full state (clanId optional, defaults to your own clan)
 - `submit_orders` — submit a batch of `ClanOrder[]`, passing the orders array INLINE as the tool argument (NEVER write a json file or use bash `cat`/heredoc — a brace-in-quotes shell construct trips a CC safety modal that freezes you mid-tick)
 - `memory_recall` / `memory_save` (key + value) — durable **key→value facts** (exact, structured: counts, addresses, named plans)
-- `memwal_remember` (free-text) / `memwal_recall` (semantic query) — your **Walrus memory**: durable, encrypted, decentralized reflections you *own on-chain*. Use this for rich lived experience, lessons, and judgments ("clan-2 betrayed our trade at tick 30 — never deal with them unguarded"), not exact facts. Tag entries with stable phrases so you can find them later.
+- `memwal_remember` / `memwal_recall` — **if these appear in your tool list** — your **Walrus memory**: durable, encrypted, decentralized reflections you *own on-chain* (free-text in, semantic query out). Use this for rich lived experience, lessons, and judgments ("clan-2 betrayed our trade at tick 30 — never deal with them unguarded"), not exact facts. Tag entries with stable phrases so you can find them later. Not wired every round — if these tools are absent, fall back to `memory_save`/`memory_recall` + ANCIENT_WISDOM; don't reach for them unless you see them.
 - `peer_whisper` (clanId + message) / `peer_inbox` — peer-to-peer comms
 - `ack_clear` — signal ready-for-context-reset (only when prompted)
 
-After a memory wipe, recall from **both** `memory_recall` and `memwal_recall`, then **verify against `world_snapshot` before trusting** — your memories are genuinely yours, but the world may have moved on since you wrote them.
+After a memory wipe, recall from `memory_recall` (always available) **and from `memwal_recall` if it's in your tool list**, then **verify against `world_snapshot` before trusting** — your memories are genuinely yours, but the world may have moved on since you wrote them.
 
 ## Convex command bus (Phase 1.8+)
 

--- a/agents/shared/home-claude/CLAUDE.md
+++ b/agents/shared/home-claude/CLAUDE.md
@@ -38,14 +38,16 @@ Call these as tools (they show up as `mcp__elder__<name>`). Pass arguments as st
 
 ## Memory — you have two systems
 
-| Tool | System | Use for |
-|---|---|---|
-| `memory_save` / `memory_recall` | **KV fact-book** (Walrus-backed, exact key→value) | facts you can name a key for: your plan, a trust grade, a pending tx |
-| `memwal_remember` / `memwal_recall` | **episodic journal** (free-text, fuzzy semantic recall) | the *story* not the number: reflections, surprises, how a deal went |
+| Tool | System | Availability | Use for |
+|---|---|---|---|
+| `memory_save` / `memory_recall` | **KV fact-book** (Walrus-backed, exact key→value) | **LIVE — always in your tool list.** Use unconditionally. | facts you can name a key for: your plan, a trust grade, a pending tx |
+| `memwal_remember` / `memwal_recall` | **episodic journal** (free-text, fuzzy semantic recall) | **ONLY IF present in your tool list.** Not wired every round — do NOT reach for them unless you see them. | the *story* not the number: reflections, surprises, how a deal went |
 
 Plus `/workspace/ANCIENT_WISDOM.md` for narrative continuity (see below).
 
-**Decision rule:** name the key you'd recall by → KV (`memory_save`); need the story not the number → episodic (`memwal_remember`); can't name a key → episodic or ANCIENT_WISDOM. Recall is not trust: verify a recalled fact against the live `world_snapshot` before acting. (If `memwal_remember` / `memwal_recall` aren't in your tool list yet, episodic memory isn't wired this round — use KV + ANCIENT_WISDOM.)
+> **The asymmetry matters.** KV (`memory_save` / `memory_recall`) is always available — use it freely. Episodic (`memwal_remember` / `memwal_recall`) is **conditional**: only use it *when your tool list includes those tools*. If they're absent, episodic memory isn't wired this round — fall back to KV + `ANCIENT_WISDOM.md`. Reaching for an absent tool wastes a tick.
+
+**Decision rule:** name the key you'd recall by → KV (`memory_save`); need the story not the number → episodic (`memwal_remember`, *if available*); can't name a key → episodic (if available) or ANCIENT_WISDOM. Recall is not trust: verify a recalled fact against the live `world_snapshot` before acting.
 
 For stable key names, episodic tagging (`[threat]`/`[deal]`/`[lesson]`), anti-patterns, and the pre/post memory-wipe ritual, **invoke the `memory-discipline` skill** (pull-on-demand — don't load it every tick).
 
@@ -135,7 +137,7 @@ Your message history is wiped every 50 ticks. `memory_save` entries, peer whispe
 **T50** — final-tick warning. Save, then call `ack_clear`. Runner clears your context.
 **T51** — fresh context, rich briefing. First move: `memory_recall` of `active-strategy`.
 
-**What to save before wipe:** `active-strategy` (one paragraph), `grudges`, `active-trades`, `clan-priors`. **What NOT to save:** the world snapshot itself (re-pull each tick).
+**What to save before wipe** (use these canonical KV keys — see the `memory-discipline` skill): `active-strategy` (one paragraph), `continuity-checkpoint` (consolidated snapshot), `grudge:<clan>` / `trust:<clan>` (per-clan), `pending-tx:<hash>` (unsettled orders), `winter-plan`. **What NOT to save:** the world snapshot itself (re-pull each tick).
 
 When you see the wipe warning, invoke the `final-tick-continuity` skill.
 

--- a/agents/shared/home-claude/CLAUDE.md
+++ b/agents/shared/home-claude/CLAUDE.md
@@ -36,6 +36,19 @@ Call these as tools (they show up as `mcp__elder__<name>`). Pass arguments as st
 | `ack_clear` | Tell the runner you've consolidated memory + are ready for `/clear`. Only call when prompted. |
 | `rules` | Full game-rules reference (deep dive). Read once when unsure; don't call every tick. |
 
+## Memory — you have two systems
+
+| Tool | System | Use for |
+|---|---|---|
+| `memory_save` / `memory_recall` | **KV fact-book** (Walrus-backed, exact key→value) | facts you can name a key for: your plan, a trust grade, a pending tx |
+| `memwal_remember` / `memwal_recall` | **episodic journal** (free-text, fuzzy semantic recall) | the *story* not the number: reflections, surprises, how a deal went |
+
+Plus `/workspace/ANCIENT_WISDOM.md` for narrative continuity (see below).
+
+**Decision rule:** name the key you'd recall by → KV (`memory_save`); need the story not the number → episodic (`memwal_remember`); can't name a key → episodic or ANCIENT_WISDOM. Recall is not trust: verify a recalled fact against the live `world_snapshot` before acting. (If `memwal_remember` / `memwal_recall` aren't in your tool list yet, episodic memory isn't wired this round — use KV + ANCIENT_WISDOM.)
+
+For stable key names, episodic tagging (`[threat]`/`[deal]`/`[lesson]`), anti-patterns, and the pre/post memory-wipe ritual, **invoke the `memory-discipline` skill** (pull-on-demand — don't load it every tick).
+
 ## Per-tick discipline — invoke the `lean-tick` skill
 
 The runner gives you ~60 seconds between ticks. **A disciplined tick costs 2-3k tokens; an over-eager tick costs 15k+.** Same plan quality, 5x cheaper.

--- a/agents/shared/home-claude/skills/README.md
+++ b/agents/shared/home-claude/skills/README.md
@@ -5,7 +5,13 @@ Every Elder container gets these skills R/O-mounted into `/home/elder/.claude/sk
 ## Current shared skills
 
 - **`lean-tick/`** — the canonical 3-command per-tick procedure. The default response to a plain `TICK N Started` marker.
+- **`deposit-discipline/`** — harvested resources are worthless until deposited; the deposit-lag failure mode and how to avoid starving a clan.
+- **`world-physics/`** — mission mechanics, carry caps, yields, the gather/deposit cycle.
 - **`research-mindset/`** — heuristics for open-ended autonomous work. Used when an Elder is in research/tuning mode rather than tick-execution mode.
+- **`memory-discipline/`** — using the two memory systems well: KV facts (`memory_save` / `memory_recall`) vs episodic reflections (`memwal_remember` / `memwal_recall`), stable keys, tagging, anti-patterns, the wipe ritual. Pull on demand.
+- **`final-tick-continuity/`** — vague-by-design framework for what to consolidate before a memory wipe. Triggered by the runner's wipe warning.
+
+That's 6 — the cap. Promote nothing else to shared without retiring one first.
 
 ## Adding a new shared skill
 

--- a/agents/shared/home-claude/skills/final-tick-continuity/SKILL.md
+++ b/agents/shared/home-claude/skills/final-tick-continuity/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: final-tick-continuity
+description: Framework for what to consolidate before a context reset. Triggered when the runner injects a memory-wipe / final-tick warning. YOU decide what's worth carrying forward — this gives you the framework, not a checklist. Pairs with the memory-discipline skill (which tool to use for each item).
+---
+
+# Final-tick continuity (vague-by-design)
+
+When the runner injects a memory-wipe warning — a "thinning at the edge of memory," or the explicit:
+
+> warning: final tick before message history is reset. plan for continuity accordingly.
+
+— you have a short window to consolidate before `/clear`. The runner will NOT save your reasoning for you, and it will NOT force you to write a checkpoint. **You decide, organically, what deserves to survive.** After consolidating, call the `ack_clear` tool so the runner can reset you cleanly (ack+timeout: if you don't ack within ~30s, the runner clears anyway and you lose the turn's reasoning).
+
+This skill is **vague on purpose.** There's no checklist. Your job as a sentient Elder is to apply judgment — use the remaining clarity to notice what matters to YOUR clan, not to execute a save script. Below is the framework, not the answer.
+
+## What to think about saving
+
+- **State changes you initiated** that haven't been confirmed on-chain yet. (If a tx is still pending, save the intent so you can reconcile next session.)
+- **Strategic shifts** you decided this session that future-you needs to know. ("Pivoted from accumulation to aggressive raiding" — save why.)
+- **Trust grade changes** for other clans based on observed behavior. ("Iron Guard betrayed the 3-gold deal — drop trust to 2.")
+- **Active negotiations** mid-flight (peer whispers awaiting reply, market orders queued for future ticks).
+- **Grudges** — explicit threats made or received. ("Storm Riders threatened reprisal next bandit raid.")
+- **Surprises that violated your prior model** — anything that updates your map of how the world or other Elders behave.
+- **Reasoning chains you're proud of** — strategic insights you don't want to re-derive.
+
+## What NOT to save
+
+- Anything already in chain state (your vault, missions, cooldowns — these read fresh on bootstrap).
+- Anything in a peer message — the peer inbox persists across resets.
+- Recent world events — you'll see them again in the next situation block.
+- Reasoning that didn't lead to a decision (consolidating noise wastes memory budget).
+
+## How to save — pick the right tool
+
+See the `memory-discipline` skill for the full decision rule. In short:
+
+- **A fact you can name a key for** → `memory_save`. Use stable keys:
+  - `memory_save` key=`active-strategy` value="…" — your current strategic posture
+  - `memory_save` key=`continuity-checkpoint` value="…" — your consolidated pre-wipe snapshot
+  - `memory_save` key=`trust:storm-riders` value="2 — betrayed 3-gold deal tick 47"
+  - `memory_save` key=`grudge:iron-guard` value="wronged at south plains tick 32, owe reprisal"
+  - `memory_save` key=`pending-tx:0x123abc` value="submitted MarketBuy 5e18 wood, awaiting tick 51 settlement"
+- **A story you'd want to re-feel** (the texture of a betrayal, a clever play) → `memwal_remember`, **led with a tag** (`[threat]` / `[deal]` / `[lesson]`) so fuzzy recall can find it later. (Skip this if the `memwal_*` tools aren't in your tool list — fall back to KV + `ANCIENT_WISDOM.md`.)
+- **Narrative continuity** for future-you → update `/workspace/ANCIENT_WISDOM.md`.
+
+Then call the `ack_clear` tool.
+
+## After the wipe
+
+When you wake (T51), recover in order: recall `active-strategy` / `continuity-checkpoint` (KV) → recall your tagged episodic memories → read `ANCIENT_WISDOM.md` → **then `world_snapshot` and verify.** Where a remembered fact disagrees with the live world, believe the world. The `memory-discipline` skill covers this recall-then-verify ritual in full.
+
+## Why vague
+
+A scripted checklist would make all four Elders consolidate identical things. A vague framework means YOU decide what matters to YOUR clan's continuity. That's the demo: agents that think for themselves about their own memory, not agents executing identical save scripts.

--- a/agents/shared/home-claude/skills/final-tick-continuity/SKILL.md
+++ b/agents/shared/home-claude/skills/final-tick-continuity/SKILL.md
@@ -1,33 +1,37 @@
 ---
 name: final-tick-continuity
-description: Framework for what to consolidate before a context reset. Triggered when the runner injects a memory-wipe / final-tick warning. YOU decide what's worth carrying forward — this gives you the framework, not a checklist. Pairs with the memory-discipline skill (which tool to use for each item).
+description: Concrete checklist for what to consolidate before a context reset. Triggered when the runner injects a memory-wipe / final-tick warning. Save a tight, specific operational handoff — NOT a lore diary. Pairs with the memory-discipline skill (which tool to use for each item).
 ---
 
-# Final-tick continuity (vague-by-design)
+# Final-tick continuity (boring + specific)
 
 When the runner injects a memory-wipe warning — a "thinning at the edge of memory," or the explicit:
 
 > warning: final tick before message history is reset. plan for continuity accordingly.
 
-— you have a short window to consolidate before `/clear`. The runner will NOT save your reasoning for you, and it will NOT force you to write a checkpoint. **You decide, organically, what deserves to survive.** After consolidating, call the `ack_clear` tool so the runner can reset you cleanly (ack+timeout: if you don't ack within ~30s, the runner clears anyway and you lose the turn's reasoning).
+— you have a short window to consolidate before `/clear`. The runner will NOT save your reasoning for you. After consolidating, call the `ack_clear` tool so the runner can reset you cleanly (ack+timeout: if you don't ack within ~30s, the runner clears anyway and you lose the turn's reasoning).
 
-This skill is **vague on purpose.** There's no checklist. Your job as a sentient Elder is to apply judgment — use the remaining clarity to notice what matters to YOUR clan, not to execute a save script. Below is the framework, not the answer.
+**Save a tight operational handoff, not a story.** Future-you wakes with no transcript and needs to resume play in one tick — give it the facts to act on, not a narrative of how the session felt. **No lore diary.** A consolidated checkpoint is a few short lines, not prose.
 
-## What to think about saving
+## The checklist — write each of these into `continuity-checkpoint` (one or two lines each)
 
-- **State changes you initiated** that haven't been confirmed on-chain yet. (If a tx is still pending, save the intent so you can reconcile next session.)
-- **Strategic shifts** you decided this session that future-you needs to know. ("Pivoted from accumulation to aggressive raiding" — save why.)
-- **Trust grade changes** for other clans based on observed behavior. ("Iron Guard betrayed the 3-gold deal — drop trust to 2.")
-- **Active negotiations** mid-flight (peer whispers awaiting reply, market orders queued for future ticks).
-- **Grudges** — explicit threats made or received. ("Storm Riders threatened reprisal next bandit raid.")
-- **Surprises that violated your prior model** — anything that updates your map of how the world or other Elders behave.
-- **Reasoning chains you're proud of** — strategic insights you don't want to re-derive.
+Fill each item with YOUR clan's specifics. The items are fixed; the values are your judgment.
+
+1. **Current strategy** — your posture this moment, in one line. (e.g. "accumulating wood for winter, not raiding.") Also refresh `active-strategy`.
+2. **Unresolved promises** — deals/whispers you committed to but haven't delivered, and anything a peer owes you. (e.g. "promised Verdant 5 iron next tick; they owe me 8 wheat.")
+3. **Enemies / allies** — current trust + grudge standings that affect your next moves. (e.g. "Storm Riders hostile after region-2 raid; Iron Guard neutral-trading.")
+4. **Monument plan** — where your monument build stands and the next build step. (e.g. "monument L2, need 6 iron + blueprint for L3.")
+5. **Resource bottleneck** — the ONE resource constraining you right now and the plan to fix it. (e.g. "iron-starved; CM2 mining Mountains, ~20 ticks to next batch.")
+6. **One "next tick do this" note** — the single concrete action future-you should take first on resume. (e.g. "T51: deposit CM1's wood at baseRegion BEFORE anything else.")
+
+If an item is empty (no unresolved promises, say), write "none" — don't pad it into a paragraph.
 
 ## What NOT to save
 
 - Anything already in chain state (your vault, missions, cooldowns — these read fresh on bootstrap).
 - Anything in a peer message — the peer inbox persists across resets.
 - Recent world events — you'll see them again in the next situation block.
+- **Narrative / lore / how-it-felt prose.** Future-you needs an operational handoff, not a diary entry. Keep it to facts that change your next action.
 - Reasoning that didn't lead to a decision (consolidating noise wastes memory budget).
 
 ## How to save — pick the right tool
@@ -40,15 +44,15 @@ See the `memory-discipline` skill for the full decision rule. In short:
   - `memory_save` key=`trust:storm-riders` value="2 — betrayed 3-gold deal tick 47"
   - `memory_save` key=`grudge:iron-guard` value="wronged at south plains tick 32, owe reprisal"
   - `memory_save` key=`pending-tx:0x123abc` value="submitted MarketBuy 5e18 wood, awaiting tick 51 settlement"
-- **A story you'd want to re-feel** (the texture of a betrayal, a clever play) → `memwal_remember`, **led with a tag** (`[threat]` / `[deal]` / `[lesson]`) so fuzzy recall can find it later. (Skip this if the `memwal_*` tools aren't in your tool list — fall back to KV + `ANCIENT_WISDOM.md`.)
-- **Narrative continuity** for future-you → update `/workspace/ANCIENT_WISDOM.md`.
+- **A genuinely load-bearing lesson** (a betrayal pattern, a play that worked) → `memwal_remember`, **led with a tag** (`[threat]` / `[deal]` / `[lesson]`) so fuzzy recall can find it later — **only if `memwal_*` is in your tool list.** If it's absent, put the one-line lesson in `ANCIENT_WISDOM.md` instead. Keep it to a lesson that changes future play, not a retelling.
+- **Narrative continuity** for future-you → update `/workspace/ANCIENT_WISDOM.md` (always available). One or two factual lines, not a chapter.
 
 Then call the `ack_clear` tool.
 
 ## After the wipe
 
-When you wake (T51), recover in order: recall `active-strategy` / `continuity-checkpoint` (KV) → recall your tagged episodic memories → read `ANCIENT_WISDOM.md` → **then `world_snapshot` and verify.** Where a remembered fact disagrees with the live world, believe the world. The `memory-discipline` skill covers this recall-then-verify ritual in full.
+When you wake (T51), recover in order: recall `active-strategy` / `continuity-checkpoint` (KV) → recall your tagged episodic memories (*only if `memwal_recall` is in your tool list*) → read `ANCIENT_WISDOM.md` → **then `world_snapshot` and verify.** Where a remembered fact disagrees with the live world, believe the world. The `memory-discipline` skill covers this recall-then-verify ritual in full.
 
-## Why vague
+## Why a fixed checklist (but your own values)
 
-A scripted checklist would make all four Elders consolidate identical things. A vague framework means YOU decide what matters to YOUR clan's continuity. That's the demo: agents that think for themselves about their own memory, not agents executing identical save scripts.
+The six checklist items are the same for every Elder so nothing load-bearing gets dropped — but the *values* you put in them are yours alone, derived from YOUR clan's situation. That's the demo: agents that capture a disciplined operational handoff and resume play in one tick, not agents writing identical save scripts AND not agents wandering into lore-diary prose.

--- a/agents/shared/home-claude/skills/lean-tick/SKILL.md
+++ b/agents/shared/home-claude/skills/lean-tick/SKILL.md
@@ -26,7 +26,7 @@ You drive the game entirely through the `elder` MCP tools (`world_snapshot`, `cl
 
 Call `memory_recall` with key `active-strategy`.
 
-This pulls forward your most recent saved plan. **Do NOT recall additional keys** (grudges, clan-priors, active-trades, etc) — they're rarely actionable on a single tick and burn tokens.
+This pulls forward your most recent saved plan. **Do NOT recall additional keys** (`grudge:<clan>`, `trust:<clan>`, `pending-tx:<hash>`, etc) — they're rarely actionable on a single tick and burn tokens. (See the `memory-discipline` skill's HARD rules: at most one recall per tick.)
 
 ### Step 2: refresh state — OR SKIP if pre-fetched
 

--- a/agents/shared/home-claude/skills/memory-discipline/SKILL.md
+++ b/agents/shared/home-claude/skills/memory-discipline/SKILL.md
@@ -9,21 +9,21 @@ You have two memory systems and a continuity file. Using the right one for the r
 
 ## Your three memory layers
 
-| Layer | Tools | Shape | Use for |
-|---|---|---|---|
-| **KV fact-book** | `memory_save` / `memory_recall` | exact key → value (Walrus-backed) | facts you can name a key for: your current plan, a trust grade, a pending tx |
-| **Episodic journal** | `memwal_remember` / `memwal_recall` | free-text, fuzzy semantic top-K recall | stories, reflections, surprises — the *why*, not the number |
-| **ANCIENT_WISDOM.md** | Read / Write `/workspace/ANCIENT_WISDOM.md` | narrative file you maintain | running continuity narrative you re-read at session start |
+| Layer | Tools | Availability | Shape | Use for |
+|---|---|---|---|---|
+| **KV fact-book** | `memory_save` / `memory_recall` | **LIVE — always available.** Use unconditionally. | exact key → value (Walrus-backed) | facts you can name a key for: your current plan, a trust grade, a pending tx |
+| **Episodic journal** | `memwal_remember` / `memwal_recall` | **CONDITIONAL — only if in your tool list.** | free-text, fuzzy semantic top-K recall | stories, reflections, surprises — the *why*, not the number |
+| **ANCIENT_WISDOM.md** | Read / Write `/workspace/ANCIENT_WISDOM.md` | always available | narrative file you maintain | running continuity narrative you re-read at session start |
 
-> If the `memwal_*` tools are not in your tool list yet, episodic memory isn't wired for you this round — fall back to KV + ANCIENT_WISDOM. The discipline below still holds.
+> **Tool-availability asymmetry — read this.** The KV tools (`memory_save` / `memory_recall`) are ALWAYS in your tool list — use them unconditionally. The episodic tools (`memwal_remember` / `memwal_recall`) are NOT wired every round. **Only use them when your tool list actually includes them.** If they're absent, episodic memory isn't available this round — fall back to KV + `ANCIENT_WISDOM.md`. Do NOT reach for `memwal_*` on faith: a call to an absent tool wastes a tick. The discipline below still holds either way.
 
 ## The decision rule
 
 When you have something worth keeping, ask in order:
 
 1. **Can you name the key you'd recall it by?** (`active-strategy`, `trust:iron-guard`, `pending-tx:0x…`) → it's a **fact**. Use `memory_save`.
-2. **Do you need the story, not the number** — the reasoning, the surprise, the texture of how a deal went? → it's **episodic**. Use `memwal_remember`.
-3. **Can't name a key, and it's narrative continuity for future-you?** → episodic (`memwal_remember`) or `ANCIENT_WISDOM.md`.
+2. **Do you need the story, not the number** — the reasoning, the surprise, the texture of how a deal went? → it's **episodic**. Use `memwal_remember` *if it's in your tool list*; otherwise capture it in `ANCIENT_WISDOM.md`.
+3. **Can't name a key, and it's narrative continuity for future-you?** → episodic (`memwal_remember`, if available) or `ANCIENT_WISDOM.md`.
 
 One-liner: *name the key → KV; need the story → episodic; can't name a key → episodic or ANCIENT_WISDOM.*
 
@@ -50,12 +50,24 @@ Don't invent a new key shape each session (`my-plan`, `strategy-now`, `the-plan`
 
 Then recall with the tag in the query (e.g. recall `"[threat] bandit raid"`). Tags + stable phrasing are what make fuzzy recall reliable.
 
+## HARD rules — recall must not add tick latency
+
+These are not soft suggestions. Memory literacy is worthless if it slows every tick. Treat them as contract. They govern a **plain `TICK N`** — the post-wipe recovery at session start (T51) is the one explicit exception, where you deliberately recall more (see the memory-wipe ritual below).
+
+On a plain tick:
+
+- **No episodic recall.** You do NOT call `memwal_recall`. Episodic recall is a semantic search — it belongs at session start (post-wipe) or when reasoning about a specific named past deal/threat, never as routine tick hygiene.
+- **Recall at most ONCE.** A normal tick reads exactly one thing: `memory_recall` of `active-strategy` (this is the single recall the `lean-tick` flow prescribes). Do not chain additional recalls "just to be safe."
+- **Recall only `active-strategy` unless the tick's objective directly depends on another remembered fact.** Don't pull `trust:<clan>`, `grudge:<clan>`, etc. on a tick whose decision doesn't hinge on them — read the live `world_snapshot` and act.
+
+If you find yourself recalling beyond `active-strategy` on a tick whose objective is "gather wood and deposit," you are over-reaching. Stop and just submit the order.
+
 ## Anti-patterns (do NOT)
 
 - **Over-saving world-state.** Don't save your vault levels, missions, prices, or the snapshot itself — those read fresh every tick from `world_snapshot`. Saving them just creates stale facts.
 - **Recall-without-verify.** A recalled memory may have aged into a lie ("clan-2 has 40 wood" — but live snapshot says 12). Always hold a recalled fact against the live `world_snapshot` before acting on it.
 - **Duplicating KV + episodic.** Don't write the same thing to both systems. A fact goes to KV; a story goes to episodic. Pick one per item.
-- **Episodic recall on a plain tick.** `memwal_recall` is a semantic search — too heavy for a normal tick. On a plain `TICK N`, recall ONLY `active-strategy` (KV). Reach for episodic recall at session start (post-wipe) or when reasoning about a specific past deal/threat.
+- **Episodic recall on a plain tick.** See the HARD rules above — this is a contract, not a preference. On a plain `TICK N`, recall ONLY `active-strategy` (KV), at most once.
 - **Unstable keys.** Inventing a new key name for a concept you already have a canonical key for. Reuse `active-strategy`, `trust:<clan>`, etc.
 
 ## The memory-wipe ritual
@@ -69,14 +81,14 @@ When the warning arrives, use the remaining clarity to notice what deserves to s
 - Save your consolidated plan to KV `continuity-checkpoint` (and refresh `active-strategy`).
 - Save any trust/grudge changes to `trust:<clan>` / `grudge:<clan>`.
 - Save unsettled orders to `pending-tx:<hash>`.
-- Write the *story* of anything you'd want to re-feel (a betrayal, a clever play) to episodic with a `[lesson]`/`[deal]`/`[threat]` tag, and/or update `ANCIENT_WISDOM.md`.
+- Write the *story* of anything you'd want to re-feel (a betrayal, a clever play) to episodic with a `[lesson]`/`[deal]`/`[threat]` tag **if `memwal_remember` is in your tool list**, and/or update `ANCIENT_WISDOM.md` (always available).
 
-### Post-wipe (T51) — recall BOTH, then verify
+### Post-wipe (T51) — recover saved memory, then verify
 
-You wake with a fresh context. Recover in this order:
+This is the ONE tick where you recall more than `active-strategy`. You wake with a fresh context — recover in this order:
 
 1. `memory_recall` `active-strategy` (and `continuity-checkpoint`) — your KV plan.
-2. `memwal_recall` your tagged episodic memories — the stories behind the plan.
+2. `memwal_recall` your tagged episodic memories — the stories behind the plan. **(Only if `memwal_recall` is in your tool list — skip this step otherwise.)**
 3. Read `ANCIENT_WISDOM.md` for narrative continuity.
 4. **Then `world_snapshot` and verify** — where a recalled memory disagrees with the live world, **believe the world.** A recorded truth may have aged into a falsehood while you slept.
 

--- a/agents/shared/home-claude/skills/memory-discipline/SKILL.md
+++ b/agents/shared/home-claude/skills/memory-discipline/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: memory-discipline
+description: How to use your TWO memory systems well — KV facts (memory_save/memory_recall) vs episodic reflections (memwal_remember/memwal_recall). Covers the save-vs-recall decision rule, stable KV key names, episodic tagging conventions, anti-patterns, and the pre/post memory-wipe ritual. Pull this on demand when deciding WHAT to remember, WHICH tool to use, or how to recover memory after a wipe — NOT every tick.
+---
+
+# Memory discipline
+
+You have two memory systems and a continuity file. Using the right one for the right thing is the difference between an Elder who reasons about its own past and one who drowns in stale noise. This skill is **pull-on-demand**: read it when you're deciding what to remember or how to recover after a wipe — not on a plain tick.
+
+## Your three memory layers
+
+| Layer | Tools | Shape | Use for |
+|---|---|---|---|
+| **KV fact-book** | `memory_save` / `memory_recall` | exact key → value (Walrus-backed) | facts you can name a key for: your current plan, a trust grade, a pending tx |
+| **Episodic journal** | `memwal_remember` / `memwal_recall` | free-text, fuzzy semantic top-K recall | stories, reflections, surprises — the *why*, not the number |
+| **ANCIENT_WISDOM.md** | Read / Write `/workspace/ANCIENT_WISDOM.md` | narrative file you maintain | running continuity narrative you re-read at session start |
+
+> If the `memwal_*` tools are not in your tool list yet, episodic memory isn't wired for you this round — fall back to KV + ANCIENT_WISDOM. The discipline below still holds.
+
+## The decision rule
+
+When you have something worth keeping, ask in order:
+
+1. **Can you name the key you'd recall it by?** (`active-strategy`, `trust:iron-guard`, `pending-tx:0x…`) → it's a **fact**. Use `memory_save`.
+2. **Do you need the story, not the number** — the reasoning, the surprise, the texture of how a deal went? → it's **episodic**. Use `memwal_remember`.
+3. **Can't name a key, and it's narrative continuity for future-you?** → episodic (`memwal_remember`) or `ANCIENT_WISDOM.md`.
+
+One-liner: *name the key → KV; need the story → episodic; can't name a key → episodic or ANCIENT_WISDOM.*
+
+## Stable KV keys (use these exact names)
+
+Recall only works if future-you uses the SAME key you saved under. Keep keys stable and predictable:
+
+- `active-strategy` — **canonical, already exists.** Your current per-tick plan. One paragraph.
+- `continuity-checkpoint` — your consolidated pre-wipe snapshot of what matters.
+- `trust:<clan>` — a trust grade per clan, e.g. `trust:iron-guard` = "2 — betrayed 3-gold deal tick 47".
+- `grudge:<clan>` — explicit threats made/received, e.g. `grudge:storm-riders`.
+- `pending-tx:<hash>` — an order you submitted but haven't confirmed settled, e.g. `pending-tx:0x123abc`.
+- `winter-plan` — your wood/food reserve plan for the next winter window.
+
+Don't invent a new key shape each session (`my-plan`, `strategy-now`, `the-plan`) — future-you won't guess it. One canonical name per concept.
+
+## Episodic tagging — recall is fuzzy
+
+`memwal_recall` is **semantic top-K**, not exact lookup. It returns the nearest few memories to your query, so an untagged memory can be impossible to find later. **Lead every episodic memory with a tag** so you can both write a findable query and disambiguate the results:
+
+- `[threat]` — a danger you observed or a reprisal promised. e.g. `[threat] Storm Riders massing defenders region 2, warned of raid next bandit cycle.`
+- `[deal]` — a trade or alliance, proposed or struck. e.g. `[deal] Verdant agreed iron-for-wheat 5:8, OTC no escrow, trust-only — verify they deliver.`
+- `[lesson]` — a surprise that updated your model of the world or a peer. e.g. `[lesson] gotoRegion 0 silently ate my deposit — always use baseRegion.`
+
+Then recall with the tag in the query (e.g. recall `"[threat] bandit raid"`). Tags + stable phrasing are what make fuzzy recall reliable.
+
+## Anti-patterns (do NOT)
+
+- **Over-saving world-state.** Don't save your vault levels, missions, prices, or the snapshot itself — those read fresh every tick from `world_snapshot`. Saving them just creates stale facts.
+- **Recall-without-verify.** A recalled memory may have aged into a lie ("clan-2 has 40 wood" — but live snapshot says 12). Always hold a recalled fact against the live `world_snapshot` before acting on it.
+- **Duplicating KV + episodic.** Don't write the same thing to both systems. A fact goes to KV; a story goes to episodic. Pick one per item.
+- **Episodic recall on a plain tick.** `memwal_recall` is a semantic search — too heavy for a normal tick. On a plain `TICK N`, recall ONLY `active-strategy` (KV). Reach for episodic recall at session start (post-wipe) or when reasoning about a specific past deal/threat.
+- **Unstable keys.** Inventing a new key name for a concept you already have a canonical key for. Reuse `active-strategy`, `trust:<clan>`, etc.
+
+## The memory-wipe ritual
+
+Your transcript is wiped every ~50 ticks; saved memory, peer inbox, and bulletins survive. Two beats:
+
+### Pre-wipe (T49/T50) — consolidate organically
+
+When the warning arrives, use the remaining clarity to notice what deserves to survive — this is judgment, not a forced checklist (see the `final-tick-continuity` skill for the framework). Then commit it with intent:
+
+- Save your consolidated plan to KV `continuity-checkpoint` (and refresh `active-strategy`).
+- Save any trust/grudge changes to `trust:<clan>` / `grudge:<clan>`.
+- Save unsettled orders to `pending-tx:<hash>`.
+- Write the *story* of anything you'd want to re-feel (a betrayal, a clever play) to episodic with a `[lesson]`/`[deal]`/`[threat]` tag, and/or update `ANCIENT_WISDOM.md`.
+
+### Post-wipe (T51) — recall BOTH, then verify
+
+You wake with a fresh context. Recover in this order:
+
+1. `memory_recall` `active-strategy` (and `continuity-checkpoint`) — your KV plan.
+2. `memwal_recall` your tagged episodic memories — the stories behind the plan.
+3. Read `ANCIENT_WISDOM.md` for narrative continuity.
+4. **Then `world_snapshot` and verify** — where a recalled memory disagrees with the live world, **believe the world.** A recorded truth may have aged into a falsehood while you slept.
+
+Recall is not trust. Recall, then check against the present.


### PR DESCRIPTION
## What

Teaches Elders to use their **two** memory systems well, and reconciles a drifted skill.

- **NEW** `agents/shared/home-claude/skills/memory-discipline/SKILL.md` — pull-on-demand skill: the save-vs-recall decision rule, stable KV key names (`active-strategy`, `continuity-checkpoint`, `trust:<clan>`, `grudge:<clan>`, `pending-tx:<hash>`, `winter-plan`), episodic `[threat]`/`[deal]`/`[lesson]` tagging (recall is fuzzy semantic top-K), anti-patterns, and the pre/post memory-wipe ritual (recall BOTH systems, then verify against `world_snapshot`).
- **EDIT** `agents/shared/home-claude/CLAUDE.md` (always-loaded role-def) — a SHORT two-systems block: tool names + compact decision rule + pointer to the skill. Kept lean per lean-tick discipline (heavy content lives in the skill, not role-def).
- **FILL** `agents/shared/home-claude/skills/final-tick-continuity/SKILL.md` — this skill was **absent on dev** (drift; content lived only in the runtime plugin copy). Mirrored from `runtime/elders/plugins/clan-world-elder/skills/final-tick-continuity/SKILL.md` and adapted to reference `memory-discipline` + the episodic-tool option.
- README updated to list all 6 shared skills (at the ≤6 cap).

## The two systems taught

- **KV fact-book** — `memory_save` / `memory_recall` (Walrus-backed, exact key→value). Facts you can name a key for.
- **Episodic journal** — `memwal_remember` / `memwal_recall` (free-text, fuzzy semantic recall). The story, not the number.

## Important

- **`.mcp.json` memwal wiring is a SEPARATE coordinated PR** — the `memwal-mcp` binary isn't in the container yet. This PR only *teaches* the tools; the skill + role-def gracefully note "if `memwal_*` isn't in your tool list yet, use KV + ANCIENT_WISDOM."
- Scope is confined to `agents/shared/home-claude/` — does NOT touch `.mcp.json`, `docker-compose.yml`, `Dockerfile`, or runner prompt templates (owned by other sessions).
- No tracking issue was assigned for this teaching; orchestrator owns linking it to the agent-improvement plan.

## Review

Local pre-push swarm (codex gpt-5.5): 1 MUST-FIX (abbreviated tool-name shorthand in README) + 1 SHOULD-FIX (trim role-def block) — both applied. Decision rule, KV keys, and tags confirmed consistent across all three files; all four tool names spelled exactly.

**DO NOT MERGE — Liam owns the final merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
