### PR TITLE
fix(v2.17.1): post-release Codex findings — creds-link, mobile inft compat, heartbeat test 30s

### DIFF
--- a/agents/shared/run.sh
+++ b/agents/shared/run.sh
@@ -141,30 +141,32 @@ MCP_CONFIG_ELDER_ONLY="/opt/clan-world/shared/elder-mcp.elder-only.json"
 # Bridge the per-Elder MemWal credentials from the docker secret mount into the
 # location memwal-mcp reads ($HOME/.memwal/credentials.json). Docker secrets land
 # read-only at /run/secrets/<name>; memwal-mcp's auth.js resolves creds via
-# homedir() + "/.memwal/credentials.json", so we symlink. The secret-path
-# derivation and the symlink itself happen ONLY inside the enabled branch
-# below — `ELDER_ID` is already validated as required at the top of this
-# script (fail-closed, exit 2), but keeping the expansion out of the always-run
-# top scope avoids any set -u surprise on the live boot path.
-
-if [ "${MEMWAL_MCP_ENABLED:-false}" = "true" ] && [ -x "$MEMWAL_BIN" ]; then
-  # Link the per-Elder creds secret into the path memwal-mcp reads. Any failure
-  # here (missing secret, non-symlink file already present, R/O home) is
-  # NON-FATAL — we never want the live boot path to die for a creds glitch. On
-  # failure we keep the full config selected anyway: memwal-mcp then serves its
-  # auth-required stub (remember/recall return a login prompt) without crashing
-  # claude, and the elder + KV memory are unaffected.
-  MEMWAL_CREDS_SECRET="/run/secrets/memwal-creds-${ELDER_ID#elder-}"
-  MEMWAL_CREDS_DEST="$HOME/.memwal/credentials.json"
-  if [ -r "$MEMWAL_CREDS_SECRET" ]; then
-    if mkdir -p "$HOME/.memwal" 2>/dev/null && ln -sfn "$MEMWAL_CREDS_SECRET" "$MEMWAL_CREDS_DEST" 2>/dev/null; then
-      echo "[run.sh] MemWal creds linked: $MEMWAL_CREDS_SECRET -> $MEMWAL_CREDS_DEST"
-    else
-      echo "[run.sh] WARNING: failed to link MemWal creds ($MEMWAL_CREDS_SECRET -> $MEMWAL_CREDS_DEST). memwal-mcp will serve auth-required until creds resolve. Boot continues." >&2
-    fi
+# homedir() + "/.memwal/credentials.json", so we symlink. This linking is
+# DECOUPLED from MEMWAL_MCP_ENABLED on purpose: we link whenever the secret is
+# present so that enabling the flag later does NOT depend on creds-link ordering
+# (no boot replay, no race between flag flip and creds availability). `ELDER_ID`
+# is already validated as required at the top of this script (fail-closed,
+# exit 2), so referencing it here is safe under `set -u`. The whole block is
+# fully NON-FATAL — a missing/unreadable secret or a R/O home only warns and
+# continues; we never crash the live boot path for a creds glitch.
+MEMWAL_CREDS_SECRET="/run/secrets/memwal-creds-${ELDER_ID#elder-}"
+MEMWAL_CREDS_DEST="$HOME/.memwal/credentials.json"
+if [ -r "$MEMWAL_CREDS_SECRET" ]; then
+  if mkdir -p "$HOME/.memwal" 2>/dev/null && ln -sfn "$MEMWAL_CREDS_SECRET" "$MEMWAL_CREDS_DEST" 2>/dev/null; then
+    echo "[run.sh] MemWal creds linked: $MEMWAL_CREDS_SECRET -> $MEMWAL_CREDS_DEST"
   else
-    echo "[run.sh] WARNING: MEMWAL_MCP_ENABLED=true but creds secret $MEMWAL_CREDS_SECRET missing/unreadable — memwal-mcp will serve auth-required (no remember/recall) until creds present" >&2
+    echo "[run.sh] WARNING: failed to link MemWal creds ($MEMWAL_CREDS_SECRET -> $MEMWAL_CREDS_DEST). memwal-mcp will serve auth-required until creds resolve. Boot continues." >&2
   fi
+else
+  # No secret mounted for this Elder yet (expected under the default-off
+  # rollout). Non-fatal: if/when MemWal is enabled, memwal-mcp serves its
+  # auth-required stub (remember/recall return a login prompt) until creds
+  # appear; the elder + KV memory are unaffected.
+  echo "[run.sh] MemWal creds secret $MEMWAL_CREDS_SECRET absent/unreadable — skipping creds link (boot continues)"
+fi
+
+# --- MCP config selection (the ONLY part gated on MEMWAL_MCP_ENABLED) -------
+if [ "${MEMWAL_MCP_ENABLED:-false}" = "true" ] && [ -x "$MEMWAL_BIN" ]; then
   echo "[run.sh] MemWal enabled (flag set + binary present) — using elder+memwal MCP config"
   MCP_CONFIG="$MCP_CONFIG_FULL"
 else

--- a/apps/server/convex/inft.ts
+++ b/apps/server/convex/inft.ts
@@ -1,5 +1,41 @@
-import { mutation } from "./_generated/server";
+import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
+
+/**
+ * COMPAT SHIM — pending mobile migration.
+ *
+ * The 0G/iNFT strip (#657) removed the `inftTokens` / `inftTransfers` tables and
+ * dropped this query. The Android app (apps/clan-world-mobile) still calls
+ * `inft:getInftDemoState` from InftDetailViewModel / HallViewModel /
+ * StrategyEditorViewModel, so removing the query makes those Convex calls 500.
+ *
+ * This shim restores the query with the SAME response shape the mobile client
+ * deserializes ({ token, transfers, memory, bulletins }). Because the iNFT
+ * tables are gone, `token` is always null and `transfers` is always empty —
+ * which is exactly what the Kotlin model already tolerates (InftDemoState.token
+ * is nullable, transfers defaults to emptyList). The live `memory` + `bulletins`
+ * data is still served from the surviving tables, so the mobile memory/bulletin
+ * panels keep working. Remove this shim once mobile stops calling it.
+ */
+export const getInftDemoState = query({
+  args: { clanId: v.number() },
+  handler: async (ctx, { clanId }) => {
+    const memory = await ctx.db
+      .query("memoryEntries")
+      .withIndex("by_clan", (q) => q.eq("clanId", clanId))
+      .order("desc")
+      .take(20);
+    const bulletins = await ctx.db
+      .query("bulletins")
+      .withIndex("by_clan_slot", (q) => q.eq("clanId", clanId))
+      .order("desc")
+      .take(8);
+
+    // token/transfers came from the now-removed iNFT tables; return the
+    // empty/null defaults the mobile model already expects.
+    return { token: null, transfers: [], memory, bulletins };
+  },
+});
 
 /**
  * Mirror mutations require INDEXER_SECRET to match the Convex env var of the

--- a/packages/contracts/test/HackathonGather2x.t.sol
+++ b/packages/contracts/test/HackathonGather2x.t.sol
@@ -74,15 +74,15 @@ contract HackathonGather2xTest is Test {
         return world.getClansman(csId);
     }
 
-    /// @dev HEARTBEAT_INTERVAL is now 20s, so a single tick advance schedules
-    ///      the next heartbeat exactly 20s out.
-    function test_heartbeatIntervalIs20() public {
-        assertEq(world.heartbeatIntervalSeconds(), 20, "interval == 20");
+    /// @dev HEARTBEAT_INTERVAL is 30s (ClanWorldConstants.HEARTBEAT_INTERVAL_SECONDS),
+    ///      so a single tick advance schedules the next heartbeat exactly 30s out.
+    function test_heartbeatIntervalIs30() public {
+        assertEq(world.heartbeatIntervalSeconds(), 30, "interval == 30");
         uint64 before = world.getWorldState().nextHeartbeatAtTs;
         vm.warp(before);
         world.heartbeat();
         uint64 after_ = world.getWorldState().nextHeartbeatAtTs;
-        assertEq(after_, uint64(block.timestamp) + 20, "next heartbeat is +20s");
+        assertEq(after_, uint64(block.timestamp) + 30, "next heartbeat is +30s");
     }
 
     /// @dev WOOD non-crit yield is now 2e18/tick (was 1e18). Use prevrandao


### PR DESCRIPTION
Post-release fix-patch addressing 3 Codex review findings from the merged **v2.17.0** release PR #696. Lands on `dev` (the live demo deploys from dev).

**DO NOT MERGE — Liam owns the merge trigger.**

## Finding 1 (P1) — `agents/shared/run.sh`: link MemWal creds regardless of `MEMWAL_MCP_ENABLED`
The per-Elder creds symlink (`/run/secrets/memwal-creds-N` -> `$HOME/.memwal/credentials.json`) was nested inside the `MEMWAL_MCP_ENABLED=true` branch, so the default-`false` rollout skipped it. Hoisted the symlink so it runs **whenever the secret is present** — enabling the flag later no longer depends on creds-link ordering (no boot replay / no flag-vs-creds race). Only the MCP-config *selection* stays flag-gated.

- Fully non-fatal: missing/unreadable secret or RO home only warns + continues (`2>/dev/null` + guarded `if`/`&&`).
- `set -euo pipefail` safe: `ELDER_ID` is validated as required (fail-closed, exit 2) at the top of the script, so `${ELDER_ID#elder-}` is safe outside the branch; `$HOME` is exported earlier. `bash -n` passes.

## Finding 2 (P2) — `apps/server/convex/inft.ts`: restore `getInftDemoState` (verify-then-decide -> RESTORE)
**Verified mobile DOES still call it.** Grep evidence (`apps/clan-world-mobile/`):
```
data/ClanWorldConvexClient.kt:56:    callQuery("inft:getInftDemoState", ...)
viewmodel/InftDetailViewModel.kt:49:      convex.getInftDemoState(clanId)
viewmodel/HallViewModel.kt:86:            convex.getInftDemoState(clanId)
viewmodel/StrategyEditorViewModel.kt:47:      convex.getInftDemoState(clanId)
```
So the finding is **real** — removing the query 500s the mobile path. Restored as a **compat shim**: the 0G strip (#657) removed the `inftTokens`/`inftTransfers` tables, so the shim returns `{ token: null, transfers: [], memory, bulletins }` from the surviving `memoryEntries` (`by_clan`) + `bulletins` (`by_clan_slot`) tables. This matches the Kotlin `InftDemoState` model (nullable `token`, `transfers` defaults to `emptyList`), so the mobile memory/bulletin panels keep working. Comment marks it as a shim pending mobile migration.

## Finding 3 (P1) — `packages/contracts/test/HackathonGather2x.t.sol`: align heartbeat test to 30s
The test asserted a stale `20`. Production constant is `HEARTBEAT_INTERVAL_SECONDS = 30` (`IClanWorld.sol:28` + generated `packages/sdk/src/generated/constants.ts`). Updated assertions, warp math, fn name (`test_heartbeatIntervalIs30`), and comment to 30.

```
forge test --match-path test/HackathonGather2x.t.sol
[PASS] test_heartbeatIntervalIs30()  [PASS] test_wheatYieldDoubled()  [PASS] test_woodYieldDoubled()
3 passed; 0 failed
```

## Verification
- **#3:** `forge test --match-path test/HackathonGather2x.t.sol` -> 3/3 pass.
- **#2:** `apps/server` codegen + `tsc --noEmit` typecheck CLEAN. (One pre-existing `indexer.test.ts` tick-epoch failure confirmed identical on clean `origin/dev` — unrelated to this patch.)
- **#1:** `bash -n agents/shared/run.sh` passes; env-guard branches traced.
- **Local swarm:** codex CLEAN (0 findings), gemini CLEAN, self-review CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)